### PR TITLE
Add factory create policies for devWorkspaces

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/index.module.css
@@ -4,7 +4,6 @@
 
 .statusLabel {
   text-transform: capitalize;
-  vertical-align: middle;
 }
 
 svg.rotate {

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -187,7 +187,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     if (this.isCreatePolicy(policy)) {
       return policy;
     }
-    this.showAlert(`Unsupported create policy ${policy} is specified while the only following are supported: peruser, perclick. Please fix 'policies.create' parameter and try again.`);
+    this.showAlert(`Unsupported create policy '${policy}' is specified while the only following are supported: peruser, perclick. Please fix 'policies.create' parameter and try again.`);
     return undefined;
   }
 

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -187,7 +187,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     if (this.isCreatePolicy(policy)) {
       return policy;
     }
-    this.showAlert(`Unsupported create policy 'policies.create=${policy}'`);
+    this.showAlert(`Unsupported create policy ${policy} is specified while the only following are supported: peruser, perclick. Please fix 'policies.create' parameter and try again.`);
     return undefined;
   }
 

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/updateDevfileMetadata.ts
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/updateDevfileMetadata.ts
@@ -11,36 +11,37 @@
  */
 
 import { isDevfileV2 } from '../../services/workspaceAdapter';
-import { safeDump } from 'js-yaml';
+import { safeDump, safeLoad } from 'js-yaml';
 import {
   DEVWORKSPACE_DEVFILE_SOURCE,
   DEVWORKSPACE_METADATA_ANNOTATION
 } from '../../services/workspace-client/devWorkspaceClient';
+import { CreatePolicy } from './index';
 import getRandomString from '../../services/helpers/random';
 
-export function updateDevfileMetadata(devfile: api.che.workspace.devfile.Devfile, meta?: che.DevfileMetaData): api.che.workspace.devfile.Devfile {
+export type FactorySource = { factory?: { params: string } };
+
+export default function updateDevfileMetadata(devfile: api.che.workspace.devfile.Devfile, factoryUrl: string, createPolicy: CreatePolicy): api.che.workspace.devfile.Devfile {
   if (isDevfileV2(devfile)) {
-    // provide metadata about the origin of the devfile with DevWorkspace
-    const devfileSource = safeDump(meta ? {
-      sample: {
-        registry: meta.registry,
-        displayName: meta.displayName,
-        location: meta.links?.v2,
-      },
-    } : {
-      custom: {},
-    });
     const metadata = devfile.metadata;
-    if (meta && metadata.name) {
-      metadata.name = `${metadata.name}-${getRandomString(4).toLowerCase()}`;
-    }
     if (!metadata.attributes) {
       metadata.attributes = {};
     }
+    const dwMetadataAnnotations =  metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION];
+    let devfileSource =  dwMetadataAnnotations ? dwMetadataAnnotations[DEVWORKSPACE_DEVFILE_SOURCE] : undefined;
+    let devfileSourceObj = devfileSource ? safeLoad(devfileSource) : {};
+    if (typeof devfileSourceObj !== 'object') {
+      devfileSourceObj = {};
+    }
+    (devfileSourceObj as FactorySource).factory = { params: `url=${factoryUrl}` };
+    devfileSource = safeDump(devfileSourceObj);
     if (!metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION]) {
       metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION] = {};
     }
     metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION][DEVWORKSPACE_DEVFILE_SOURCE] = devfileSource;
+    if (createPolicy !== 'peruser' && metadata.name) {
+       metadata.name = `${metadata.name}-${getRandomString(4).toLowerCase()}`;
+    }
     return Object.assign({}, devfile, { metadata });
   }
 

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/updateDevfileMetadata.ts
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/updateDevfileMetadata.ts
@@ -21,7 +21,7 @@ import getRandomString from '../../services/helpers/random';
 
 export type FactorySource = { factory?: { params: string } };
 
