### PR TITLE
feat: make backend respect internal URL, CAs and http proxy settings

### DIFF
--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -167,6 +167,7 @@
 | [`@types/eslint-visitor-keys@1.0.0`](https://www.github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/express-serve-static-core@4.17.24`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/express@4.17.13`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
+| [`@types/fs-extra@9.0.12`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/glob@7.1.4`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/graceful-fs@4.1.5`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/history@4.7.9`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
@@ -208,6 +209,7 @@
 | [`@types/stylelint@13.13.2`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/tapable@1.0.8`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/testing-library__jest-dom@5.14.1`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
+| [`@types/tunnel@0.0.1`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/uglify-js@3.13.1`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/unist@2.0.6`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/vfile-message@2.0.0`](https://github.com/vfile/vfile-message#readme) | MIT | clearlydefined |
@@ -289,7 +291,6 @@
 | [`async-each@1.0.3`](git://github.com/paulmillr/async-each.git) | MIT | clearlydefined |
 | [`async-limiter@1.0.1`](https://github.com/strml/async-limiter.git) | MIT | clearlydefined |
 | [`async@2.6.3`](https://github.com/caolan/async.git) | MIT | clearlydefined |
-| [`at-least-node@1.0.0`](git+https://github.com/RyanZim/at-least-node.git) | ISC | clearlydefined |
 | [`atob@2.1.2`](git://git.coolaj86.com/coolaj86/atob.js.git) | (MIT OR Apache-2.0) | #1027 |
 | [`autoprefixer@9.8.6`](https://github.com/postcss/autoprefixer.git) | MIT | clearlydefined |
 | [`axios-mock-adapter@1.20.0`](git+https://github.com/ctimmerm/axios-mock-adapter.git) | MIT | clearlydefined |
@@ -493,7 +494,7 @@
 | [`eslint-visitor-keys@1.3.0`](https://github.com/eslint/eslint-visitor-keys.git) | Apache-2.0 | clearlydefined |
 | [`eslint@7.32.0`](https://github.com/eslint/eslint.git) | MIT | clearlydefined |
 | [`espree@7.3.1`](https://github.com/eslint/espree.git) | BSD-2-Clause | #903 |
-| [`esquery@1.4.0`](https://github.com/estools/esquery.git) | BSD-3-Clause | clearlydefined |
+| [`esquery@1.4.0`](https://github.com/estools/esquery.git) | BSD-3-Clause | #1100 |
 | [`esrecurse@4.3.0`](https://github.com/estools/esrecurse.git) | BSD-2-Clause | clearlydefined |
 | [`estraverse@5.2.0`](http://github.com/estools/estraverse.git) | BSD-2-Clause | #881 |
 | [`eventemitter3@4.0.7`](git://github.com/primus/eventemitter3.git) | MIT | clearlydefined |
@@ -532,7 +533,6 @@
 | [`for-in@1.0.2`](https://github.com/jonschlinkert/for-in.git) | MIT | clearlydefined |
 | [`fragment-cache@0.2.1`](https://github.com/jonschlinkert/fragment-cache.git) | MIT | clearlydefined |
 | [`from2@2.3.0`](git://github.com/hughsk/from2) | MIT | clearlydefined |
-| [`fs-extra@9.1.0`](https://github.com/jprichardson/node-fs-extra) | MIT | clearlydefined |
 | [`fs-write-stream-atomic@1.0.10`](https://github.com/npm/fs-write-stream-atomic) | ISC | clearlydefined |
 | `fsevents@2.3.2` |  |  |
 | [`functional-red-black-tree@1.0.1`](git://github.com/mikolalysenko/functional-red-black-tree.git) | MIT | clearlydefined |
@@ -561,7 +561,6 @@
 | [`globby@11.0.4`](https://github.com/sindresorhus/globby.git) | MIT | clearlydefined |
 | [`globjoin@0.1.4`](git+https://github.com/amobiz/globjoin.git) | MIT | clearlydefined |
 | [`gonzales-pe@4.3.0`](http://github.com/tonyganch/gonzales-pe.git) | MIT | clearlydefined |
-| [`graceful-fs@4.2.8`](https://github.com/isaacs/node-graceful-fs) | ISC | clearlydefined |
 | [`growly@1.3.0`](http://github.com/theabraham/growly) | MIT | clearlydefined |
 | [`handle-thing@2.0.1`](git+ssh://git@github.com/indutny/handle-thing.git) | MIT | clearlydefined |
 | [`handlebars@4.7.7`](https://github.com/wycats/handlebars.js.git) | MIT | clearlydefined |
@@ -711,7 +710,6 @@
 | [`json-parse-even-better-errors@2.3.1`](https://github.com/npm/json-parse-even-better-errors) | MIT | clearlydefined |
 | [`json-stable-stringify-without-jsonify@1.0.1`](git://github.com/samn/json-stable-stringify.git) | MIT | clearlydefined |
 | [`json5@2.2.0`](git+https://github.com/json5/json5.git) | MIT | clearlydefined |
-| [`jsonfile@6.1.0`](git@github.com:jprichardson/node-jsonfile.git) | MIT | clearlydefined |
 | [`jsonparse@1.3.1`](http://github.com/creationix/jsonparse.git) | MIT | clearlydefined |
 | [`jsx-ast-utils@3.2.0`](https://github.com/evcohen/jsx-ast-utils) | MIT | clearlydefined |
 | [`keycloak-js@10.0.2`](https://github.com/keycloak/keycloak) | Apache-2.0 | clearlydefined |

--- a/.deps/problems.md
+++ b/.deps/problems.md
@@ -5,7 +5,6 @@
 1. `glob-to-regexp@0.3.0`
 2. `tslib@2.3.1`
 3. `umd-compat-loader@2.1.1`
-4. `uri-js@4.4.1`
 
 ## UNRESOLVED Development dependencies
 

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -53,6 +53,7 @@
 | [`assert-plus@1.0.0`](https://github.com/mcavage/node-assert-plus.git) | MIT | clearlydefined |
 | [`ast-types@0.9.14`](git://github.com/benjamn/ast-types.git) | MIT | clearlydefined |
 | [`asynckit@0.4.0`](git+https://github.com/alexindigo/asynckit.git) | MIT | clearlydefined |
+| [`at-least-node@1.0.0`](git+https://github.com/RyanZim/at-least-node.git) | ISC | clearlydefined |
 | [`atomic-sleep@1.0.0`](git+https://github.com/davidmarkclements/atomic-sleep.git) | MIT | clearlydefined |
 | [`attr-accept@1.1.3`](https://github.com/okonet/attr-accept.git) | MIT | [CQ22348](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22348) |
 | [`avvio@7.2.2`](git+https://github.com/fastify/avvio.git) | MIT | clearlydefined |
@@ -161,6 +162,7 @@
 | [`form-data@2.5.1`](git://github.com/form-data/form-data.git) | MIT | clearlydefined |
 | [`forwarded@0.2.0`](https://github.com/jshttp/forwarded.git) | MIT | clearlydefined |
 | [`fresh@0.5.2`](https://github.com/jshttp/fresh.git) | MIT | clearlydefined |
+| [`fs-extra@9.1.0`](https://github.com/jprichardson/node-fs-extra) | MIT | clearlydefined |
 | [`fs-minipass@2.1.0`](git+https://github.com/npm/fs-minipass.git) | ISC | clearlydefined |
 | [`fs.realpath@1.0.0`](git+https://github.com/isaacs/fs.realpath.git) | ISC | clearlydefined |
 | [`function-bind@1.1.1`](git://github.com/Raynos/function-bind.git) | MIT | clearlydefined |
@@ -171,6 +173,7 @@
 | [`glob@7.1.7`](git://github.com/isaacs/node-glob.git) | ISC | #994 |
 | [`globals@9.18.0`](https://github.com/sindresorhus/globals.git) | MIT | clearlydefined |
 | [`got@11.8.2`](https://github.com/sindresorhus/got.git) | MIT | clearlydefined |
+| [`graceful-fs@4.2.8`](https://github.com/isaacs/node-graceful-fs) | ISC | clearlydefined |
 | [`gravatar-url@3.1.0`](https://github.com/sindresorhus/gravatar-url.git) | MIT | clearlydefined |
 | [`har-schema@2.0.0`](https://github.com/ahmadnassri/har-schema.git) | ISC | clearlydefined |
 | [`har-validator@5.1.5`](https://github.com/ahmadnassri/node-har-validator.git) | MIT | clearlydefined |
@@ -222,6 +225,7 @@
 | [`json3@3.3.3`](git://github.com/bestiejs/json3.git) | MIT | clearlydefined |
 | [`json5@1.0.1`](git+https://github.com/json5/json5.git) | MIT | [CQ22351](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22351) |
 | [`jsonc-parser@3.0.0`](https://github.com/microsoft/node-jsonc-parser) | MIT | clearlydefined |
+| [`jsonfile@6.1.0`](git@github.com:jprichardson/node-jsonfile.git) | MIT | clearlydefined |
 | [`jsonpath-plus@0.19.0`](git://github.com/s3u/JSONPath.git) | MIT | clearlydefined |
 | [`jsprim@1.4.1`](git://github.com/joyent/node-jsprim.git) | MIT | clearlydefined |
 | [`keyv@4.0.3`](git+https://github.com/lukechilds/keyv.git) | MIT | clearlydefined |
@@ -385,7 +389,8 @@
 | [`umd-compat-loader@2.1.1`](http://github.com/matt-gadd/umd-compat-loader.git) | BSD |  |
 | [`underscore@1.13.1`](git://github.com/jashkenas/underscore.git) | MIT | clearlydefined |
 | [`undici@3.3.6`](git+https://github.com/nodejs/undici.git) | MIT | clearlydefined |
-| [`uri-js@4.4.1`](http://github.com/garycourt/uri-js) | BSD-2-Clause |  |
+| [`universalify@2.0.0`](git+https://github.com/RyanZim/universalify.git) | MIT | clearlydefined |
+| [`uri-js@4.4.1`](http://github.com/garycourt/uri-js) | BSD-2-Clause | #1086 |
 | [`url-parse@1.5.3`](https://github.com/unshiftio/url-parse.git) | MIT | clearlydefined |
 | [`util-deprecate@1.0.2`](git://github.com/TooTallNate/util-deprecate.git) | MIT | clearlydefined |
 | [`uuid@7.0.3`](https://github.com/uuidjs/uuid.git) | MIT | #57 |

--- a/packages/dashboard-backend/package.json
+++ b/packages/dashboard-backend/package.json
@@ -30,11 +30,15 @@
     "fastify-static": "^4.2.2",
     "fastify-swagger": "^4.9.0",
     "fastify-websocket": "^3.2.0",
+    "tunnel": "0.0.6",
+    "fs-extra": "9.1.0",
     "reflect-metadata": "^0.1.13",
     "ws": "^8.2.1"
   },
   "devDependencies": {
     "@types/args": "^3.0.1",
+    "@types/fs-extra": "^9.0.12",
+    "@types/tunnel": "0.0.1",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.35",
     "copy-webpack-plugin": "^6.0.2",

--- a/packages/dashboard-backend/src/services/che-http/CertsProvider.ts
+++ b/packages/dashboard-backend/src/services/che-http/CertsProvider.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+export class CertsProvider {
+  // self signed cert used for Che routing
+  public static CHE_SS_CRT_PATH = '/public-certs/che-self-signed/ca.crt';
+  // custom self-signed cert used for Che routing
+  public static CUSTOM_CRTS_PATH = '/public-certs/custom';
+
+  public async getCertificateAuthority(): Promise<Array<Buffer> | undefined> {
+    const certificateAuthority: Buffer[] = [];
+    const existsSSCRT = await fs.pathExists(CertsProvider.CHE_SS_CRT_PATH);
+    if (existsSSCRT) {
+      const content = await fs.readFile(CertsProvider.CHE_SS_CRT_PATH);
+      certificateAuthority.push(content);
+    }
+
+    const existsPublicCrt = await fs.pathExists(CertsProvider.CUSTOM_CRTS_PATH);
+    if (existsPublicCrt) {
+      const publicCertificates = await fs.readdir(CertsProvider.CUSTOM_CRTS_PATH);
+      for (const publicCertificate of publicCertificates) {
+        const certPath = path.join(CertsProvider.CUSTOM_CRTS_PATH, publicCertificate);
+        if ((await fs.pathExists(certPath)) && (await fs.stat(certPath)).isFile()) {
+          const content = await fs.readFile(certPath);
+          certificateAuthority.push(content);
+        }
+      }
+    }
+
+    return certificateAuthority.length > 0 ? certificateAuthority : undefined;
+  }
+}

--- a/packages/dashboard-backend/src/services/che-http/CertsProvider.ts
+++ b/packages/dashboard-backend/src/services/che-http/CertsProvider.ts
@@ -1,12 +1,14 @@
-/**********************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
- *
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- ***********************************************************************/
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 
 import * as fs from 'fs-extra';
 import * as path from 'path';

--- a/packages/dashboard-backend/src/services/che-http/CheAxiosFactory.ts
+++ b/packages/dashboard-backend/src/services/che-http/CheAxiosFactory.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as https from 'https';
+import * as tunnel from 'tunnel';
+import * as url from 'url';
+import { CertsProvider } from './CertsProvider';
+
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+export class CheAxiosFactory {
+  private certsProvider: CertsProvider;
+
+  constructor() {
+    this.certsProvider = new CertsProvider();
+  }
+
+  /**
+   * Use proxy and/or certificates.
+   */
+  public async getAxiosInstance(uri: string): Promise<AxiosInstance> {
+    const certificateAuthority = await this.certsProvider.getCertificateAuthority();
+
+    const proxyUrl = process.env.HTTP_PROXY || process.env.http_proxy;
+    if (proxyUrl && proxyUrl !== '') {
+      const parsedUrl = url.parse(uri);
+      if (parsedUrl.hostname && this.shouldProxy(parsedUrl.hostname)) {
+        const axiosRequestConfig: AxiosRequestConfig | undefined = {
+          proxy: false,
+        };
+        const parsedProxyUrl = url.parse(proxyUrl);
+        const mainProxyOptions = CheAxiosFactory.getMainProxyOptions(parsedProxyUrl);
+        const httpsProxyOptions = CheAxiosFactory.getHttpsProxyOptions(mainProxyOptions, parsedUrl.hostname, certificateAuthority);
+        const httpOverHttpAgent = tunnel.httpOverHttp({ proxy: mainProxyOptions });
+        const httpOverHttpsAgent = tunnel.httpOverHttps({ proxy: httpsProxyOptions });
+        const httpsOverHttpAgent = tunnel.httpsOverHttp({
+          proxy: mainProxyOptions,
+          ca: certificateAuthority ? certificateAuthority : undefined,
+        });
+        const httpsOverHttpsAgent = tunnel.httpsOverHttps({
+          proxy: httpsProxyOptions,
+          ca: certificateAuthority ? certificateAuthority : undefined,
+        });
+        const urlIsHttps = (parsedUrl.protocol || 'http:').startsWith('https:');
+        const proxyIsHttps = (parsedProxyUrl.protocol || 'http:').startsWith('https:');
+        if (urlIsHttps) {
+          axiosRequestConfig.httpsAgent = proxyIsHttps ? httpsOverHttpsAgent : httpsOverHttpAgent;
+        } else {
+          axiosRequestConfig.httpAgent = proxyIsHttps ? httpOverHttpsAgent : httpOverHttpAgent;
+        }
+        return axios.create(axiosRequestConfig);
+      }
+    }
+
+    if (uri.startsWith('https') && certificateAuthority) {
+      return axios.create({
+        httpsAgent: new https.Agent({
+          ca: certificateAuthority,
+        }),
+      });
+    }
+
+    return axios;
+  }
+
+  private static getHttpsProxyOptions(
+    mainProxyOptions: tunnel.ProxyOptions,
+    servername: string | undefined,
+    certificateAuthority: Buffer[] | undefined
+  ): tunnel.HttpsProxyOptions {
+    return {
+      host: mainProxyOptions.host,
+      port: mainProxyOptions.port,
+      proxyAuth: mainProxyOptions.proxyAuth,
+      servername,
+      ca: certificateAuthority ? certificateAuthority : undefined,
+    };
+  }
+
+  private static getMainProxyOptions(parsedProxyUrl: url.UrlWithStringQuery): tunnel.ProxyOptions {
+    const port = Number(parsedProxyUrl.port);
+    return {
+      host: parsedProxyUrl.hostname!,
+      port: parsedProxyUrl.port !== '' && !isNaN(port) ? port : 3128,
+      proxyAuth: parsedProxyUrl.auth && parsedProxyUrl.auth !== '' ? parsedProxyUrl.auth : undefined,
+    };
+  }
+
+  private shouldProxy(hostname: string): boolean {
+    const noProxyEnv = process.env.no_proxy || process.env.NO_PROXY;
+    const noProxy: string[] = noProxyEnv ? noProxyEnv.split(',').map(s => s.trim()) : [];
+    return !noProxy.some(rule => {
+      if (!rule) {
+        return false;
+      }
+      if (rule === '*') {
+        return true;
+      }
+      if (rule[0] === '.' && hostname.substr(hostname.length - rule.length) === rule) {
+        return true;
+      }
+      return hostname === rule;
+    });
+  }
+}

--- a/packages/dashboard-backend/src/services/che-http/CheAxiosFactory.ts
+++ b/packages/dashboard-backend/src/services/che-http/CheAxiosFactory.ts
@@ -10,16 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-/**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
- *
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- ***********************************************************************/
-
 import * as https from 'https';
 import * as tunnel from 'tunnel';
 import * as url from 'url';

--- a/packages/dashboard-backend/tslint.json
+++ b/packages/dashboard-backend/tslint.json
@@ -18,8 +18,7 @@
     "class-name": true,
     "comment-format": [
       true,
-      "check-space",
-      "check-lowercase"
+      "check-space"
     ],
     "curly": true,
     "eofline": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fs-extra@^9.0.12":
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.12.tgz#9b8f27973df8a7a3920e8461517ebf8a7d4fdfaf"
+  integrity sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
@@ -2251,6 +2258,13 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.1.tgz#8f80dd965ad81f3e1bc26d6f5c727e132721ff40"
   integrity sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
+
+"@types/tunnel@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.1.tgz#0d72774768b73df26f25df9184273a42da72b19c"
+  integrity sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/uglify-js@*":
   version "3.13.1"
@@ -6245,16 +6259,7 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^9.1.0:
+fs-extra@9.1.0, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -6263,6 +6268,15 @@ fs-extra@^9.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-minipass@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
### What does this PR do?
This PR makes dashboard backend uses internal Che Server URL when available and respect CAs, Http proxy settings in the same way as Theia does.
Probably it makes sense to move that logic to workspace-client library, but at this point I decided to take easier/quicker way since workspace-client has a lot of outdated stuff. So, I see that possible it will land to newer Che Typescript client, with devworkspaces and newer stuff.

Prereq for merging is https://github.com/eclipse-che/che-operator/pull/1073

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20367

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
### How to test this PR?
This is copied/pasted from Che operator PR:
Http proxy and custom certs are not easy to test, so I just copied Theia solution on dashboard side and assume it works.
1. For Che Self Signed certs verification you need to test Che on minikube:
```sh
cat EOF << > /tmp/che-cluster-patch.yaml
spec:
  k8s:
    singleHostExposureType: gateway
  server:
    dashboardImage: 'sleshchenko/che-dashboard:che-ca'
    dashboardImagePullPolicy: Always
    customCheProperties:
      CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S: "true"
EOF
chectl server:deploy --installer=operator --platform=minikube \
  --che-operator-cr-patch-yaml=che-cluster-patch.yaml \
  --che-operator-image=sleshchenko/che-operator:dashboard-ca \
  --workspace-engine=dev-workspace
```
2. Open Dashboard and make sure dashboard reports the right values in logs:
![Screenshot_20210916_152206](https://user-images.githubusercontent.com/5887312/133611584-e1c47250-9f24-4fa4-9f64-a0b4442fed9c.png)

3. Disable internal URLs
```
oc patch checluster/eclipse-che -n eclipse-che --type=merge \
    --patch "{\"spec\":{\"server\":{\"disableInternalClusterSVCNames\":true}}}"
```
4. After Che operator did its job check Che Operator and Dashboard collaborate together well, and now public Che URL is used:
![Screenshot_20210916_152924](https://user-images.githubusercontent.com/5887312/133612338-a55ab339-7dcc-405f-bbba-a884b632875c.png)

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
