### PR TITLE
fix: make dashboard rest k8s like

### DIFF
--- a/packages/dashboard-backend/src/index.ts
+++ b/packages/dashboard-backend/src/index.ts
@@ -66,7 +66,7 @@ server.addContentTypeParser(
 );
 
 server.get(
-  "/workspace/namespace/:namespace",
+  "/namespace/:namespace/devworkspaces",
   {
     schema: {
       headers: authenticationHeaderSchema,
@@ -85,7 +85,7 @@ server.get(
 );
 
 server.post(
-  "/workspace",
+  "/namespace/:namespace/devworkspaces",
   {
     schema: {
       headers: authenticationHeaderSchema,
@@ -104,7 +104,7 @@ server.post(
 );
 
 server.get(
-  "/workspace/namespace/:namespace/:workspaceName",
+  "/namespace/:namespace/devworkspaces/:workspaceName",
   {
     schema: {
       headers: authenticationHeaderSchema,
@@ -126,7 +126,7 @@ server.get(
 );
 
 server.delete(
-  "/workspace/namespace/:namespace/:workspaceName",
+  "/namespace/:namespace/devworkspaces/:workspaceName",
   {
     schema: {
       headers: authenticationHeaderSchema,
@@ -148,7 +148,7 @@ server.delete(
 );
 
 server.patch(
-  "/workspace/namespace/:namespace/:workspaceName",
+  "/namespace/:namespace/devworkspaces/:workspaceName",
   {
     schema: {
       headers: authenticationHeaderSchema,


### PR DESCRIPTION
### What does this PR do?
fix: make dashboard rest k8s like. Example:
```
https://$CHE_HOST/api/unsupported/k8s/apis/workspace.devfile.io/v1alpha2/namespaces/opentlc-mgr-che/devworkspaces/quarkus-quickstart
```

### What issues does this PR fix or reference?
N/A

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
