### PR TITLE
Provide default devfile v2 in the devworkspace mode

### DIFF
--- a/packages/dashboard-frontend/src/containers/FactoryLoader/devfile-converter.ts
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/devfile-converter.ts
@@ -238,7 +238,7 @@ export class DevfileConverter {
     return devfileV1Project;
   }
 
-  devfileV2toDevfileV1(devfileV2: devfileApi.Devfile): cheApi.workspace.devfile.Devfile {
+  devfileV2toDevfileV1(devfileV2: devfileApi.Devfile): che.WorkspaceDevfile {
     const devfileV1: cheApi.workspace.devfile.Devfile = {
       apiVersion: '1.0.0',
       metadata: this.metadataV2toMetadataV1(devfileV2.metadata),
@@ -280,6 +280,6 @@ export class DevfileConverter {
       delete devfileV1Any.commands;
     }
 
-    return devfileV1;
+    return devfileV1 as che.WorkspaceDevfile;
   }
 }

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -36,7 +36,7 @@ import { KeycloakAuthService } from '../../services/keycloak/auth';
 import { getEnvironment, isDevEnvironment } from '../../services/helpers/environment';
 import { isOAuthResponse } from '../../store/FactoryResolver';
 import { updateDevfile } from '../../services/storageTypes';
-import { isCheDevfile, isCheWorkspace, Workspace } from '../../services/workspace-adapter';
+import { Devfile, isCheDevfile, isCheWorkspace, Workspace } from '../../services/workspace-adapter';
 import { AlertOptions } from '../../pages/FactoryLoader';
 import {
   selectDefaultNamespace,
@@ -123,13 +123,13 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     this.overrideDevfileObject[key] = val;
   }
 
-  private getTargetDevfile(): api.che.workspace.devfile.Devfile | undefined {
-    let devfile = this.factoryResolver.resolver.devfile;
-    if (!devfile) {
-      return undefined;
-    }
+  private getTargetDevfile(): Devfile {
+    // at this point the resolver object is defined
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    let devfile = this.factoryResolver.resolver!.devfile;
 
     if (
+      isCheDevfile(devfile) &&
       devfile?.attributes?.persistVolumes === undefined &&
       devfile?.attributes?.asyncPersist === undefined &&
       this.props.preferredStorageType
@@ -299,9 +299,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     return attrs;
   }
 
-  private async resolveDevfile(
-    location: string,
-  ): Promise<api.che.workspace.devfile.Devfile | undefined> {
+  private async resolveDevfile(location: string): Promise<Devfile | undefined> {
     const override = Object.entries(this.overrideDevfileObject).length
       ? this.overrideDevfileObject
       : undefined;
@@ -445,7 +443,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
           undefined,
           namespace,
           attrs,
-          this.factoryResolver.resolver.optionalFilesContent || {},
+          this.factoryResolver.resolver?.optionalFilesContent || {},
         );
         this.props.setWorkspaceQualifiedName(namespace, devfile.metadata.name as string);
         workspace = this.props.activeWorkspace;

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/DevfileSelector/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/DevfileSelector/index.tsx
@@ -86,7 +86,10 @@ export class DevfileSelectorFormGroup extends React.PureComponent<Props, State> 
     try {
       if (cheDevworkspaceEnabled) {
         await this.props.requestFactoryResolver(meta.links.v2);
-        devfile = updateDevfileMetadata(this.props.factoryResolver.resolver.devfile, meta);
+        // at this point the resolver object is defined
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const resolvedDevfile = this.props.factoryResolver.resolver!.devfile;
+        devfile = updateDevfileMetadata(resolvedDevfile, meta);
       } else {
         devfile = safeLoad((await this.props.requestDevfile(meta.links.self)) as string);
       }
@@ -106,7 +109,9 @@ export class DevfileSelectorFormGroup extends React.PureComponent<Props, State> 
     try {
       this.setState({ isLoading: true });
       await this.props.requestFactoryResolver(location);
-      const { resolver } = this.factoryResolver;
+      // at this point the resolver object is defined
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const resolver = this.factoryResolver.resolver!;
       if (resolver.source === 'repo') {
         throw new Error('devfile.yaml not found in the specified GitHub repository root.');
       }

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/index.tsx
@@ -26,6 +26,7 @@ import { WorkspaceNameFormGroup } from './WorkspaceName';
 import DevfileSelectorFormGroup from './DevfileSelector';
 import InfrastructureNamespaceFormGroup from './InfrastructureNamespace';
 import {
+  selectCheDevworkspaceEnabled,
   selectPreferredStorageType,
   selectWorkspacesSettings,
 } from '../../../store/Workspaces/Settings/selectors';
@@ -33,9 +34,8 @@ import { attributesToType, updateDevfile } from '../../../services/storageTypes'
 import { safeLoad } from 'js-yaml';
 import { updateDevfileMetadata } from '../updateDevfileMetadata';
 import { Devfile, isCheDevfile } from '../../../services/workspace-adapter';
-import getRandomString from '../../../services/helpers/random';
 import { isDevfileV2Like } from '../../../services/devfileApi';
-import { isDevworkspacesEnabled } from '../../../services/helpers/devworkspace';
+import getDefaultDevfile from '../../../services/helpers/getDefaultDevfile';
 
 type Props = MappedProps & {
   onDevfile: (
@@ -78,22 +78,8 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
     this.devfileEditorRef = React.createRef<Editor>();
   }
 
-  private buildInitialDevfile(generateName = 'wksp-'): Devfile {
-    const devfile = isDevworkspacesEnabled(this.props.workspacesSettings)
-      ? {
-          schemaVersion: '2.1.0',
-          metadata: {
-            name: generateName + getRandomString(4).toLowerCase(),
-          },
-        }
-      : {
-          apiVersion: '1.0.0',
-          metadata: {
-            generateName,
-          },
-        };
-
-    return updateDevfile(devfile as Devfile, this.props.preferredStorageType);
+  private buildInitialDevfile(): Devfile {
+    return getDefaultDevfile(this.props.cheDevworkspacesEnabled, this.props.preferredStorageType);
   }
 
   private handleInfrastructureNamespaceChange(namespace: che.KubernetesNamespace): void {
@@ -290,6 +276,7 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   workspacesSettings: selectWorkspacesSettings(state),
   preferredStorageType: selectPreferredStorageType(state),
+  cheDevworkspacesEnabled: selectCheDevworkspaceEnabled(state),
 });
 
 const connector = connect(mapStateToProps);

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/index.tsx
@@ -73,7 +73,9 @@ export class ImportFromGit extends React.PureComponent<Props, State> {
     try {
       this.setState({ isLoading: true });
       await this.props.requestFactoryResolver(location);
-      const { resolver } = this.factoryResolver;
+      // at this point the resolver object is defined
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const resolver = this.factoryResolver.resolver!;
       this.props.onDevfileResolve(resolver, location);
       this.setState({ isLoading: false });
     } catch (e) {

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
@@ -19,7 +19,7 @@ import { Provider } from 'react-redux';
 import mockMetadata from '../../__tests__/devfileMetadata.json';
 import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
 import { BrandingData } from '../../../../services/bootstrap/branding.constant';
-import { WorkspaceSettings } from 'che';
+import { Devfile } from '../../../../services/workspace-adapter';
 
 const requestFactoryResolverMock = jest.fn().mockResolvedValue(undefined);
 
@@ -153,11 +153,11 @@ function createFakeStore(metadata?: che.DevfileMetaData[], devWorkspaceEnabled?:
         storageTypes: 'https://docs.location',
       },
     } as BrandingData)
-    .withWorkspacesSettings(workspaceSettings as WorkspaceSettings)
+    .withWorkspacesSettings(workspaceSettings as che.WorkspaceSettings)
     .withFactoryResolver({
       v: '4.0',
       source: 'devfile.yaml',
-      devfile: {},
+      devfile: {} as Devfile,
       location: 'http://fake-location',
       scm_info: {
         clone_url: 'http://github.com/clone-url',

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/getDefaultDevfile.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/getDefaultDevfile.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import getDefaultDevfile from '../getDefaultDevfile';
+
+describe('getDefaultDevfile', () => {
+  it('should return devfile v1', () => {
+    const isDevworkspacesEnabled = true;
+    const preferredStorageType = 'ephemeral';
+    const devfile = getDefaultDevfile(isDevworkspacesEnabled, preferredStorageType);
+
+    expect(devfile).toEqual({
+      schemaVersion: '2.1.0',
+      metadata: {
+        name: expect.stringMatching(/^wksp-/),
+      },
+    });
+  });
+  it('should return devfile v2', () => {
+    const isDevworkspacesEnabled = false;
+    const preferredStorageType = 'ephemeral';
+    const devfile = getDefaultDevfile(isDevworkspacesEnabled, preferredStorageType);
+
+    expect(devfile).toEqual({
+      apiVersion: '1.0.0',
+      attributes: {
+        persistVolumes: 'false',
+      },
+      metadata: {
+        generateName: 'wksp-',
+      },
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/getDefaultDevfile.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/getDefaultDevfile.spec.ts
@@ -13,7 +13,7 @@
 import getDefaultDevfile from '../getDefaultDevfile';
 
 describe('getDefaultDevfile', () => {
-  it('should return devfile v1', () => {
+  it('should return devfile v2', () => {
     const isDevworkspacesEnabled = true;
     const preferredStorageType = 'ephemeral';
     const devfile = getDefaultDevfile(isDevworkspacesEnabled, preferredStorageType);
@@ -25,7 +25,7 @@ describe('getDefaultDevfile', () => {
       },
     });
   });
-  it('should return devfile v2', () => {
+  it('should return devfile v1', () => {
     const isDevworkspacesEnabled = false;
     const preferredStorageType = 'ephemeral';
     const devfile = getDefaultDevfile(isDevworkspacesEnabled, preferredStorageType);

--- a/packages/dashboard-frontend/src/services/helpers/getDefaultDevfile.ts
+++ b/packages/dashboard-frontend/src/services/helpers/getDefaultDevfile.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import getRandomString from './random';
+import { updateDevfile } from '../storageTypes';
+import { Devfile } from '../workspace-adapter';
+import devfileApi from '../devfileApi';
+
+export function getDefaultDevfileV1(
+  preferredStorageType: che.WorkspaceStorageType,
+  generateName = 'wksp-',
+): che.WorkspaceDevfile {
+  const devfile = {
+    apiVersion: '1.0.0',
+    metadata: {
+      generateName,
+    },
+  };
+
+  return updateDevfile(devfile as Devfile, preferredStorageType) as che.WorkspaceDevfile;
+}
+
+export function getDefaultDevfileV2(generateName = 'wksp-'): devfileApi.Devfile {
+  return {
+    schemaVersion: '2.1.0',
+    metadata: {
+      name: generateName + getRandomString(4).toLowerCase(),
+    },
+  } as devfileApi.Devfile;
+}
+
+export default function getDefaultDevfile(
+  isDevworkspacesEnabled: boolean,
+  preferredStorageType: che.WorkspaceStorageType,
+  generateName = 'wksp-',
+): Devfile {
+  if (isDevworkspacesEnabled) {
+    return getDefaultDevfileV2(generateName);
+  } else {
+    return getDefaultDevfileV1(preferredStorageType, generateName);
+  }
+}

--- a/packages/dashboard-frontend/src/services/helpers/getDefaultDevfile.ts
+++ b/packages/dashboard-frontend/src/services/helpers/getDefaultDevfile.ts
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import getRandomString from './random';
 import { updateDevfile } from '../storageTypes';
 import { Devfile } from '../workspace-adapter';
 import devfileApi from '../devfileApi';
@@ -29,11 +28,11 @@ export function getDefaultDevfileV1(
   return updateDevfile(devfile as Devfile, preferredStorageType) as che.WorkspaceDevfile;
 }
 
-export function getDefaultDevfileV2(generateName = 'wksp-'): devfileApi.Devfile {
+export function getDefaultDevfileV2(name = 'wksp'): devfileApi.Devfile {
   return {
     schemaVersion: '2.1.0',
     metadata: {
-      name: generateName + getRandomString(4).toLowerCase(),
+      name,
     },
   } as devfileApi.Devfile;
 }

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -12,6 +12,7 @@
 
 import { AlertVariant } from '@patternfly/react-core';
 import * as React from 'react';
+import { Devfile } from '../workspace-adapter';
 
 export interface AlertItem {
   key: string;
@@ -23,7 +24,7 @@ export interface AlertItem {
 export interface FactoryResolver {
   v: string;
   source?: string;
-  devfile: api.che.workspace.devfile.Devfile;
+  devfile: Devfile;
   location?: string;
   scm_info?: FactoryResolverScmInfo;
   links: api.che.core.rest.Link[];

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/getDevfile.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/getDevfile.spec.ts
@@ -13,6 +13,7 @@
 import { getDevfile } from '../getDevfile';
 import { FactoryResolverBuilder } from '../../__mocks__/factoryResolverBuilder';
 import { safeDump } from 'js-yaml';
+import devfileApi from '../../../services/devfileApi';
 
 describe('Get a devfile from factory resolver object', () => {
   const location = 'http://dummy/test.com/project-demo';
@@ -26,7 +27,7 @@ describe('Get a devfile from factory resolver object', () => {
     };
     const factoryResolver = new FactoryResolverBuilder().withDevfile(devfile).build();
 
-    const targetDevfile = getDevfile(factoryResolver, location);
+    const targetDevfile = getDevfile(factoryResolver, location, false);
 
     expect(targetDevfile).toEqual(devfile);
   });
@@ -35,7 +36,7 @@ describe('Get a devfile from factory resolver object', () => {
     const devfile = getV2Devfile();
     const factoryResolver = new FactoryResolverBuilder().withDevfile(devfile).build();
 
-    const targetDevfile = getDevfile(factoryResolver, location);
+    const targetDevfile = getDevfile(factoryResolver, location, true);
 
     expect(targetDevfile).toEqual(devfile);
   });
@@ -50,7 +51,7 @@ describe('Get a devfile from factory resolver object', () => {
       })
       .build();
 
-    const targetDevfile = getDevfile(factoryResolver, location);
+    const targetDevfile = getDevfile(factoryResolver, location, true);
 
     expect(targetDevfile).toEqual(
       expect.objectContaining({
@@ -89,7 +90,7 @@ describe('Get a devfile from factory resolver object', () => {
       },
     };
 
-    const targetDevfile = getDevfile(factoryResolver, location);
+    const targetDevfile = getDevfile(factoryResolver, location, true) as devfileApi.Devfile;
 
     expect(targetDevfile.metadata.attributes).toEqual(attributes);
   });
@@ -117,7 +118,7 @@ describe('Get a devfile from factory resolver object', () => {
       },
     };
 
-    const targetDevfile = getDevfile(factoryResolver, location);
+    const targetDevfile = getDevfile(factoryResolver, location, true) as devfileApi.Devfile;
 
     expect(targetDevfile.metadata.attributes).toEqual(attributes);
   });
@@ -133,9 +134,26 @@ describe('Get a devfile from factory resolver object', () => {
       },
     };
 
-    const targetDevfile = getDevfile(factoryResolver, location);
+    const targetDevfile = getDevfile(factoryResolver, location, true) as devfileApi.Devfile;
 
     expect(targetDevfile.metadata.attributes).toEqual(attributes);
+  });
+
+  it('should return the default devfile v2 if devworkspace engine enabled and no devfiles in the repo', () => {
+    const devfile = {
+      apiVersion: '1.0.0',
+      metadata: {
+        name: 'spring-petclinic',
+      },
+    };
+    const factoryResolver = new FactoryResolverBuilder()
+      .withDevfile(devfile)
+      .withSource('repo')
+      .build();
+
+    const targetDevfile = getDevfile(factoryResolver, location, true);
+
+    expect(targetDevfile).toEqual(expect.objectContaining({ schemaVersion: '2.1.0' }));
   });
 });
 

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/getDevfile.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/getDevfile.spec.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { getDevfile } from '../../FactoryResolver/getDevfile';
+import { getDevfile } from '../getDevfile';
 import { FactoryResolverBuilder } from '../../__mocks__/factoryResolverBuilder';
 import { safeDump } from 'js-yaml';
 

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { MockStoreEnhanced } from 'redux-mock-store';
+import { ThunkDispatch } from 'redux-thunk';
+import common from '@eclipse-che/common';
+import { AppState } from '../..';
+import { FakeStoreBuilder } from '../../__mocks__/storeBuilder';
+import devfileApi from '../../../services/devfileApi';
+import { container } from '../../../inversify.config';
+import { CheWorkspaceClient } from '../../../services/workspace-client/cheworkspace/cheWorkspaceClient';
+import * as factoryResolverStore from '..';
+import { AxiosError } from 'axios';
+import { KubernetesNamespace } from '@eclipse-che/workspace-client/dist/rest/resources';
+
+const cheWorkspaceClient = container.get(CheWorkspaceClient);
+jest
+  .spyOn(cheWorkspaceClient.restApiClient, 'provisionKubernetesNamespace')
+  .mockResolvedValue({} as KubernetesNamespace);
+
+describe('FactoryResolver store', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('actions', () => {
+    it('should create REQUEST_FACTORY_RESOLVER and RECEIVE_FACTORY_RESOLVER', async () => {
+      const resolver: factoryResolverStore.ResolverState = {
+        devfile: {
+          schemaVersion: '2.0.0',
+        } as devfileApi.Devfile,
+      };
+
+      const getFactoryResolverSpy = jest
+        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
+        .mockResolvedValue(resolver);
+
+      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const location = 'factory-link';
+      await store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location));
+
+      const actions = store.getActions();
+      const expectedActions: factoryResolverStore.KnownAction[] = [
+        {
+          type: 'REQUEST_FACTORY_RESOLVER',
+        },
+        {
+          type: 'RECEIVE_FACTORY_RESOLVER',
+          resolver: expect.objectContaining(resolver),
+        },
+      ];
+      expect(actions).toEqual(expectedActions);
+
+      getFactoryResolverSpy.mockRestore();
+    });
+
+    it('should create REQUEST_FACTORY_RESOLVER and RECEIVE_FACTORY_RESOLVER_ERROR', async () => {
+      const spyGetFactoryResolver = jest
+        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
+        .mockRejectedValue({
+          isAxiosError: true,
+          code: '500',
+          response: {
+            data: {
+              message: 'Something unexpected happened.',
+            },
+          },
+        } as AxiosError);
+      // mute the error outputs
+      console.error = jest.fn();
+
+      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const actions = store.getActions();
+      const expectedActions: factoryResolverStore.KnownAction[] = [
+        {
+          type: 'REQUEST_FACTORY_RESOLVER',
+        },
+        {
+          type: 'RECEIVE_FACTORY_RESOLVER_ERROR',
+          error: expect.stringContaining('Failed to request factory resolver'),
+        },
+      ];
+
+      const spyIsAxiosError = jest
+        .spyOn(common.helpers.errors, 'isAxiosError')
+        .mockImplementation(() => true);
+      const spyIsAxiosResponse = jest
+        .spyOn(common.helpers.errors, 'isAxiosResponse')
+        .mockImplementation(() => true);
+
+      const location = 'factory-link';
+      await expect(
+        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
+      ).rejects.toMatch('Failed to request factory resolver');
+      expect(actions).toEqual(expectedActions);
+
+      spyGetFactoryResolver.mockRestore();
+      spyIsAxiosError.mockRestore();
+      spyIsAxiosResponse.mockRestore();
+    });
+
+    it('should throw if it resolves no devfile', async () => {
+      const resolver = {} as factoryResolverStore.ResolverState;
+
+      const spyGetFactoryResolver = jest
+        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
+        .mockResolvedValue(resolver);
+
+      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const actions = store.getActions();
+      const expectedActions: factoryResolverStore.KnownAction[] = [
+        {
+          type: 'REQUEST_FACTORY_RESOLVER',
+        },
+        {
+          type: 'RECEIVE_FACTORY_RESOLVER_ERROR',
+          error: expect.stringContaining('The specified link does not contain a valid Devfile.'),
+        },
+      ];
+
+      const location = 'factory-link';
+      await expect(
+        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
+      ).rejects.toMatch('The specified link does not contain a valid Devfile.');
+      expect(actions).toEqual(expectedActions);
+
+      spyGetFactoryResolver.mockRestore();
+    });
+
+    it('should reject if authentication is needed', async () => {
+      const spyGetFactoryResolver = jest
+        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
+        .mockRejectedValue({
+          isAxiosError: true,
+          code: '401',
+          response: {
+            status: 401,
+            data: {
+              attributes: {
+                oauth_provider: 'oauth_provider',
+                oauth_authentication_url: 'oauth_authentication_url',
+              },
+            },
+          },
+        } as AxiosError);
+
+      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const spyIsAxiosError = jest
+        .spyOn(common.helpers.errors, 'isAxiosError')
+        .mockReturnValue(true);
+      const spyIsAxiosResponse = jest
+        .spyOn(common.helpers.errors, 'isAxiosResponse')
+        .mockReturnValue(true);
+
+      const location = 'factory-link';
+      await expect(
+        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
+      ).rejects.toEqual({
+        attributes: {
+          oauth_provider: 'oauth_provider',
+          oauth_authentication_url: 'oauth_authentication_url',
+        },
+      });
+
+      spyGetFactoryResolver.mockRestore();
+      spyIsAxiosError.mockRestore();
+      spyIsAxiosResponse.mockRestore();
+    });
+  });
+
+  describe('reducers', () => {
+    it('should return initial state', () => {
+      const incomingAction: factoryResolverStore.KnownAction = {
+        type: 'REQUEST_FACTORY_RESOLVER',
+      };
+
+      const initialState = factoryResolverStore.reducer(undefined, incomingAction);
+      const expectedState: factoryResolverStore.State = {
+        isLoading: false,
+      };
+
+      expect(initialState).toEqual(expectedState);
+    });
+
+    it('should return state if action is not matched', () => {
+      const initialState: factoryResolverStore.State = {
+        isLoading: true,
+      };
+      const incomingAction = {
+        type: 'OTHER_ACTION',
+      };
+
+      const newState = factoryResolverStore.reducer(initialState, incomingAction);
+      const expectedState: factoryResolverStore.State = {
+        isLoading: true,
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle REQUEST_FACTORY_RESOLVER', () => {
+      const initialState: factoryResolverStore.State = {
+        isLoading: false,
+      };
+      const incomingAction: factoryResolverStore.KnownAction = {
+        type: 'REQUEST_FACTORY_RESOLVER',
+      };
+
+      const newState = factoryResolverStore.reducer(initialState, incomingAction);
+      const expectedState: factoryResolverStore.State = {
+        isLoading: true,
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVE_FACTORY_RESOLVER', () => {
+      const initialState: factoryResolverStore.State = {
+        isLoading: true,
+      };
+      const resolver: factoryResolverStore.ResolverState = {
+        devfile: {
+          schemaVersion: '2.0.0',
+        } as devfileApi.Devfile,
+      };
+      const incomingAction: factoryResolverStore.KnownAction = {
+        type: 'RECEIVE_FACTORY_RESOLVER',
+        resolver,
+      };
+
+      const newState = factoryResolverStore.reducer(initialState, incomingAction);
+      const expectedState: factoryResolverStore.State = {
+        isLoading: false,
+        resolver,
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVE_FACTORY_RESOLVER_ERROR', () => {
+      const initialState: factoryResolverStore.State = {
+        isLoading: true,
+      };
+      const incomingAction: factoryResolverStore.KnownAction = {
+        type: 'RECEIVE_FACTORY_RESOLVER_ERROR',
+        error: 'Unexpected error',
+      };
+
+      const newState = factoryResolverStore.reducer(initialState, incomingAction);
+      const expectedState: factoryResolverStore.State = {
+        isLoading: false,
+        error: 'Unexpected error',
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/store/FactoryResolver/getDevfile.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/getDevfile.ts
@@ -25,6 +25,7 @@ import getRandomString from '../../services/helpers/random';
  * Returns a devfile from the FactoryResolver object.
  * @param data a FactoryResolver object.
  * @param location a source location.
+ * @param isDevworkspacesEnabled indicates if devworkspace engine is enabled.
  */
 export function getDevfile(
   data: FactoryResolver,

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -11,8 +11,7 @@
  */
 
 import { Action, Reducer } from 'redux';
-import { RequestError } from '@eclipse-che/workspace-client';
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import common from '@eclipse-che/common';
 import { FactoryResolver } from '../../services/helpers/types';
 import { container } from '../../inversify.config';
@@ -20,6 +19,8 @@ import { CheWorkspaceClient } from '../../services/workspace-client/cheworkspace
 import { AppThunk } from '../index';
 import { createObject } from '../helpers';
 import { getDevfile } from './getDevfile';
+import { selectCheDevworkspaceEnabled } from '../Workspaces/Settings/selectors';
+import { Devfile } from '../../services/workspace-adapter';
 
 const WorkspaceClient = container.get(CheWorkspaceClient);
 
@@ -33,8 +34,11 @@ export type OAuthResponse = {
   message: string;
 };
 
-export function isOAuthResponse(response: any): response is OAuthResponse {
-  if (response?.attributes?.oauth_provider && response?.attributes?.oauth_authentication_url) {
+export function isOAuthResponse(responseData: any): responseData is OAuthResponse {
+  if (
+    responseData?.attributes?.oauth_provider &&
+    responseData?.attributes?.oauth_authentication_url
+  ) {
     return true;
   }
   return false;
@@ -42,7 +46,7 @@ export function isOAuthResponse(response: any): response is OAuthResponse {
 export interface ResolverState {
   location?: string;
   source?: string;
-  devfile?: api.che.workspace.devfile.Devfile;
+  devfile: Devfile;
   scm_info?: {
     clone_url: string;
     scm_provider: string;
@@ -55,7 +59,7 @@ export interface ResolverState {
 
 export interface State {
   isLoading: boolean;
-  resolver: ResolverState;
+  resolver?: ResolverState;
   error?: string;
 }
 
@@ -73,7 +77,7 @@ interface ReceiveFactoryResolverErrorAction {
   error: string;
 }
 
-type KnownAction =
+export type KnownAction =
   | RequestFactoryResolverAction
   | ReceiveFactoryResolverAction
   | ReceiveFactoryResolverErrorAction;
@@ -128,7 +132,7 @@ export const actionCreators: ActionCreators = {
       location: string,
       overrideParams?: { [params: string]: string },
     ): AppThunk<KnownAction, Promise<void>> =>
-    async (dispatch): Promise<void> => {
+    async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_FACTORY_RESOLVER' });
 
       try {
@@ -154,7 +158,10 @@ export const actionCreators: ActionCreators = {
         if (cheEditor) {
           optionalFilesContent['.che/che-editor.yaml'] = cheEditor;
         }
-        const devfile = getDevfile(data, location);
+
+        const state = getState();
+        const isDevworkspacesEnabled = selectCheDevworkspaceEnabled(state);
+        const devfile = getDevfile(data, location, isDevworkspacesEnabled);
 
         const { source, scm_info } = data;
         dispatch({
@@ -163,11 +170,14 @@ export const actionCreators: ActionCreators = {
         });
         return;
       } catch (e) {
-        const error = e as RequestError;
-        const response = error.response as AxiosResponse;
-        const responseData = response.data;
-        if (response.status === 401 && isOAuthResponse(responseData)) {
-          throw responseData;
+        if (
+          common.helpers.errors.isAxiosError(e) &&
+          common.helpers.errors.isAxiosResponse(e.response)
+        ) {
+          const responseData = e.response.data;
+          if (e.response.status === 401 && isOAuthResponse(responseData)) {
+            throw responseData;
+          }
         }
         const errorMessage =
           'Failed to request factory resolver: ' + common.helpers.errors.getMessage(e);
@@ -182,7 +192,6 @@ export const actionCreators: ActionCreators = {
 
 const unloadedState: State = {
   isLoading: false,
-  resolver: {},
 };
 
 export const reducer: Reducer<State> = (


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

When Che is running devworkspace mode, the dashboard should supply the default devfile v2 instead of a devfile v1 resolved by Che Server.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/20705

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

Create a workspace using factory flow from `<che-host>#https://github.com/eclipse/che`
