### PR TITLE
Add in a rhel dockerfile

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     '.github/',
     '.vscode/',
     'assets/',
-    'build/',
+    'lib/',
     '*.js',
   ],
   parser: '@typescript-eslint/parser',

--- a/.github/workflows/ci-multiarch.yaml
+++ b/.github/workflows/ci-multiarch.yaml
@@ -65,7 +65,7 @@ jobs:
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE_FULL }}
           cache-to: type=registry,ref=${{ env.CACHE_IMAGE_FULL }},mode=max
           context: .
-          file: ./apache.Dockerfile
+          file: ./build/dockerfiles/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: true
           tags: ${{ env.IMAGE }}:${{ matrix.arch }}-next

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,6 @@ jobs:
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE_FULL }}
           cache-to: type=registry,ref=${{ env.CACHE_IMAGE_FULL }},mode=max
           context: .
-          file: ./apache.Dockerfile
+          file: ./build/dockerfiles/Dockerfile
           push: true
           tags: ${{ env.IMAGE_FULL }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -122,7 +122,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           context: ./${{ env.DIR_DASHBOARD }}
-          file: ./${{ env.DIR_DASHBOARD }}/apache.Dockerfile
+          file: ./${{ env.DIR_DASHBOARD }}/build/dockerfiles/Dockerfile
           platforms: ${{ matrix.platform }}
           push: ${{ matrix.default == true }}
           tags: ${{ env.ORGANIZATION }}/che-dashboard:${{ env.IMAGE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./apache.Dockerfile
+          file: ./build/dockerfiles/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: true
           tags: ${{ env.IMAGE }}:${{ github.event.inputs.version }}-${{ matrix.arch }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ yarn-error.log
 
 .deps/tmp/
 
-build/
+lib/
 
 .theia/
 .idea/

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+RedirectMatch ^/$ /dashboard/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "search.exclude": {
     "**/.yarn": true,
     "**/.pnp.*": true,
-    "**/build": true,
+    "**/lib": true,
     "**/coverage": true
   },
   "eslint.nodePath": ".yarn/sdks",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Below you can find installation instructions
 ## Quick start
 
 ```sh
-docker build . -f apache.Dockerfile -t quay.io/che-incubator/che-dashboard-next:next
+docker build . -f build/dockerfiles/Dockerfile -t quay.io/che-incubator/che-dashboard-next:next
 ```
 
 ## Running

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -30,5 +30,5 @@ RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/
     chmod -R g+rwX /usr/local/apache2 && \
     echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf
 
-COPY --from=builder /dashboard/build /usr/local/apache2/htdocs/dashboard
+COPY --from=builder /dashboard/lib /usr/local/apache2/htdocs/dashboard
 RUN sed -i -r -e 's#<base href="/">#<base href="/dashboard/"#g'  /usr/local/apache2/htdocs/dashboard/index.html

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020     Red Hat, Inc.
+# Copyright (c) 2021     Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -1,0 +1,59 @@
+# Copyright (c) 2021     Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-77 as builder
+USER 0
+RUN yum -y -q update && \
+    yum -y -q clean all && rm -rf /var/cache/yum
+
+RUN npm install yarn -g && \
+    yarn -v && \
+    # Set the default to yarn 2
+    yarn set version berry
+
+COPY package.json /dashboard/
+COPY yarn.lock /dashboard/
+COPY .yarn/releases/yarn-*.cjs /dashboard/.yarn/releases/
+COPY .yarnrc.yml /dashboard/
+WORKDIR /dashboard
+RUN yarn install
+COPY . /dashboard/
+RUN yarn compile
+
+# https://access.redhat.com/containers/?tab=support#/registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/rhscl/httpd-24-rhel7:2.4-114
+
+# DOWNSTREAM: use RHEL8/httpd
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/httpd-24
+# FROM registry.redhat.io/rhel8/httpd-24:1-92
+USER 0
+
+# latest httpd container doesn't include ssl cert, so generate one
+RUN chmod +x /usr/share/container-scripts/httpd/pre-init/40-ssl-certs.sh && \
+    /usr/share/container-scripts/httpd/pre-init/40-ssl-certs.sh
+RUN yum update -y systemd && yum clean all && rm -rf /var/cache/yum && \
+    echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
+
+# configure apache
+RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /etc/httpd/conf/httpd.conf && \
+    sed -i 's|Listen 80|Listen 8080|' /etc/httpd/conf/httpd.conf && \
+    mkdir -p /var/www && ln -s /etc/httpd/htdocs /var/www/html && \
+    chmod -R g+rwX /etc/httpd/ && \
+    echo "ServerName localhost" >> /etc/httpd/conf/httpd.conf
+
+COPY .htaccess /var/www/html/
+COPY --from=builder /dashboard/lib /var/www/html/dashboard
+RUN sed -i -r -e 's#<base href="/">#<base href="/dashboard/"#g'  /var/www/html/dashboard/index.html
+
+COPY build/dockerfiles/rhel.entrypoint.sh /usr/local/bin
+CMD ["/usr/local/bin/rhel.entrypoint.sh"]
+
+## Append Brew metadata

--- a/build/dockerfiles/rhel.entrypoint.sh
+++ b/build/dockerfiles/rhel.entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-jboss}:x:$(id -u):0:${USER_NAME:-jboss} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+set -x
+
+# start httpd
+if [[ -x /usr/sbin/httpd ]]; then
+  /usr/sbin/httpd -D FOREGROUND
+elif [[ -x /usr/bin/run-httpd ]]; then
+  /usr/bin/run-httpd
+fi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "react",
     "module": "esnext",
     "noImplicitAny": false,
-    "outDir": "./build/",
+    "outDir": "./lib/",
     "preserveConstEnums": true,
     "removeComments": true,
     "sourceMap": true,

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -23,7 +23,7 @@ module.exports = {
     client: path.join(__dirname, 'src/index.tsx'),
   },
   output: {
-    path: path.join(__dirname, 'build'),
+    path: path.join(__dirname, 'lib'),
     publicPath: '/',
     filename: 'client.[hash].js',
     chunkFilename: '[name].[chunkhash].js',

--- a/webpack.config.prod-dev.js
+++ b/webpack.config.prod-dev.js
@@ -22,7 +22,7 @@ module.exports = env => {
     mode: 'production',
     devServer: {
       contentBase: [
-        path.join(__dirname, 'build'),
+        path.join(__dirname, 'lib'),
       ],
       clientLogLevel: 'debug',
       contentBasePublicPath: '/',


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds in a rhel dockerfile that will be used downstream. ~~The reason why its added to /dockerfiles instead of build/dockerfiles is that build is currently being [used for something else](https://github.com/eclipse-che/che-dashboard/blob/main/tsconfig.json#L8).~~ In the newest version I've made the build output into the /lib folder like che-theia does and use build/dockerfiles for the dockerfiles

### What issues does this PR fix or reference?
Part of https://issues.redhat.com/browse/CRW-1728

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
