### PR TITLE
Save timestamp of the last modification as a devworkspace annotation

### DIFF
--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src"
-  }, 
+  },
   "include": [
     "src",
   ],

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
@@ -104,7 +104,7 @@ export function buildRow(
   );
 
   /* last modified time */
-  const lastModifiedMs = workspace.updated ? workspace.updated : workspace.created;
+  const lastModifiedMs = workspace.updated;
   let lastModifiedDate = '';
   if (lastModifiedMs) {
     const nowMs = Date.now();

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -12,7 +12,7 @@
 
 import { V1alpha2DevWorkspaceMetadata } from '@devfile/api';
 
-export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'updatingTimestamp';
+export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'che.eclipse.org/last-updated-timestamp';
 type DevWorkspaceMetadataAnnotation = {
   DEVWORKSPACE_UPDATING_TIME_ANNOTATION?: string;
 }

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -12,5 +12,13 @@
 
 import { V1alpha2DevWorkspaceMetadata } from '@devfile/api';
 
+export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'updatingTimestamp';
+type DevWorkspaceMetadataAnnotation = {
+  DEVWORKSPACE_UPDATING_TIME_ANNOTATION?: string;
+}
+
 export type DevWorkspaceMetadata = V1alpha2DevWorkspaceMetadata
-  & Required<Pick<V1alpha2DevWorkspaceMetadata, 'labels' | 'name' | 'namespace' | 'uid'>>;
+  & Required<Pick<V1alpha2DevWorkspaceMetadata, 'labels' | 'name' | 'namespace' | 'uid'>>
+  & {
+    annotations?: DevWorkspaceMetadataAnnotation;
+  }

--- a/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
@@ -15,6 +15,7 @@ import { convertWorkspace } from '..';
 import { CheWorkspaceBuilder, CHE_DEVFILE_STUB, CHE_RUNTIME_STUB } from '../../../store/__mocks__/cheWorkspaceBuilder';
 import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
 import { DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION } from '../../devfileApi/devWorkspace/metadata';
+import { DevWorkspaceStatus } from '../../helpers/types';
 import { StorageTypeTitle } from '../../storageTypes';
 
 /**
@@ -339,10 +340,10 @@ describe('Workspace adapter', () => {
     it('should return status', () => {
       const status = 'STARTING';
       const devWorkspace = new DevWorkspaceBuilder()
-        .withStatus(status)
+        .withStatus({ phase: status })
         .build();
       const workspace = convertWorkspace(devWorkspace);
-      expect(workspace.status).toEqual(status);
+      expect(workspace.status).toEqual(DevWorkspaceStatus[status]);
     });
 
     it('should return ideUrl', () => {

--- a/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
@@ -14,6 +14,7 @@ import { cloneDeep } from 'lodash';
 import { convertWorkspace } from '..';
 import { CheWorkspaceBuilder, CHE_DEVFILE_STUB, CHE_RUNTIME_STUB } from '../../../store/__mocks__/cheWorkspaceBuilder';
 import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
+import { DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION } from '../../devfileApi/devWorkspace/metadata';
 import { StorageTypeTitle } from '../../storageTypes';
 
 /**
@@ -325,10 +326,12 @@ describe('Workspace adapter', () => {
     // todo fix that stub implementation
     it('should return timestamp of updating', () => {
       const timestamp = 22222222;
-      const updated = new Date(timestamp);
+      const updated = new Date(timestamp).toISOString();
       const devWorkspace = new DevWorkspaceBuilder()
         .build();
-      devWorkspace.metadata.creationTimestamp = updated;
+      devWorkspace.metadata.annotations = {
+        [DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]: updated,
+      };
       const workspace = convertWorkspace(devWorkspace);
       expect(workspace.updated).toEqual(timestamp);
     });

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '../../../../inversify.config';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import { DevWorkspaceClient } from '../devWorkspaceClient';
+import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
+
+describe('DevWorkspace client, changeWorkspaceStatus', () => {
+
+  let client: DevWorkspaceClient;
+
+  const timestampOld = '2021-09-01T00:00:01.000Z';
+  const timestampNew = '2021-10-01T00:00:01.000Z';
+  const dateConstructor = window.Date;
+
+  beforeEach(() => {
+    client = container.get(DevWorkspaceClient);
+
+    class MockDate extends Date {
+      constructor() {
+        super(timestampNew);
+      }
+    }
+    window.Date = MockDate as DateConstructor;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    window.Date = dateConstructor;
+  });
+
+  it('should add annotation of last update time', async () => {
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withName('wksp-test')
+      .withStatus({
+        phase: 'RUNNING',
+        mainUrl: 'link/ide'
+      })
+      .build();
+
+    const spyPatchWorkspace = jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
+
+    await client.changeWorkspaceStatus(testWorkspace, true);
+
+    expect(spyPatchWorkspace).toBeCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.arrayContaining([
+        {
+          op: 'add',
+          path: '/metadata/annotations/che.eclipse.org~1last-updated-timestamp',
+          value: timestampNew,
+        },
+      ]),
+    );
+  });
+
+  it('should replace annotation of last update time', async () => {
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withName('wksp-test')
+      .withMetadata({
+        annotations: {
+          'che.eclipse.org/last-updated-timestamp': timestampOld,
+        }
+      })
+      .withStatus({
+        phase: 'RUNNING',
+        mainUrl: 'link/ide'
+      })
+      .build();
+
+    const spyPatchWorkspace = jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
+
+    await client.changeWorkspaceStatus(testWorkspace, true);
+
+    expect(spyPatchWorkspace).toBeCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.arrayContaining([
+        {
+          op: 'replace',
+          path: '/metadata/annotations/che.eclipse.org~1last-updated-timestamp',
+          value: timestampNew,
+        },
+      ]),
+    );
+  });
+
+  it('should not add/replace annotation of last update time while stopping workspace', async () => {
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withName('wksp-test')
+      .withStatus({
+        phase: 'RUNNING',
+        mainUrl: 'link/ide'
+      })
+      .build();
+
+    const spyPatchWorkspace = jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
+
+    await client.changeWorkspaceStatus(testWorkspace, false);
+
+    expect(spyPatchWorkspace).toBeCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.not.arrayContaining([
+        {
+          path: '/metadata/annotations/che.eclipse.org~1last-updated-timestamp',
+        },
+      ]),
+    );
+  });
+
+});

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '../../../../inversify.config';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import { DevWorkspaceClient } from '../devWorkspaceClient';
+import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
+import devfileApi from '../../../devfileApi';
+
+describe('DevWorkspace client, create', () => {
+
+  let client: DevWorkspaceClient;
+
+  const timestampNew = '2021-10-01T00:00:01.000Z';
+  const dateConstructor = window.Date;
+
+  beforeEach(() => {
+    client = container.get(DevWorkspaceClient);
+
+    class MockDate extends Date {
+      constructor() {
+        super(timestampNew);
+      }
+    }
+    window.Date = MockDate as DateConstructor;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    window.Date = dateConstructor;
+  });
+
+  it('should add annotation of last update time', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testDevfile: devfileApi.Devfile = {
+      schemaVersion: '2.1.0',
+      metadata: {
+        namespace,
+        name,
+      },
+    };
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .build();
+
+    const spyCreateWorkspace = jest.spyOn(DwApi, 'createWorkspace').mockResolvedValueOnce(testWorkspace);
+    jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
+
+    await client.create(testDevfile, namespace, [], undefined, undefined, {});
+
+    expect(spyCreateWorkspace).toBeCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          annotations: {
+            'che.eclipse.org/last-updated-timestamp': timestampNew,
+          },
+        }),
+      }),
+    );
+  });
+
+});

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '../../../../inversify.config';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import mockAxios from 'axios';
+import { DevWorkspaceClient } from '../devWorkspaceClient';
+
+describe('DevWorkspace client', () => {
+
+  let client: DevWorkspaceClient;
+
+  beforeEach(() => {
+    client = container.get(DevWorkspaceClient);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should check for devworkspace error', () => {
+    const devWorkspace1 = new DevWorkspaceBuilder()
+      .withId('id-wksp-test')
+      .withName('wksp-test')
+      .withNamespace('test')
+      .withStatus({
+        phase: 'RUNNING',
+      })
+      .build();
+    expect(
+      () => client.checkForDevWorkspaceError(devWorkspace1)
+    ).not.toThrow();
+
+    const devWorkspace2 = new DevWorkspaceBuilder()
+      .withId('id-wksp-test')
+      .withName('wksp-test')
+      .withNamespace('test')
+      .withStatus({
+        phase: 'FAILED',
+      })
+      .build();
+    expect(
+      () => client.checkForDevWorkspaceError(devWorkspace2)
+    ).toThrowError(new Error('Unknown error occured when trying to process the devworkspace'));
+
+    const devWorkspace3 = new DevWorkspaceBuilder()
+      .withId('id-wksp-test')
+      .withName('wksp-test')
+      .withNamespace('test')
+      .withStatus({
+        phase: 'FAILED',
+        message: 'failure reason if any',
+      })
+      .build();
+    expect(
+      () => client.checkForDevWorkspaceError(devWorkspace3)
+    ).toThrowError(new Error('failure reason if any'));
+  });
+
+  it('should fetch all devworkspaces', async () => {
+    const items = [
+      new DevWorkspaceBuilder().withId('id-wksp-1').build(),
+      new DevWorkspaceBuilder().withId('id-wksp-2').build(),
+      new DevWorkspaceBuilder().withId('id-wksp-3').build(),
+      new DevWorkspaceBuilder()
+        .withMetadata({
+          labels: {
+            'console.openshift.io/terminal': 'true',
+          },
+          name: 'wksp-4',
+          namespace: 'test',
+          uid: 'id-wksp-4',
+        })
+        .build(),
+    ];
+    (mockAxios.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        items,
+        metadata: {
+          resourceVersion: 'test',
+        },
+      },
+    });
+    const { workspaces } = await client.getAllWorkspaces('test');
+    expect(workspaces.length).toEqual(3);
+  });
+
+  it('should get devworkspace by name', async () => {
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspaceNotReady = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .build();
+    (mockAxios.get as jest.Mock).mockResolvedValueOnce({
+      data: workspaceNotReady,
+    });
+    const workspaceReady = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withStatus({
+        phase: 'RUNNING',
+        mainUrl: 'main_url',
+      })
+      .build();
+    (mockAxios.get as jest.Mock).mockResolvedValueOnce({
+      data: workspaceReady,
+    });
+    const newWorkspace = await client.getWorkspaceByName(namespace, name);
+    expect(newWorkspace).toEqual(workspaceReady);
+  });
+
+});

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '../../../../inversify.config';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import { DevWorkspaceClient } from '../devWorkspaceClient';
+import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
+
+describe('DevWorkspace client, update', () => {
+
+  let client: DevWorkspaceClient;
+
+  const timestampOld = '2021-09-01T00:00:01.000Z';
+  const timestampNew = '2021-10-01T00:00:01.000Z';
+  const dateConstructor = window.Date;
+
+  beforeEach(() => {
+    client = container.get(DevWorkspaceClient);
+
+    class MockDate extends Date {
+      constructor() {
+        super(timestampNew);
+      }
+    }
+    window.Date = MockDate as DateConstructor;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    window.Date = dateConstructor;
+  });
+
+  it('should add annotation of last update time', async () => {
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withName('wksp-test')
+      .withStatus({
+        phase: 'RUNNING',
+        mainUrl: 'link/ide'
+      })
+      .build();
+
+    jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
+    const spyPatchWorkspace = jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
+
+    await client.update(testWorkspace);
+
+    expect(spyPatchWorkspace).toBeCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.arrayContaining([
+        {
+          op: 'add',
+          path: '/metadata/annotations/che.eclipse.org~1last-updated-timestamp',
+          value: timestampNew,
+        },
+      ]),
+    );
+  });
+
+  it('should replace annotation of last update time', async () => {
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withName('wksp-test')
+      .withMetadata({
+        annotations: {
+          'che.eclipse.org/last-updated-timestamp': timestampOld,
+        }
+      })
+      .withStatus({
+        phase: 'RUNNING',
+        mainUrl: 'link/ide'
+      })
+      .build();
+
+    jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
+    const spyPatchWorkspace = jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
+
+    await client.update(testWorkspace);
+
+    expect(spyPatchWorkspace).toBeCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.arrayContaining([
+        {
+          op: 'replace',
+          path: '/metadata/annotations/che.eclipse.org~1last-updated-timestamp',
+          value: timestampNew,
+        },
+      ]),
+    );
+  });
+
+});

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
@@ -19,7 +19,7 @@ export const devworkspaceSingularSubresource = 'devworkspace';
 export function devfileToDevWorkspace(devfile: devfileApi.Devfile, routingClass: string, started: boolean): devfileApi.DevWorkspace {
   const devfileAttributes = devfile.metadata.attributes || {};
   const devWorkspaceAnnotations = devfileAttributes['dw.metadata.annotations'] || {};
-  const template = {
+  const template: devfileApi.DevWorkspace = {
     apiVersion: `${devWorkspaceApiGroup}/${devworkspaceVersion}`,
     kind: 'DevWorkspace',
     metadata: {
@@ -36,7 +36,7 @@ export function devfileToDevWorkspace(devfile: devfileApi.Devfile, routingClass:
         components: []
       }
     }
-  } as devfileApi.DevWorkspace;
+  };
   if (devfile.projects) {
     template.spec.template.projects = devfile.projects;
   }

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -149,7 +149,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
   async getWorkspaceByName(namespace: string, workspaceName: string): Promise<devfileApi.DevWorkspace> {
     let workspace = await DwApi.getWorkspaceByName(namespace, workspaceName);
     let attempted = 0;
-    while ((!workspace.status || !workspace.status.phase || !workspace.status.mainUrl) && attempted < this.maxStatusAttempts) {
+    while ((!workspace.status?.phase || !workspace.status.mainUrl) && attempted < this.maxStatusAttempts) {
       workspace = await DwApi.getWorkspaceByName(namespace, workspaceName);
       attempted += 1;
       await delay();

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -33,6 +33,7 @@ import { AppAlerts } from '../../alerts/appAlerts';
 import { AlertVariant } from '@patternfly/react-core';
 import { WorkspaceAdapter } from '../../workspace-adapter';
 import { safeLoad } from 'js-yaml';
+import { DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION } from '../../devfileApi/devWorkspace/metadata';
 
 export interface IStatusUpdate {
   error?: string;
@@ -178,6 +179,12 @@ export class DevWorkspaceClient extends WorkspaceClient {
 
     const routingClass = 'che';
     const devworkspace = devfileToDevWorkspace(devfile, routingClass, true);
+
+    if (devworkspace.metadata.annotations === undefined) {
+      devworkspace.metadata.annotations = {};
+    }
+    devworkspace.metadata.annotations[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION] = new Date().toISOString();
+
     const createdWorkspace = await DwApi.createWorkspace(devworkspace);
     const namespace = createdWorkspace.metadata.namespace;
     const name = createdWorkspace.metadata.name;
@@ -265,10 +272,10 @@ export class DevWorkspaceClient extends WorkspaceClient {
       }
 
       // Update the namespace
-      (template.metadata as any).namespace = namespace;
+      template.metadata.namespace = namespace;
 
       // Update owner reference (to allow automatic cleanup)
-      (template.metadata as any).ownerReferences = [
+      template.metadata.ownerReferences = [
         {
           apiVersion: devfileGroupVersion,
           kind: devworkspaceSingularSubresource,
@@ -342,21 +349,31 @@ export class DevWorkspaceClient extends WorkspaceClient {
 
     const patch: IPatch[] = [];
 
-    if (workspace.metadata.annotations?.[DEVWORKSPACE_NEXT_START_ANNOTATION]) {
+    const updatingTimeAnnotationPath = '/metadata/annotations/' + this.escape(DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION);
+    if (workspace.metadata.annotations?.[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION] === undefined) {
+      patch.push({
+        op: 'add',
+        path: updatingTimeAnnotationPath,
+        value: new Date().toISOString(),
+      });
+    } else {
+      patch.push({
+        op: 'replace',
+        path: updatingTimeAnnotationPath,
+        value: new Date().toISOString(),
+      });
+    }
 
+    const nextStartAnnotationPath = '/metadata/annotations/' + this.escape(DEVWORKSPACE_NEXT_START_ANNOTATION);
+    if (workspace.metadata.annotations?.[DEVWORKSPACE_NEXT_START_ANNOTATION]) {
       /**
        * This is the case when you are annotating a devworkspace and will restart it later
        */
-      patch.push(
-        {
-          op: 'add',
-          path: '/metadata/annotations',
-          value: {
-            [DEVWORKSPACE_NEXT_START_ANNOTATION]: workspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION]
-          }
-        },
-
-      );
+      patch.push({
+        op: 'add',
+        path: nextStartAnnotationPath,
+        value: workspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION],
+      });
     } else {
       /**
        * This is the case when you are updating a devworkspace normally
@@ -372,11 +389,10 @@ export class DevWorkspaceClient extends WorkspaceClient {
 
       // If the workspace currently has DEVWORKSPACE_NEXT_START_ANNOTATION then delete it since we are starting a devworkspace normally
       if (onClusterWorkspace.metadata.annotations && onClusterWorkspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION]) {
-        const escapedAnnotation = this.escape(DEVWORKSPACE_NEXT_START_ANNOTATION);
         patch.push(
           {
             op: 'remove',
-            path: `/metadata/annotations/${escapedAnnotation}`,
+            path: nextStartAnnotationPath,
           }
         );
       }
@@ -430,12 +446,31 @@ export class DevWorkspaceClient extends WorkspaceClient {
     return await DwApi.patchWorkspace(workspace.metadata.namespace, workspace.metadata.name, patch);
   }
 
-  async changeWorkspaceStatus(namespace: string, name: string, started: boolean, skipErrorCheck?: boolean): Promise<devfileApi.DevWorkspace> {
-    const changedWorkspace = await DwApi.patchWorkspace(namespace, name, [{
+  async changeWorkspaceStatus(workspace: devfileApi.DevWorkspace, started: boolean, skipErrorCheck?: boolean): Promise<devfileApi.DevWorkspace> {
+    const patch: IPatch[] = [{
       op: 'replace',
       path: '/spec/started',
       value: started
-    }]);
+    }];
+
+    if (started) {
+      const updatingTimeAnnotationPath = '/metadata/annotations/' + this.escape(DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION);
+      if (workspace.metadata.annotations?.[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION] === undefined) {
+        patch.push({
+          op: 'add',
+          path: updatingTimeAnnotationPath,
+          value: new Date().toISOString(),
+        });
+      } else {
+        patch.push({
+          op: 'replace',
+          path: updatingTimeAnnotationPath,
+          value: new Date().toISOString(),
+        });
+      }
+    }
+
+    const changedWorkspace = await DwApi.patchWorkspace(workspace.metadata.namespace, workspace.metadata.name, patch);
     if (!started) {
       this.lastDevWorkspaceLog.delete(WorkspaceAdapter.getId(changedWorkspace));
     }

--- a/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
@@ -103,8 +103,8 @@ export const selectAllWorkspacesSortedByTime = createSelector(
   }
 );
 const sortByUpdatedTimeFn = (workspaceA: Workspace, workspaceB: Workspace): -1 | 0 | 1 => {
-  const timeA = workspaceA.updated || workspaceA.created || 0;
-  const timeB = workspaceB.updated || workspaceB.created || 0;
+  const timeA = workspaceA.updated;
+  const timeB = workspaceB.updated;
   if (timeA > timeB) {
     return -1;
   } else if (timeA < timeB) {

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -63,6 +63,11 @@ export class DevWorkspaceBuilder {
     return this;
   }
 
+  /**
+   * @deprecated use `withStatus`
+   * @param ideUrl
+   * @returns
+   */
   withIdeUrl(ideUrl: string): DevWorkspaceBuilder {
     if (this.workspace.status === undefined) {
       this.workspace.status = this.buildStatus();
@@ -71,11 +76,27 @@ export class DevWorkspaceBuilder {
     return this;
   }
 
-  withStatus(status: keyof typeof WorkspaceStatus | keyof typeof DevWorkspaceStatus): DevWorkspaceBuilder {
+  withStatus(status: {
+    phase?: keyof typeof DevWorkspaceStatus,
+    devworkspaceId?: string,
+    mainUrl?: string,
+    message?: string,
+  }): DevWorkspaceBuilder {
     if (this.workspace.status === undefined) {
       this.workspace.status = this.buildStatus();
     }
-    this.workspace.status.phase = status;
+    if (status.phase) {
+      this.workspace.status.phase = DevWorkspaceStatus[status.phase];
+    }
+    if (status.devworkspaceId) {
+      this.workspace.status.devworkspaceId = status.devworkspaceId;
+    }
+    if (status.mainUrl) {
+      this.workspace.status.mainUrl = status.mainUrl;
+    }
+    if (status.message) {
+      this.workspace.status.message = status.message;
+    }
     return this;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
+    "sourceMap": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noEmit": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,10 +341,10 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.36.0.tgz#db8774cbf688df140631c0e60107bef36c194fb1"
   integrity sha512-ephKJ3rDG53CdhfWHZ5byR2MRnTlbKObOph4+aNH9DO+rI44GTX2f9U2DjwQmHCAyGEXJkT1DdRum6C6ZbfCKA==
 
-"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1623136422":
-  version "0.0.1-1623136422"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1623136422.tgz#f611cc39ac31863fd38a58ab4e07dc69cff4f66b"
-  integrity sha512-2wT75rnPG4dCsVx2Fx90I73a0QwJ0wntEb39ew3qQVHTfE9lk2wVPvg6WJnIcTHI8kpRot9QFQce98+qfsOBRQ==
+"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1632729321":
+  version "0.0.1-1632729321"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1632729321.tgz#bc4954c0c5c2805044b2fc5b7cc8c1e0e8bbaafa"
+  integrity sha512-lg7SgGmyodCWROzZ3VP7v+Kyf+z4ipmRbjSwsO76MtjLgpA0Bo6Zx48hxaqvGkSbZtSokjXhYrEzL2Y3cmLsgw==
   dependencies:
     "@devfile/api" latest
     axios "0.21.1"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The timestamp of a devworkspace last modification is stored as the annotation and gets updated each time it's started or changed using the devfile editor. 


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/19815


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Start frontend dev-server against Che deployed with devworkspaces enabled
2. Create devworkspace, go to workspaces list and see that its "Last Modified" time is "less than a minute ago"
3. Wait for a few minutes and (re)start the workspace, the "Last Modified" time should be updated.
