### PR TITLE
fix: fix link to nodejs 12 from redhat container catalog

### DIFF
--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -33,7 +33,7 @@ RUN yarn install
 COPY packages/ /dashboard/packages
 RUN yarn build
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12:1-90.1626843814
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
 FROM registry.access.redhat.com/ubi8/nodejs-12:1-90.1626843814
 USER 0
 


### PR DESCRIPTION
### What does this PR do?
fix: fix link to nodejs 12 from redhat container catalog.
https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12:1-90.1626843814 leads to 404
while the value used for base image is correct https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12

### What issues does this PR fix or reference?
N/A

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