-export default function updateDevfileMetadata(devfile: api.che.workspace.devfile.Devfile, factoryUrl: string, createPolicy: CreatePolicy): api.che.workspace.devfile.Devfile {
+export default function updateDevfileMetadata(devfile: api.che.workspace.devfile.Devfile, factoryParams: string, createPolicy: CreatePolicy): api.che.workspace.devfile.Devfile {
   if (isDevfileV2(devfile)) {
     const metadata = devfile.metadata;
     if (!metadata.attributes) {
@@ -33,7 +33,7 @@ export default function updateDevfileMetadata(devfile: api.che.workspace.devfile
     if (typeof devfileSourceObj !== 'object') {
       devfileSourceObj = {};
     }
-    (devfileSourceObj as FactorySource).factory = { params: `url=${factoryUrl}` };
+    (devfileSourceObj as FactorySource).factory = { params: factoryParams };
     devfileSource = safeDump(devfileSourceObj);
     if (!metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION]) {
       metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION] = {};

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -22,6 +22,9 @@ import { WorkspaceStatus } from '../../services/helpers/types';
 import FactoryLoaderContainer, { LoadFactorySteps } from '../FactoryLoader';
 import { AlertOptions } from '../../pages/IdeLoader';
 import { convertWorkspace, Workspace } from '../../services/workspaceAdapter';
+import { DevWorkspaceBuilder } from '../../store/__mocks__/devWorkspaceBuilder';
+import { IDevWorkspace } from '@eclipse-che/devworkspace-client';
+import { safeDump } from 'js-yaml';
 
 const showAlertMock = jest.fn();
 const createWorkspaceFromDevfileMock = jest.fn().mockResolvedValue(undefined);
@@ -31,7 +34,6 @@ const requestFactoryResolverMock = jest.fn().mockResolvedValue(undefined);
 const setWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
 const clearWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
 
-let workspaceFromDevfile: Workspace;
 jest.mock('../../store/Workspaces/index', () => {
   return {
     actionCreators: {
@@ -45,7 +47,14 @@ jest.mock('../../store/Workspaces/index', () => {
         async (): Promise<Workspace> => {
           createWorkspaceFromDevfileMock(devfile, namespace, infrastructureNamespace, attributes);
           jest.runOnlyPendingTimers();
-          return convertWorkspace({ id: 'id-wksp-test', attributes, namespace, devfile, temporary: false, status: 'STOPPED' });
+          return convertWorkspace({
+            id: 'id-wksp-test',
+            attributes,
+            namespace,
+            devfile,
+            temporary: false,
+            status: 'STOPPED'
+          });
         },
       setWorkspaceId: (id: string) => async (): Promise<void> => {
         setWorkspaceIdMock(id);
@@ -109,135 +118,312 @@ describe('Factory Loader container', () => {
     jest.useRealTimers();
   });
 
-  it('should resolve the factory, create and start a new workspace', async () => {
-    const location = 'http://test-location';
-    const workspace = createFakeCheWorkspace('wrksp-test-id', 'wrksp-test-name');
-    workspaceFromDevfile = convertWorkspace(workspace);
+  describe('Use a devfile V1', () => {
 
-    renderComponent(location, workspace);
+    it('should resolve the factory, create and start a new workspace', async () => {
+      const location = 'http://test-location';
+      const workspace = createFakeCheWorkspace('wrksp-test-id', 'wrksp-test-name');
+      const workspaceAdapter = convertWorkspace(workspace);
 
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      renderComponentV1(location, workspace);
 
-    await waitFor(() => expect(clearWorkspaceIdMock).toHaveBeenCalled());
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
 
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+      await waitFor(() => expect(clearWorkspaceIdMock).toHaveBeenCalled());
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
 
-    jest.runOnlyPendingTimers();
-    await waitFor(() =>
-      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(workspace.devfile, undefined, undefined, { stackName: location + '/' }));
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
 
-    jest.runOnlyPendingTimers();
-    expect(showAlertMock).not.toHaveBeenCalled();
-    await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceFromDevfile));
-    await waitFor(() => expect(startWorkspaceMock).toHaveBeenCalledWith(workspaceFromDevfile));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.START_WORKSPACE]);
-  });
+      jest.runOnlyPendingTimers();
+      await waitFor(() =>
+        expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(workspace.devfile, undefined, undefined, { stackName: location + '/' }));
 
-  it('should resolve the factory, create a new workspace and open IDE', async () => {
-    const location = 'http://test-location';
-    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test');
-    workspaceFromDevfile = convertWorkspace(workspace);
-
-    renderComponent(location, workspace);
-
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-
-    await waitFor(() => expect(clearWorkspaceIdMock).toHaveBeenCalled());
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() =>
-      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(workspace.devfile, undefined, undefined, { stackName: location + '/' }));
-
-    jest.runOnlyPendingTimers();
-    expect(showAlertMock).toBeCalledWith({
-      alertVariant: AlertVariant.warning,
-      title: 'You\'re starting an ephemeral workspace. All changes to the source code will be lost ' +
-        'when the workspace is stopped unless they are pushed to a remote code repository.'
+      jest.runOnlyPendingTimers();
+      expect(showAlertMock).not.toHaveBeenCalled();
+      await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceAdapter));
+      await waitFor(() => expect(startWorkspaceMock).toHaveBeenCalledWith(workspaceAdapter));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.START_WORKSPACE]);
     });
-    expect(setWorkspaceIdMock).toHaveBeenCalledWith(workspace.id);
-    await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceFromDevfile));
-    await waitFor(() => expect(startWorkspaceMock).not.toHaveBeenCalled());
 
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceFromDevfile));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.OPEN_IDE]);
+    it('should resolve the factory, create a new workspace and open IDE', async () => {
+      const location = 'http://test-location';
+      const workspace = createFakeWorkspaceWithRuntimeV1('id-wksp-test');
+      const workspaceAdapter = convertWorkspace(workspace);
+
+      renderComponentV1(location, workspace);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+
+      await waitFor(() => expect(clearWorkspaceIdMock).toHaveBeenCalled());
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() =>
+        expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(workspace.devfile, undefined, undefined, { stackName: location + '/' }));
+
+      jest.runOnlyPendingTimers();
+      expect(showAlertMock).toBeCalledWith({
+        alertVariant: AlertVariant.warning,
+        title: 'You\'re starting an ephemeral workspace. All changes to the source code will be lost ' +
+          'when the workspace is stopped unless they are pushed to a remote code repository.'
+      });
+      expect(setWorkspaceIdMock).toHaveBeenCalledWith(workspace.id);
+      await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceAdapter));
+      await waitFor(() => expect(startWorkspaceMock).not.toHaveBeenCalled());
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceAdapter));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.OPEN_IDE]);
+    });
+
+    it('should resolve the factory, create a new workspace with param overriding', async () => {
+      const location = 'http://test-location&override.metadata.generateName=testPrefix';
+      const workspace = createFakeWorkspaceWithRuntimeV1('id-wksp-test', location);
+      renderComponentV1(location, workspace);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(
+        location.split('&')[0], {
+          'override.metadata.generateName': 'testPrefix'
+        }));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() =>
+        expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+          {
+            apiVersion: '1.0.0',
+            metadata: {
+              name: 'name-wksp-2',
+            },
+            attributes: { persistVolumes: 'false' }
+          }, undefined, undefined,
+          { stackName: 'http://test-location/?override.metadata.generateName=testPrefix' }));
+    });
+
+    it('should show a target error with "error_code=invalid_request"', () => {
+      const location = 'http://test-location&error_code=invalid_request';
+      const workspace = createFakeWorkspaceWithRuntimeV1('id-wksp-test');
+
+      renderComponentV1(location, workspace);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.INITIALIZING]);
+
+      expect(showAlertMock).toHaveBeenCalledWith(expect.objectContaining({
+        alertVariant: 'danger',
+        title: 'Could not resolve devfile from private repository because authentication request is missing a parameter,' +
+          ' contains an invalid parameter, includes a parameter more than once, or is otherwise invalid.',
+      }));
+    });
+
+    it('should show a target error with "error_code=access_denied"', () => {
+      const location = 'http://test-location&error_code=access_denied';
+      const workspace = createFakeWorkspaceWithRuntimeV1('id-wksp-test');
+
+      renderComponentV1(location, workspace);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.INITIALIZING]);
+
+      expect(showAlertMock).toHaveBeenCalledWith(expect.objectContaining({
+        alertVariant: 'danger',
+        title: 'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
+      }));
+    });
+
+    it('should resolve the factory with "policies.create=peruser"', async () => {
+      const location = 'http://test-location&policies.create=peruser';
+      const workspace = createFakeWorkspaceWithRuntimeV1('id-wksp-test', 'http://test-location/?policies.create=peruser');
+      const workspaceAdapter = convertWorkspace(workspace);
+
+      renderComponentV1(location, workspace);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      expect(createWorkspaceFromDevfileMock).not.toHaveBeenCalled();
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceAdapter));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.OPEN_IDE]);
+    });
+
+    it('should resolve the factory with  the preferred storage type "persistent"', async () => {
+      const location = 'http://test-location';
+      const preferredStorageType = 'persistent';
+      const workspace = createFakeWorkspaceWithRuntimeV1('test-wksp-id', 'test-stack-name', 'test-wksp-name', {});
+
+      renderComponentV1(location, workspace, preferredStorageType);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() =>
+        expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+          {
+            apiVersion: '1.0.0',
+            metadata: {
+              name: 'test-wksp-name',
+            },
+          }, undefined, undefined, { stackName: location + '/' }));
+    });
+
+    it('should resolve the factory with  the preferred storage type "ephemeral"', async () => {
+      const location = 'http://test-location';
+      const preferredStorageType = 'ephemeral';
+      const workspace = createFakeWorkspaceWithRuntimeV1('test-wksp-id', 'test-stack-name', 'test-wksp-name', {});
+
+      renderComponentV1(location, workspace, preferredStorageType);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() =>
+        expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            attributes: {
+              persistVolumes: 'false',
+            },
+          }), undefined, undefined, { stackName: location + '/' }));
+    });
+
+    it('should resolve the factory with  the preferred storage type "async"', async () => {
+      const location = 'http://test-location';
+      const preferredStorageType = 'async';
+      const workspace = createFakeWorkspaceWithRuntimeV1('test-wksp-id', 'test-stack-name', 'test-wksp-name', {});
+
+      renderComponentV1(location, workspace, preferredStorageType);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() =>
+        expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            attributes: {
+              persistVolumes: 'false',
+              asyncPersist: 'true',
+            },
+          }), undefined, undefined, { stackName: location + '/' }));
+    });
+
+    it('should show an error if something wrong with Repository/Devfile URL', async () => {
+      const message = 'Repository/Devfile URL is missing. Please specify it via url query param: ' +
+        window.location.origin + window.location.pathname + '#/load-factory?url= .';
+      const workspace = createFakeWorkspaceWithRuntimeV1('id-wksp-test');
+      renderComponentV1('', workspace);
+
+      expect(requestFactoryResolverMock).not.toBeCalled();
+      await waitFor(() => expect(showAlertMock).toBeCalledWith({ alertVariant: AlertVariant.danger, title: message }));
+      const elementHasError = screen.getByTestId('factory-loader-has-error');
+      expect(elementHasError.innerHTML).toEqual('true');
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.CREATE_WORKSPACE]);
+    });
   });
 
