### PR TITLE
Displays devfile v2 getting started if devWorkspace toggle is enabled

### DIFF
--- a/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
+++ b/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
@@ -32,6 +32,9 @@ import * as DevfileRegistriesStore from '../../../store/DevfileRegistries';
 import { SampleCard } from './SampleCard';
 import { AlertItem } from '../../../services/helpers/types';
 import { selectMetadataFiltered } from '../../../store/DevfileRegistries/selectors';
+import { selectWorkspacesSettings } from '../../../store/Workspaces/Settings/selectors';
+import * as FactoryResolverStore from '../../../store/FactoryResolver';
+import stringify from '../../../services/helpers/editor';
 
 type Props =
   MappedProps
@@ -44,12 +47,18 @@ type State = {
 
 export class SamplesListGallery extends React.PureComponent<Props, State> {
 
+  private factoryResolver: FactoryResolverStore.State;
+
   constructor(props: Props) {
     super(props);
 
     this.state = {
       alerts: [],
     };
+  }
+
+  public componentDidUpdate(): void {
+    this.factoryResolver = this.props.factoryResolver;
   }
 
   private removeAlert(key: string): void {
@@ -85,8 +94,17 @@ export class SamplesListGallery extends React.PureComponent<Props, State> {
 
   private async fetchDevfile(meta: che.DevfileMetaData): Promise<void> {
     try {
-      const devfile = await this.props.requestDevfile(meta.links.self) as string;
-      this.props.onCardClick(devfile, meta.displayName);
+      const cheDevworkspaceEnabled = this.props.workspacesSettings['che.devworkspaces.enabled'] === 'true';
+      let devfileContent;
+      if (cheDevworkspaceEnabled) {
+        const link = meta.links.v2;
+        await this.props.requestFactoryResolver(link);
+        const { devfile } = this.factoryResolver.resolver;
+        devfileContent = stringify(devfile);
+      } else {
+        devfileContent = await this.props.requestDevfile(meta.links.self) as string;
+      }
+      this.props.onCardClick(devfileContent, meta.displayName);
     } catch (e) {
       console.warn('Failed to load devfile.', e);
 
@@ -134,12 +152,15 @@ export class SamplesListGallery extends React.PureComponent<Props, State> {
 
 const mapStateToProps = (state: AppState) => ({
   metadataFiltered: selectMetadataFiltered(state),
+  workspacesSettings: selectWorkspacesSettings(state),
+  factoryResolver: state.factoryResolver,
 });
 
 const connector = connect(
   mapStateToProps,
   {
     ...DevfileRegistriesStore.actionCreators,
+    ...FactoryResolverStore.actionCreators,
   }
 );
 

--- a/src/services/registry/devfiles.ts
+++ b/src/services/registry/devfiles.ts
@@ -34,12 +34,17 @@ function resolveIconUrl(metadata: che.DevfileMetaData, baseUrl: string): string 
   return createURL(metadata.icon, baseUrl).href;
 }
 
-function resolveLinkSelf(metadata: che.DevfileMetaData, baseUrl: string): string {
-  if (metadata.links.self.startsWith('http')) {
-    return metadata.links.self;
-  }
-
-  return createURL(metadata.links.self, baseUrl).href;
+function resolveLinks(metadata: che.DevfileMetaData, baseUrl: string): any {
+  const resolvedLinks = {};
+  const linkNames = Object.keys(metadata.links);
+  linkNames.map(linkName => {
+    let updatedLink = metadata.links[linkName];
+    if (!updatedLink.startsWith('http')) {
+      updatedLink = createURL(updatedLink, baseUrl).href;
+    }
+    resolvedLinks[linkName] = updatedLink;
+  });
+  return resolvedLinks;
 }
 
 export async function fetchRegistryMetadata(registryUrl: string): Promise<che.DevfileMetaData[]> {
@@ -51,7 +56,7 @@ export async function fetchRegistryMetadata(registryUrl: string): Promise<che.De
 
     return response.data.map(meta => {
       meta.icon = resolveIconUrl(meta, registryUrl);
-      meta.links.self = resolveLinkSelf(meta, registryUrl);
+      meta.links = resolveLinks(meta, registryUrl);
       return meta;
     });
   } catch (e) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Display in getting started the `v2` links of devfile registries if DevWorkspace support is enabled.
![image](https://user-images.githubusercontent.com/436777/120667852-2d56de80-c48e-11eb-8b07-3d6429156490.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19923

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
