### PR TITLE
Suggest devfile v2 template when enabling DevWorkspaces

### DIFF
--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/DevfileSelector/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/DevfileSelector/index.tsx
@@ -37,11 +37,12 @@ import { updateDevfileMetadata } from '../../updateDevfileMetadata';
 import { selectWorkspacesSettings } from '../../../../store/Workspaces/Settings/selectors';
 
 import styles from './index.module.css';
+import { Devfile } from 'dashboard-frontend/src/services/workspace-adapter';
 
 type Props =
   MappedProps
   & {
-    onDevfile: (devfile: che.WorkspaceDevfile) => void;
+    onDevfile: (devfile: Devfile) => void;
     onClear?: () => void;
   };
 type State = {
@@ -110,7 +111,7 @@ export class DevfileSelectorFormGroup extends React.PureComponent<Props, State> 
       if (resolver.source === 'repo') {
         throw new Error('devfile.yaml not found in the specified GitHub repository root.');
       }
-      this.props.onDevfile(resolver.devfile as che.WorkspaceDevfile);
+      this.props.onDevfile(resolver.devfile as Devfile);
       this.setState({ isLoading: false });
     } catch (e) {
       this.setState({ isLoading: false });

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/StorageType/index.module.css
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/StorageType/index.module.css
@@ -15,6 +15,10 @@
   margin-right: 10px;
 }
 
+.storageTypeSelector button[disabled] svg {
+  display: none;
+}
+
 .experimentalStorageType {
   color: #f37943;
   font-size: 0.8em;

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/StorageType/index.module.css
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/StorageType/index.module.css
@@ -15,10 +15,6 @@
   margin-right: 10px;
 }
 
