### PR TITLE
feat(getting-started): Display devfile v2 if che-server has devWorkspace support enabled

### DIFF
--- a/src/pages/GetStarted/__tests__/devfileMetadata.json
+++ b/src/pages/GetStarted/__tests__/devfileMetadata.json
@@ -185,7 +185,8 @@
     "icon": "/images/springboot.svg",
     "globalMemoryLimit": "3372Mi",
     "links": {
-      "self": "/devfiles/java-mysql/devfile.yaml"
+      "self": "/devfiles/java-mysql/devfile.yaml",
+      "v2": "http://my-fake-repository.com/"
     }
   },
   {

--- a/src/services/registry/devfiles.ts
+++ b/src/services/registry/devfiles.ts
@@ -34,12 +34,17 @@ function resolveIconUrl(metadata: che.DevfileMetaData, baseUrl: string): string 
   return createURL(metadata.icon, baseUrl).href;
 }
 
-function resolveLinkSelf(metadata: che.DevfileMetaData, baseUrl: string): string {
-  if (metadata.links.self.startsWith('http')) {
-    return metadata.links.self;
-  }
-
-  return createURL(metadata.links.self, baseUrl).href;
+function resolveLinks(metadata: che.DevfileMetaData, baseUrl: string): any {
+  const resolvedLinks = {};
+  const linkNames = Object.keys(metadata.links);
+  linkNames.map(linkName => {
+    let updatedLink = metadata.links[linkName];
+    if (!updatedLink.startsWith('http')) {
+      updatedLink = createURL(updatedLink, baseUrl).href;
+    }
+    resolvedLinks[linkName] = updatedLink;
+  });
+  return resolvedLinks;
 }
 
 export async function fetchRegistryMetadata(registryUrl: string): Promise<che.DevfileMetaData[]> {
@@ -51,7 +56,7 @@ export async function fetchRegistryMetadata(registryUrl: string): Promise<che.De
 
     return response.data.map(meta => {
       meta.icon = resolveIconUrl(meta, registryUrl);
-      meta.links.self = resolveLinkSelf(meta, registryUrl);
+      meta.links = resolveLinks(meta, registryUrl);
       return meta;
     });
   } catch (e) {


### PR DESCRIPTION
### What does this PR do?
Display in getting started the `v2` links of devfile registries if DevWorkspace support is enabled.
![image](https://user-images.githubusercontent.com/436777/120667852-2d56de80-c48e-11eb-8b07-3d6429156490.png)

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/19923

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
