### PR TITLE
Add "Restart" action to the IDE loading flow

### DIFF
--- a/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
@@ -27,6 +27,7 @@ import { ActionCreators } from '../../store/Workspaces';
 import { Workspace } from '../../services/workspace-adapter';
 
 const showAlertMock = jest.fn();
+const hideAlertMock = jest.fn();
 const requestWorkspaceMock = jest.fn().mockResolvedValue(undefined);
 const startWorkspaceMock = jest.fn().mockResolvedValue(undefined);
 const setWorkspaceIdMock = jest.fn();
@@ -69,10 +70,12 @@ jest.mock('../../pages/IdeLoader', () => {
     ideUrl?: string;
     callbacks?: {
       showAlert?: (alertOptions: AlertOptions) => void;
+      hideAlert?: () => void;
     };
   }): React.ReactElement {
     if (props.callbacks) {
       props.callbacks.showAlert = showAlertMock;
+      props.callbacks.hideAlert = hideAlertMock;
     }
     return (
       <div>
@@ -179,10 +182,11 @@ describe('IDE Loader container', () => {
     expect(requestWorkspaceMock).toBeCalled();
     expect(startWorkspaceMock).not.toBeCalled();
 
-    expect(showAlertMock).toBeCalledTimes(1);
+    expect(showAlertMock).toBeCalled();
 
     const errorAlerts = (
       <React.Fragment>
+        <AlertActionLink onClick={() => jest.fn()}>Restart</AlertActionLink>
         <AlertActionLink onClick={() => jest.fn()}>Open in Verbose mode</AlertActionLink>
         <AlertActionLink onClick={() => jest.fn()}>Open Logs</AlertActionLink>
       </React.Fragment>

--- a/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
@@ -167,10 +167,11 @@ describe('IDE Loader container', () => {
     const elementHasError = screen.getByTestId('ide-loader-has-error');
     expect(elementHasError.innerHTML).toEqual('true');
 
-    const elementCurrentStep = screen.getByTestId('ide-loader-current-step');
-    expect(LoadIdeSteps[elementCurrentStep.innerHTML]).toEqual(
-      LoadIdeSteps[LoadIdeSteps.INITIALIZING],
+    const elementCurrentStep = Number.parseInt(
+      screen.getByTestId('ide-loader-current-step').innerHTML,
+      10,
     );
+    expect(LoadIdeSteps[elementCurrentStep]).toEqual(LoadIdeSteps[LoadIdeSteps.INITIALIZING]);
   });
 
   it('error links are passed to alert when workspace start error is found', () => {
@@ -201,10 +202,11 @@ describe('IDE Loader container', () => {
 
     expect(setWorkspaceIdMock).toBeCalled();
 
-    const elementCurrentStep = screen.getByTestId('ide-loader-current-step');
-    expect(LoadIdeSteps[elementCurrentStep.innerHTML]).toEqual(
-      LoadIdeSteps[LoadIdeSteps.START_WORKSPACE],
+    const elementCurrentStep = Number.parseInt(
+      screen.getByTestId('ide-loader-current-step').innerHTML,
+      10,
     );
+    expect(LoadIdeSteps[elementCurrentStep]).toEqual(LoadIdeSteps[LoadIdeSteps.START_WORKSPACE]);
   });
 
   it('should have correct WORKSPACE START and waiting for the workspace runtime', async () => {
@@ -229,10 +231,11 @@ describe('IDE Loader container', () => {
     const elementWorkspaceName = screen.getByTestId('ide-loader-workspace-name');
     expect(elementWorkspaceName.innerHTML).toEqual(workspaceName);
 
-    const elementCurrentStep = screen.getByTestId('ide-loader-current-step');
-    expect(LoadIdeSteps[elementCurrentStep.innerHTML]).toEqual(
-      LoadIdeSteps[LoadIdeSteps.START_WORKSPACE],
+    const elementCurrentStep = Number.parseInt(
+      screen.getByTestId('ide-loader-current-step').innerHTML,
+      10,
     );
+    expect(LoadIdeSteps[elementCurrentStep]).toEqual(LoadIdeSteps[LoadIdeSteps.START_WORKSPACE]);
 
     const elementIdeUrl = screen.getByTestId('ide-loader-workspace-ide-url');
     expect(elementIdeUrl.innerHTML).toEqual('');
@@ -254,8 +257,11 @@ describe('IDE Loader container', () => {
     const elementWorkspaceName = screen.getByTestId('ide-loader-workspace-name');
     expect(elementWorkspaceName.innerHTML).toEqual(workspaceName);
 
-    const elementCurrentStep = screen.getByTestId('ide-loader-current-step');
-    expect(LoadIdeSteps[elementCurrentStep.innerHTML]).toEqual(LoadIdeSteps[LoadIdeSteps.OPEN_IDE]);
+    const elementCurrentStep = Number.parseInt(
+      screen.getByTestId('ide-loader-current-step').innerHTML,
+      10,
+    );
+    expect(LoadIdeSteps[elementCurrentStep]).toEqual(LoadIdeSteps[LoadIdeSteps.OPEN_IDE]);
 
     const elementWorkspaceId = screen.getByTestId('ide-loader-workspace-id');
     expect(elementWorkspaceId.innerHTML).toEqual('');

--- a/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
@@ -73,7 +73,7 @@ export type AlertOptions = {
 };
 
 class IdeLoader extends React.PureComponent<Props, State> {
-  public readonly hideAlert: () => void;
+  private readonly hideAlert: () => void;
   private readonly handleTabClick: (
     event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: React.ReactText,

--- a/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
@@ -48,6 +48,7 @@ type Props = {
   isDevWorkspace: boolean;
   callbacks?: {
     showAlert?: (alertOptions: AlertOptions) => void;
+    hideAlert?: () => void;
   };
 };
 
@@ -72,7 +73,7 @@ export type AlertOptions = {
 };
 
 class IdeLoader extends React.PureComponent<Props, State> {
-  private readonly hideAlert: () => void;
+  public readonly hideAlert: () => void;
   private readonly handleTabClick: (
     event: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: React.ReactText,
@@ -130,12 +131,24 @@ class IdeLoader extends React.PureComponent<Props, State> {
         alertOptions.alertVariant === AlertVariant.success ? 2000 : 10000,
       );
     };
-    this.hideAlert = (): void => this.setState({ alertVisible: false });
+    this.hideAlert = (): void => {
+      this.setState({
+        alertVisible: false,
+        currentRequestError: '',
+      });
+    };
     // Prepare showAlert as a callback
-    if (this.props.callbacks && !this.props.callbacks.showAlert) {
-      this.props.callbacks.showAlert = (alertOptions: AlertOptions) => {
-        this.showAlert(alertOptions);
-      };
+    if (this.props.callbacks) {
+      if (this.props.callbacks.showAlert === undefined) {
+        this.props.callbacks.showAlert = (alertOptions: AlertOptions) => {
+          this.showAlert(alertOptions);
+        };
+      }
+      if (this.props.callbacks.hideAlert === undefined) {
+        this.props.callbacks.hideAlert = () => {
+          this.hideAlert();
+        };
+      }
     }
   }
 
@@ -215,22 +228,16 @@ class IdeLoader extends React.PureComponent<Props, State> {
   private getIcon(step: LoadIdeSteps, className = ''): React.ReactNode {
     const { currentStep, hasError } = this.props;
     if (currentStep > step) {
-      return (
-        <React.Fragment>
-          <CheckCircleIcon className={className} color="green" />
-        </React.Fragment>
-      );
+      return <CheckCircleIcon className={className} color="green" />;
     } else if (currentStep === step) {
       if (hasError) {
         return <ExclamationCircleIcon className={className} color="red" />;
       }
       return (
-        <React.Fragment>
-          <InProgressIcon
-            className={`${workspaceStatusLabelStyles.rotate} ${className}`}
-            color="#0e6fe0"
-          />
-        </React.Fragment>
+        <InProgressIcon
+          className={`${workspaceStatusLabelStyles.rotate} ${className}`}
+          color="#0e6fe0"
+        />
       );
     }
     return '';

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -297,16 +297,15 @@ export const actionCreators: ActionCreators = {
     async (dispatch): Promise<void> => {
       const defer: IDeferred<void> = getDefer();
       const toDispose = new DisposableCollection();
-      const onStatusChangeCallback = status => {
+      const onStatusChangeCallback = async status => {
         if (status === DevWorkspaceStatus.STOPPED || status === DevWorkspaceStatus.FAILED) {
           toDispose.dispose();
-          dispatch(actionCreators.startWorkspace(workspace))
-            .then(() => {
-              defer.resolve();
-            })
-            .catch(e => {
-              defer.reject(`Failed to restart the workspace ${workspace.metadata.name}. ${e}`);
-            });
+          try {
+            await dispatch(actionCreators.startWorkspace(workspace));
+            defer.resolve();
+          } catch (e) {
+            defer.reject(`Failed to restart the workspace ${workspace.metadata.name}. ${e}`);
+          }
         }
       };
       if (


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds the ability to restart a failed workspace directly on the IDE loading page. 


![Screenshot 2021-11-04 at 16 23 42](https://user-images.githubusercontent.com/16220722/140331202-fc5dc9a0-09b0-4a85-9ac4-4904e3a94760.png)


### What issues does this PR fix or reference?

fix https://github.com/eclipse/che/issues/19105

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Modify an existing workspace devfile to make it broken, e.g. change a container image name to a non-existing one.
2. Try to load the workspace.

