### PR TITLE
Do not build Che Server anymore

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -124,66 +124,14 @@ jobs:
           context: ./${{ env.DIR_DASHBOARD }}
           file: ./${{ env.DIR_DASHBOARD }}/apache.Dockerfile
           platforms: ${{ matrix.platform }}
-          push: true
+          push: ${{ matrix.default == true }}
           tags: ${{ env.ORGANIZATION }}/che-dashboard:${{ env.IMAGE_VERSION }}
-
-  che-server-build:
-    needs: docker-build
-    runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-    steps:
-      -
-        name: "Checkout Eclipse Che source code"
-        uses: actions/checkout@v2
-        with:
-          repository: "eclipse/che"
-          ref: master
-          path: ${{ env.DIR_CHE }}
-      -
-        name: "Set up JDK 11"
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      -
-        name: "Cache local Maven repository"
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      -
-        name: "Maven build"
-        run: |
-          cd ${GITHUB_WORKSPACE}/${DIR_CHE} && mvn clean install -DskipTests
-      -
-        name: "Docker build"
-        uses: nick-invision/retry@v1
-        env:
-          CHE_VERSION: next
-        with:
-          timeout_minutes: 100
-          max_attempts: 5
-          retry_wait_seconds: 60
-          command: |
-            bash ${GITHUB_WORKSPACE}/${DIR_CHE}/dockerfiles/che/build.sh --skip-tests --tag:${IMAGE_VERSION} --organization:${ORGANIZATION} --build-arg:"CHE_DASHBOARD_VERSION=${IMAGE_VERSION},CHE_DASHBOARD_ORGANIZATION=${ORGANIZATION},CHE_WORKSPACE_LOADER_VERSION=${CHE_VERSION}"
-      -
-        name: "Docker docker.io Login"
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_MAXURA_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_MAXURA_PASSWORD }}
-      -
-        name: "Docker push"
-        run: |
-          docker push ${ORGANIZATION}/che-server:${IMAGE_VERSION}
       -
         name: "Comment with image name"
         uses: actions/github-script@v3
+        if: ${{ matrix.default == true }}
         with:
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const imageCheServer = '${{ env.ORGANIZATION }}/che-server:${{ env.IMAGE_VERSION }}';
-            github.issues.createComment({ issue_number, owner, repo, body: 'Docker image build succeeded: **' + imageCheServer + '**' });
+            const dashboardImage = '${{ env.ORGANIZATION }}/che-dashboard:${{ env.IMAGE_VERSION }}';
+            github.issues.createComment({ issue_number, owner, repo, body: 'Docker image build succeeded: **' + dashboardImage + '**' });


### PR DESCRIPTION
### What does this PR do?
This PR removes building of Che Server since dashboard is run as separate deployment.

### What issues does this PR fix or reference?
:warning: it depends on eclipse-che/che-operator#684
It's done in a scope of https://github.com/eclipse/che/issues/17802
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
