### PR TITLE
feat: Allow to switch editor on factory link URL

### DIFF
--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -41,7 +41,7 @@ import { DEVWORKSPACE_DEVFILE_SOURCE } from '../../services/workspace-client/dev
 import devfileApi from '../../services/devfileApi';
 import getRandomString from '../../services/helpers/random';
 
-const WS_ATTRIBUTES_TO_SAVE: string[] = ['workspaceDeploymentLabels', 'workspaceDeploymentAnnotations', 'policies.create'];
+const WS_ATTRIBUTES_TO_SAVE: string[] = ['workspaceDeploymentLabels', 'workspaceDeploymentAnnotations', 'policies.create', 'che-editor'];
 
 const DEFAULT_CREATE_POLICY = 'perclick';
 

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -38,8 +38,23 @@ export function buildFactoryLoaderLocation(url?: string): Location {
   if (!url) {
     pathAndQuery = ROUTE.LOAD_FACTORY;
   } else {
-    url = encodeURIComponent(url);
-    pathAndQuery = ROUTE.LOAD_FACTORY_URL.replace(':url', url);
+    // try to extract some parameters before doing the relocation
+    const fullUrl = new window.URL(url.toString());
+
+    // search for an editor switch and if there is one, remove it from the URL
+    const editorParam = fullUrl.searchParams.get('che-editor');
+    let editor;
+    if (editorParam && typeof(editorParam) === 'string') {
+        editor = editorParam.slice();
+    }
+    fullUrl.searchParams.delete('che-editor');
+    const encodedUrl = encodeURIComponent(fullUrl.toString());
+
+    // if editor specified, add it as a new parameter
+    pathAndQuery = ROUTE.LOAD_FACTORY_URL.replace(':url', encodedUrl);
+    if (editor) {
+      pathAndQuery = `${pathAndQuery}&che-editor=${editor}`;
+    }
   }
   return _buildLocationObject(pathAndQuery);
 }

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
@@ -90,7 +90,7 @@ describe('dwPlugins store', () => {
       expect(actions).toEqual(expectedActions);
     });
 
