### PR TITLE
fix(devfilev2): Handle case when there is no component in the devfile

### DIFF
--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -311,7 +311,10 @@ export class DevWorkspaceClient extends WorkspaceClient {
    * @param pluginName The name of the plugin
    */
   private addPlugin(workspace: IDevWorkspace, pluginName: string, namespace: string) {
-    workspace.spec.template.components!.push({
+    if (!workspace.spec.template.components) {
+      workspace.spec.template.components = [];
+    }
+    workspace.spec.template.components.push({
       name: pluginName,
       plugin: {
         kubernetes: {

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -181,6 +181,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
       sidecarPolicy,
       suffix: workspaceId,
     });
+    console.debug('Devfile updated to', devfile, ' and templates updated to', devWorkspaceTemplates);
 
     await Promise.all(devWorkspaceTemplates.map(async template => {
       if (!template.metadata) {


### PR DESCRIPTION
### What does this PR do?
Dashboard tries to add a component to the current list of components but this list may be undefined with case of 'empty devfile' like:

```yaml
schemaVersion: 2.1.0-alpha
metadata:
  name: devfile
```

note: I've added a trace for customers/end-users so they might look at what is happening under the hood (I just used a breakpoint)

![image](https://user-images.githubusercontent.com/436777/121688302-97d9d100-cac3-11eb-93ef-ce5a21aaf29a.png)


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/19964

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
