### PR TITLE
feat: commit hash in dashboard version

### DIFF
--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -546,6 +546,7 @@
 | [`get-value@2.0.6`](https://github.com/jonschlinkert/get-value.git) | MIT | clearlydefined |
 | [`git-raw-commits@2.0.10`](https://github.com/conventional-changelog/conventional-changelog.git) | MIT | clearlydefined |
 | [`git-remote-origin-url@2.0.0`](https://github.com/sindresorhus/git-remote-origin-url.git) | MIT | clearlydefined |
+| [`git-revision-webpack-plugin@3.0.6`](https://github.com/pirelenito/git-revision-webpack-plugin.git) | MIT | clearlydefined |
 | [`git-semver-tags@4.1.1`](https://github.com/conventional-changelog/conventional-changelog.git) | MIT | clearlydefined |
 | [`git-up@4.0.5`](https://github.com/IonicaBizau/git-up.git) | MIT | clearlydefined |
 | [`git-url-parse@11.6.0`](git+ssh://git@github.com/IonicaBizau/git-url-parse.git) | MIT | clearlydefined |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -126,6 +126,7 @@
     "eslint-plugin-react": "^7.26.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "file-loader": "^6.0.0",
+    "git-revision-webpack-plugin": "3.0.6",
     "hard-source-webpack-plugin": "^0.13.1",
     "html-webpack-plugin": "^4.3.0",
     "jest": "^26.0.1",

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/Modal.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/Modal.tsx
@@ -44,6 +44,9 @@ export class AboutModal extends React.PureComponent<Props> {
 
   private buildContent(): React.ReactElement {
     const dashboardVersion = process.env.DASHBOARD_VERSION;
+    const version = process.env.VERSION;
+    const commitHash = process.env.COMMITHASH;
+    const commitUrl = `https://github.com/eclipse-che/che-dashboard/commit/${commitHash}`;
     const serverVersion = this.props.serverVersion;
     const username = this.props.username;
     const browserVersion = this.browserVersion;
@@ -61,7 +64,11 @@ export class AboutModal extends React.PureComponent<Props> {
                 className="co-select-to-copy"
                 data-testid="dashboard-version"
               >
-                {dashboardVersion}
+                {dashboardVersion} (
+                <a href={commitUrl} target="_blank" rel="noreferrer">
+                  {version}
+                </a>
+                )
               </TextListItem>
             </>
           )}

--- a/packages/dashboard-frontend/webpack.config.common.js
+++ b/packages/dashboard-frontend/webpack.config.common.js
@@ -14,9 +14,12 @@ const CopyPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const stylus_plugin = require('poststylus');
+const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const stylusLoader = require('stylus-loader');
 const path = require('path');
 const webpack = require('webpack');
+
+const gitRevisionPlugin = new GitRevisionPlugin();
 
 const config = {
   entry: {
@@ -137,6 +140,8 @@ const config = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.DASHBOARD_VERSION': JSON.stringify(require('./package.json').version),
+      'process.env.COMMITHASH': JSON.stringify(gitRevisionPlugin.commithash()),
+      'process.env.VERSION': JSON.stringify(gitRevisionPlugin.version()),
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, './index.html'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6432,6 +6432,11 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
+git-revision-webpack-plugin@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.6.tgz#5dd6c6829fae05b405059dea6195b23875d69d4d"
+  integrity sha512-vW/9dBahGbpKPcccy3xKkHgdWoH/cAPPc3lQw+3edl7b4j29JfNGVrja0a1d8ZoRe4nTN8GCPrF9aBErDnzx5Q==
+
 git-semver-tags@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-4.1.1.tgz#63191bcd809b0ec3e151ba4751c16c444e5b5780"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

It adds commit ID to the Dashboard Version field.

<img width="1121" alt="Screenshot 2021-11-08 at 13 38 34" src="https://user-images.githubusercontent.com/16220722/140767540-45f5fdce-d127-4863-a21a-c8b10de29413.png">