-  it('should resolve the factory, create a new workspace with param overriding', async () => {
-    const location = 'http://test-location&override.metadata.generateName=testPrefix';
-    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test', location);
-    renderComponent(location, workspace);
+  describe('Use a devfile V2', () => {
 
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+    it('should resolve the factory with create policie "peruser" and open existing workspace', async () => {
+      const location = 'http://test-location&policies.create=peruser';
+      const name = 'test-name';
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withId('id-wksp-test')
+        .withName(name)
+        .withNamespace('test')
+        .build();
+      renderComponentV2(location, devWorkspace);
 
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(
-      location.split('&')[0], {
-      'override.metadata.generateName': 'testPrefix'
-    }));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
 
-    jest.runOnlyPendingTimers();
-    await waitFor(() =>
-      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
-        {
-          apiVersion: '1.0.0',
-          metadata: {
-            name: 'name-wksp-2',
-          },
-          attributes: { persistVolumes: 'false' }
-        }, undefined, undefined,
-        { stackName: 'http://test-location/?override.metadata.generateName=testPrefix' }));
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+
+      await waitFor(() => expect(createWorkspaceFromDevfileMock).not.toBeCalled());
+    });
+
+    it('should resolve the factory with create policie "peruser" and create a new workspace', async () => {
+      const location = 'http://test2-location&policies.create=peruser';
+      const name = 'test-name';
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withId('id-wksp-test')
+        .withName(name)
+        .withNamespace('test')
+        .build();
+      renderComponentV2(location, devWorkspace);
+
+      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
+      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
+
+      jest.runOnlyPendingTimers();
+
+      await waitFor(() =>
+        expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+          {
+            schemaVersion: '2.1.0',
+            metadata: {
+              name: name,
+              namespace: 'test',
+              attributes: {
+                'dw.metadata.annotations': {
+                  'che.eclipse.org/devfile-source': safeDump({ factory: { params: 'url=http://test2-location/?policies.create=peruser' } })
+                }
+              }
+            }
+          }, undefined, undefined, {
+            factoryUrl: 'http://test2-location/?policies.create=peruser',
+            'policies.create': 'peruser'
+          }));
+    });
   });
 
