### PR TITLE
fix(scm): Always get raw content from scm resolver

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devWorkspaceClient.ts
@@ -159,15 +159,20 @@ export class DevWorkspaceClient extends WorkspaceClient {
     }
     console.debug('Loading devfile', devfile, 'with optional .che/che-theia-plugins.yaml', cheTheiaPluginsContent, 'and .vscode/extensions.json', vscodeExtensionsJsonContent, 'with sidecar policy', sidecarPolicy);
     // call library to update devWorkspace and add optional templates
-    await cheTheiaPluginsDevfileResolver.handle({
-      devfile,
-      cheTheiaPluginsContent,
-      vscodeExtensionsJsonContent,
-      devWorkspace,
-      devWorkspaceTemplates,
-      sidecarPolicy,
-      suffix: workspaceId,
-    });
+    try {
+      await cheTheiaPluginsDevfileResolver.handle({
+        devfile,
+        cheTheiaPluginsContent,
+        vscodeExtensionsJsonContent,
+        devWorkspace,
+        devWorkspaceTemplates,
+        sidecarPolicy,
+        suffix: workspaceId,
+      });
+    } catch (error) {
+      console.error(error);
+      throw new Error(`Unable to update the devWorkspace with the devfile resolver: ${error.message}`);
+    }
     console.debug('Devfile updated to', devfile, ' and templates updated to', devWorkspaceTemplates);
 
     await Promise.all(devWorkspaceTemplates.map(async template => {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -93,7 +93,9 @@ export async function grabLink(links: api.che.core.rest.Link, filename: string):
   // remove first part of the link until /api (to avoid the full links and use only relative links)
   const href = foundLink.href.substring(foundLink.href.indexOf('/api/scm'));
   try {
-    const response = await axios.get<string>(href, { responseType: 'text' });
+    // load it in raw format
+    // see https://github.com/axios/axios/issues/907
+    const response = await axios.get<string>(href, { responseType: 'text', transformResponse: [(data) => { return data; }] });
     return response.data;
   } catch (error) {
     // content may not be there


### PR DESCRIPTION
### What does this PR do?
Axios is returning a JSON object even if we specify a raw content
https://github.com/axios/axios/issues/907
Need to workaround with a custom transformResponse

Also, provide a better error message to isolate the root cause

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20271

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
