### PR TITLE
Do not request plugins for devworkspaces

### DIFF
--- a/src/services/bootstrap/PreloadData.ts
+++ b/src/services/bootstrap/PreloadData.ts
@@ -129,11 +129,6 @@ export class PreloadData {
     promises.push(
       requestDwDevfiles(`${settings.cheWorkspacePluginRegistryUrl}/plugins/${settings['che.factory.default_editor']}/devfile.yaml`)(this.store.dispatch, this.store.getState, undefined),
     );
-    if (settings['che.factory.default_plugins']) {
-      promises.push(
-        requestDwDevfiles(`${settings.cheWorkspacePluginRegistryUrl}/plugins/${settings['che.factory.default_plugins']}/devfile.yaml`)(this.store.dispatch, this.store.getState, undefined)
-      );
-    }
 
     await Promise.all(promises);
   }


### PR DESCRIPTION
### What does this PR do?
This PR removes requesting default plugins for devworkspaces, since we don't have any ATM but https://github.com/eclipse/che/pull/19725 adds Theia extension there which does not have devfile at all.

### What issues does this PR fix or reference?
It unblocks https://github.com/eclipse/che/pull/19725

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
