### PR TITLE
chore: Adding 'try-in-web-ide' ci yaml

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -1,0 +1,16 @@
+# Add Web IDE link on PRs
+name: web-ide
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  add-link:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Web IDE Pull Request Check
+        id: try-in-web-ide
+        uses: redhat-actions/try-in-web-ide@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -13,4 +13,4 @@ jobs:
         id: try-in-web-ide
         uses: redhat-actions/try-in-web-ide@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this PR do?
chore: Adding 'try-in-web-ide' ci yaml

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20664

### Is it tested? How?

Currently failing for me with: 
```
Failed to run the workspace: "Unrecoverable event occurred: 'Failed', 'Failed to pull image "docker.io/node:12.20.1-alpine3.12": rpc error: code = Unknown desc = loading manifest for target platform: reading manifest sha256:e63dd88799eeccf4f2869963bf79fb2aa7fa24aacf22ef9d6603c0c3ee7f4a07 in docker.io/library/node: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit', 'workspace4ojyba69btvx9mqw.dashboard-dev-75c7d7894d-gktbs'"
```
The problem is related to the dockerhub pull rate limit, and I believe we need to move the devfile related images to [quai](https://quay.io/).

#### Release Notes
N/A

#### Docs PR
N/A