-  it('should show a target error with \'error_code=invalid_request\'', () => {
-    const location = 'http://test-location&error_code=invalid_request';
-    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test');
-    workspaceFromDevfile = convertWorkspace(workspace);
-
-    renderComponent(location, workspace);
-
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.INITIALIZING]);
-
-    expect(showAlertMock).toHaveBeenCalledWith(expect.objectContaining({
-      alertVariant: 'danger',
-      title: 'Could not resolve devfile from private repository because authentication request is missing a parameter,' +
-        ' contains an invalid parameter, includes a parameter more than once, or is otherwise invalid.',
-    }));
-  });
-
-  it('should show a target error with \'error_code=access_denied\'', () => {
-    const location = 'http://test-location&error_code=access_denied';
-    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test');
-    workspaceFromDevfile = convertWorkspace(workspace);
-
-    renderComponent(location, workspace);
-
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.INITIALIZING]);
-
-    expect(showAlertMock).toHaveBeenCalledWith(expect.objectContaining({
-      alertVariant: 'danger',
-      title: 'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
-    }));
-  });
-
-  it('should resolve the factory with \'policies.create=peruser\'', async () => {
-    const location = 'http://test-location&policies.create=peruser';
-    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test', 'http://test-location/?policies.create=peruser');
-    workspaceFromDevfile = convertWorkspace(workspace);
-
-    renderComponent(location, workspace);
+  it('should resolve the factory with create policie "perclick" and create a new workspace', async () => {
+    const location = 'http://test-location&policies.create=perclick';
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withId('id-wksp-test')
+      .withName('test-name')
+      .withNamespace('test')
+      .build();
+    renderComponentV2(location, devWorkspace);
 
     const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
     expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
@@ -247,121 +433,31 @@ describe('Factory Loader container', () => {
     expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
 
     jest.runOnlyPendingTimers();
-    expect(createWorkspaceFromDevfileMock).not.toHaveBeenCalled();
 
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestWorkspaceMock).toHaveBeenCalledWith(workspaceFromDevfile));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.OPEN_IDE]);
+    await waitFor(() => expect(createWorkspaceFromDevfileMock).toHaveBeenCalledTimes(1));
   });
 
