### PR TITLE
Use up to date e2e test image

### DIFF
--- a/.ci/resources/pod-che-happy-path.yaml
+++ b/.ci/resources/pod-che-happy-path.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
     # container containing the tests
     - name: happy-path-test
-      image: quay.io/eclipse/che-e2e:nightly
+      image: quay.io/eclipse/che-e2e:next
       imagePullPolicy: Always
       env:
         - name: TEST_SUITE


### PR DESCRIPTION
### What does this PR do?
Use up-to-date e2e test image.
It's the same fix done as Maxim did for DWO side: https://github.com/devfile/devworkspace-operator/pull/574

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/20389

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
