### PR TITLE
feat: get rid of -alpha suffix in schemaVersion for unreleased version

### DIFF
--- a/src/store/DevfileRegistries/index.ts
+++ b/src/store/DevfileRegistries/index.ts
@@ -173,7 +173,7 @@ export const actionCreators: ActionCreators = {
 
         const schemav200 = await WorkspaceClient.restApiClient.getDevfileSchema('2.0.0');
         const schemav210 = await WorkspaceClient.restApiClient.getDevfileSchema('2.1.0');
-        const schemav220alpha = await WorkspaceClient.restApiClient.getDevfileSchema('2.2.0-alpha');
+        const schemav220alpha = await WorkspaceClient.restApiClient.getDevfileSchema('2.2.0');
         schema = {
           oneOf: [
             parsedSchemaV1,


### PR DESCRIPTION
### What does this PR do?
Adapts dashboard to getting rid of alpha suffix in schemaVersion for unreleased devfiles.
Depends on https://github.com/eclipse-che/che-server/pull/27

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
