### PR TITLE
fix: provision Che env var into theia generated resources

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devWorkspaceClient.ts
@@ -126,23 +126,6 @@ export class DevWorkspaceClient extends WorkspaceClient {
       // TODO handle error in a proper way
       const pluginName = this.normalizePluginName(pluginDevfile.metadata.name, workspaceId);
 
-      // propagate the plugin registry and dashboard urls to the containers in the initial devworkspace templates
-      for (const component of pluginDevfile.components) {
-        const container = component.container;
-        if (container) {
-          if (!container.env) {
-            container.env = [];
-          }
-          container.env.push(...[{
-            name: this.dashboardUrlEnvName,
-            value: window.location.origin,
-          }, {
-            name: this.pluginRegistryUrlEnvName,
-            value: pluginRegistryUrl
-          }]);
-        }
-      }
-
       const theiaDWT = {
         kind: 'DevWorkspaceTemplate',
         apiVersion: devfileGroupVersion,
@@ -204,6 +187,25 @@ export class DevWorkspaceClient extends WorkspaceClient {
           uid: createdWorkspace.metadata.uid
         }
       ];
+
+      // propagate the plugin registry and dashboard urls to the containers in the initial devworkspace templates
+      if (template.spec?.components) {
+        for (const component of template.spec?.components) {
+          const container = component.container;
+          if (container) {
+            if (!container.env) {
+              container.env = [];
+            }
+            container.env.push(...[{
+              name: this.dashboardUrlEnvName,
+              value: window.location.origin,
+            }, {
+              name: this.pluginRegistryUrlEnvName,
+              value: pluginRegistryUrl || ''
+            }]);
+          }
+        }
+      }
 
       const pluginDWT = await this.dwtApi.create(<IDevWorkspaceTemplate>template);
       this.addPlugin(createdWorkspace, pluginDWT.metadata.name, pluginDWT.metadata.namespace);


### PR DESCRIPTION
### What does this PR do?
fix: provision Che env var into theia generated resources.

To test it:
1. deploy Che with devworkspace enabled.
2. Create devworkspace.
3. Check that VSX installer has needed env vars
![Screenshot_20210726_162554](https://user-images.githubusercontent.com/5887312/126996611-cbb94eca-542b-4260-b74a-70b5f2ef4bb3.png)


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
