### PR TITLE
fix: better report resolved devfile during factory flow

### DIFF
--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -282,12 +282,12 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     //  - repo: means no devfile is found and default is generated
     //  - any other - devfile is found in repository as filename from the value
     if (!source) {
-      resolvedDevfileMessage = `Devfile is loaded from ${searchParam.get('url')}`;
+      resolvedDevfileMessage = `Devfile loaded from ${searchParam.get('url')}`;
     } else {
       if (source === 'repo') {
-        resolvedDevfileMessage = `No devfile is found in the specified git repo ${searchParam.get('url')}. Applying default configuration`;
+        resolvedDevfileMessage = `Devfile could not be found in ${searchParam.get('url')}. Applying the default configuration`;
       } else {
-        resolvedDevfileMessage = `Devfile is found in repo ${searchParam.get('url')} as '${source}'. Applying it`;
+        resolvedDevfileMessage = `Devfile found in repo ${searchParam.get('url')} as '${source}'. Applying it`;
       }
     }
     this.setState({ resolvedDevfileMessage });

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -61,7 +61,7 @@ type Props =
 type State = {
   search?: string;
   location?: string;
-  devfileLocationInfo?: string;
+  resolvedDevfileMessage?: string;
   currentStep: LoadFactorySteps;
   hasError: boolean;
   createPolicy: CreatePolicy;
@@ -276,10 +276,21 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     }
     const { source } = this.factoryResolver.resolver;
     const searchParam = new window.URLSearchParams(this.state.search);
-    const devfileLocationInfo = !source || source === 'repo' ?
-      `${searchParam.get('url')}` :
-      `\`${source}\` in github repo ${location}`;
-    this.setState({ devfileLocationInfo });
+    let resolvedDevfileMessage: string;
+    // source tells where devfile comes from
+    //  - no source: the url to raw content is used
+    //  - repo: means no devfile is found and default is generated
+    //  - any other - devfile is found in repository as filename from the value
+    if (!source) {
+      resolvedDevfileMessage = `Devfile is loaded from ${searchParam.get('url')}`;
+    } else {
+      if (source === 'repo') {
+        resolvedDevfileMessage = `No devfile is found in the specified git repo ${searchParam.get('url')}. Applying default configuration`;
+      } else {
+        resolvedDevfileMessage = `Devfile is found in repo ${searchParam.get('url')} as '${source}'. Applying it`;
+      }
+    }
+    this.setState({ resolvedDevfileMessage });
     return this.getTargetDevfile();
   }
 
