### PR TITLE
Bump version of @eclipse-che/che-theia-devworkspace-handler to the latest released

### DIFF
--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -33,7 +33,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1623136422",
+    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1632729321",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",


### PR DESCRIPTION
### What does this PR do?
Bump version of `@eclipse-che/che-theia-devworkspace-handler` to the https://www.npmjs.com/package/@eclipse-che/che-theia-devworkspace-handler/v/0.0.1-1632729321 which doesn't contains vsix-installer image.

Part of https://github.com/eclipse-che/che-theia/pull/1222

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1731

### Is it tested? How?
TBD


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