-  it('should resolve the factory with  the preferred storage type \'persistent\'', async () => {
-    const location = 'http://test-location';
-    const preferredStorageType = 'persistent';
-    const workspace = createFakeWorkspaceWithRuntime('test-wksp-id', 'test-stack-name', 'test-wksp-name', {});
-
-    renderComponent(location, workspace, preferredStorageType);
-
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() =>
-      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
-        {
-          apiVersion: '1.0.0',
-          metadata: {
-            name: 'test-wksp-name',
-          },
-        }, undefined, undefined, { stackName: location + '/' }));
-  });
-
-  it('should resolve the factory with  the preferred storage type \'ephemeral\'', async () => {
-    const location = 'http://test-location';
-    const preferredStorageType = 'ephemeral';
-    const workspace = createFakeWorkspaceWithRuntime('test-wksp-id', 'test-stack-name', 'test-wksp-name', {});
-
-    renderComponent(location, workspace, preferredStorageType);
-
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() =>
-      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          attributes: {
-            persistVolumes: 'false',
-          },
-        }), undefined, undefined, { stackName: location + '/' }));
-  });
-
-  it('should resolve the factory with  the preferred storage type \'async\'', async () => {
-    const location = 'http://test-location';
-    const preferredStorageType = 'async';
-    const workspace = createFakeWorkspaceWithRuntime('test-wksp-id', 'test-stack-name', 'test-wksp-name', {});
-
-    renderComponent(location, workspace, preferredStorageType);
-
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]));
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE]);
-
-    jest.runOnlyPendingTimers();
-    await waitFor(() =>
-      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          attributes: {
-            persistVolumes: 'false',
-            asyncPersist: 'true',
-          },
-        }), undefined, undefined, { stackName: location + '/' }));
-  });
-
-  it('should show an error if something wrong with Repository/Devfile URL', async () => {
-    const message = 'Repository/Devfile URL is missing. Please specify it via url query param: ' +
-      window.location.origin + window.location.pathname + '#/load-factory?url= .';
-    const workspace = createFakeWorkspaceWithRuntime('id-wksp-test');
-    renderComponent('', workspace);
-
-    expect(requestFactoryResolverMock).not.toBeCalled();
-    await waitFor(() => expect(showAlertMock).toBeCalledWith({ alertVariant: AlertVariant.danger, title: message }));
-    const elementHasError = screen.getByTestId('factory-loader-has-error');
-    expect(elementHasError.innerHTML).toEqual('true');
-
-    const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-    expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(LoadFactorySteps[LoadFactorySteps.CREATE_WORKSPACE]);
-  });
 });
 
