### PR TITLE
Add in the ability to edit devworkspaces in the dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@eclipse-che/devworkspace-client": "^0.0.1-1617871695",
+    "@eclipse-che/devworkspace-client": "^0.0.1-1619438984",
     "@eclipse-che/workspace-client": "^0.0.1-1618916247",
     "@patternfly/react-core": "~4.84.4",
     "@patternfly/react-icons": "^4.3.5",

--- a/src/components/DevfileEditor/index.tsx
+++ b/src/components/DevfileEditor/index.tsx
@@ -165,7 +165,6 @@ export class DevfileEditor extends React.PureComponent<Props, State> {
     const element = $('.devfile-editor .monaco').get(0);
     if (element) {
       const value = stringify(this.props.devfile);
-      MONACO_CONFIG.readOnly = this.props.isReadonly !== undefined ? this.props.isReadonly : false;
       this.editor = editor.create(element, Object.assign(
         { value },
         MONACO_CONFIG,

--- a/src/components/DevfileEditor/index.tsx
+++ b/src/components/DevfileEditor/index.tsx
@@ -229,15 +229,10 @@ export class DevfileEditor extends React.PureComponent<Props, State> {
     const href = this.props.branding.data.docs.devfile;
     const { errorMessage } = this.state;
 
-    let message = errorMessage;
-    if (this.props.isReadonly) {
-      message = 'DevWorkspace editor support has not been enabled. Editor is in Readonly mode.';
-    }
-
     return (
       <div className='devfile-editor'>
         <div className='monaco'>&nbsp;</div>
-        <div className='error'>{message}</div>
+        <div className='error'>{errorMessage}</div>
         <a target='_blank' rel='noopener noreferrer' href={href}>Devfile Documentation</a>
       </div>
     );

--- a/src/pages/WorkspaceDetails/EditorTab/index.tsx
+++ b/src/pages/WorkspaceDetails/EditorTab/index.tsx
@@ -36,7 +36,7 @@ import './EditorTab.styl';
 type Props = {
   onSave: (workspace: Workspace) => Promise<void>;
   workspace: Workspace;
-  hasDevWorkspaceWarning: () => void;
+  onDevWorkspaceWarning: () => void;
 };
 
 type State = {
@@ -192,7 +192,7 @@ export class EditorTab extends React.PureComponent<Props, State> {
         [DEVWORKSPACE_NEXT_START_ANNOTATION]: JSON.stringify((convertedDevWorkspace.ref as IDevWorkspace)),
       };
       convertedDevWorkspace.ref.status = devworkspace.status;
-      this.props.hasDevWorkspaceWarning();
+      this.props.onDevWorkspaceWarning();
       this.props.onSave(convertedDevWorkspace);
       this.setState({
         showDevfileV2ConfirmationModal: false

--- a/src/pages/WorkspaceDetails/index.tsx
+++ b/src/pages/WorkspaceDetails/index.tsx
@@ -40,7 +40,7 @@ import { selectIsLoading, selectWorkspaceById } from '../../store/Workspaces/sel
 import { History } from 'history';
 
 import './WorkspaceDetails.styl';
-import { Workspace } from '../../services/workspaceAdapter';
+import { isWorkspaceV1, Workspace } from '../../services/workspaceAdapter';
 
 export const SECTION_THEME = PageSectionVariants.light;
 
@@ -208,7 +208,10 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
               <EditorTab
                 ref={this.editorTabPageRef}
                 workspace={workspace}
-                onSave={workspace => this.onSave(workspace)} />
+                onSave={workspace => this.onSave(workspace)}
+                hasDevWorkspaceWarning={() => this.setState({
+                  hasWarningMessage: true
+                })} />
             </Tab>
             {/* <Tab eventKey={WorkspaceDetailsTabs.Logs} title={WorkspaceDetailsTabs[WorkspaceDetailsTabs.Logs]}>*/}
             {/*  <LogsTab workspaceId={workspace.id} />*/}
@@ -238,7 +241,7 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
   }
 
   private async onSave(workspace: Workspace): Promise<void> {
-    if (this.props.workspace && (WorkspaceStatus[this.props.workspace.status] !== WorkspaceStatus.STOPPED)) {
+    if (this.props.workspace && (WorkspaceStatus[this.props.workspace.status] !== WorkspaceStatus.STOPPED) && isWorkspaceV1((this.props.workspace as Workspace).ref)) {
       this.setState({ hasWarningMessage: true });
     }
     await this.props.onSave(workspace, this.state.activeTabKey);

--- a/src/pages/WorkspaceDetails/index.tsx
+++ b/src/pages/WorkspaceDetails/index.tsx
@@ -209,7 +209,7 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
                 ref={this.editorTabPageRef}
                 workspace={workspace}
                 onSave={workspace => this.onSave(workspace)}
-                hasDevWorkspaceWarning={() => this.setState({
+                onDevWorkspaceWarning={() => this.setState({
                   hasWarningMessage: true
                 })} />
             </Tab>

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -156,7 +156,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     const namespace = workspace.metadata.namespace;
     const name = workspace.metadata.name;
 
-    const patch = [] as Patch[];
+    const patch: Patch[] = [];
 
     if (workspace.metadata.annotations && workspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION]) {
 

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -31,7 +31,7 @@ export interface IStatusUpdate {
   workspaceId: string;
 }
 
-export const DEVWORKSPACE_NEXT_START_ANNOTATION = 'che.eclipse.org/dashboard-next-run';
+export const DEVWORKSPACE_NEXT_START_ANNOTATION = 'che.eclipse.org/next-start-cfg';
 
 /**
  * This class manages the connection between the frontend and the devworkspace typescript library

--- a/src/services/workspaceAdapter/index.ts
+++ b/src/services/workspaceAdapter/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@eclipse-che/devworkspace-client';
 import { attributesToType, typeToAttributes } from '../storageTypes';
 import { DevWorkspaceStatus, WorkspaceStatus } from '../helpers/types';
+import { DEVWORKSPACE_NEXT_START_ANNOTATION } from '../workspace-client/devWorkspaceClient';
 
 const ROUTING_CLASS = 'che';
 
@@ -178,7 +179,12 @@ export class WorkspaceAdapter<T extends che.Workspace | IDevWorkspace> implement
     if (isWorkspaceV1(this.workspace)) {
       return this.workspace.devfile as T extends che.Workspace ? che.WorkspaceDevfile : IDevWorkspaceDevfile;
     } else {
-      return devWorkspaceToDevfile((this.workspace as IDevWorkspace)) as T extends che.Workspace ? che.WorkspaceDevfile : IDevWorkspaceDevfile;
+      const currentWorkspace = this.workspace as IDevWorkspace;
+      if (currentWorkspace.metadata.annotations && currentWorkspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION]) {
+        return devWorkspaceToDevfile(JSON.parse(currentWorkspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION]));
+      } else {
+        return devWorkspaceToDevfile(currentWorkspace) as T extends che.Workspace ? che.WorkspaceDevfile : IDevWorkspaceDevfile;
+      }
     }
   }
 

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -13,7 +13,7 @@
 import { Reducer } from 'redux';
 import { AppThunk } from '../';
 import { createState } from '../helpers';
-import { IDevWorkspaceDevfile } from '@eclipse-che/devworkspace-client';
+import { IDevWorkspace, IDevWorkspaceDevfile } from '@eclipse-che/devworkspace-client';
 import { convertWorkspace, isWorkspaceV2, isDevfileV2, Workspace } from '../../services/workspaceAdapter';
 import * as CheWorkspacesStore from './cheWorkspaces';
 import * as DevWorkspacesStore from './devWorkspaces';
@@ -232,8 +232,8 @@ export const actionCreators: ActionCreators = {
     try {
       const state = getState();
       const cheDevworkspaceEnabled = state.cheWorkspaces.settings['che.devworkspaces.enabled'] === 'true';
-      if (cheDevworkspaceEnabled && isWorkspaceV2(workspace.ref)) {
-        await dispatch(DevWorkspacesStore.actionCreators.updateWorkspace(workspace.ref));
+      if (cheDevworkspaceEnabled) {
+        await dispatch(DevWorkspacesStore.actionCreators.updateWorkspace(workspace.ref as IDevWorkspace));
       } else {
         await dispatch(CheWorkspacesStore.actionCreators.updateWorkspace(workspace.ref as che.Workspace));
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,15 +642,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eclipse-che/devworkspace-client@npm:^0.0.1-1617871695":
-  version: 0.0.1-1617871695
-  resolution: "@eclipse-che/devworkspace-client@npm:0.0.1-1617871695"
+"@eclipse-che/devworkspace-client@npm:^0.0.1-1619438984":
+  version: 0.0.1-1619438984
+  resolution: "@eclipse-che/devworkspace-client@npm:0.0.1-1619438984"
   dependencies:
     "@kubernetes/client-node": ^0.14.0
     axios: ^0.21.1
     inversify: ^5.0.5
     reflect-metadata: ^0.1.13
-  checksum: 8f8bd417ff1c963d8db896493283940f6c44632e40937a01604dc5e11faa0f04f44ccfb8f54821dc3a5fe632e5e20f1651c1e9705f52556cec9ccecf332af0b9
+  checksum: 532f9da3b7416fda54569186d1dd981d769ecf4180c101850556a3aaf0fe5a2069e02f6bb5b7abec43b2457c68a8bc4ae35b5f555c68a9bbfa0464b4c8480c76
   languageName: node
   linkType: hard
 
@@ -3657,7 +3657,7 @@ __metadata:
   resolution: "che-dashboard@workspace:."
   dependencies:
     "@eclipse-che/api": ^7.18.1
-    "@eclipse-che/devworkspace-client": ^0.0.1-1617871695
+    "@eclipse-che/devworkspace-client": ^0.0.1-1619438984
     "@eclipse-che/workspace-client": ^0.0.1-1618916247
     "@patternfly/react-core": ~4.84.4
     "@patternfly/react-icons": ^4.3.5


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR makes so it so that you are able to edit devworkspaces in the dashboard and save them to your cluster.
The basic flow with editing devworkspaces is:
- If you are saving a devworkspace and the devworkspace is not running then save it directly to the cluster without asking
- If you are saving a devworkspace and the devworkspace is running then ask for confirmation if they want to restart or not
    - If they say they want to restart then update the devworkspace directly on the cluster and then restart the devworkspace
        - This will also remove the `che.eclipse.org/dashboard-next-run` annotation if it is present and proceed with whatever was directly in the devfile editor 
    - If they say they do not want to restart then add in a `che.eclipse.org/dashboard-next-run` annotation which will store the devworkspace to run next time the devworkspace is started
        - The next time the devworkspace is started if `che.eclipse.org/dashboard-next-run` exists it will patch the devfile of the current workspace with the devfile from `che.eclipse.org/dashboard-next-run` and start the workspace
        - If the `che.eclipse.org/dashboard-next-run` annotation does not exist when starting a devworkspace then just proceed as normal 

Also:
- `che.eclipse.org/dashboard-next-run` is present when opening a devworkspace in the editor, then that is the devfile that will be shown to the user in the editor
- If someone changes the devworkspace on the cluster when you are editing the devfile in the dashboard an error will be thrown and the user editing the devfile in the dashboard will have to reload

![restart-workspace](https://user-images.githubusercontent.com/8839537/115927745-e919fc80-a452-11eb-8068-9b20308d65ae.png)

This PR depends on https://github.com/che-incubator/devworkspace-client/pull/21

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/19330

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
