### PR TITLE
feat: Fix for copy paste is not working in chromium environment 

### DIFF
--- a/src/pages/IdeLoader/index.tsx
+++ b/src/pages/IdeLoader/index.tsx
@@ -241,7 +241,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
     if (ideUrl) {
       return (
         <div className="ide-iframe-page">
-          <iframe id="ide-iframe" src="./static/loader.html" allow="fullscreen *" />
+          <iframe id="ide-iframe" src="./static/loader.html" allow="fullscreen *;clipboard-write *;clipboard-read *" />
         </div>
       );
     }


### PR DESCRIPTION
che's iframe blocks the clipboard access so added clipboard permission for iframe

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
allows to copy paste inside an iframe

### What issue does resolve this PR?
https://github.com/eclipse/che/issues/17475

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

