### PR TITLE
Show devworkspace logs when starting a devworkspace

### DIFF
--- a/src/containers/FactoryLoader.tsx
+++ b/src/containers/FactoryLoader.tsx
@@ -327,7 +327,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     }
     // check if it ephemeral
     // not implemented for dev workspaces yet
-    if (workspace.storageType === 'ephemeral') {
+    if (isWorkspaceV1(workspace.ref) && workspace.storageType === 'ephemeral') {
       this.showAlert('You\'re starting an ephemeral workspace. All changes to the source code will be lost ' +
         'when the workspace is stopped unless they are pushed to a remote code repository.', AlertVariant.warning);
     }

--- a/src/services/helpers/types.ts
+++ b/src/services/helpers/types.ts
@@ -37,8 +37,10 @@ export enum WorkspaceStatus {
 }
 
 export enum DevWorkspaceStatus {
-  FAILED = 1,
-  RUNNING = 2
+  FAILED = 'Failed',
+  RUNNING = 'Running',
+  STOPPED = 'Stopped',
+  STOPPING = 'Stopping'
 }
 
 export type GettingStartedTab = 'get-started'

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -87,7 +87,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     const workspaceStatus = workspace.status;
     if (!workspaceStatus || !workspaceStatus.phase) {
       throw new Error(`Could not retrieve devworkspace status information from ${workspaceName} in namespace ${namespace}`);
-    } else if (workspaceStatus.phase.toUpperCase() === DevWorkspaceStatus[DevWorkspaceStatus.RUNNING] && !workspaceStatus?.ideUrl) {
+    } else if (workspaceStatus.phase === DevWorkspaceStatus.RUNNING && !workspaceStatus?.ideUrl) {
       throw new Error('Could not retrieve ideUrl for the running workspace');
     }
     return workspace;
@@ -241,7 +241,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
 
   checkForDevWorkspaceError(devworkspace: IDevWorkspace) {
     const currentPhase = devworkspace.status?.phase;
-    if (currentPhase && currentPhase.toUpperCase() === DevWorkspaceStatus[DevWorkspaceStatus.FAILED]) {
+    if (currentPhase && currentPhase === DevWorkspaceStatus.FAILED) {
       const message = devworkspace.status.message;
       if (message) {
         throw new Error(devworkspace.status.message);

--- a/src/services/workspaceAdapter/index.ts
+++ b/src/services/workspaceAdapter/index.ts
@@ -120,8 +120,7 @@ export class WorkspaceAdapter<T extends che.Workspace | IDevWorkspace> implement
     } else {
       let status = (this.workspace as IDevWorkspace).status?.phase;
       if (status) {
-        status = status.toUpperCase();
-        if (status === DevWorkspaceStatus[DevWorkspaceStatus.FAILED]) {
+        if (status === DevWorkspaceStatus.FAILED) {
           status = WorkspaceStatus[WorkspaceStatus.ERROR];
         }
       }

--- a/src/store/Workspaces/devWorkspaces/index.ts
+++ b/src/store/Workspaces/devWorkspaces/index.ts
@@ -15,7 +15,7 @@ import * as api from '@eclipse-che/api';
 import { ThunkDispatch } from 'redux-thunk';
 import { AppThunk } from '../..';
 import { container } from '../../../inversify.config';
-import { WorkspaceStatus } from '../../../services/helpers/types';
+import { DevWorkspaceStatus, WorkspaceStatus } from '../../../services/helpers/types';
 import { createState } from '../../helpers';
 import { DevWorkspaceClient, IStatusUpdate } from '../../../services/workspace-client/devWorkspaceClient';
 import { CheWorkspaceClient } from '../../../services/workspace-client/cheWorkspaceClient';
@@ -339,7 +339,7 @@ function onStatusUpdateReceived(
        * Don't add in messages with no workspaces id or with stopped or stopping messages. The stopped and stopping messages
        * only appear because we initially create a stopped devworkspace, add in devworkspace templates, and then start the devworkspace
        */
-      if (workspace.status.devworkspaceId !== '' && workspace.status.message !== 'Stopped' && workspace.status.message !== 'Stopping') {
+      if (workspace.status.devworkspaceId !== '' && workspace.status.message !== DevWorkspaceStatus.STOPPED && workspace.status.message !== DevWorkspaceStatus.STOPPING) {
         workspacesLogs.set(workspace.status.devworkspaceId, [statusUpdate.message]);
         dispatch({
           type: 'DEV_UPDATE_WORKSPACES_LOGS',


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR makes it so that devworkspace messages are logged both through normal workspace startup and the factory flow. For now the PR is made against the workspace-adapter branch but once that PR is merged I'll switch the base to be master

![devworkspace logs](https://user-images.githubusercontent.com/8839537/114442142-3caa6180-9b9a-11eb-92e2-8014f2393775.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19327

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