@@ -498,7 +509,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
 
   render() {
     const { workspace } = this.props;
-    const { currentStep, devfileLocationInfo, hasError } = this.state;
+    const { currentStep, resolvedDevfileMessage, hasError } = this.state;
     const workspaceName = workspace ? workspace.name : '';
     const workspaceId = workspace ? workspace.id : '';
 
@@ -506,7 +517,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       <FactoryLoader
         currentStep={currentStep}
         hasError={hasError}
-        devfileLocationInfo={devfileLocationInfo}
+        resolvedDevfileMessage={resolvedDevfileMessage}
         workspaceId={workspaceId}
         workspaceName={workspaceName}
         callbacks={this.factoryLoaderCallbacks}

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -88,7 +88,7 @@ jest.mock('../../pages/FactoryLoader', () => {
     currentStep: LoadFactorySteps,
     workspaceName: string;
     workspaceId: string;
-    devfileLocationInfo?: string;
+    resolvedDevfileMessage?: string;
     callbacks?: {
       showAlert?: (alertOptions: AlertOptions) => void
     }
@@ -101,7 +101,7 @@ jest.mock('../../pages/FactoryLoader', () => {
       <div data-testid="factory-loader-current-step">{props.currentStep}</div>
       <div data-testid="factory-loader-workspace-name">{props.workspaceName}</div>
       <div data-testid="factory-loader-workspace-id">{props.workspaceId}</div>
-      <div data-testid="factory-loader-devfile-location-info">{props.devfileLocationInfo}</div>
+      <div data-testid="factory-loader-devfile-location-info">{props.resolvedDevfileMessage}</div>
     </div>);
   };
 });

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/FactoryLoader.spec.tsx
@@ -53,8 +53,8 @@ describe('The Factory Loader page  component', () => {
   it('should render LOOKING_FOR_DEVFILE step with devfile location correctly', () => {
     const currentStep = LoadFactorySteps.LOOKING_FOR_DEVFILE;
     const hasError = false;
-    const devfileLocationInfo = '`devfile.yaml`  in github repo https://github.com/test/test.git';
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError, devfileLocationInfo);
+    const resolvedDevfileMessage = '`devfile.yaml` in git repo https://github.com/test/test.git';
+    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError, resolvedDevfileMessage);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -122,7 +122,7 @@ function renderComponent(
   workspaceName: string,
   workspaceId: string,
   hasError: boolean,
-  devfileLocationInfo?: string,
+  resolvedDevfileMessage?: string,
 ): ReactTestRenderer {
   return renderer.create(
     <Provider store={store}>
@@ -131,7 +131,7 @@ function renderComponent(
         workspaceName={workspaceName}
         workspaceId={workspaceId}
         hasError={hasError}
-        devfileLocationInfo={devfileLocationInfo}
+        resolvedDevfileMessage={resolvedDevfileMessage}
       />
     </Provider>,
   );

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/__snapshots__/FactoryLoader.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/__snapshots__/FactoryLoader.spec.tsx.snap
@@ -415,7 +415,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found
+                            Devfile could not be found
                           </span>
                         </button>
                       </li>
@@ -983,7 +983,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found
+                            Devfile could not be found
                           </span>
                         </button>
                       </li>
@@ -4084,7 +4084,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found
+                            Devfile could not be found
                           </span>
                         </button>
                       </li>
@@ -4640,7 +4640,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found
+                            Devfile could not be found
                           </span>
                         </button>
                       </li>
@@ -5179,7 +5179,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found
+                            Devfile could not be found
                           </span>
                         </button>
                       </li>

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/__snapshots__/FactoryLoader.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/__snapshots__/FactoryLoader.spec.tsx.snap
@@ -415,7 +415,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found in repository root. Default environment will be applied
+                            Devfile is not found
                           </span>
                         </button>
                       </li>
@@ -983,7 +983,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found 
+                            Devfile is not found
                           </span>
                         </button>
                       </li>
@@ -4084,7 +4084,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found in repository root. Default environment will be applied
+                            Devfile is not found
                           </span>
                         </button>
                       </li>
@@ -4640,7 +4640,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found in repository root. Default environment will be applied
+                            Devfile is not found
                           </span>
                         </button>
                       </li>
@@ -5179,7 +5179,7 @@ Array [
                           <span
                             className=""
                           >
-                            Devfile is not found 
+                            Devfile is not found
                           </span>
                         </button>
                       </li>

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
@@ -180,7 +180,7 @@ class FactoryLoader extends React.PureComponent<Props, State> {
                 'Looking for devfile' :
                 resolvedDevfileMessage ?
                   `${resolvedDevfileMessage}` :
-                  'Devfile is not found',
+                  'Devfile could not be found',
             ),
             canJumpTo: currentStep >= LoadFactorySteps.LOOKING_FOR_DEVFILE,
           },

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
@@ -52,7 +52,7 @@ type Props = {
   currentStep: LoadFactorySteps,
   workspaceName: string;
   workspaceId: string;
-  devfileLocationInfo?: string;
+  resolvedDevfileMessage?: string;
   callbacks?: {
     showAlert?: (options: AlertOptions) => void
   }
@@ -142,7 +142,7 @@ class FactoryLoader extends React.PureComponent<Props, State> {
   }
 
   private getSteps(): WizardStep[] {
-    const { currentStep, devfileLocationInfo, hasError } = this.props;
+    const { currentStep, resolvedDevfileMessage, hasError } = this.props;
 
     const getTitle = (step: LoadFactorySteps, title: string, iconClass?: string) => {
       let className = '';
@@ -178,9 +178,9 @@ class FactoryLoader extends React.PureComponent<Props, State> {
               LoadFactorySteps.LOOKING_FOR_DEVFILE,
               currentStep <= LoadFactorySteps.LOOKING_FOR_DEVFILE ?
                 'Looking for devfile' :
-                devfileLocationInfo ?
-                  `Devfile is found as ${devfileLocationInfo}` :
-                  `Devfile is not found ${!hasError ? 'in repository root. Default environment will be applied' : ''}`,
+                resolvedDevfileMessage ?
+                  `${resolvedDevfileMessage}` :
+                  'Devfile is not found',
             ),
             canJumpTo: currentStep >= LoadFactorySteps.LOOKING_FOR_DEVFILE,
           },


### PR DESCRIPTION
### What does this PR do?
fix: better report resolved devfile during factory flow.

Mainly there are three cases:
1. devfile is found in git repo
$CHE_HOST/#https://github.com/eclipse-che/che-server
![Screenshot_20210729_134954](https://user-images.githubusercontent.com/5887312/127479893-10b92a97-aea1-41d6-849b-fefff2e6106c.png)
^ note now we report resolved devfile filename

2. devfile is not found, using default configuration
$CHE_HOST/#https://github.com/eclipse/che-dashboard
![Screenshot_20210729_134905](https://user-images.githubusercontent.com/5887312/127480025-e77246a2-b910-4431-8d1f-bf99dcd94f7f.png)

3. devfile is specified with raw content url
$CHE_HOST/#https://raw.githubusercontent.com/l0rd/spring-petclinic/devfile2/devfile.yaml
![Screenshot_20210729_135037](https://user-images.githubusercontent.com/5887312/127480089-3d222f85-45b5-453d-a6bb-683c0a5c43b4.png)

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/20209
fixes https://github.com/eclipse/che/issues/19753

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