-    it('should create REQUEST_DW_PLUGIN and RECEIVE_DW_PLUGIN when fetching the default editor', async () => {
+    it('should create REQUEST_DW_EDITOR and RECEIVE_DW_EDITOR when fetching the default editor', async () => {
       (mockAxios.get as jest.Mock).mockResolvedValueOnce({
         data: JSON.stringify(plugin),
       });
@@ -102,61 +102,23 @@ describe('dwPlugins store', () => {
         'che.factory.default_editor': 'default-editor',
       } as che.WorkspaceSettings;
       await store.dispatch(dwPluginsStore.actionCreators.requestDwDefaultEditor(settings));
-
+      const spyOnRequestDwDefaultEditor = spyOn(dwPluginsStore.actionCreators, 'requestDwDefaultEditor');
       const actions = store.getActions();
 
-      const expectedActions: dwPluginsStore.KnownAction[] = [{
-        type: 'REQUEST_DW_PLUGIN',
-        url: expect.stringContaining('default-editor'),
-      }, {
+      const expectedActions: dwPluginsStore.KnownAction[] = [ {
         type: 'REQUEST_DW_DEFAULT_EDITOR',
-      }, {
-        type: 'RECEIVE_DW_PLUGIN',
-        plugin,
-        url: expect.stringContaining('default-editor'),
+      },{
+        type: 'RECEIVE_DW_DEFAULT_EDITOR',
+        defaultEditorName: 'default-editor',
+      },
+      {
+        type: 'REQUEST_DW_EDITOR',
+        editorName: 'default-editor',
       }];
-
       expect(actions).toEqual(expectedActions);
     });
 
-    it('should create REQUEST_DW_PLUGIN, RECEIVE_DW_PLUGIN_ERROR and RECEIVE_DW_DEFAULT_EDITOR_ERROR when failed to fetch the default editor', async () => {
-      (mockAxios.get as jest.Mock).mockRejectedValueOnce({
-        isAxiosError: true,
-        code: '500',
-        message: 'unexpected error',
-      } as AxiosError);
-
-      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, dwPluginsStore.KnownAction>>;
-
-      const settings = {
-        cheWorkspacePluginRegistryUrl: 'plugin-registry-location',
-        'che.factory.default_editor': 'default-editor',
-      } as che.WorkspaceSettings;
-      try {
-        await store.dispatch(dwPluginsStore.actionCreators.requestDwDefaultEditor(settings));
-      } catch (e) {
-        // noop
-      }
-      const actions = store.getActions();
-
-      const expectedActions: dwPluginsStore.KnownAction[] = [{
-        type: 'REQUEST_DW_PLUGIN',
-        url: expect.stringContaining('default-editor'),
-      }, {
-        type: 'REQUEST_DW_DEFAULT_EDITOR',
-      }, {
-        type: 'RECEIVE_DW_PLUGIN_ERROR',
-        error: expect.stringContaining('unexpected error'),
-        url: expect.stringContaining('default-editor'),
-      }, {
-        type: 'RECEIVE_DW_DEFAULT_EDITOR_ERROR',
-        error: expect.stringContaining('unexpected error'),
-      }];
-
-      expect(actions).toEqual(expectedActions);
-    });
-
-    it('should create only RECEIVE_DW_DEFAULT_EDITOR_ERROR if workspace settings don"t have necessary fields', async () => {
+    it('should create only RECEIVE_DW_DEFAULT_EDITOR_ERROR if workspace settings don\'t have necessary fields', async () => {
       (mockAxios.get as jest.Mock).mockResolvedValueOnce({
         data: {},
       });
@@ -171,13 +133,56 @@ describe('dwPlugins store', () => {
       }
       const actions = store.getActions();
 
-      const expectedActions: dwPluginsStore.KnownAction[] = [{
+      const expectedActions: dwPluginsStore.KnownAction[] = [
+        {
+          type: 'REQUEST_DW_DEFAULT_EDITOR',
+        },
+        {
         type: 'RECEIVE_DW_DEFAULT_EDITOR_ERROR',
-        error: 'Failed to load the default editor, reason: plugin registry URL or default editor ID is not provided by Che server.',
+        error: 'Failed to load the default editor, reason: default editor ID is not provided by Che server.',
       }];
 
       expect(actions).toEqual(expectedActions);
       expect(mockAxios.get).not.toHaveBeenCalled();
+    });
+
+    it('should create REQUEST_DW_EDITOR and RECEIVE_DW__EDITOR_ERROR when missing plugin registry URL to fetch the editor', async () => {
+      (mockAxios.get as jest.Mock).mockRejectedValueOnce({
+        isAxiosError: true,
+        code: '500',
+        message: 'unexpected error',
+      } as AxiosError);
+
+      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, dwPluginsStore.KnownAction>>;
+
+      const settings = {
+        'che.factory.default_editor': 'default-editor',
+      } as che.WorkspaceSettings;
+      try {
+        await store.dispatch(dwPluginsStore.actionCreators.requestDwDefaultEditor(settings));
+      } catch (e) {
+        // noop
+      }
+      const actions = store.getActions();
+
+      const expectedActions: dwPluginsStore.KnownAction[] = [{
+        type: 'REQUEST_DW_DEFAULT_EDITOR',
+      },
+      {
+        type: 'RECEIVE_DW_DEFAULT_EDITOR',
+        defaultEditorName: 'default-editor',
+      },
+      {
+        type: 'REQUEST_DW_EDITOR',
+        editorName: 'default-editor',
+      },
+      {
+        type: 'RECEIVE_DW_EDITOR_ERROR',
+        editorName: 'default-editor',
+        error: expect.stringContaining(' plugin registry URL is not provided'),
+      },
+      ];
+      expect(actions).toEqual(expectedActions);
     });
 
   });
@@ -194,6 +199,7 @@ describe('dwPlugins store', () => {
       const expectedState: dwPluginsStore.State = {
         isLoading: false,
         plugins: {},
+        editors: {},
       };
 
       expect(initialState).toEqual(expectedState);
@@ -202,6 +208,7 @@ describe('dwPlugins store', () => {
     it('should return state if action type is not matched', () => {
       const initialState: dwPluginsStore.State = {
         isLoading: true,
+        editors: {},
         plugins: {},
       } as dwPluginsStore.State;
       const incomingAction = {
@@ -212,6 +219,7 @@ describe('dwPlugins store', () => {
       const expectedState: dwPluginsStore.State = {
         isLoading: true,
         plugins: {},
+        editors: {},
       };
       expect(newState).toEqual(expectedState);
 
@@ -220,6 +228,7 @@ describe('dwPlugins store', () => {
     it('should handle REQUEST_DW_PLUGIN', () => {
       const initialState: dwPluginsStore.State = {
         isLoading: false,
+        editors: {},
         plugins: {
           'devfile-location': {
             error: 'unexpected error',
@@ -235,6 +244,7 @@ describe('dwPlugins store', () => {
 
       const expectedState: dwPluginsStore.State = {
         isLoading: true,
+        editors: {},
         plugins: {
           'devfile-location': {},
         },
@@ -243,9 +253,40 @@ describe('dwPlugins store', () => {
       expect(newState).toEqual(expectedState);
     });
 
+    it('should handle REQUEST_DW_EDITOR', () => {
+      const initialState: dwPluginsStore.State = {
+        isLoading: false,
+        editors: {
+          'foo': {
+            error: 'unexpected error',
+          }
+        },
+        plugins: {},
+      };
+      const incomingAction: dwPluginsStore.RequestDwEditorAction = {
+        type: 'REQUEST_DW_EDITOR',
+        editorName: 'foo',
+      };
+
+      const newState = dwPluginsStore.reducer(initialState, incomingAction);
+
+      const expectedState: dwPluginsStore.State = {
+        isLoading: true,
+        editors: {
+          'foo': {
+            plugin: undefined
+          }
+        },
+        plugins: {},
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
     it('should handle REQUEST_DW_DEFAULT_EDITOR', () => {
       const initialState: dwPluginsStore.State = {
         isLoading: false,
+        editors: {},
         plugins: {},
         defaultEditorError: 'unexpected error',
       };
@@ -257,6 +298,7 @@ describe('dwPlugins store', () => {
 
       const expectedState: dwPluginsStore.State = {
         isLoading: true,
+        editors: {},
         plugins: {},
       };
 
@@ -266,6 +308,7 @@ describe('dwPlugins store', () => {
     it('should handle RECEIVE_DW_PLUGIN', () => {
       const initialState: dwPluginsStore.State = {
         isLoading: true,
+        editors: {},
         plugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwPluginAction = {
@@ -278,6 +321,7 @@ describe('dwPlugins store', () => {
 
       const expectedState: dwPluginsStore.State = {
         isLoading: false,
+        editors: {},
         plugins: {
           'devfile-location': {
             plugin,
@@ -288,9 +332,37 @@ describe('dwPlugins store', () => {
       expect(newState).toEqual(expectedState);
     });
 
+    it('should handle RECEIVE_DW_EDITOR', () => {
+      const initialState: dwPluginsStore.State = {
+        isLoading: true,
+        editors: {},
+        plugins: {},
+      };
+      const incomingAction: dwPluginsStore.ReceiveDwEditorAction = {
+        type: 'RECEIVE_DW_EDITOR',
+        editorName: 'my-editor',
+        plugin,
+      };
+
+      const newState = dwPluginsStore.reducer(initialState, incomingAction);
+
+      const expectedState: dwPluginsStore.State = {
+        isLoading: false,
+        editors: {
+          'my-editor': {
+            plugin
+          }
+        },
+        plugins: {},
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
     it('should handle RECEIVE_DW_PLUGIN_ERROR', () => {
       const initialState: dwPluginsStore.State = {
         isLoading: true,
+        editors: {},
         plugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwPluginErrorAction = {
@@ -303,6 +375,7 @@ describe('dwPlugins store', () => {
 
       const expectedState: dwPluginsStore.State = {
         isLoading: false,
+        editors: {},
         plugins: {
           'devfile-location': {
             error: 'unexpected error',
@@ -313,9 +386,37 @@ describe('dwPlugins store', () => {
       expect(newState).toEqual(expectedState);
     });
 
+    it('should handle RECEIVE_DW_EDITOR_ERROR', () => {
+      const initialState: dwPluginsStore.State = {
+        isLoading: true,
+        editors: {},
+        plugins: {},
+      };
+      const incomingAction: dwPluginsStore.RequestDwEditorErrorAction = {
+        type: 'RECEIVE_DW_EDITOR_ERROR',
+        editorName: 'foo',
+        error: 'unexpected error',
+      };
+
+      const newState = dwPluginsStore.reducer(initialState, incomingAction);
+
+      const expectedState: dwPluginsStore.State = {
+        isLoading: false,
+        editors: {
+          'foo': {
+            error: 'unexpected error'
+          }
+        },
+        plugins: {},
+      };
+
+      expect(newState).toEqual(expectedState);
+    });    
+
     it('should handle RECEIVE_DW_DEFAULT_EDITOR_ERROR', () => {
       const initialState: dwPluginsStore.State = {
         isLoading: true,
+        editors: {},
         plugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwDefaultEditorErrorAction = {
@@ -327,6 +428,7 @@ describe('dwPlugins store', () => {
 
       const expectedState: dwPluginsStore.State = {
         isLoading: false,
+        editors: {},
         plugins: {},
         defaultEditorError: 'unexpected error',
       };

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
@@ -18,16 +18,25 @@ import { AppThunk } from '../..';
 import { fetchDevfile, fetchData } from '../../../services/registry/devfiles';
 import { createObject } from '../../helpers';
 
+export interface PluginDefinition {
+    plugin?: devfileApi.Devfile;
+    error?: string;
+}
+
 export interface State {
   isLoading: boolean;
   plugins: {
-    [url: string]: {
-      plugin?: devfileApi.Devfile;
-      error?: string;
-    };
+    [url: string]: PluginDefinition;
   };
-
+  editors: {
+    [editorName: string]: PluginDefinition;
+  };
+  defaultEditorName?: string;
   defaultEditorError?: string;
+}
+
+export interface RequestDwDefaultEditorAction {
+  type: 'REQUEST_DW_DEFAULT_EDITOR';
 }
 
 export interface RequestDwPluginAction {
@@ -47,8 +56,26 @@ export interface ReceiveDwPluginErrorAction {
   error: string;
 }
 
-export interface RequestDwDefaultEditorAction {
-  type: 'REQUEST_DW_DEFAULT_EDITOR';
+export interface ReceiveDwEditorAction {
+  type: 'RECEIVE_DW_EDITOR';
+  editorName: string;
+  plugin: devfileApi.Devfile;
+}
+
+export interface RequestDwEditorAction {
+  type: 'REQUEST_DW_EDITOR';
+  editorName: string;
+}
+
+export interface ReceiveDwDefaultEditorAction {
+  type: 'RECEIVE_DW_DEFAULT_EDITOR';
+  defaultEditorName: string;
+}
+
+export interface RequestDwEditorErrorAction {
+  type: 'RECEIVE_DW_EDITOR_ERROR';
+  editorName: string;
+  error: string;
 }
 
 export interface ReceiveDwDefaultEditorErrorAction {
@@ -60,11 +87,45 @@ export type KnownAction = RequestDwPluginAction
   | ReceiveDwPluginAction
   | ReceiveDwPluginErrorAction
   | RequestDwDefaultEditorAction
-  | ReceiveDwDefaultEditorErrorAction;
+  | ReceiveDwDefaultEditorAction
+  | ReceiveDwDefaultEditorErrorAction
+  | RequestDwEditorAction
+  | ReceiveDwEditorAction
+  | RequestDwEditorErrorAction;
 
 export type ActionCreators = {
   requestDwDevfiles: (url: string) => AppThunk<KnownAction, Promise<void>>;
   requestDwDefaultEditor: (settings: che.WorkspaceSettings) => AppThunk<KnownAction, Promise<void>>;
+  requestDwEditor: (settings: che.WorkspaceSettings, editorName: string) => AppThunk<KnownAction, Promise<void>>;
+}
+
+export function mergeEditors(stateActionEditorsMap: {[key: string]: PluginDefinition}, actionEditorsMap: {[key: string]: PluginDefinition}): {[key: string]: PluginDefinition} {
+
+  if (!stateActionEditorsMap || Object.keys(stateActionEditorsMap).length === 0) {
+    return actionEditorsMap;
+  }
+
+  const returnValues: {[key: string]: PluginDefinition} = {};
+
+  Object.keys(stateActionEditorsMap).forEach(stateActionKey => {
+
+    const stateValue = stateActionEditorsMap[stateActionKey];
+    const merge = (stateValue: PluginDefinition, actionValue: PluginDefinition | undefined): PluginDefinition => {
+
+      if (!actionValue) {
+        return stateValue;
+      }
+      return actionValue;
+    };
+    returnValues[stateActionKey] = merge(stateValue, actionEditorsMap[stateActionKey]);
+  });
+
+  Object.keys(actionEditorsMap).forEach(actionEditorKey => {
+    if (!returnValues[actionEditorKey]) {
+      returnValues[actionEditorKey] = actionEditorsMap[actionEditorKey];
+    }
+  });
+  return returnValues;
 }
 
 export const actionCreators: ActionCreators = {
@@ -94,56 +155,75 @@ export const actionCreators: ActionCreators = {
     }
   },
 
-  requestDwDefaultEditor: (settings: che.WorkspaceSettings): AppThunk<KnownAction, Promise<void>> => async (dispatch): Promise<void> => {
+  requestDwEditor: (settings: che.WorkspaceSettings, editorName: string): AppThunk<KnownAction, Promise<void>> => async (dispatch): Promise<void> => {
+    dispatch({
+      type: 'REQUEST_DW_EDITOR',
+      editorName: editorName,
+    });
     const pluginRegistryUrl = settings.cheWorkspacePluginRegistryUrl;
-    const defaultEditor = settings['che.factory.default_editor'];
-
-    if (!pluginRegistryUrl || !defaultEditor) {
-      const errorMessage = 'Failed to load the default editor, reason: plugin registry URL or default editor ID is not provided by Che server.';
+    const editorUrl = `${settings.cheWorkspacePluginRegistryUrl}/plugins/${editorName}/devfile.yaml`;
+    if (!pluginRegistryUrl) {
+      const errorMessage = 'Failed to load the default editor, reason: plugin registry URL is not provided by Che server.';
       dispatch({
-        type: 'RECEIVE_DW_DEFAULT_EDITOR_ERROR',
+        type: 'RECEIVE_DW_EDITOR_ERROR',
+        editorName,
         error: errorMessage,
       });
       throw errorMessage;
     }
 
-    const defaultEditorUrl = `${settings.cheWorkspacePluginRegistryUrl}/plugins/${settings['che.factory.default_editor']}/devfile.yaml`;
-
-    dispatch({
-      type: 'REQUEST_DW_PLUGIN',
-      url: defaultEditorUrl,
-    });
-    dispatch({
-      type: 'REQUEST_DW_DEFAULT_EDITOR',
-    });
     try {
-      const pluginContent = await fetchData<string>(defaultEditorUrl);
+      const pluginContent = await fetchData<string>(editorUrl);
       const plugin = safeLoad(pluginContent) as devfileApi.Devfile;
       dispatch({
-        type: 'RECEIVE_DW_PLUGIN',
-        url: defaultEditorUrl,
+        type: 'RECEIVE_DW_EDITOR',
+        editorName,
         plugin,
       });
     } catch (error) {
-      const errorMessage = `Failed to load the default editor, reason: "${defaultEditorUrl}" responds "${error}".`;
+      const errorMessage = `Failed to load the editor, reason: "${editorUrl}" responds "${error}".`;
       dispatch({
-        type: 'RECEIVE_DW_PLUGIN_ERROR',
-        url: defaultEditorUrl,
-        error: errorMessage,
-      });
-      dispatch({
-        type: 'RECEIVE_DW_DEFAULT_EDITOR_ERROR',
+        type: 'RECEIVE_DW_EDITOR_ERROR',
+        editorName,
         error: errorMessage,
       });
       throw errorMessage;
     }
   },
 
+  requestDwDefaultEditor: (settings: che.WorkspaceSettings): AppThunk<KnownAction, Promise<void>> => async (dispatch): Promise<void> => {
+    const defaultEditor = settings['che.factory.default_editor'];
+
+    dispatch({
+      type: 'REQUEST_DW_DEFAULT_EDITOR'
+    });
+
+    if (!defaultEditor) {
+      const errorMessage = 'Failed to load the default editor, reason: default editor ID is not provided by Che server.';
+      dispatch({
+        type: 'RECEIVE_DW_DEFAULT_EDITOR_ERROR',
+        error: errorMessage,
+      });
+      throw errorMessage;
+    }
+
+    dispatch({
+      type: 'RECEIVE_DW_DEFAULT_EDITOR',
+      defaultEditorName: defaultEditor,
+    });
+
+    // request default editor
+    dispatch(actionCreators.requestDwEditor(settings, defaultEditor));
+
+  }
+
 };
 
 const unloadedState: State = {
   isLoading: false,
   plugins: {},
+  editors: {},
+  defaultEditorName: undefined,
 };
 
 export const reducer: Reducer<State> = (state: State | undefined, incomingAction: Action): State => {
@@ -163,9 +243,19 @@ export const reducer: Reducer<State> = (state: State | undefined, incomingAction
           }
         },
       });
+    case 'REQUEST_DW_EDITOR': 
+        return createObject(state, {
+          isLoading: true,
+          editors: mergeEditors(state.editors, {
+            [action.editorName]: {
+              plugin: undefined,
+            }
+          }),
+        });
     case 'REQUEST_DW_DEFAULT_EDITOR':
       return createObject(state, {
         isLoading: true,
+        defaultEditorName: undefined,
         defaultEditorError: undefined,
       });
     case 'RECEIVE_DW_PLUGIN':
@@ -177,6 +267,24 @@ export const reducer: Reducer<State> = (state: State | undefined, incomingAction
           }
         }
       });
+    case 'RECEIVE_DW_EDITOR': 
+      return createObject(state, {
+          isLoading: false,
+          editors: mergeEditors(state.editors, {
+            [action.editorName]: {
+              plugin: action.plugin,
+            }
+          })
+        });
+     case 'RECEIVE_DW_EDITOR_ERROR':
+          return createObject(state, {
+            isLoading: false,
+            editors: {
+              [action.editorName]: {
+                error: action.error,
+              }
+            }});
+      
     case 'RECEIVE_DW_PLUGIN_ERROR':
       return createObject(state, {
         isLoading: false,
@@ -193,7 +301,12 @@ export const reducer: Reducer<State> = (state: State | undefined, incomingAction
         isLoading: false,
         defaultEditorError: action.error,
       });
-    default:
+    case 'RECEIVE_DW_DEFAULT_EDITOR':
+        return createObject(state, {
+          isLoading: false,
+          defaultEditorName: action.defaultEditorName,
+        });
+      default:
       return state;
   }
 };

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/selectors.ts
@@ -29,6 +29,14 @@ export const selectDwPluginsList = createSelector(
     .filter(plugin => plugin) as devfileApi.Devfile[],
 );
 
+export const selectDwEditorsPluginsList = EDITOR_NAME => createSelector(
+  selectState,
+  state => Object.keys(state.editors)
+    .filter(key => key === EDITOR_NAME)
+    .map(key => state.editors[key])
+    .map(entry => entry.plugin) as devfileApi.Devfile[],
+);
+
 export const selectDwDefaultEditorError = createSelector(
   selectState,
   state => state.defaultEditorError,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -27,11 +27,11 @@ import devfileApi, { isDevWorkspace } from '../../../services/devfileApi';
 import { deleteLogs, mergeLogs } from '../logs';
 import { getDefer, IDeferred } from '../../../services/helpers/deferred';
 import { DisposableCollection } from '../../../services/helpers/disposable';
-import { selectDwPluginsList } from '../../Plugins/devWorkspacePlugins/selectors';
+import { selectDwEditorsPluginsList, selectDwPluginsList } from '../../Plugins/devWorkspacePlugins/selectors';
 import { devWorkspaceKind } from '../../../services/devfileApi/devWorkspace';
 import { WorkspaceAdapter } from '../../../services/workspace-adapter';
 import { DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION } from '../../../services/devfileApi/devWorkspace/metadata';
-
+import * as DwPluginsStore from '../../Plugins/devWorkspacePlugins';
 const cheWorkspaceClient = container.get(CheWorkspaceClient);
 const devWorkspaceClient = container.get(DevWorkspaceClient);
 
@@ -130,6 +130,7 @@ export type ActionCreators = {
   },
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
+    attributes: { [key: string]: string },
   ) => AppThunk<KnownAction, Promise<void>>;
 
   deleteWorkspaceLogs: (workspaceId: string) => AppThunk<DeleteWorkspaceLogsAction, void>;
@@ -224,7 +225,7 @@ export const actionCreators: ActionCreators = {
       if (workspace.metadata.annotations?.[DEVWORKSPACE_NEXT_START_ANNOTATION]) {
         // If the workspace has DEVWORKSPACE_NEXT_START_ANNOTATION then update the devworkspace with the DEVWORKSPACE_NEXT_START_ANNOTATION annotation value and then start the devworkspace
         const state = getState();
-        const plugins = selectDwPluginsList(state);
+        const plugins = selectDwEditorsPluginsList(state.dwPlugins.defaultEditorName)(state);
 
         const storedDevWorkspace = JSON.parse(workspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION]) as unknown;
         if (!isDevWorkspace(storedDevWorkspace)) {
@@ -347,21 +348,35 @@ export const actionCreators: ActionCreators = {
     },
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
+    attributes: { [key: string]: string },
   ): AppThunk<KnownAction, Promise<void>> => async (dispatch, getState): Promise<void> => {
 
-    const state = getState();
+    let state = getState();
+
+    console.log(`Default editor is ${state.dwPlugins.defaultEditorName}`);
+    // do we have an optional editor parameter ?
+    const cheEditor = attributes?.['che-editor'];
+    if (cheEditor) {
+      // if the editor is different than the current default one, need to load a specific one
+      if (cheEditor !== state.dwPlugins.defaultEditorName) {
+        console.log(`User specified a different editor than the current default. Loading ${cheEditor} definition.`);
+        await dispatch(DwPluginsStore.actionCreators.requestDwEditor(state.workspacesSettings.settings, cheEditor));
+      }
+    }
 
     if (state.dwPlugins.defaultEditorError) {
       throw `Required sources failed when trying to create the workspace: ${state.dwPlugins.defaultEditorError}`;
     }
 
+    // refresh state
+    state = getState();
     dispatch({ type: 'REQUEST_DEVWORKSPACE' });
     try {
       // If the devworkspace doesn't have a namespace then we assign it to the default kubernetesNamespace
       const devWorkspaceDevfile = devfile as devfileApi.Devfile;
       const defaultNamespace = await cheWorkspaceClient.getDefaultNamespace();
-      const dwPlugins = selectDwPluginsList(state);
-      const workspace = await devWorkspaceClient.create(devWorkspaceDevfile, defaultNamespace, dwPlugins, pluginRegistryUrl, pluginRegistryInternalUrl, optionalFilesContent);
+      const dwEditors = selectDwEditorsPluginsList(cheEditor)(state);
+      const workspace = await devWorkspaceClient.create(devWorkspaceDevfile, defaultNamespace, dwEditors, pluginRegistryUrl, pluginRegistryInternalUrl, optionalFilesContent);
 
       dispatch({
         type: 'ADD_DEVWORKSPACE',

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -265,7 +265,7 @@ export const actionCreators: ActionCreators = {
       if (cheDevworkspaceEnabled && isDevfileV2(devfile)) {
         const pluginRegistryUrl = state.workspacesSettings.settings['cheWorkspacePluginRegistryUrl'];
         const pluginRegistryInternalUrl = state.workspacesSettings.settings['cheWorkspacePluginRegistryInternalUrl'];
-        await dispatch(DevWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile, optionalFilesContent || {}, pluginRegistryUrl, pluginRegistryInternalUrl));
+        await dispatch(DevWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile, optionalFilesContent || {}, pluginRegistryUrl, pluginRegistryInternalUrl, attributes));
         dispatch({ type: 'ADD_WORKSPACE' });
       } else {
         await dispatch(CheWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile as che.WorkspaceDevfile, namespace, infrastructureNamespace, attributes));

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -91,6 +91,7 @@ export class FakeStoreBuilder {
     },
     dwPlugins: {
       isLoading: false,
+      editors: {},
       plugins: {},
     },
   };


### PR DESCRIPTION
### What does this PR do?
Allow to select the editor when providing the factory URL

We can add ?`che-editor=<editor-entry-in-plugin-registry>`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20508

### Is it tested? How?
Tested by trying to select other editor from the plug-in registry
It adds `editors` entries in the dwPlugins state. Default-editor is still loaded when booting the application and we lazy load the custom editor in case it's not the same than the default one.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
