### PR TITLE
Backport adapting dashboard to optional default DW plugins

### DIFF
--- a/src/services/bootstrap/PreloadData.ts
+++ b/src/services/bootstrap/PreloadData.ts
@@ -123,13 +123,17 @@ export class PreloadData {
   private async updateDwPlugins(settings: che.WorkspaceSettings): Promise<void> {
     const { requestDwDevfiles } = DwPlugins.actionCreators;
 
-    return Promise.all([
+    const promises: Array<Promise<void>> = [];
+    promises.push(
       requestDwDevfiles(`${settings.cheWorkspacePluginRegistryUrl}/plugins/${settings['che.factory.default_editor']}/devfile.yaml`)(this.store.dispatch, this.store.getState, undefined),
-      requestDwDevfiles(`${settings.cheWorkspacePluginRegistryUrl}/plugins/${settings['che.factory.default_plugins']}/devfile.yaml`)(this.store.dispatch, this.store.getState, undefined)
-    ])
-      .then(() => {
-        // noop
-      });
+    );
+    if (settings['che.factory.default_plugins']) {
+      promises.push(
+        requestDwDevfiles(`${settings.cheWorkspacePluginRegistryUrl}/plugins/${settings['che.factory.default_plugins']}/devfile.yaml`)(this.store.dispatch, this.store.getState, undefined)
+      );
+    }
+
+    await Promise.all(promises);
   }
 
   private async updateInfrastructureNamespaces(): Promise<void> {

--- a/src/typings/che.d.ts
+++ b/src/typings/che.d.ts
@@ -33,11 +33,11 @@ declare namespace che {
 
   export interface WorkspaceSettings {
     cheWorkspaceDevfileRegistryUrl?: string;
-    cheWorkspacePluginRegistryUrl: string;
+    cheWorkspacePluginRegistryUrl?: string;
     'che.workspace.storage.available_types': string;
     'che.workspace.storage.preferred_type': WorkspaceStorageType;
     supportedRecipeTypes: string;
-    'che.factory.default_plugins': string;
+    'che.factory.default_plugins'?: string;
     'che.factory.default_editor': string;
     'che.devworkspaces.enabled': 'true' | 'false';
   }


### PR DESCRIPTION
### What does this PR do?
Backports adapting dashboard to optional default DW plugins.
I'm not sure if it prevents workspace from starting, but at least it helps to avoid error state where error is logged into browser console. Probably it works without it, but I haven't checked since I found another issue where CRW 2.8 plugin registry does not return Theia devfile.yaml

### What issues does this PR fix or reference?
Backport https://github.com/eclipse-che/che-dashboard/pull/209/commits/7acb70c0dc5d40d02850fa94f851b3ef491a443a

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
