### PR TITLE
feat: Handle custom editor in repository or inlined in devfile

### DIFF
--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -125,7 +125,7 @@ export const actionCreators: ActionCreators = {
       if (cheTheiaPlugins) {
         optionalFilesContent['.che/che-theia-plugins.yaml'] = cheTheiaPlugins;
       }
-      const cheEditor = await grabLink(data.links, 'che editor file');
+      const cheEditor = await grabLink(data.links, '.che/che-editor.yaml');
       if (cheEditor) {
         optionalFilesContent['.che/che-editor.yaml'] = cheEditor;
       }


### PR DESCRIPTION
### What does this PR do?
Allow to specify a custom editor in the repository or being inlined in the devfile.
With it, it's really convenient to try new editor or editor settings with DevWorkspace mode

### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/20258

### Is it tested? How?
With this PR enabled
I'm using `https://che-host#https://github.com/benoitf/dev-workspace-custom-editor/tree/ee1646a487c93a9fa1bcbda16e0dd50d0f1442a1` link

I've a custom che-theia starting with more memory (2048Mi vs 512Mi)
![image](https://user-images.githubusercontent.com/436777/133796477-7a22585a-4320-475e-becd-8d2407d38446.png)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
