### PR TITLE
Fix updating branding data

### DIFF
--- a/packages/dashboard-frontend/src/store/Branding/index.ts
+++ b/packages/dashboard-frontend/src/store/Branding/index.ts
@@ -69,6 +69,10 @@ export const actionCreators: ActionCreators = {
       try {
         const receivedBranding = await fetchBranding(url);
         branding = getBrandingData(receivedBranding);
+        dispatch({
+          type: 'RECEIVED_BRANDING',
+          data: branding,
+        });
       } catch (e) {
         const errorMessage = `Failed to fetch branding data by URL: "${url}", reason: ` + common.helpers.errors.getMessage(e);
         dispatch({
@@ -78,30 +82,24 @@ export const actionCreators: ActionCreators = {
         throw errorMessage;
       }
 
-      try {
-        // Use the products version if specified in product.json, otherwise use the default version given by che server
-        if (branding.productVersion) {
+      // Use the products version if specified in product.json, otherwise use the default version given by che server
+      if (!branding.productVersion) {
+        try {
+          const apiInfo = await getApiInfo();
+          branding.productVersion = apiInfo.implementationVersion;
+
           dispatch({
             type: 'RECEIVED_BRANDING',
             data: branding,
           });
-          return;
+        } catch (e) {
+          const errorMessage = 'OPTIONS request to "/api/" failed, reason: ' + common.helpers.errors.getMessage(e);
+          dispatch({
+            type: 'RECEIVED_BRANDING_ERROR',
+            error: errorMessage,
+          });
+          throw errorMessage;
         }
-
-        const apiInfo = await getApiInfo();
-        branding.productVersion = apiInfo.implementationVersion;
-
-        dispatch({
-          type: 'RECEIVED_BRANDING',
-          data: branding,
-        });
-      } catch (e) {
-        const errorMessage = 'OPTIONS request to "/api/" failed, reason: ' + common.helpers.errors.getMessage(e);
-        dispatch({
-          type: 'RECEIVED_BRANDING_ERROR',
-          error: errorMessage,
-        });
-        throw errorMessage;
       }
     },
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Branding on the Dashboard now gets updated immediately with any portion of data received without waiting for the complete set of data.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-1948

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy multi-host Che Server with a custom product.json on minikube
2. Do not import the certificate
3. Go to the Dashboard, open the About widget. There you should be able to see the custom product name.

