### PR TITLE
add error handlers for codes from oauth flow

### DIFF
--- a/src/containers/FactoryLoader.tsx
+++ b/src/containers/FactoryLoader.tsx
@@ -396,21 +396,23 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     }
 
     const errorCode = this.getErrorCode(search);
-    if (errorCode === ErrorCodes.ACCESS_DENIED) {
-      this.showAlert({
-        alertActionLinks: this.errorActionLinks(),
-        title: 'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
-        alertVariant: AlertVariant.danger
-      });
-      return;
-    } else if (errorCode === ErrorCodes.INVALID_REQUEST) {
-      const alertActionLinks = this.errorActionLinks();
+    if (errorCode === ErrorCodes.INVALID_REQUEST) {
       this.showAlert({
         alertActionLinks: this.errorActionLinks(),
         title: 'Could not resolve devfile from private repository because authentication request is missing' +
           ' a parameter, contains an invalid parameter, includes a parameter more than once, or is otherwise invalid.',
-        alertVariant: AlertVariant.danger
+        alertVariant: AlertVariant.danger,
       });
+      return;
+    }
+    if (errorCode === ErrorCodes.ACCESS_DENIED) {
+      if (!this.state.hasError) {
+        this.showAlert({
+          alertActionLinks: this.errorActionLinks(),
+          title: 'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
+          alertVariant: AlertVariant.danger,
+        });
+      }
       return;
     }
 

--- a/src/containers/FactoryLoader.tsx
+++ b/src/containers/FactoryLoader.tsx
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { AlertVariant } from '@patternfly/react-core';
+import { AlertActionLink, AlertVariant } from '@patternfly/react-core';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { History } from 'history';
@@ -28,15 +28,17 @@ import { getEnvironment, isDevEnvironment } from '../services/helpers/environmen
 import { isOAuthResponse } from '../store/FactoryResolver';
 import { updateDevfile } from '../services/storageTypes';
 import { isWorkspaceV1, Workspace } from '../services/workspaceAdapter';
+import { AlertOptions } from '../pages/FactoryLoader';
 
 const WS_ATTRIBUTES_TO_SAVE: string[] = ['workspaceDeploymentLabels', 'workspaceDeploymentAnnotations', 'policies.create'];
 
 const DEFAULT_CREATE_POLICY = 'perclick';
 type CreatePolicy = 'perclick' | 'peruser';
 
-type Props =
-  MappedProps
-  & { history: History };
+enum ErrorCodes {
+  INVALID_REQUEST = 'invalid_request',
+  ACCESS_DENIED = 'access_denied'
+}
 
 export enum LoadFactorySteps {
   INITIALIZING = 0,
@@ -46,6 +48,10 @@ export enum LoadFactorySteps {
   START_WORKSPACE,
   OPEN_IDE
 }
+
+type Props =
+  MappedProps
+  & { history: History };
 
 type State = {
   search?: string;
@@ -57,7 +63,7 @@ type State = {
 };
 
 export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
-  private factoryLoaderCallbacks: { showAlert?: (variant: AlertVariant, title: string) => void } = {};
+  private factoryLoaderCallbacks: { showAlert?: (options: AlertOptions) => void } = {};
   private factoryResolver: FactoryResolverStore.State;
   private overrideDevfileObject: {
     [params: string]: string
@@ -104,14 +110,21 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     return devfile;
   }
 
-  public showAlert(message: string, alertVariant: AlertVariant = AlertVariant.danger): void {
-    if (alertVariant === AlertVariant.danger) {
+  public showAlert(alertOptions: string | AlertOptions): void {
+    if (typeof alertOptions == 'string') {
+      const currentAlertOptions = alertOptions;
+      alertOptions = {
+        title: currentAlertOptions,
+        alertVariant: AlertVariant.danger
+      } as AlertOptions;
+    }
+    if (alertOptions.alertVariant === AlertVariant.danger) {
       this.setState({ hasError: true });
     }
     if (this.factoryLoaderCallbacks.showAlert) {
-      this.factoryLoaderCallbacks.showAlert(alertVariant, message);
+      this.factoryLoaderCallbacks.showAlert(alertOptions);
     } else {
-      console.error(message);
+      console.error(alertOptions.title);
     }
   }
 
@@ -190,6 +203,15 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       );
     }
     return search;
+  }
+
+  private getErrorCode(search: string): string | undefined {
+    const searchParam = new window.URLSearchParams(search);
+    const errorCode = searchParam.get('error_code');
+    if (!errorCode) {
+      return;
+    }
+    return errorCode;
   }
 
   private getLocation(search: string): string | undefined {
@@ -316,11 +338,31 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     // check if it ephemeral
     // not implemented for dev workspaces yet
     if (isWorkspaceV1(workspace.ref) && workspace.storageType === 'ephemeral') {
-      this.showAlert('You\'re starting an ephemeral workspace. All changes to the source code will be lost ' +
-        'when the workspace is stopped unless they are pushed to a remote code repository.', AlertVariant.warning);
+      this.showAlert({
+        title: 'You\'re starting an ephemeral workspace. All changes to the source code will be lost ' +
+          'when the workspace is stopped unless they are pushed to a remote code repository.',
+        alertVariant: AlertVariant.warning
+      });
     }
 
     return workspace;
+  }
+
+  private tryAgainHandler(): void {
+    const searchParams = new window.URLSearchParams(this.props.history.location.search);
+    searchParams.delete('error_code');
+    this.props.history.location.search = searchParams.toString();
+    this.props.history.push(this.props.history.location);
+  }
+
+  private errorActionLinks(): React.ReactFragment {
+    return (
+      <React.Fragment>
+        <AlertActionLink onClick={() => {
+          this.tryAgainHandler();
+        }}>Click to try again</AlertActionLink>
+      </React.Fragment>
+    );
   }
 
   private async startWorkspace(): Promise<void> {
@@ -352,6 +394,26 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     if (!search) {
       return;
     }
+
+    const errorCode = this.getErrorCode(search);
+    if (errorCode === ErrorCodes.ACCESS_DENIED) {
+      this.showAlert({
+        alertActionLinks: this.errorActionLinks(),
+        title: 'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
+        alertVariant: AlertVariant.danger
+      });
+      return;
+    } else if (errorCode === ErrorCodes.INVALID_REQUEST) {
+      const alertActionLinks = this.errorActionLinks();
+      this.showAlert({
+        alertActionLinks: this.errorActionLinks(),
+        title: 'Could not resolve devfile from private repository because authentication request is missing' +
+          ' a parameter, contains an invalid parameter, includes a parameter more than once, or is otherwise invalid.',
+        alertVariant: AlertVariant.danger
+      });
+      return;
+    }
+
     this.setState({ search, currentStep: LoadFactorySteps.CREATE_WORKSPACE });
 
     const location = this.getLocation(search);

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -286,7 +286,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
     );
   }
 
-  private async verboseModeHandler(workspace: Workspace) {
+  private async verboseModeHandler(workspace: Workspace): Promise<void> {
     try {
       await this.props.startWorkspace(workspace, { 'debug-workspace-start': true });
       this.props.deleteWorkspaceLogs(workspace.id);

--- a/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -199,6 +199,39 @@ describe('Factory Loader container', () => {
         { stackName: 'http://test-location/?override.metadata.generateName=testPrefix' }));
   });
 
+  it('should show a target error with \'error_code=invalid_request\'', () => {
+    const location = 'http://test-location&error_code=invalid_request';
+    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test');
+    workspaceFromDevfile = convertWorkspace(workspace);
+
+    renderComponent(location, workspace);
+
+    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.INITIALIZING]);
+
+    expect(showAlertMock).toHaveBeenCalledWith(expect.objectContaining({
+      alertVariant: 'danger',
+      title: 'Could not resolve devfile from private repository because authentication request is missing a parameter,' +
+        ' contains an invalid parameter, includes a parameter more than once, or is otherwise invalid.',
+    }));
+  });
+
+  it('should show a target error with \'error_code=access_denied\'', () => {
+    const location = 'http://test-location&error_code=access_denied';
+    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test');
+    workspaceFromDevfile = convertWorkspace(workspace);
+
+    renderComponent(location, workspace);
+
+    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.INITIALIZING]);
+
+    expect(showAlertMock).toHaveBeenCalledWith(expect.objectContaining({
+      alertVariant: 'danger',
+      title: 'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
+    }));
+  });
+
   it('should resolve the factory with \'policies.create=peruser\'', async () => {
     const location = 'http://test-location&policies.create=peruser';
     const workspace = createFakeWorkspaceWithRuntime('id-wksp-test', 'http://test-location/?policies.create=peruser');

--- a/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -157,11 +157,11 @@ describe('Factory Loader container', () => {
       expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(workspace.devfile, undefined, undefined, { stackName: location + '/' }));
 
     jest.runOnlyPendingTimers();
-    expect(showAlertMock).toBeCalledWith(
-      AlertVariant.warning,
-      'You\'re starting an ephemeral workspace. All changes to the source code will be lost ' +
-      'when the workspace is stopped unless they are pushed to a remote code repository.'
-    );
+    expect(showAlertMock).toBeCalledWith({
+      alertVariant: AlertVariant.warning,
+      title: 'You\'re starting an ephemeral workspace. All changes to the source code will be lost ' +
+        'when the workspace is stopped unless they are pushed to a remote code repository.'
+    });
     expect(setWorkspaceIdMock).toHaveBeenCalledWith(workspace.id);
     await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceFromDevfile));
     await waitFor(() => expect(startWorkspaceMock).not.toHaveBeenCalled());
@@ -302,7 +302,7 @@ describe('Factory Loader container', () => {
     renderComponent('', workspace);
 
     expect(requestFactoryResolverMock).not.toBeCalled();
-    await waitFor(() => expect(showAlertMock).toBeCalledWith(AlertVariant.danger, message));
+    await waitFor(() => expect(showAlertMock).toBeCalledWith({ alertVariant: AlertVariant.danger, title: message }));
     const elementHasError = screen.getByTestId('factory-loader-has-error');
     expect(elementHasError.innerHTML).toEqual('true');
 

--- a/src/pages/IdeLoader/index.tsx
+++ b/src/pages/IdeLoader/index.tsx
@@ -255,6 +255,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
               variant={currentAlertVariant}
               title={currentRequestError}
               actionClose={<AlertActionCloseButton onClose={this.hideAlert} />}
+              actionLinks={alertActionLinks}
             />
           </AlertGroup>
         )}

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -137,12 +137,12 @@ export class DevWorkspaceClient extends WorkspaceClient {
 
   /**
    * Update a devworkspace.
-   * If the workspace you want to update has the DEVWORKSPACE_NEXT_START_ANNOTATION then 
+   * If the workspace you want to update has the DEVWORKSPACE_NEXT_START_ANNOTATION then
    * patch the cluster object with the value of DEVWORKSPACE_NEXT_START_ANNOTATION and don't restart the devworkspace.
-   * 
+   *
    * If the workspace does not specify DEVWORKSPACE_NEXT_START_ANNOTATION then
    * update the spec of the devworkspace and remove DEVWORKSPACE_NEXT_START_ANNOTATION if it exists.
-   * 
+   *
    * @param workspace The DevWorkspace you want to update
    * @param plugins The plugins you want to inject into the devworkspace
    */


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
 Add error handlers for codes from oauth flow.

![Screenshot from 2021-04-30 16-45-36](https://user-images.githubusercontent.com/6310786/116705521-48d55200-a9d5-11eb-868f-40fc03a30225.png)
![Screenshot from 2021-04-30 16-44-55](https://user-images.githubusercontent.com/6310786/116705526-4a9f1580-a9d5-11eb-800a-862c6eebae7e.png)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/19722

