### PR TITLE
chore: change PR check image repository to quay.io

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ env:
   DIR_DASHBOARD: che-dashboard
   DIR_CHE: che
   IMAGE_VERSION: che-dashboard-pull-${{ github.event.pull_request.number }}
-  ORGANIZATION: docker.io/maxura
+  ORGANIZATION: quay.io/eclipse
 
 jobs:
 
@@ -99,12 +99,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       -
-        name: "Docker docker.io Login"
+        name: "Docker quay.io Login"
         uses: docker/login-action@v1
         with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_MAXURA_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_MAXURA_PASSWORD }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       -
         name: "Build and push ${{ matrix.platform }}"
         uses: docker/build-push-action@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ on:
 env:
   DIR_DASHBOARD: che-dashboard
   DIR_CHE: che
-  IMAGE_VERSION: che-dashboard-pull-${{ github.event.pull_request.number }}
+  IMAGE_VERSION: pr-${{ github.event.pull_request.number }}
   ORGANIZATION: quay.io/eclipse
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Images that are build during PR checks, will be now pushed to quay.io/eclipse/che-dashboard:pr-<pull_request_number>, instead of Docker.io

### What issues does this PR fix or reference?
This would help normalize secrets usage across all repos https://github.com/eclipse/che/issues/20530

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
