### PR TITLE
feat: use newer devworkspace client which created namespace if it does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@devfile/api": "^0.0.1-1622573075",
     "@eclipse-che/che-theia-devworkspace-handler": "^0.0.1-1623136422",
-    "@eclipse-che/devworkspace-client": "^0.0.1-1623419569",
+    "@eclipse-che/devworkspace-client": "^0.0.1-1624633214",
     "@eclipse-che/workspace-client": "^0.0.1-1622804813",
     "@patternfly/react-core": "~4.84.4",
     "@patternfly/react-icons": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,15 +669,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eclipse-che/devworkspace-client@npm:^0.0.1-1623419569":
-  version: 0.0.1-1623419569
-  resolution: "@eclipse-che/devworkspace-client@npm:0.0.1-1623419569"
+"@eclipse-che/devworkspace-client@npm:^0.0.1-1624633214":
+  version: 0.0.1-1624633214
+  resolution: "@eclipse-che/devworkspace-client@npm:0.0.1-1624633214"
   dependencies:
     "@kubernetes/client-node": ^0.14.0
     axios: ^0.21.1
     inversify: ^5.0.5
     reflect-metadata: ^0.1.13
-  checksum: 76402e6150827babbd81bb667f4b8563b785734be60889f8a33996a49c0bfa050c30fa660bca1d60f9ed60606129c1fce760034a6705cf16d522d07f6198ddab
+  checksum: bbb5fb41e10365b79c72b711090bcf698b5423324c1772ab73343aff0c62b3662fe69e14c91b4ee61344346e68127ee31ee7a77411efd336791365b250dc614e
   languageName: node
   linkType: hard
 
@@ -3872,7 +3872,7 @@ __metadata:
     "@devfile/api": ^0.0.1-1622573075
     "@eclipse-che/api": ^7.18.1
     "@eclipse-che/che-theia-devworkspace-handler": ^0.0.1-1623136422
-    "@eclipse-che/devworkspace-client": ^0.0.1-1623419569
+    "@eclipse-che/devworkspace-client": ^0.0.1-1624633214
     "@eclipse-che/workspace-client": ^0.0.1-1622804813
     "@patternfly/react-core": ~4.84.4
     "@patternfly/react-icons": ^4.3.5


### PR DESCRIPTION
### What does this PR do?
feat: use newer devworkspace client which created namespace if it does not exist

To test this PR you need to deploy specially configured che on minikube, commands from Platform team:
```
cp -R /Users/skabashn/dev/src/eclipse-che/che-operator/deploy/*  $TMP_DIR'/che-operator'
cp -R /Users/skabashn/dev/src/eclipse-che/devworkspace-operator/deploy/*  $TMP_DIR'/devworkspace'
echo $TMP_DIR 
chectl server:deploy --platform=minikube --installer=operator --workspace-engine=dev-workspace --che-operator-image=quay.io/skabashn/che-operator:che19944 --templates $TMP_DIR 
rm -rf $TMP_DIR
kubectl patch checluster/eclipse-che -n eclipse-che --type=json -p \
   '[{"op": "replace", "path": "/spec/devWorkspace/enable", "value": true}]'
kubectl patch checluster/eclipse-che --patch "{\"spec\":{\"server\":{\"customCheProperties\": {\"CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S\": \"true\"}}}}" --type=merge -n eclipse-che
kubectl create namespace admin-che
```
then run local dashboard and make sure namespace is created for the current user if it does not exist.

### What issues does this PR fix or reference?
it's part for https://github.com/eclipse/che/issues/20014

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
