### PR TITLE
fix: avoid potential npe

### DIFF
--- a/packages/dashboard-backend/src/devworkspace-client/services/api/workspace-api.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/api/workspace-api.ts
@@ -181,12 +181,14 @@ export class DevWorkspaceApi implements IDevWorkspaceApi {
       }
     }, (error: any) => {
       let message;
-      if (error.message) {
+      if (error && error.message) {
         message = error.message;
       } else {
         // unexpected error format. Log it and expose to user what we can
-        console.log(error);
-        message = error.toString();
+        console.log('Unexpected error', error);
+        if (error) {
+          message = error.toString();
+        }
         if (!message) {
           message = 'unknown. Contact admin to check server logs';
         }


### PR DESCRIPTION
### What does this PR do?
Avoid crashing backend on some errors due to NPE failure

Using development mode I had
```
TypeError: Cannot read property 'message' of null
    at eval (webpack-internal:///./src/devworkspace-client/services/api/workspace-api.ts:165:27)
    at doneCallOnce (webpack-internal:///../../node_modules/@kubernetes/client-node/dist/watch.js:72:21)
    at LineStream.eval (webpack-internal:///../../node_modules/@kubernetes/client-node/dist/watch.js:83:38)
    at LineStream.emit (events.js:315:20)
    at emitCloseNT (internal/streams/destroy.js:87:10)
    at processTicksAndRejections (internal/process/task_queues.js:79:21)
[nodemon] app crashed - waiting for file changes before starting..
```
and then the backend crashed


### What issues does this PR fix or reference?
N/A

### Is it tested? How?
I've tested that with my fix, I never had backend crashing again


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
