### PR TITLE
feat: Allow to specify the path to the devfile with factory workflow

### DIFF
--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -42,12 +42,16 @@ export function buildFactoryLoaderLocation(url?: string): Location {
     const fullUrl = new window.URL(url.toString());
 
     // search for an editor switch and if there is one, remove it from the URL
-    const editorParam = fullUrl.searchParams.get('che-editor');
-    let editor;
-    if (editorParam && typeof(editorParam) === 'string') {
-        editor = editorParam.slice();
+    const editor = extractUrlParam(fullUrl, 'che-editor');
+
+    // search for devfile switch and if there is one, remove it from the URL
+    let devfilePath = extractUrlParam(fullUrl, 'devfilePath');
+
+    // also use short name 'df' if long name is not found
+    if (!devfilePath) {
+      devfilePath = extractUrlParam(fullUrl, 'df');
     }
-    fullUrl.searchParams.delete('che-editor');
+
     const encodedUrl = encodeURIComponent(fullUrl.toString());
 
     // if editor specified, add it as a new parameter
@@ -55,8 +59,22 @@ export function buildFactoryLoaderLocation(url?: string): Location {
     if (editor) {
       pathAndQuery = `${pathAndQuery}&che-editor=${editor}`;
     }
+    if (devfilePath) {
+      pathAndQuery = `${pathAndQuery}&override.devfileFilename=${devfilePath}`;
+    }
   }
   return _buildLocationObject(pathAndQuery);
+}
+
+// if the given param is defined in the URL, return the value and delete param from the URL
+function extractUrlParam(fullUrl: URL, paramName: string): string | undefined {
+  const param = fullUrl.searchParams.get(paramName);
+  let value;
+  if (param && typeof(param) === 'string') {
+    value = param.slice();
+  }
+  fullUrl.searchParams.delete(paramName);
+  return value;
 }
 
 export function buildWorkspacesLocation(): Location {


### PR DESCRIPTION
### What does this PR do?
Allow to specify the name of the devfile to use in the repositories
so if there are .devfile.yaml (using v1) you can add a `.devfile.v2` or `.devfilev2.yaml` in your repository and then specify the path to this file to load DevFile v2 workspaces

Appending `?devfilePath=devfilev2.yaml` or `?df=devfilev2.yaml`


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20607

### Is it tested? How?
Tested using `http://che-host/#https://github.com/benoitf/che-server?devfilePath=devfilev2.yaml`

Also use short query `df` `http://che-host/#https://github.com/benoitf/che-server?df=devfilev2.yaml`


In that case it's fetching a totally different devfile than the default one (it's the one coming from spring petclinic) so at the end the workspace is named "spring-petclinic"
if you just provide `http://che-host/#https://github.com/benoitf/che-server` it's using the default name (and will fail on a devWorkspace enabled server)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
