### PR TITLE
Fix getter for error messages

### DIFF
--- a/packages/common/src/helpers/__tests__/errors.spec.ts
+++ b/packages/common/src/helpers/__tests__/errors.spec.ts
@@ -28,15 +28,19 @@ describe('Errors helper', () => {
     mockAxios.resetHandlers();
   });
 
-  it('should return default message', () => {
-    expect(getMessage(undefined)).toEqual('Unexpected error.');
+  describe('Typeguards', () => {
+
+    it('should check if error', () => {
+      const message = 'Expected error.';
+      const error = new Error(message);
+      expect(isError(error)).toEqual(true);
+      expect(isError(message)).toEqual(false);
+    });
+
   });
 
-  it('should check if it is an error or not', () => {
-    const message = 'Expected error.';
-    const error = new Error(message);
-    expect(isError(error)).toEqual(true);
-    expect(isError(message)).toEqual(false);
+  it('should return default message', () => {
+    expect(getMessage(undefined)).toEqual('Unexpected error.');
   });
 
   it('should return message', () => {

--- a/packages/common/src/helpers/__tests__/errors.spec.ts
+++ b/packages/common/src/helpers/__tests__/errors.spec.ts
@@ -14,7 +14,7 @@ import axios, { AxiosError, AxiosResponse } from 'axios';
 import { HttpError } from '@kubernetes/client-node';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import * as http from 'http';
-import { getMessage } from '../errors';
+import { getMessage, isError } from '../errors';
 
 let mockAxios = new AxiosMockAdapter(axios);
 
@@ -30,6 +30,18 @@ describe('Errors helper', () => {
 
   it('should return default message', () => {
     expect(getMessage(undefined)).toEqual('Unexpected error.');
+  });
+
+  it('should check if it is an error or not', () => {
+    const message = 'Expected error.';
+    const error = new Error(message);
+    expect(isError(error)).toEqual(true);
+    expect(isError(message)).toEqual(false);
+  });
+
+  it('should return message', () => {
+    const message = 'Expected error message.';
+    expect(getMessage(message)).toEqual(message);
   });
 
   it('should return error message', () => {

--- a/packages/common/src/helpers/errors.ts
+++ b/packages/common/src/helpers/errors.ts
@@ -54,6 +54,10 @@ export function getMessage(error: unknown): string {
     return error.message;
   }
 
+  if (typeof (error) === 'string') {
+    return error;
+  }
+
   console.error('Unexpected error:', error);
   return 'Unexpected error. Check DevTools console and network tabs for more information.'
 }

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -268,12 +268,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
         this.resolvePrivateDevfile(e.attributes.oauth_authentication_url, location);
         return;
       }
-
-      let alertMessage = 'Failed to resolve a devfile.';
-      if (common.helpers.errors.isError(e)) {
-        alertMessage += ' ' + common.helpers.errors.getMessage(e);
-      }
-      this.showAlert(alertMessage);
+      this.showAlert(`Failed to resolve a devfile. ${common.helpers.errors.getMessage(e)}`);
       return;
     }
     if (this.factoryResolver.resolver?.location !== location) {


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix getter for error messages.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/20365

![Знімок екрана 2021-09-09 о 11 42 39](https://user-images.githubusercontent.com/6310786/132657303-0ef2d191-aea4-4728-b6da-a61bbccff6ea.png)
