### PR TITLE
Fix web worker bundle filename, prevent cache web workers

### DIFF
--- a/packages/dashboard-backend/src/static.ts
+++ b/packages/dashboard-backend/src/static.ts
@@ -34,7 +34,9 @@ export function registerStaticServer(publicFolder: string, server: FastifyInstan
   const doNotCache = [
     '/dashboard/',
     '/dashboard/index.html',
-    '/dashboard/client.bundle.js',
+    '/dashboard/client.js',
+    '/dashboard/service-worker.js',
+    '/dashboard/editor.worker.js',
     '/dashboard/assets/branding/product.json',
   ];
   server.addHook('onSend', (request: FastifyRequest, reply:  FastifyReply, payload: any, done: DoneFuncWithErrOrRes) => {

--- a/packages/dashboard-frontend/src/components/DevfileEditor/index.tsx
+++ b/packages/dashboard-frontend/src/components/DevfileEditor/index.tsx
@@ -39,7 +39,7 @@ const MONACO_CONFIG: editor.IStandaloneEditorConstructionOptions = {
 };
 
 (self as any).MonacoEnvironment = {
-  getWorkerUrl: () => './editor.worker.bundle.js'
+  getWorkerUrl: () => './editor.worker.js'
 };
 
 type Props =


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

https://github.com/eclipse-che/che-dashboard/pull/323

This PR fixes editor web worker filename caused by resolving a merge conflict in [this PR](https://github.com/eclipse-che/che-dashboard/pull/323). Additionally, it prevents browser to cache web workers. 

### What issues does this PR fix or reference?
N/a

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

Examine the Network tab of Developer tools to see that two web workers are loaded and none of them is cached by the browser.
