### PR TITLE
Fix logout for Che if it's been deployed with nativeUserMode enabled

### DIFF
--- a/packages/dashboard-frontend/src/Layout/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/index.tsx
@@ -71,7 +71,12 @@ export class Layout extends React.PureComponent<Props, State> {
   }
 
   private logout(): void {
-    this.keycloakAuthService.logout();
+    if (KeycloakAuthService.sso) {
+      this.keycloakAuthService.logout();
+    } else {
+      // assume that Che deployed with `nativeUserMode` enabled
+      window.location.href = '/oauth/sign_out';
+    }
   }
 
   private toggleNav(): void {

--- a/packages/dashboard-frontend/src/services/keycloak/setup.ts
+++ b/packages/dashboard-frontend/src/services/keycloak/setup.ts
@@ -140,7 +140,7 @@ export class KeycloakSetupService {
 
       const errorMessage = 'Cannot get Keycloak settings' + (
         e.response?.status === undefined
-          ? '.'
+          ? '. Response is not available, please check console for details.'
           : `: ${e.response?.status} ${e.response?.statusText}`
       );
       throw new Error(errorMessage);

--- a/packages/dashboard-frontend/src/services/keycloak/setup.ts
+++ b/packages/dashboard-frontend/src/services/keycloak/setup.ts
@@ -134,11 +134,16 @@ export class KeycloakSetupService {
 
       return settings;
     } catch (e) {
-      if (e.response.status === 404) {
+      if (e.response?.status === 404) {
         return;
       }
 
-      throw new Error(`Can't get Keycloak settings: ${e.response.status} ${e.response.statusText}`);
+      const errorMessage = 'Cannot get Keycloak settings' + (
+        e.response?.status === undefined
+          ? '.'
+          : `: ${e.response?.status} ${e.response?.statusText}`
+      );
+      throw new Error(errorMessage);
     }
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR provides users the ability to logout from Che Dashboard if Che is deployed with nativeUserMode.


https://user-images.githubusercontent.com/16220722/128518582-c7de09b3-3a89-4cb1-8917-f77d8f209729.mov



### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/20071
