### PR TITLE
fix: add namespace into configmap needs to allow connections from localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ The development server serves the project on [http://localhost:3000](http://loca
 Note: For Che/CRW to allow connection from localhost it should be configured in accordance.
 
 ```bash
+# Note: eclipse-che is the default target namespace but if you have custom - change it below
+CHE_NAMESPACE="eclipse-che"
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: keycloak-custom-config
+  namespace: $CHE_NAMESPACE
   labels:
     app.kubernetes.io/part-of: che.eclipse.org
     app.kubernetes.io/component: keycloak-configmap
@@ -62,8 +65,7 @@ data:
   ADDITIONAL_REDIRECT_URIS: '"http://localhost:3000/*"'
 EOF
 # Due temporary limitation we need to rollout che operator to apply changes
-# Note: eclipse-che is the default target namespace but if you have custom - change it below
-kubectl rollout restart deployment/che-operator -n eclipse-che
+kubectl rollout restart deployment/che-operator -n $CHE_NAMESPACE
 ```
 
 Note: To use CodeReady Workspaces(based on Che) Hosted by Red Hat instance at https://workspaces.openshift.com, use the fully qualified host name of the cluster.


### PR DESCRIPTION
### What does this PR do?
I thought I did it but I did not ¯\_(ツ)_/¯
So, this PR fix add namespace into configmap needed to allow connections from localhost

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
