### PR TITLE
fix: fix devworkspace happy path by using up to date sample

### DIFF
--- a/.ci/oci-dashboard-happy-path.sh
+++ b/.ci/oci-dashboard-happy-path.sh
@@ -42,7 +42,8 @@ export HAPPY_PATH_POD_NAME=happy-path-che
 # Pod created by openshift ci don't have user. Using this envs should avoid errors with git user.
 export GIT_COMMITTER_NAME="CI BOT"
 export GIT_COMMITTER_EMAIL="ci_bot@notused.com"
-export HAPPY_PATH_DEVFILE='https://gist.githubusercontent.com/l0rd/71a04dd0d8c8e921b16ba2690f7d5a47/raw/d520086e148c359b18c229328824dfefcf85e5ef/spring-petclinic-devfile-v2.0.0.yaml'
+export HAPPY_PATH_TEST_PROJECT='https://github.com/che-samples/java-spring-petclinic/tree/devfilev2'
+
 deployChe() {
   cat > /tmp/che-cr-patch.yaml <<EOL
 spec:
@@ -63,7 +64,7 @@ EOL
 startHappyPathTest() {
   # patch happy-path-che.yaml
   ECLIPSE_CHE_URL=http://$(oc get route -n "${NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
-  TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_DEVFILE}"
+  TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_TEST_PROJECT}"
   HAPPY_PATH_POD_FILE=${SCRIPT_DIR}/resources/pod-che-happy-path.yaml
   sed -i "s@CHE_URL@${ECLIPSE_CHE_URL}@g" ${HAPPY_PATH_POD_FILE}
   sed -i "s@WORKSPACE_ROUTE@${TS_SELENIUM_DEVWORKSPACE_URL}@g" ${HAPPY_PATH_POD_FILE}


### PR DESCRIPTION
### What does this PR do?
fix: fix devworkspace happy path by using up to date sample.
l0rd's sample is updated https://github.com/l0rd/spring-petclinic/pull/3 
but we depend on commit which is outdated. So, now we rely on the latest version of Che sample

### What issues does this PR fix or reference?
No issues was created.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