-.storageTypeSelector button[disabled] svg {
-  display: none;
-}
-
 .experimentalStorageType {
   color: #f37943;
   font-size: 0.8em;

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/StorageType/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/StorageType/index.tsx
@@ -36,6 +36,7 @@ type Props =
   & {
     storageType?: che.WorkspaceStorageType;
     onChange?: (storageType: che.WorkspaceStorageType) => void;
+    isDisable?: boolean;
   };
 type State = {
   isOpen: boolean;
@@ -131,6 +132,7 @@ export class StorageTypeFormGroup extends React.PureComponent<Props, State> {
 
   public render(): React.ReactNode {
     const { isOpen, selected, isModalOpen } = this.state;
+    const { isDisable } = this.props;
 
     return (
       <FormGroup
@@ -148,6 +150,7 @@ export class StorageTypeFormGroup extends React.PureComponent<Props, State> {
           onSelect={(event, selection) => this.handleSelect(selection as string)}
           selections={selected}
           isOpen={isOpen}
+          isDisabled={isDisable}
         >
           {this.options.map((option: string) => (
             <SelectOption

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/__tests__/index.spec.tsx
@@ -120,6 +120,20 @@ describe('Custom Workspace Tab', () => {
     screen.getByRole('button', { name: /create & open/i });
   });
 
+  it('should use default template with schema version "2.1.0" if devworkspaces is enabled', () => {
+    const store = createStore({
+      isDevworkspacesEnabled: true,
+    });
+    const mockOnDevfile = jest.fn();
+    renderComponent(store, mockOnDevfile);
+
+    clickOnCreateAndOpenButton();
+
+    expect(mockOnDevfile).toHaveBeenCalledWith(expect.objectContaining({
+      schemaVersion: '2.1.0'
+    }), defaultInfrastructureNamespace, undefined);
+  });
+
   it('should handle click on "Create & Open" button', () => {
     const defaultStorageType = 'persistent';
     const store = createStore({
@@ -348,7 +362,8 @@ function clickOnCreateAndOpenButton() {
 }
 
 function createStore(opts: {
-  defaultStorageType?: che.WorkspaceStorageType
+  defaultStorageType?: che.WorkspaceStorageType,
+  isDevworkspacesEnabled?: boolean
 } = {}): Store {
   return new FakeStoreBuilder()
     .withDevfileRegistries({
@@ -371,7 +386,8 @@ function createStore(opts: {
     } as any)
     .withWorkspacesSettings({
       'che.workspace.storage.available_types': 'async,ephemeral,persistent',
-      'che.workspace.storage.preferred_type': opts.defaultStorageType ? opts.defaultStorageType : 'ephemeral'
+      'che.workspace.storage.preferred_type': opts.defaultStorageType ? opts.defaultStorageType : 'ephemeral',
+      'che.devworkspaces.enabled': opts.isDevworkspacesEnabled ? 'true' : 'false'
     } as che.WorkspaceSettings)
     .build();
 }

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/__tests__/index.spec.tsx
@@ -24,6 +24,7 @@ import { toTitle } from '../../../../services/storageTypes';
 
 import CustomWorkspaceTab from '..';
 import { FactoryResolver } from '../../../../services/helpers/types';
+import { Devfile } from '../../../../services/workspace-adapter';
 
 jest.mock('../../../../components/DevfileEditor', () => {
   return forwardRef(function DummyEditor(...args: any[]): React.ReactElement {
@@ -55,7 +56,7 @@ const dummyDevfile = {
   metadata: {
     name: 'Java Maven',
   },
-} as che.WorkspaceDevfile;
+} as Devfile;
 jest.mock('../../../../store/DevfileRegistries', () => {
   return {
     actionCreators: {
@@ -85,12 +86,12 @@ jest.mock('../../../../store/FactoryResolver/index.ts', () => {
 describe('Custom Workspace Tab', () => {
 
   const defaultInfrastructureNamespace = undefined;
-  const initialDevfile: che.WorkspaceDevfile = {
+  const initialDevfile: Devfile = {
     apiVersion: '1.0.0',
     metadata: {
       generateName: 'wksp-'
     }
-  } as che.WorkspaceDevfile;
+  } as Devfile;
 
   function renderComponent(store: Store, onDevfile: jest.Mock): RenderResult {
     return render(
@@ -139,7 +140,7 @@ describe('Custom Workspace Tab', () => {
       const store = createStore({
         defaultStorageType
       });
-      const mockOnDevfile = jest.fn((devfile: che.WorkspaceDevfile, namespace: che.KubernetesNamespace) => {
+      const mockOnDevfile = jest.fn((devfile: Devfile, namespace: che.KubernetesNamespace) => {
         expect(namespace).toEqual(defaultInfrastructureNamespace);
         const expectedMeta = {
           name: 'new-workspace-name',
@@ -168,7 +169,7 @@ describe('Custom Workspace Tab', () => {
       const store = createStore({
         defaultStorageType
       });
-      const mockOnDevfile = jest.fn((devfile: che.WorkspaceDevfile, namespace: che.KubernetesNamespace) => {
+      const mockOnDevfile = jest.fn((devfile:  Devfile, namespace: che.KubernetesNamespace) => {
         expect(namespace).toEqual(defaultInfrastructureNamespace);
         const expectedAttributes: che.WorkspaceDevfileAttributes = {
           asyncPersist: 'true',
@@ -235,7 +236,7 @@ describe('Custom Workspace Tab', () => {
       const dummyCustomDevfile = {
         apiVersion: '1.0.0',
         metadata: { name: devfileName },
-      } as che.WorkspaceDevfile;
+      } as Devfile;
 
       const store = createStore();
       const mockOnDevfile = jest.fn();
@@ -361,7 +362,7 @@ function createStore(opts: {
       devfile: {
         apiVersion: '1.0.0',
         metadata: { name: 'Custom Devfile' },
-      } as che.WorkspaceDevfile,
+      } as Devfile,
     } as FactoryResolver)
     .withBranding({
       docs: {

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/index.tsx
@@ -23,6 +23,7 @@ import { selectPreferredStorageType, selectWorkspacesSettings } from '../../../s
 import { attributesToType, updateDevfile } from '../../../services/storageTypes';
 import { safeLoad } from 'js-yaml';
 import { updateDevfileMetadata } from '../updateDevfileMetadata';
+import { Devfile, isCheDevfile } from '../../../services/workspace-adapter';
 
 type Props = MappedProps
   & {
@@ -34,7 +35,7 @@ type Props = MappedProps
   };
 type State = {
   storageType: che.WorkspaceStorageType;
-  devfile: che.WorkspaceDevfile;
+  devfile: Devfile;
   namespace?: che.KubernetesNamespace;
   generateName?: string;
   workspaceName: string;
@@ -49,21 +50,20 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
     super(props);
 
     const devfile = this.buildInitialDevfile();
-    const storageType = attributesToType(devfile.attributes);
-    const workspaceName = devfile.metadata.name ? devfile.metadata.name : '';
-    const generateName = !workspaceName ? devfile.metadata.generateName : '';
+    const storageType = isCheDevfile(devfile) ? attributesToType(devfile.attributes) : 'persistent';
+    const workspaceName = devfile.metadata.name ? devfile.metadata.name || '' : '';
+    const generateName = isCheDevfile(devfile) && !workspaceName ? devfile.metadata.generateName : '';
     this.state = { devfile, storageType, generateName, workspaceName, isCreated: false };
     this.devfileEditorRef = React.createRef<Editor>();
   }
 
-  private buildInitialDevfile(generateName?: string): che.WorkspaceDevfile {
+  private buildInitialDevfile(generateName?: string): Devfile {
     const devfile = {
       apiVersion: '1.0.0',
       metadata: {
         generateName: generateName ? generateName : 'wksp-'
       },
-    } as che.WorkspaceDevfile;
-
+    } as Devfile;
     return updateDevfile(devfile, this.props.preferredStorageType);
   }
 
@@ -71,14 +71,16 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
     this.setState({ namespace });
   }
 
-  private handleWorkspaceNameChange(workspaceName: string, workspaceDevfile?: che.WorkspaceDevfile): void {
+  private handleWorkspaceNameChange(workspaceName: string, workspaceDevfile?: Devfile): void {
     const devfile = workspaceDevfile ? workspaceDevfile : this.state.devfile;
     if (!devfile) {
       return;
     }
     if (workspaceName) {
       devfile.metadata.name = workspaceName;
-      delete devfile.metadata.generateName;
+      if (isCheDevfile(devfile)) {
+        delete devfile.metadata.generateName;
+      }
       const generateName = '';
       this.setState({ workspaceName, generateName });
     }
@@ -86,7 +88,7 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
     this.updateEditor(devfile);
   }
 
-  private handleStorageChange(storageType: che.WorkspaceStorageType, workspaceDevfile?: che.WorkspaceDevfile): void {
+  private handleStorageChange(storageType: che.WorkspaceStorageType, workspaceDevfile?: Devfile): void {
     const devfile = workspaceDevfile ? workspaceDevfile : this.state.devfile;
     if (!devfile) {
       return;
@@ -101,11 +103,12 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
     this.updateEditor(newDevfile);
   }
 
-  private handleNewDevfile(devfileContent?: che.WorkspaceDevfile): void {
-    let devfile: che.WorkspaceDevfile;
+  private handleNewDevfile(devfileContent?: Devfile): void {
+    let devfile: Devfile;
     if (!devfileContent) {
       devfile = this.buildInitialDevfile();
     } else if (
+      isCheDevfile(devfileContent) &&
       devfileContent?.attributes?.persistVolumes === undefined &&
       devfileContent?.attributes?.asyncPersist === undefined &&
       this.props.preferredStorageType
@@ -133,16 +136,16 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
     if (!isValid) {
       return;
     }
-    let devfile: che.WorkspaceDevfile;
+    let devfile: Devfile;
     try {
-      devfile = safeLoad(newValue) as che.WorkspaceDevfile;
+      devfile = safeLoad(newValue) as Devfile;
     } catch (e) {
       console.error('Devfile parse error', e);
       return;
     }
     devfile = updateDevfileMetadata(devfile);
     this.setState({ devfile, isCreated: false });
-    if (devfile?.attributes) {
+    if (devfile?.attributes && isCheDevfile(devfile)) {
       const storageType = attributesToType(devfile.attributes);
       if (storageType !== this.state.storageType) {
         this.setState({ storageType });
@@ -152,13 +155,13 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
     if (workspaceName !== this.state.workspaceName) {
       this.setState({ workspaceName });
     }
-    const generateName = devfile?.metadata?.generateName;
+    const generateName = isCheDevfile(devfile) ? devfile?.metadata?.generateName : '';
     if (generateName !== this.state.generateName) {
       this.setState({ generateName });
     }
   }
 
-  private updateEditor(devfile: che.WorkspaceDevfile): void {
+  private updateEditor(devfile: Devfile): void {
     this.devfileEditorRef.current?.updateContent(devfile);
     this.setState({ isCreated: false });
   }

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/GetStartedTab.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/GetStartedTab.spec.tsx
@@ -18,6 +18,7 @@ import { SamplesListTab } from '..';
 import { selectIsLoading } from '../../../../store/Workspaces/selectors';
 import { selectPreferredStorageType, selectWorkspacesSettings } from '../../../../store/Workspaces/Settings/selectors';
 import { BrandingData } from '../../../../services/bootstrap/branding.constant';
+import { Devfile } from '../../../../services/workspace-adapter';
 
 const onDevfileMock: (devfileContent: string, stackName: string, optionalFilesContent?: { [fileName: string]: string }) => Promise<void> = jest.fn().mockResolvedValue(true);
 
@@ -26,7 +27,7 @@ const testDevfileName = 'Custom Devfile';
 const testDevfile = {
   apiVersion: '1.0.0',
   metadata: { name: testDevfileName },
-} as che.WorkspaceDevfile;
+} as Devfile;
 
 jest.mock(
   '../SamplesListGallery',

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
@@ -25,6 +25,7 @@ import { updateDevfile } from '../../../services/storageTypes';
 import stringify from '../../../services/helpers/editor';
 import ImportFromGit from './ImportFromGit';
 import { ResolverState } from '../../../store/FactoryResolver';
+import { Devfile } from '../../../services/workspace-adapter';
 
 // At runtime, Redux will merge together...
 type Props = {
@@ -80,7 +81,7 @@ export class SamplesListTab extends React.PureComponent<Props, State> {
   }
 
   private handleDevfileResolver(resolverState: ResolverState, stackName: string): Promise<void> {
-    const devfile: che.WorkspaceDevfile = resolverState.devfile;
+    const devfile: Devfile = resolverState.devfile;
     const updatedDevfile = updateDevfile(devfile, this.props.preferredStorageType);
     const devfileContent = stringify(updatedDevfile);
 

--- a/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import GetStarted from '..';
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { BrandingData } from '../../../services/bootstrap/branding.constant';
-import { convertWorkspace, Workspace } from '../../../services/workspace-adapter';
+import { convertWorkspace, Devfile, Workspace } from '../../../services/workspace-adapter';
 
 const createWorkspaceFromDevfileMock = jest.fn().mockResolvedValue(undefined);
 const startWorkspaceMock = jest.fn().mockResolvedValue(undefined);
@@ -28,7 +28,7 @@ const dummyDevfile = {
   metadata: {
     generateName: 'wksp-'
   },
-} as che.WorkspaceDevfile;
+} as Devfile;
 
 jest.mock('../../../store/Workspaces/index', () => {
   return {
@@ -36,7 +36,7 @@ jest.mock('../../../store/Workspaces/index', () => {
       createWorkspaceFromDevfile: (devfile, namespace, infrastructureNamespace, attributes) =>
         async (): Promise<Workspace> => {
           createWorkspaceFromDevfileMock(devfile, namespace, infrastructureNamespace, attributes);
-          return convertWorkspace({ id: 'id-wksp-test', attributes, namespace, devfile: dummyDevfile, temporary: false, status: 'STOPPED' });
+          return convertWorkspace({ id: 'id-wksp-test', attributes, namespace, devfile: dummyDevfile as che.WorkspaceDevfile, temporary: false, status: 'STOPPED' });
         },
       startWorkspace: workspace => async (): Promise<void> => {
         startWorkspaceMock(workspace);

--- a/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
@@ -139,7 +139,7 @@ export class GetStarted extends React.PureComponent<Props, State> {
     }
 
     if (!workspace) {
-      const errorMessage =  `Workspace "${namespace}/${devfile.metadata.name}" failed to find.`;
+      const errorMessage =  `Workspace "${namespace}/${devfile.metadata.name}" not found.`;
       this.showAlert({
         key: 'find-workspace-failed',
         variant: AlertVariant.danger,

--- a/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
@@ -34,7 +34,10 @@ import { ROUTE } from '../../route.enum';
 import { Workspace } from '../../services/workspace-adapter';
 import { selectBranding } from '../../store/Branding/selectors';
 import { selectRegistriesErrors } from '../../store/DevfileRegistries/selectors';
-import { Devfile } from '../../services/workspace-adapter';
+import { Devfile, isCheDevfile } from '../../services/workspace-adapter';
+import { selectWorkspaceByQualifiedName } from '../../store/Workspaces/selectors';
+import { selectDefaultNamespace, selectInfrastructureNamespaces } from '../../store/InfrastructureNamespaces/selectors';
+import getRandomString from '../../services/helpers/random';
 
 const SamplesListTab = React.lazy(() => import('./GetStartedTab'));
 const CustomWorkspaceTab = React.lazy(() => import('./CustomWorkspaceTab'));
@@ -114,9 +117,17 @@ export class GetStarted extends React.PureComponent<Props, State> {
     }
   ): Promise<void> {
     const attr = stackName ? { stackName } : {};
-    let workspace: Workspace;
+    if (isCheDevfile(devfile) && !devfile.metadata.name && devfile.metadata.generateName) {
+       const name = devfile.metadata.generateName + getRandomString(4).toLowerCase();
+       delete devfile.metadata.generateName;
+       devfile.metadata.name = name;
+    }
+    const namespace = infrastructureNamespace ? infrastructureNamespace : this.props.defaultNamespace.name;
+    let workspace: Workspace | undefined;
     try {
-      workspace = await this.props.createWorkspaceFromDevfile(devfile, undefined, infrastructureNamespace, attr, optionalFilesContent);
+      await this.props.createWorkspaceFromDevfile(devfile, undefined, namespace, attr, optionalFilesContent);
+      this.props.setWorkspaceQualifiedName(namespace, devfile.metadata.name as string);
+      workspace = this.props.activeWorkspace;
     } catch (e) {
       const errorMessage = common.helpers.errors.getMessage(e);
       this.showAlert({
@@ -125,6 +136,16 @@ export class GetStarted extends React.PureComponent<Props, State> {
         title: errorMessage,
       });
       throw e;
+    }
+
+    if (!workspace) {
+      const errorMessage =  `Workspace "${namespace}/${devfile.metadata.name}" failed to find.`;
+      this.showAlert({
+        key: 'find-workspace-failed',
+        variant: AlertVariant.danger,
+        title: errorMessage,
+      });
+      throw errorMessage;
     }
 
     const workspaceName = workspace.name;
@@ -237,6 +258,8 @@ export class GetStarted extends React.PureComponent<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   branding: selectBranding(state),
   registriesErrors: selectRegistriesErrors(state),
+  activeWorkspace: selectWorkspaceByQualifiedName(state),
+  defaultNamespace: selectDefaultNamespace(state),
 });
 
 const connector = connect(

--- a/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
@@ -34,6 +34,7 @@ import { ROUTE } from '../../route.enum';
 import { Workspace } from '../../services/workspace-adapter';
 import { selectBranding } from '../../store/Branding/selectors';
 import { selectRegistriesErrors } from '../../store/DevfileRegistries/selectors';
+import { Devfile } from '../../services/workspace-adapter';
 
 const SamplesListTab = React.lazy(() => import('./GetStartedTab'));
 const CustomWorkspaceTab = React.lazy(() => import('./CustomWorkspaceTab'));
@@ -105,7 +106,7 @@ export class GetStarted extends React.PureComponent<Props, State> {
   }
 
   private async createWorkspace(
-    devfile: api.che.workspace.devfile.Devfile,
+    devfile: Devfile,
     stackName: string | undefined,
     infrastructureNamespace: string | undefined,
     optionalFilesContent?: {
@@ -148,7 +149,7 @@ export class GetStarted extends React.PureComponent<Props, State> {
   }
 
   private handleDevfile(
-    devfile: api.che.workspace.devfile.Devfile,
+    devfile: Devfile,
     attrs: { stackName?: string, infrastructureNamespace?: string },
     optionalFilesContent: { [fileName: string]: string } | undefined,
   ): Promise<void> {

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/Actions.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/Actions.spec.tsx
@@ -36,6 +36,7 @@ jest.mock('../../../../../store/Workspaces/index', () => {
   };
 });
 
+const namespace = 'che';
 const workspaceName = 'test-workspace-name';
 const workspaceId = 'test-workspace-id';
 const workspaceStoppedStatus = WorkspaceStatus.STOPPED;
@@ -44,10 +45,11 @@ const store = new FakeStoreBuilder()
     workspaceId,
     workspaceName,
   })
+  .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
   .withCheWorkspaces({
     workspaces: [{
       id: workspaceId,
-      namespace: 'test',
+      namespace,
       status: WorkspaceStatus[workspaceStoppedStatus],
       devfile: {
         apiVersion: 'v1',
@@ -75,7 +77,7 @@ describe('Workspace WorkspaceAction widget', () => {
     const targetAction = screen.getByText(action);
     targetAction.click();
 
-    await waitFor(() => expect(history.location.pathname).toBe('/ide/test/test-workspace-name'));
+    await waitFor(() => expect(history.location.pathname).toBe(`/ide/${namespace}/test-workspace-name`));
   });
 
   it('should call the callback with OPEN_IN_VERBOSE_MODE action', async () => {
@@ -93,7 +95,7 @@ describe('Workspace WorkspaceAction widget', () => {
     const targetAction = screen.getByText(action);
     targetAction.click();
 
-    await waitFor(() => expect(history.location.pathname).toBe('/ide/test/test-workspace-name'));
+    await waitFor(() => expect(history.location.pathname).toBe(`/ide/${namespace}/test-workspace-name`));
   });
 
   it('should call the callback with START_IN_BACKGROUND action', () => {

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
@@ -40,7 +40,7 @@ export class OverviewTab extends React.Component<Props, State> {
     const { workspace } = this.props;
     const storageType = workspace.storageType;
     const workspaceName = workspace.name;
-    const infrastructureNamespace = workspace.infrastructureNamespace;
+    const infrastructureNamespace = workspace.namespace;
 
     this.state = {
       storageType,

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -13,4 +13,4 @@
 import { V1alpha2DevWorkspaceMetadata } from '@devfile/api';
 
 export type DevWorkspaceMetadata = V1alpha2DevWorkspaceMetadata
-  & Required<Pick<V1alpha2DevWorkspaceMetadata, 'annotations' | 'labels' | 'name' | 'namespace' | 'uid'>>;
+  & Required<Pick<V1alpha2DevWorkspaceMetadata, 'labels' | 'name' | 'namespace' | 'uid'>>;

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/index.ts
@@ -19,7 +19,7 @@ export type DevfileLike = V220Devfile
   };
 
 export type Devfile = DevfileLike
-  & Required<Pick<DevfileLike, 'metadata' | 'components'>>
+  & Required<Pick<DevfileLike, 'metadata'>>
   & {
     metadata?: DevfileMetadata;
   };

--- a/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
@@ -18,7 +18,6 @@ export function isDevfileV2Like(devfile: unknown): devfile is devfileApi.Devfile
 
 export function isDevfileV2(devfile: unknown): devfile is devfileApi.Devfile {
   return (devfile as devfileApi.Devfile).schemaVersion !== undefined
-    && (devfile as devfileApi.Devfile).components !== undefined
     && isDevfileV2Metadata((devfile as devfileApi.Devfile).metadata);
 }
 
@@ -46,7 +45,6 @@ export function isDevWorkspaceSpec(spec: unknown): spec is devfileApi.DevWorkspa
 
 export function isDevWorkspaceMetadata(metadata: unknown): metadata is devfileApi.DevWorkspaceMetadata {
   return metadata !== undefined
-    && (metadata as devfileApi.DevWorkspaceMetadata).annotations !== undefined
     && (metadata as devfileApi.DevWorkspaceMetadata).labels !== undefined
     && (metadata as devfileApi.DevWorkspaceMetadata).name !== undefined
     && (metadata as devfileApi.DevWorkspaceMetadata).namespace !== undefined

--- a/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import devfileApi from '../../devfileApi';
 import { cloneDeep } from 'lodash';
 import { convertWorkspace } from '..';
 import { CheWorkspaceBuilder, CHE_DEVFILE_STUB, CHE_RUNTIME_STUB } from '../../../store/__mocks__/cheWorkspaceBuilder';
@@ -70,7 +69,7 @@ describe('Workspace adapter', () => {
     });
 
     it('should return ID', () => {
-      const id = '1234asdf';
+      const id = 'workspace1234asdf';
       const cheWorkspace = new CheWorkspaceBuilder()
         .withId(id)
         .build();

--- a/packages/dashboard-frontend/src/services/workspace-adapter/helper.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/helper.ts
@@ -14,7 +14,17 @@ import { DevWorkspaceStatus } from '../helpers/types';
 import devfileApi from '../devfileApi';
 
 export function getId(workspace: devfileApi.DevWorkspace): string {
-  return workspace.metadata.uid;
+  if (workspace?.status?.devworkspaceId) {
+    return  workspace.status.devworkspaceId;
+  }
+
+  let workspaceId = 'workspace';
+
+  if (workspace.metadata.uid) {
+    workspaceId += workspace.metadata.uid.split('-').splice(0,3).join('');
+  }
+
+  return workspaceId;
 }
 
 export function getStatus(workspace: devfileApi.DevWorkspace): DevWorkspaceStatus {

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -21,6 +21,8 @@ import { getId, getStatus } from './helper';
 import devfileApi, { isDevfileV2, isDevWorkspace } from '../devfileApi';
 import { devWorkspaceKind } from '../devfileApi/devWorkspace';
 
+export type Devfile = che.WorkspaceDevfile | devfileApi.Devfile;
+
 export interface Workspace {
   readonly ref: che.Workspace | devfileApi.DevWorkspace;
 
@@ -32,7 +34,7 @@ export interface Workspace {
   readonly updated: number;
   status: WorkspaceStatus | DevWorkspaceStatus;
   readonly ideUrl?: string;
-  devfile: che.WorkspaceDevfile | devfileApi.Devfile;
+  devfile: Devfile;
   storageType: che.WorkspaceStorageType;
   readonly projects: string[];
   readonly isStarting: boolean;
@@ -283,6 +285,6 @@ export function isCheWorkspace(workspace: che.Workspace | devfileApi.DevWorkspac
     && (workspace as che.Workspace).status !== undefined;
 }
 
-export function isCheDevfile(devfile: che.WorkspaceDevfile | devfileApi.Devfile): devfile is che.WorkspaceDevfile {
+export function isCheDevfile(devfile: Devfile): devfile is che.WorkspaceDevfile {
   return !isDevfileV2(devfile);
 }

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -304,6 +304,9 @@ export class DevWorkspaceClient extends WorkspaceClient {
   async update(workspace: devfileApi.DevWorkspace, plugins: devfileApi.Devfile[]): Promise<devfileApi.DevWorkspace> {
     // Take the devworkspace with no plugins and then inject them
     for (const plugin of plugins) {
+      if (!plugin.metadata) {
+        continue;
+      }
       const pluginName = this.normalizePluginName(plugin.metadata.name, getId(workspace));
       this.addPlugin(workspace, pluginName, workspace.metadata.namespace);
     }

--- a/packages/dashboard-frontend/src/store/FactoryResolver/getDevfile.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/getDevfile.ts
@@ -28,6 +28,9 @@ export function getDevfile(data: FactoryResolver, location: string): api.che.wor
   let devfile = data.devfile;
 
   if (isDevfileV2(devfile)) {
+    if (!devfile.components) {
+      devfile.components = [];
+    }
     // temporary solution for fix che-server serialization bug with empty volume
     const components = devfile.components.map(component => {
       if (Object.keys(component).length === 1 && component.name) {

--- a/packages/dashboard-frontend/src/store/InfrastructureNamespaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/InfrastructureNamespaces/selectors.ts
@@ -15,6 +15,11 @@ import { AppState } from '..';
 
 const selectState = (state: AppState) => state.infrastructureNamespaces;
 
+export const selectDefaultNamespace = createSelector(
+  selectState,
+  state => state.namespaces.find(namespace => namespace.attributes.default === 'true') || state.namespaces[0],
+);
+
 export const selectInfrastructureNamespaces = createSelector(
   selectState,
   state => state.namespaces,

--- a/packages/dashboard-frontend/src/store/Workspaces/cheWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/cheWorkspaces/index.ts
@@ -108,7 +108,7 @@ export type ActionCreators = {
     namespace: string | undefined,
     infrastructureNamespace: string | undefined,
     attributes: { [key: string]: string } | {},
-  ) => AppThunk<KnownAction, Promise<che.Workspace>>;
+  ) => AppThunk<KnownAction, Promise<void>>;
   deleteWorkspaceLogs: (workspaceId: string) => AppThunk<DeleteWorkspaceLogsAction, void>;
 };
 
@@ -351,7 +351,7 @@ export const actionCreators: ActionCreators = {
     namespace: string | undefined,
     infrastructureNamespace: string | undefined,
     attributes: { [key: string]: string } = {},
-  ): AppThunk<KnownAction, Promise<che.Workspace>> => async (dispatch): Promise<che.Workspace> => {
+  ): AppThunk<KnownAction, Promise<void>> => async (dispatch): Promise<void> => {
     dispatch({ type: 'CHE_REQUEST_WORKSPACES' });
     try {
       const param = { attributes, namespace, infrastructureNamespace };
@@ -364,7 +364,6 @@ export const actionCreators: ActionCreators = {
         type: 'CHE_ADD_WORKSPACE',
         workspace,
       });
-      return workspace;
     } catch (e) {
       const errorMessage = 'Failed to create a new workspace from the devfile, reason: ' + common.helpers.errors.getMessage(e);
       dispatch({

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -125,7 +125,7 @@ export type ActionCreators = {
   },
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
-  ) => AppThunk<KnownAction, Promise<devfileApi.DevWorkspace>>;
+  ) => AppThunk<KnownAction, Promise<void>>;
 
   deleteWorkspaceLogs: (workspaceId: string) => AppThunk<DeleteWorkspaceLogsAction, void>;
 };
@@ -329,13 +329,12 @@ export const actionCreators: ActionCreators = {
   },
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
-  ): AppThunk<KnownAction, Promise<devfileApi.DevWorkspace>> => async (dispatch, getState): Promise<devfileApi.DevWorkspace> => {
+  ): AppThunk<KnownAction, Promise<void>> => async (dispatch, getState): Promise<void> => {
 
     const state = getState();
 
     if (state.dwPlugins.defaultEditorError) {
-      const message = `Required sources failed when trying to create the workspace: ${state.dwPlugins.defaultEditorError}`;
-      throw message;
+      throw `Required sources failed when trying to create the workspace: ${state.dwPlugins.defaultEditorError}`;
     }
 
     dispatch({ type: 'REQUEST_DEVWORKSPACE' });
@@ -350,7 +349,6 @@ export const actionCreators: ActionCreators = {
         type: 'ADD_DEVWORKSPACE',
         workspace,
       });
-      return workspace;
     } catch (e) {
       const errorMessage = 'Failed to create a new workspace from the devfile, reason: ' + common.helpers.errors.getMessage(e);
       dispatch({

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -116,7 +116,7 @@ export type ActionCreators = {
     optionalFilesContent?: {
       [fileName: string]: string
     }
-  ) => AppThunk<KnownAction, Promise<Workspace>>;
+  ) => AppThunk<KnownAction, Promise<void>>;
 
   setWorkspaceQualifiedName: (namespace: string, workspaceName: string) => AppThunk<SetWorkspaceQualifiedName>;
   clearWorkspaceQualifiedName: () => AppThunk<ClearWorkspaceQualifiedName>;
@@ -256,7 +256,7 @@ export const actionCreators: ActionCreators = {
     optionalFilesContent?: {
       [fileName: string]: string
     }
-  ): AppThunk<KnownAction, Promise<Workspace>> => async (dispatch, getState): Promise<Workspace> => {
+  ): AppThunk<KnownAction, Promise<void>> => async (dispatch, getState): Promise<void> => {
     dispatch({ type: 'REQUEST_WORKSPACES' });
     try {
       const state = getState();
@@ -265,15 +265,13 @@ export const actionCreators: ActionCreators = {
       if (cheDevworkspaceEnabled && isDevfileV2(devfile)) {
         const pluginRegistryUrl = state.workspacesSettings.settings['cheWorkspacePluginRegistryUrl'];
         const pluginRegistryInternalUrl = state.workspacesSettings.settings['cheWorkspacePluginRegistryInternalUrl'];
-        const devWorkspace = await dispatch(DevWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile, optionalFilesContent || {}, pluginRegistryUrl, pluginRegistryInternalUrl));
+        await dispatch(DevWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile, optionalFilesContent || {}, pluginRegistryUrl, pluginRegistryInternalUrl));
         dispatch({ type: 'ADD_WORKSPACE' });
-        return convertWorkspace(devWorkspace);
       } else {
-        const cheWorkspace = await dispatch(CheWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile as che.WorkspaceDevfile, namespace, infrastructureNamespace, attributes));
+        await dispatch(CheWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile as che.WorkspaceDevfile, namespace, infrastructureNamespace, attributes));
         dispatch({
           type: 'ADD_WORKSPACE',
         });
-        return convertWorkspace(cheWorkspace);
       }
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });

--- a/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
@@ -15,7 +15,6 @@ import { AppState } from '..';
 import { convertWorkspace, Workspace } from '../../services/workspace-adapter';
 import { selectCheWorkspacesError } from './cheWorkspaces/selectors';
 import { selectDevWorkspacesError } from './devWorkspaces/selectors';
-import { isDevfileV2Metadata } from '../../services/devfileApi';
 
 const selectState = (state: AppState) => state.workspaces;
 const selectCheWorkspacesState = (state: AppState) => state.cheWorkspaces;
@@ -40,9 +39,7 @@ export const selectAllWorkspaces = createSelector(
   (cheWorkspacesState, devWorkspacesState) => {
     return [
       ...cheWorkspacesState.workspaces,
-      // we were needed to add a filter because at first, we can get a new workspace object without metadata
-      // and then will get the update event with metadata.
-      ...(devWorkspacesState.workspaces.filter(workspace => isDevfileV2Metadata(workspace.metadata))),
+      ...devWorkspacesState.workspaces,
     ].map(workspace => convertWorkspace(workspace));
   }
 );
@@ -51,11 +48,8 @@ export const selectWorkspaceByQualifiedName = createSelector(
   selectState,
   selectAllWorkspaces,
   (state, allWorkspaces) => {
-    if (!allWorkspaces) {
-      return null;
-    }
     return allWorkspaces.find(workspace =>
-      workspace.namespace === state.namespace && workspace.name === state.workspaceName);
+      workspace.infrastructureNamespace === state.namespace && workspace.name === state.workspaceName);
   }
 );
 
@@ -63,9 +57,6 @@ export const selectWorkspaceById = createSelector(
   selectState,
   selectAllWorkspaces,
   (state, allWorkspaces) => {
-    if (!allWorkspaces) {
-      return null;
-    }
     return allWorkspaces.find(workspace => workspace.id === state.workspaceId);
   }
 );

--- a/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
@@ -15,6 +15,7 @@ import { AppState } from '..';
 import { convertWorkspace, Workspace } from '../../services/workspace-adapter';
 import { selectCheWorkspacesError } from './cheWorkspaces/selectors';
 import { selectDevWorkspacesError } from './devWorkspaces/selectors';
+import { isDevfileV2Metadata } from '../../services/devfileApi';
 
 const selectState = (state: AppState) => state.workspaces;
 const selectCheWorkspacesState = (state: AppState) => state.cheWorkspaces;
@@ -39,7 +40,9 @@ export const selectAllWorkspaces = createSelector(
   (cheWorkspacesState, devWorkspacesState) => {
     return [
       ...cheWorkspacesState.workspaces,
-      ...devWorkspacesState.workspaces,
+      // we were needed to add a filter because at first, we can get a new workspace object without metadata
+      // and then will get the update event with metadata.
+      ...(devWorkspacesState.workspaces.filter(workspace => isDevfileV2Metadata(workspace.metadata))),
     ].map(workspace => convertWorkspace(workspace));
   }
 );

--- a/packages/dashboard-frontend/src/store/__mocks__/cheWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/cheWorkspaceBuilder.ts
@@ -62,7 +62,7 @@ export class CheWorkspaceBuilder {
   }
 
   withAttributes(attributes: che.WorkspaceAttributes): CheWorkspaceBuilder {
-    this.workspace.attributes = cloneDeep(attributes);
+    this.workspace.attributes = Object.assign({}, this.workspace.attributes, attributes);
     return this;
   }
 
@@ -83,6 +83,10 @@ export class CheWorkspaceBuilder {
 
   withNamespace(namespace: string): CheWorkspaceBuilder {
     this.workspace.namespace = namespace;
+    if (!this.workspace.attributes) {
+      this.workspace.attributes = {} as che.WorkspaceAttributes;
+    }
+    this.workspace.attributes.infrastructureNamespace = namespace;
     return this;
   }
 

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -40,7 +40,10 @@ export class DevWorkspaceBuilder {
   }
 
   withId(id: string): DevWorkspaceBuilder {
-    this.workspace.metadata.uid = id;
+    if (this.workspace.status === undefined) {
+      this.workspace.status = this.buildStatus();
+    }
+    this.workspace.status.devworkspaceId = id;
     return this;
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR brings a new default devfile template for the custom workspace panels. Now it depends on enabling DevWorkspaces.
If DevWorkspaces is enabled it will suggest a devfile V2.1.0.
If DevWorkspaces is disabled it will suggest a devfile V1.

![Знімок екрана 2021-09-14 о 15 47 07](https://user-images.githubusercontent.com/6310786/133260556-76d56521-616b-4b1f-82a9-407506ddedb0.png)
![Знімок екрана 2021-09-14 о 15 49 04](https://user-images.githubusercontent.com/6310786/133260563-2426dfac-15a9-44c8-8c24-33ac7f2a59de.png)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/19996
