### PR TITLE
Don't hide the navbar if it's not the IDE page

### DIFF
--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Page } from '@patternfly/react-core';
 import { History } from 'history';
+import { matchPath } from 'react-router';
 
 import Header from './Header';
 import Sidebar from './Sidebar';
@@ -27,6 +28,7 @@ import { IssueComponent } from './ErrorReporter/Issue';
 import { BannerAlert } from '../components/BannerAlert';
 import { ErrorBoundary } from './ErrorBoundary';
 import { DisposableCollection } from '../services/helpers/disposable';
+import { ROUTE } from '../route.enum';
 
 const THEME_KEY = 'theme';
 const IS_MANAGED_SIDEBAR = false;
@@ -81,9 +83,26 @@ export class Layout extends React.PureComponent<Props, State> {
     window.sessionStorage.setItem(THEME_KEY, theme);
   }
 
+  /**
+   * Returns `true` if current location matches the IDE page path.
+   */
+  private testIdePath(): boolean {
+    const currentPath = this.props.history.location.pathname;
+    const match = matchPath(currentPath, {
+      path: ROUTE.IDE_LOADER,
+      exact: true,
+      strict: false,
+    });
+    return match !== null;
+  }
+
   public componentDidMount(): void {
     const handleMessage = (event: MessageEvent): void => {
       if (typeof event.data !== 'string') {
+        return;
+      }
+
+      if (this.testIdePath() === false) {
         return;
       }
       if (event.data === 'show-navbar') {

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -12,15 +12,11 @@
 
 import { Reducer } from 'redux';
 import { AppThunk } from '../';
-import { container } from '../../inversify.config';
-import { CheWorkspaceClient } from '../../services/workspace-client/cheWorkspaceClient';
 import { createState } from '../helpers';
 import { IDevWorkspaceDevfile } from '@eclipse-che/devworkspace-client';
 import { convertWorkspace, isWorkspaceV2, isDevfileV2, Workspace } from '../../services/workspaceAdapter';
 import * as CheWorkspacesStore from './cheWorkspaces';
 import * as DevWorkspacesStore from './devWorkspaces';
-
-const cheWorkspaceClient = container.get(CheWorkspaceClient);
 
 // This state defines the type of data maintained in the Redux store.
 export interface State {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR prevents unwanted hiding the navbar, which happens sometimes when a user navigates from Theia IDE that is starting to any other UD page. Now the UD checks if it's the IDE page and only then hides the navbar.