### PR TITLE
Remove test-coverage-diff job in favor of codecov workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,32 +45,6 @@ jobs:
         name: "Run unit tests"
         run: yarn test --runInBand
 
-  test-coverage-diff:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      -
-        name: "Checkout che-dashboard source code"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      -
-        name: "Use Node.js ${{ matrix.node-version }}"
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      -
-        name: "Install dependencies"
-        run: yarn
-      -
-        name: "Jest Coverage Diff"
-        uses: anuraag016/Jest-Coverage-Diff@1.0
-        with:
-          fullCoverageDiff: false
-
   docker-build:
     needs: build-and-test
     runs-on: ubuntu-18.04


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR simply removes the `test-coverage-diff` job from the `PR` workflow in favor of `codecov` workflow.
