### PR TITLE
Add an ability to run local dashboard against Che behind OpenShift OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ As an alternative for frontend you can run Dev Server
 cd packages/dashboard-frontend && yarn start --env.server=http://localhost:8080/
 ```
 
-Note: For Che/CRW to allow connection from localhost it should be configured in accordance:
+Depending on your Che Cluster's routing, it may need additional configuration. See below:
 
 ### Keycloak
-
+Note: For Che/CRW to allow connection from localhost it should be configured in accordance:
 ```bash
 # Note: eclipse-che is the default target namespace but if you have custom - change it below
 CHE_NAMESPACE="eclipse-che"
@@ -89,7 +89,8 @@ kubectl rollout restart deployment/che-operator -n $CHE_NAMESPACE
 
 ### Native Auth
 
-Not supported yet.
+With Native Auth, routes are secured with OpenShift OAuth which we can't deal with easily.
+So, instead when you do `./local-start.sh` we by pass OpenShift OAuth proxy while requesting Che Server by doing `kubectl port-forward`. So, no additional configuration is needed but note that your Dashboard will be authentication with the user from the current KUBECONFIG.
 
 ### Dependencies IP
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "lerna run build --scope=@eclipse-che/dashboard-*",
     "prebuild": "lerna run build --scope=@eclipse-che/common",
     "frontend:start": "yarn workspace @eclipse-che/dashboard-frontend start $@",
-    "start": "${PWD}/local-start.sh",
+    "start": "${PWD}/local-start.sh $@",
     "license:check": "docker run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses:next --check",
     "license:generate": "docker run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses:next",
     "test": "lerna run test --stream -- $@",

--- a/packages/dashboard-backend/src/local-run/che-server.ts
+++ b/packages/dashboard-backend/src/local-run/che-server.ts
@@ -9,10 +9,14 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
+
 import { FastifyInstance, FastifyRequest, RouteShorthandOptions } from 'fastify';
 import fastifyHttpProxy from 'fastify-http-proxy';
 
-export function registerCheApiProxy(server: FastifyInstance, cheApiProxyUpstream: string, origin: string) {
+export function registerCheApiProxy(server: FastifyInstance,
+                                    cheApiProxyUpstream: string,
+                                    origin: string,
+                                    clusterAccessToken?: string) {
   console.log(`Dashboard proxies requests to Che Server API on ${cheApiProxyUpstream}/api.`);
   // server api
   server.register(fastifyHttpProxy, {
@@ -23,6 +27,10 @@ export function registerCheApiProxy(server: FastifyInstance, cheApiProxyUpstream
     websocket: false,
     replyOptions: {
       rewriteRequestHeaders: (originalReq, headers) => {
+        if (clusterAccessToken) {
+          headers.authorization = 'Bearer ' + clusterAccessToken;
+        }
+
         return Object.assign({...headers}, { origin });
       }
     }

--- a/packages/dashboard-backend/src/local-run/dashboard.ts
+++ b/packages/dashboard-backend/src/local-run/dashboard.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance } from 'fastify';
+
+export function authenticateDashboardRequestsHook(server: FastifyInstance, clusterAccessToken: string) {
+  // authenticate requests to Dashboard Backend
+  server.addHook('onRequest', (request, reply, done) => {
+    if (request.url.startsWith('/dashboard/api')) {
+      request.headers.authorization = 'Bearer ' + clusterAccessToken;
+    }
+    done();
+  });
+}

--- a/packages/dashboard-backend/src/services/kubeclient/keycloak.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/keycloak.ts
@@ -14,7 +14,7 @@ import { getMessage } from '@eclipse-che/common/lib/helpers/errors';
 import { createFastifyError } from '../helpers';
 import { URL } from 'url';
 import { CheAxiosFactory } from '../che-http/CheAxiosFactory';
-import { isLocalRun } from "../../local-run";
+import { isLocalRun } from '../../local-run';
 
 const CHE_HOST = process.env.CHE_INTERNAL_URL || process.env.CHE_HOST;
 const ENDPOINT = 'che.keycloak.userinfo.endpoint';

--- a/packages/dashboard-frontend/webpack.config.dev-server.js
+++ b/packages/dashboard-frontend/webpack.config.dev-server.js
@@ -27,7 +27,7 @@ module.exports = (env = {}) => {
     headers['Authorization'] = `Bearer ${env.token}`;
   }
 
-  const dashboardServer = env.dashboardServer ? env.dashboardServer : 'http://localhost:8080';
+  const dashboardServer = env.dashboardServer ? env.dashboardServer : proxyTarget;
 
   return merge(devConfig(env), {
     devServer: {


### PR DESCRIPTION
### What does this PR do?
Add an ability to run local dashboard against Che behind OpenShift OAuth.
It's achieved by using port-forward and using token from the current kubeconfig.


Possible alternative - run locally docker container with OpenShift OAuth and configure it with OAuth client from the cluster. It also requires modifying OAuthClient CR. It does not see easier, so post poning for time we'll see need for that.

<details>
<summary>Details</summary>

```yaml
    - resources: {}
      terminationMessagePath: /dev/termination-log
      name: oauth-proxy
      securityContext:
        capabilities:
          drop:
            - KILL
            - MKNOD
            - SETGID
            - SETUID
        runAsUser: 1000630000
      ports:
        - containerPort: 8080
          protocol: TCP
      imagePullPolicy: Always
      volumeMounts:
        - name: oauth-proxy-config
          mountPath: /etc/oauth-proxy
        - name: kube-api-access-sp8cg
          readOnly: true
          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      terminationMessagePolicy: File
      image: 'quay.io/openshift/origin-oauth-proxy:4.7'
      args:
        - '--config=/etc/oauth-proxy/oauth-proxy.cfg'
```

```

http_address = ":8080"
https_address = ""
provider = "openshift"
redirect_url = "https://che-eclipse-che.apps.cluster-d8b3.d8b3.sandbox312.opentlc.com/oauth/callback"
upstreams = [
  "http://127.0.0.1:8081/"
]
client_id = "eclipse-che-openshift-identity-provider-3dkdqx"
client_secret = "XXXX"
scope = "user:full"
openshift_service_account = "che-gateway"
cookie_secret = "WlBXXXXXNIMGlMTGtPUg=="
cookie_expire = "24h0m0s"
email_domains = "*"
cookie_httponly = false
pass_access_token = true
skip_provider_button = true
```

</details>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20272

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
