### PR TITLE
feat: Propagate the plugin registry and dashboard urls to the containers in the initial devworkspace templates

### DIFF
--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -48,8 +48,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
   private initializing: Promise<void>;
   private lastDevWorkspaceLog: Map<string, string>;
   private devWorkspacesIds: string[];
-  private pluginRegistryUrlName: string;
-  private dashboardUrlName: string;
+  private pluginRegistryUrlEnvName: string;
+  private dashboardUrlEnvName: string;
 
   constructor(@inject(KeycloakSetupService) keycloakSetupService: KeycloakSetupService) {
     super(keycloakSetupService);
@@ -62,8 +62,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
     this.maxStatusAttempts = 10;
     this.lastDevWorkspaceLog = new Map();
     this.devWorkspacesIds = [];
-    this.pluginRegistryUrlName = 'PLUGIN_REGISTRY_URL';
-    this.dashboardUrlName = 'DASHBOARD_URL';
+    this.pluginRegistryUrlEnvName = 'CHE_PLUGIN_REGISTRY_URL';
+    this.dashboardUrlEnvName = 'CHE_DASHBOARD_URL';
   }
 
   isEnabled(): Promise<boolean> {
@@ -124,10 +124,10 @@ export class DevWorkspaceClient extends WorkspaceClient {
             container.env = [];
           }
           container.env.push(...[{
-            name: this.dashboardUrlName,
+            name: this.dashboardUrlEnvName,
             value: window.location.origin,
           }, {
-            name: this.pluginRegistryUrlName,
+            name: this.pluginRegistryUrlEnvName,
             value: pluginRegistryUrl
           }]);
         }

--- a/src/store/Workspaces/devWorkspaces/index.ts
+++ b/src/store/Workspaces/devWorkspaces/index.ts
@@ -298,8 +298,9 @@ export const actionCreators: ActionCreators = {
         devWorkspaceDevfile.metadata.namespace = defaultNamespace;
       }
 
+      const pluginRegistryUrl = state.workspacesSettings.settings.cheWorkspacePluginRegistryUrl;
       const dwPlugins = state.dwPlugins.plugins;
-      const workspace = await devWorkspaceClient.create(devWorkspaceDevfile, dwPlugins);
+      const workspace = await devWorkspaceClient.create(devWorkspaceDevfile, dwPlugins, pluginRegistryUrl);
 
       dispatch({
         type: 'ADD_DEVWORKSPACE',


### PR DESCRIPTION
…ers in the initial devworkspace templates

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR propagates the plugin registry and dashboard urls to every container in the initial devworkspacetemplate

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19933

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
