### PR TITLE
feat: update to the latest theia DW library

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,7 +5,7 @@
 | [`@babel/runtime@7.15.4`](https://github.com/babel/babel.git) | MIT | clearlydefined |
 | [`@devfile/api@2.2.0-alpha-1633545768`](https://github.com/devfile/api.git) | EPL-2.0 | clearlydefined |
 | `@eclipse-che/api@7.36.0` | EPL-2.0 | clearlydefined |
-| [`@eclipse-che/che-theia-devworkspace-handler@0.0.1-1636123638`](git+https://github.com/eclipse-che/che-theia.git) | EPL-2.0 | clearlydefined |
+| [`@eclipse-che/che-theia-devworkspace-handler@0.0.1-1637592995`](git+https://github.com/eclipse-che/che-theia.git) | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/common@7.37.0-SNAPSHOT`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-backend@7.37.0-SNAPSHOT`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-frontend@7.37.0-SNAPSHOT`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | N/A |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -36,7 +36,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1636123638",
+    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1637592995",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,13 +341,14 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.36.0.tgz#db8774cbf688df140631c0e60107bef36c194fb1"
   integrity sha512-ephKJ3rDG53CdhfWHZ5byR2MRnTlbKObOph4+aNH9DO+rI44GTX2f9U2DjwQmHCAyGEXJkT1DdRum6C6ZbfCKA==
 
-"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1636123638":
-  version "0.0.1-1636123638"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1636123638.tgz#ac78cd914dc972a147c4ef1afe2205f92c851624"
-  integrity sha512-r5qiKe44OSnoOGo4RioKRcKJCZtuh4gXuUxYapJiFNGMBVOaBRHOL7OYbUl3P73v07xsfCwy02saHWtQGKcEfg==
+"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1637592995":
+  version "0.0.1-1637592995"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1637592995.tgz#cc584fa11b06dc19f9c5b33d33334d29abd07a1e"
+  integrity sha512-TP6lSNf1g9aLHHIZWoK/GJU2fO8sqpEXfI+TnS+ZaYXggJLuK+t87waGZCij42227iRsX4tUx1P6XFOJrk/SCw==
   dependencies:
     "@devfile/api" latest
     axios "0.21.2"
+    fs-extra "^9.1.0"
     inversify "^5.0.1"
     js-yaml "^4.0.0"
     jsonc-parser "^3.0.0"


### PR DESCRIPTION
### What does this PR do?
Use last version of the library:
- Add volume components if plug-ins have defined volumeMounts
- Handle override of che-theia-plugins

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20805
Fixes https://github.com/eclipse/che/issues/20596

### Is it tested? How?
Use tests provided by the two PRs:
https://github.com/eclipse-che/che-theia/pull/1262
https://github.com/eclipse-che/che-theia/pull/1263

I tested using:
- start from `https://<che-host>#https://github.com/l0rd/spring-petclinic?devfilePath=.devfilev2.yaml` should succeed instead of reporting an error as today
- start from `https://<che-host>#https://github.com/svor/java-spring-petclinic/tree/sv-che-preferences` and check that java language server is started with LightWeight mode


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
