### PR TITLE
Dashboard warns users that Safari is not supported 

### DIFF
--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__tests__/index.spec.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BannerAlertNotSupportedBrowser from '..';
+import { isSafari } from '../../../../services/helpers/detectBrowser';
+
+const unsupportedBrowserMessage = 'The browser you are using is not supported.';
+
+describe('BannerAlertNotSupportedBrowser component', () => {
+
+  it('should not show error message', () => {
+    render(<BannerAlertNotSupportedBrowser />);
+    expect(screen.queryByText(unsupportedBrowserMessage, {
+      exact: false
+    })).toBeFalsy();
+  });
+
+  it('should show error message when error found after mounting', () => {
+    (isSafari as any) = true;
+    render(<BannerAlertNotSupportedBrowser />);
+
+    expect(screen.queryByText(unsupportedBrowserMessage, {
+      exact: false
+    })).toBeTruthy();
+  });
+
+});

--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/index.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Banner } from '@patternfly/react-core';
+import React from 'react';
+import { isSafari } from '../../../services/helpers/detectBrowser';
+
+type Props = {};
+
+type State = {
+  isNotSupported: boolean;
+};
+
+export default class BannerAlertNotSupportedBrowser extends React.PureComponent<Props, State> {
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      isNotSupported: isSafari,
+    };
+  }
+
+  render() {
+    if (this.state.isNotSupported === false) {
+      return null;
+    }
+
+    return (
+      <Banner className="pf-u-text-align-center" variant="warning">
+        The browser you are using is not supported. We recommend using <b>Google Chrome</b> to have the best possible experience.
+      </Banner>
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/components/BannerAlert/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/index.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import BannerAlertBranding from './Branding';
 import BannerAlertWebSocket from './WebSocket';
 import BannerAlertCustomWarning from './Custom';
+import BannerAlertNotSupportedBrowser from './NotSupportedBrowser';
 
 type Props = {};
 
@@ -27,6 +28,7 @@ export class BannerAlert extends React.PureComponent<Props, State> {
     super(props);
     this.state = {
       bannerAlerts: [
+        <BannerAlertNotSupportedBrowser key="BannerAlertNotSupportedBrowser"></BannerAlertNotSupportedBrowser>,
         <BannerAlertWebSocket key="BannerAlertWebSocket"></BannerAlertWebSocket>,
         <BannerAlertBranding key="BannerAlertBranding"></BannerAlertBranding>,
         <BannerAlertCustomWarning key="BannerAlertCustomWarning"></BannerAlertCustomWarning>,

--- a/packages/dashboard-frontend/src/services/helpers/detectBrowser.ts
+++ b/packages/dashboard-frontend/src/services/helpers/detectBrowser.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

In this PR I added the fix that allows Dashboard to run in Safari. And since Safari is not supported users will always see the permanent banner with the warning message at the top of the page.

<img width="954" alt="Screenshot 2021-08-02 at 11 40 42" src="https://user-images.githubusercontent.com/16220722/127831487-fae05099-84f4-4812-bd9d-28e2d24ac2ef.png">


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/20123