-function renderComponent(
+function renderComponentV2(
   url: string,
-  workspace: che.Workspace,
-  preferredStorageType?: che.WorkspaceStorageType
+  workspace: IDevWorkspace,
 ): RenderResult {
-  const settings = preferredStorageType ? { 'che.workspace.storage.preferred_type': preferredStorageType } : {};
+  const wrks = convertWorkspace(workspace);
+  (wrks.ref as IDevWorkspace).metadata.annotations = {
+    'che.eclipse.org/devfile-source': safeDump({ factory: { params: 'url=http://test-location/?policies.create=peruser' } })
+  };
   const store = new FakeStoreBuilder()
-    .withCheWorkspaces({
+    .withDevWorkspaces({
       workspaces: [workspace],
     })
     .withWorkspaces({
-      workspaceId: workspace.id
+      workspaceId: workspace.status.devworkspaceId
     })
-    .withWorkspacesSettings(settings as che.WorkspaceSettings)
     .withFactoryResolver({
       v: '4.0',
       source: 'devfile.yaml',
-      devfile: workspace.devfile as api.che.workspace.devfile.Devfile,
+      devfile: convertWorkspace(workspace).devfile,
       location: url.split('&')[0],
       scm_info: {
         clone_url: 'http://github.com/clone-url',
@@ -381,7 +477,40 @@ function renderComponent(
   );
 }
 
-function createFakeWorkspaceWithRuntime(
+function renderComponentV1(
+  url: string,
+  workspace: che.Workspace,
+  preferredStorageType?: che.WorkspaceStorageType
+): RenderResult {
+  const settings = preferredStorageType ? { 'che.workspace.storage.preferred_type': preferredStorageType } : {};
+  const store = new FakeStoreBuilder()
+    .withCheWorkspaces({
+      workspaces: [workspace],
+    })
+    .withWorkspaces({
+      workspaceId: workspace.id
+    })
+    .withWorkspacesSettings(settings as che.WorkspaceSettings)
+    .withFactoryResolver({
+      v: '4.0',
+      source: 'devfile.yaml',
+      devfile: workspace.devfile as api.che.workspace.devfile.Devfile,
+      location: url.split('&')[0],
+      links: []
+    })
+    .build();
+  const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url });
+
+  return render(
+    <Provider store={store}>
+      <FactoryLoaderContainer
+        {...props}
+      />
+    </Provider>,
+  );
+}
+
+function createFakeWorkspaceWithRuntimeV1(
   workspaceId: string,
   stackName = '',
   workspaceName = 'name-wksp-2',

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -405,12 +405,12 @@ describe('Factory Loader container', () => {
               namespace: 'test',
               attributes: {
                 'dw.metadata.annotations': {
-                  'che.eclipse.org/devfile-source': safeDump({ factory: { params: 'url=http://test2-location/?policies.create=peruser' } })
+                  'che.eclipse.org/devfile-source': safeDump({ factory: { params: 'url=http://test2-location&policies.create=peruser' } })
                 }
               }
             }
           }, undefined, undefined, {
-            factoryUrl: 'http://test2-location/?policies.create=peruser',
+            factoryParams: 'url=http://test2-location&policies.create=peruser',
             'policies.create': 'peruser'
           }));
     });
@@ -445,7 +445,7 @@ function renderComponentV2(
 ): RenderResult {
   const wrks = convertWorkspace(workspace);
   (wrks.ref as IDevWorkspace).metadata.annotations = {
-    'che.eclipse.org/devfile-source': safeDump({ factory: { params: 'url=http://test-location/?policies.create=peruser' } })
+    'che.eclipse.org/devfile-source': safeDump({ factory: { params: 'url=http://test-location&policies.create=peruser' } })
   };
   const store = new FakeStoreBuilder()
     .withDevWorkspaces({

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/__snapshots__/FactoryLoader.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/__snapshots__/FactoryLoader.spec.tsx.snap
@@ -173,7 +173,6 @@ Array [
       <section
         className="pf-c-page__main-section"
       >
-        
         <div
           className="pf-c-wizard load-factory-wizard"
           style={
@@ -1309,7 +1308,6 @@ Array [
       <section
         className="pf-c-page__main-section"
       >
-        
         <div
           className="pf-c-wizard load-factory-wizard"
           style={
@@ -2793,7 +2791,6 @@ Array [
       <section
         className="pf-c-page__main-section"
       >
-        
         <div
           className="pf-c-wizard load-factory-wizard"
           style={
@@ -3343,7 +3340,6 @@ Array [
       <section
         className="pf-c-page__main-section"
       >
-        
         <div
           className="pf-c-wizard load-factory-wizard"
           style={
@@ -3893,7 +3889,6 @@ Array [
       <section
         className="pf-c-page__main-section"
       >
-        
         <div
           className="pf-c-wizard load-factory-wizard"
           style={
@@ -4450,7 +4445,6 @@ Array [
       <section
         className="pf-c-page__main-section"
       >
-        
         <div
           className="pf-c-wizard load-factory-wizard"
           style={

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
@@ -237,7 +237,7 @@ class FactoryLoader extends React.PureComponent<Props, State> {
             <Tab eventKey={LoadFactoryTabs.Progress} title={LoadFactoryTabs[LoadFactoryTabs.Progress]}
               id="factory-loader-page-wizard-tab">
               <PageSection>
-                {(this.state.currentRequestError) && (
+                {(hasError && this.state.currentRequestError) && (
                   <Alert
                     isInline
                     variant={currentAlertVariant}

--- a/packages/dashboard-frontend/src/services/helpers/devworkspace.ts
+++ b/packages/dashboard-frontend/src/services/helpers/devworkspace.ts
@@ -15,5 +15,6 @@
  * @param workspaceOrDevfile The workspace or devfile you want to check
  */
 export function isWebTerminal(workspaceOrDevfile: che.Workspace | api.che.workspace.devfile.Devfile): boolean {
-  return !!workspaceOrDevfile?.metadata?.labels['console.openshift.io/terminal'];
+  const labels = workspaceOrDevfile?.metadata?.labels;
+  return !!labels && !!labels['console.openshift.io/terminal'];
 }

--- a/packages/dashboard-frontend/src/services/workspace-client/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devWorkspaceClient.ts
@@ -36,6 +36,10 @@ export interface IStatusUpdate {
 
 export const DEVWORKSPACE_NEXT_START_ANNOTATION = 'che.eclipse.org/next-start-cfg';
 
+export const DEVWORKSPACE_DEVFILE_SOURCE = 'che.eclipse.org/devfile-source';
+
+export const DEVWORKSPACE_METADATA_ANNOTATION =  'dw.metadata.annotations';
+
 /**
  * This class manages the connection between the frontend and the devworkspace typescript library
  */

--- a/packages/dashboard-frontend/src/store/FactoryResolver/getDevfile.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/getDevfile.ts
@@ -14,6 +14,10 @@ import { FactoryResolver, DevfileV2ProjectSource } from '../../services/helpers/
 import { isDevfileV2 } from '../../services/workspaceAdapter';
 import { getProjectName } from '../../services/helpers/getProjectName';
 import { safeDump } from 'js-yaml';
+import {
+  DEVWORKSPACE_DEVFILE_SOURCE,
+  DEVWORKSPACE_METADATA_ANNOTATION
+} from '../../services/workspace-client/devWorkspaceClient';
 
 /**
  * Returns a devfile from the FactoryResolver object.
@@ -72,7 +76,10 @@ export function getDevfile(data: FactoryResolver, location: string): api.che.wor
     if (!metadata.attributes) {
       metadata.attributes = {};
     }
-    metadata.attributes['dw.metadata.annotations'] = { 'che.eclipse.org/devfile-source': devfileSource };
+    if (!metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION]) {
+      metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION] = {};
+    }
+    metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION][DEVWORKSPACE_DEVFILE_SOURCE] = devfileSource;
     devfile = Object.assign({}, devfile, { metadata });
   }
 


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add factory create policies for devWorkspaces.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/19711
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


### Steps for testing this PR: 
1. Create several workspaces from the same sample. 

* expected result: Workspace names should have generated parts at the end.

 2. Resolve the factory with 'policies.create=peruser'
```{che-server}/f?url=https://raw.githubusercontent.com/che-samples/java-spring-petclinic/devfilev2/devfile.yaml&policies.create=peruser```
several times.

* expected result: A new workspace was created only in the first attempt. 
