### PR TITLE
Fix changing workspace storage type from the overview tab

### DIFF
--- a/packages/dashboard-frontend/src/Layout/Header/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/__tests__/index.spec.tsx
@@ -18,14 +18,17 @@ import Header from '..';
 
 jest.mock(
   '../Tools',
-  () =>
-    (props: {
+  () => {
+    const FakeTools = (props: {
       logout: () => void,
       changeTheme: () => void
     }) => <React.Fragment>
         <button onClick={() => props.logout()}>logout</button>
         <button onClick={() => props.changeTheme()}>change theme</button>
-      </React.Fragment>
+      </React.Fragment>;
+    FakeTools.displayName = 'Tools';
+    return FakeTools;
+  },
 );
 
 describe('Page header', () => {

--- a/packages/dashboard-frontend/src/containers/__tests__/WorkspacesList.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/WorkspacesList.spec.tsx
@@ -41,9 +41,12 @@ jest.mock('../../store/Workspaces/selectors.ts', () => {
     selectWorkspacesError: () => undefined,
   };
 });
-jest.mock('../../pages/WorkspacesList', () => () => (
-  <div>Workspaces List Page</div>
-));
+jest.mock('../../pages/WorkspacesList', () => {
+  const FakeWorkspacesList = () => <div>Workspaces List Page</div>;
+  FakeWorkspacesList.displayName = 'WorkspacesList';
+  return FakeWorkspacesList;
+},
+);
 jest.mock('../../components/Fallback', () => (
   <div>Fallback Spinner</div>
 ));

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/GetStartedTab.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/GetStartedTab.spec.tsx
@@ -30,14 +30,17 @@ const testDevfile = {
 
 jest.mock(
   '../SamplesListGallery',
-  () =>
-    (props: {
+  () => {
+    const FakeSamplesListGallery = (props: {
       onCardClick: (devfileContent: string, stackName: string) => void
     }) => <div>
         <button data-testid="sample-item-id" onClick={() => {
           props.onCardClick(JSON.stringify(testDevfile), testStackName);
         }}>logout</button>
-      </div>
+      </div>;
+    FakeSamplesListGallery.displayName = 'SamplesListGallery';
+    return FakeSamplesListGallery;
+  },
 );
 
 describe('Samples list tab', () => {

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/__tests__/index.spec.tsx
@@ -30,8 +30,11 @@ import { container } from '../../../../inversify.config';
 jest.mock('../../../../components/DevfileEditor');
 jest.mock(
   '../EditorTools',
-  () =>
-    () => <div>Editor Tools</div>
+  () => {
+    const FakeEditorTools = () => <div>Editor Tools</div>;
+    FakeEditorTools.displayName = 'EditorTools';
+    return FakeEditorTools;
+  },
 );
 
 describe('Editor Tab', () => {

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
@@ -279,11 +279,16 @@ describe('Workspaces List Page', () => {
       // check state of action buttons
       const startDebugAction = screen.getByRole('button', { name: /verbose mode/i });
       expect(startDebugAction).toBeEnabled();
+
       const openInBackgroundAction = screen.getByRole('button', { name: /background/i });
       expect(openInBackgroundAction).toBeEnabled();
-      // TODO it seems that bumping up the @patternfly/react-core version makes this expectation fail
-      // const stopAction = screen.getByRole('button', { name: /stop workspace/i });
-      // expect(stopAction).toBeDisabled();
+      
+      const restartAction = screen.getByRole('button', { name: /restart/i });
+      expect(restartAction).toHaveAttribute('aria-disabled', 'true');
+
+      const stopAction = screen.getByRole('button', { name: /stop workspace/i });
+      expect(stopAction).toHaveAttribute('aria-disabled', 'true');
+
       const deleteAction = screen.getByRole('button', { name: /delete workspace/i });
       expect(deleteAction).toBeEnabled();
     });

--- a/packages/dashboard-frontend/src/services/workspaceAdapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspaceAdapter/__tests__/index.spec.ts
@@ -11,12 +11,22 @@
  */
 
 import { IDevWorkspace } from '@eclipse-che/devworkspace-client';
+import { cloneDeep } from 'lodash';
 import { convertWorkspace } from '..';
 import { CheWorkspaceBuilder, CHE_DEVFILE_STUB, CHE_RUNTIME_STUB } from '../../../store/__mocks__/cheWorkspaceBuilder';
 import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
 import { StorageTypeTitle } from '../../storageTypes';
 
+/**
+ * @jest-environment node
+ */
 describe('Workspace adapter', () => {
+
+  let cheDevfile: che.WorkspaceDevfile;
+
+  beforeEach(() => {
+    cheDevfile = cloneDeep(CHE_DEVFILE_STUB);
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -140,29 +150,27 @@ describe('Workspace adapter', () => {
     });
 
     it('should return storage type', () => {
-      const devfile = CHE_DEVFILE_STUB;
-      devfile.attributes = {
+      cheDevfile.attributes = {
         persistVolumes: 'false',
         asyncPersist: 'false',
       };
       const cheWorkspace = new CheWorkspaceBuilder()
-        .withDevfile(devfile)
+        .withDevfile(cheDevfile)
         .build();
       const workspace = convertWorkspace(cheWorkspace);
       expect(workspace.storageType).toEqual(StorageTypeTitle.ephemeral.toLowerCase());
     });
 
     it('should return devfile', () => {
-      const devfile = CHE_DEVFILE_STUB;
-      devfile.attributes = {
+      cheDevfile.attributes = {
         persistVolumes: 'true',
         asyncPersist: 'false',
       };
       const cheWorkspace = new CheWorkspaceBuilder()
-        .withDevfile(devfile)
+        .withDevfile(cheDevfile)
         .build();
       const workspace = convertWorkspace(cheWorkspace);
-      expect(workspace.devfile).toMatchObject(devfile);
+      expect(workspace.devfile).toMatchObject(cheDevfile);
     });
 
     it('should return list of project names', () => {
@@ -184,6 +192,58 @@ describe('Workspace adapter', () => {
         .build();
       const workspace = convertWorkspace(cheWorkspace);
       expect(workspace.projects).toEqual([projects[0].name, projects[1].name]);
+    });
+
+    it('should set "ephemeral" storage type', () => {
+      const cheWorkspace = new CheWorkspaceBuilder()
+        .withDevfile(cheDevfile)
+        .build();
+      const workspace = convertWorkspace(cheWorkspace);
+
+      expect(workspace.storageType).toEqual('persistent');
+      expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual(undefined);
+
+      workspace.storageType = 'ephemeral';
+
+      expect(workspace.storageType).toEqual('ephemeral');
+      expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual({
+        persistVolumes: 'false',
+      });
+    });
+
+    it('should set "async" storage type', () => {
+      const cheWorkspace = new CheWorkspaceBuilder()
+        .withDevfile(cheDevfile)
+        .build();
+      const workspace = convertWorkspace(cheWorkspace);
+
+      expect(workspace.storageType).toEqual('persistent');
+      expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual(undefined);
+
+      workspace.storageType = 'async';
+
+      expect(workspace.storageType).toEqual('async');
+      expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual({
+        persistVolumes: 'false',
+        asyncPersist: 'true',
+      });
+    });
+
+    it('should set "persistent" storage type', () => {
+      cheDevfile.attributes = {
+        persistVolumes: 'false',
+      };
+      const cheWorkspace = new CheWorkspaceBuilder()
+        .withDevfile(cheDevfile)
+        .build();
+      const workspace = convertWorkspace(cheWorkspace);
+
+      expect(workspace.storageType).toEqual('ephemeral');
+
+      workspace.storageType = 'persistent';
+
+      expect(workspace.storageType).toEqual('persistent');
+      expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual(undefined);
     });
 
   });

--- a/packages/dashboard-frontend/src/services/workspaceAdapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspaceAdapter/__tests__/index.spec.ts
@@ -246,6 +246,27 @@ describe('Workspace adapter', () => {
       expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual(undefined);
     });
 
+    it('should preserve other attributes when changing storage type', () => {
+      cheDevfile.attributes = {
+        customAttribute: 'value',
+        persistVolumes: 'false',
+        asyncPersist: 'true',
+      };
+      const cheWorkspace = new CheWorkspaceBuilder()
+        .withDevfile(cheDevfile)
+        .build();
+      const workspace = convertWorkspace(cheWorkspace);
+
+      expect(workspace.storageType).toEqual('async');
+
+      workspace.storageType = 'persistent';
+
+      expect(workspace.storageType).toEqual('persistent');
+      expect((workspace.devfile as che.WorkspaceDevfile).attributes).toMatchObject({
+        customAttribute: 'value',
+      });
+    });
+
   });
 
   describe('for Dev workspace', () => {

--- a/packages/dashboard-frontend/src/services/workspaceAdapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspaceAdapter/index.ts
@@ -200,7 +200,14 @@ export class WorkspaceAdapter<T extends che.Workspace | IDevWorkspace> implement
   set storageType(type: che.WorkspaceStorageType) {
     if (isWorkspaceV1(this.workspace)) {
       const attributes = typeToAttributes(type);
-      Object.assign(this.workspace.devfile.attributes, attributes);
+      if (!this.workspace.devfile.attributes) {
+        this.workspace.devfile.attributes = {};
+      }
+      if (attributes) {
+        Object.assign(this.workspace.devfile.attributes, attributes);
+      } else {
+        delete this.workspace.devfile.attributes;
+      }
     } else {
       console.error('Not implemented: set storage type of the devworkspace.');
     }

--- a/packages/dashboard-frontend/src/services/workspaceAdapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspaceAdapter/index.ts
@@ -202,10 +202,14 @@ export class WorkspaceAdapter<T extends che.Workspace | IDevWorkspace> implement
       const attributes = typeToAttributes(type);
       if (!this.workspace.devfile.attributes) {
         this.workspace.devfile.attributes = {};
+      } else {
+        delete this.workspace.devfile.attributes.asyncPersist;
+        delete this.workspace.devfile.attributes.persistVolumes;
       }
       if (attributes) {
         Object.assign(this.workspace.devfile.attributes, attributes);
-      } else {
+      }
+      if (Object.keys(this.workspace.devfile.attributes).length === 0) {
         delete this.workspace.devfile.attributes;
       }
     } else {

--- a/packages/dashboard-frontend/src/store/__mocks__/cheWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/cheWorkspaceBuilder.ts
@@ -12,6 +12,7 @@
 
 import getRandomString from '../../services/helpers/random';
 import { WorkspaceStatus } from '../../services/helpers/types';
+import { cloneDeep } from 'lodash';
 
 export const CHE_DEVFILE_STUB: che.WorkspaceDevfile = {
   apiVersion: '1.0.0',
@@ -61,17 +62,17 @@ export class CheWorkspaceBuilder {
   }
 
   withAttributes(attributes: che.WorkspaceAttributes): CheWorkspaceBuilder {
-    this.workspace.attributes = attributes;
+    this.workspace.attributes = cloneDeep(attributes);
     return this;
   }
 
   withDevfile(devfile: che.WorkspaceDevfile): CheWorkspaceBuilder {
-    this.workspace.devfile = devfile;
+    this.workspace.devfile = cloneDeep(devfile);
     return this;
   }
 
   withProjects(projects: any[]): CheWorkspaceBuilder {
-    this.workspace.devfile.projects = projects;
+    this.workspace.devfile.projects = cloneDeep(projects);
     return this;
   }
 
@@ -86,7 +87,7 @@ export class CheWorkspaceBuilder {
   }
 
   withRuntime(runtime: che.WorkspaceRuntime): CheWorkspaceBuilder {
-    this.workspace.runtime = runtime;
+    this.workspace.runtime = cloneDeep(runtime);
     this.workspace.status = WorkspaceStatus.RUNNING;
     return this;
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The PR fixes a regression when changing workspace storage type on the workspace overview tab doesn't change the workspace devfile.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/19939
