### PR TITLE
Prevent browser to cache index.html and product.json

### DIFF
--- a/packages/static-server/src/index.ts
+++ b/packages/static-server/src/index.ts
@@ -63,7 +63,7 @@ server.addHook('onSend', (request, reply, payload: any, done) => {
     reply.header('cache-control', 'no-store, max-age=0');
   }
   done(err, payload);
-})
+});
 
 server.listen(port, hostname, (err, address) => {
   if (err) throw err;

--- a/packages/static-server/src/index.ts
+++ b/packages/static-server/src/index.ts
@@ -42,11 +42,29 @@ server.register(fastifyStatic, {
   lastModified: true,
   prefix: '/dashboard/',
 });
+
 server.get('/', async (request, reply) => {
   reply.code(204);
   return reply.send();
 });
 
+server.get('/dashboard', async (request, reply) => {
+  return reply.redirect('/dashboard/');
+});
+
+const doNotCache = [
+  '/dashboard/',
+  '/dashboard/index.html',
+  '/dashboard/assets/branding/product.json',
+];
+server.addHook('onSend', (request, reply, payload: any, done) => {
+  const err = null;
+  if (doNotCache.includes(request.url)) {
+    reply.header('cache-control', 'no-store, max-age=0');
+  }
+  done(err, payload);
+})
+
 server.listen(port, hostname, (err, address) => {
   if (err) throw err;
-})
+});


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds a hook for the static server that updates the `cache-control` header for resources that should not be cached by browsers.
Additionally, added redirection from `/dashboard` to `/dashboard/`.


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/20266
