### PR TITLE
feat: upgrade dwclient to one with 2.1.0 schemaVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@devfile/api": "^0.0.1-1622573075",
     "@eclipse-che/che-theia-devworkspace-handler": "^0.0.1-1623136422",
-    "@eclipse-che/devworkspace-client": "^0.0.1-1620800867",
+    "@eclipse-che/devworkspace-client": "^0.0.1-1623318990",
     "@eclipse-che/workspace-client": "^0.0.1-1622804813",
     "@patternfly/react-core": "~4.84.4",
     "@patternfly/react-icons": "^4.3.5",

--- a/src/services/workspaceAdapter/__tests__/index.spec.ts
+++ b/src/services/workspaceAdapter/__tests__/index.spec.ts
@@ -281,7 +281,7 @@ describe('Workspace adapter', () => {
 
     it('should return devfile', () => {
       const devfile = {
-        schemaVersion: '2.0.0',
+        schemaVersion: '2.1.0',
         metadata: {
           name: 'my-wksp',
           namespace: 'my-namespace',

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,15 +669,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eclipse-che/devworkspace-client@npm:^0.0.1-1620800867":
-  version: 0.0.1-1620800867
-  resolution: "@eclipse-che/devworkspace-client@npm:0.0.1-1620800867"
+"@eclipse-che/devworkspace-client@npm:^0.0.1-1623318990":
+  version: 0.0.1-1623318990
+  resolution: "@eclipse-che/devworkspace-client@npm:0.0.1-1623318990"
   dependencies:
     "@kubernetes/client-node": ^0.14.0
     axios: ^0.21.1
     inversify: ^5.0.5
     reflect-metadata: ^0.1.13
-  checksum: afa4c09b1e22acffec051968f6b6959de30861238998111c5fc808aaab2d4d7b6b63544db480295b56198a356e8bdd15c55a243f71bacf5bac6e4de74409f152
+  checksum: e005cb13cc53fa3f7724c918f1d202696b19e4ce8029df3ef830d8cb1b2d203c6ade72d0c48a7d14c75de48cada4cf625a11d88aa2cb854a6e410e02fa8b8a20
   languageName: node
   linkType: hard
 
@@ -3872,7 +3872,7 @@ __metadata:
     "@devfile/api": ^0.0.1-1622573075
     "@eclipse-che/api": ^7.18.1
     "@eclipse-che/che-theia-devworkspace-handler": ^0.0.1-1623136422
-    "@eclipse-che/devworkspace-client": ^0.0.1-1620800867
+    "@eclipse-che/devworkspace-client": ^0.0.1-1623318990
     "@eclipse-che/workspace-client": ^0.0.1-1622804813
     "@patternfly/react-core": ~4.84.4
     "@patternfly/react-icons": ^4.3.5


### PR DESCRIPTION
### What does this PR do?
Use newer dwclient to one with 2.1.0 schemaVersion. https://github.com/che-incubator/devworkspace-client/pull/24

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
