### PR TITLE
fix: devfile converted usage

### DIFF
--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -328,23 +328,20 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     //  - repo: means no devfile is found and default is generated
     //  - any other - devfile is found in repository as filename from the value
     if (!source) {
-      resolvedDevfileMessage = `Devfile loaded from ${searchParam.get('url')}`;
+      resolvedDevfileMessage = `Devfile loaded from ${searchParam.get('url')}.`;
+    } else if (source === 'repo') {
+      resolvedDevfileMessage = `Devfile could not be found in ${searchParam.get(
+        'url',
+      )}. Applying the default configuration.`;
     } else {
-      if (source === 'repo') {
-        resolvedDevfileMessage = `Devfile could not be found in ${searchParam.get(
-          'url',
-        )}. Applying the default configuration`;
-      } else {
-        if (this.props.cheDevworkspaceEnabled === false && isDevfileV2(devfile)) {
-          resolvedDevfileMessage = `Devfile 2.x version found in repo ${searchParam.get(
-            'url',
-          )} as '${source}', converting it to devfile version 1`;
-          devfile = this.converter.devfileV2toDevfileV1(devfile);
-        } else {
-          resolvedDevfileMessage = `Devfile found in repo ${searchParam.get('url')} as '${source}'`;
-        }
-      }
+      resolvedDevfileMessage = `Devfile found in repo ${searchParam.get('url')} as '${source}'.`;
     }
+
+    if (this.props.cheDevworkspaceEnabled === false && isDevfileV2(devfile)) {
+      resolvedDevfileMessage += ' Devfile 2.x version found, converting it to devfile version 1.';
+      devfile = this.converter.devfileV2toDevfileV1(devfile);
+    }
+
     this.setState({ resolvedDevfileMessage });
     return devfile;
   }

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -158,7 +158,7 @@ describe('Factory Loader container', () => {
           v: '4.0',
           source: 'devfile.yaml',
           devfile: workspace.devfile,
-          location: location.split('&')[0],
+          location,
           links: [],
         })
         .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
@@ -217,7 +217,7 @@ describe('Factory Loader container', () => {
           v: '4.0',
           source: 'devfile.yaml',
           devfile: workspace.devfile,
-          location: location.split('&')[0],
+          location,
           links: [],
         })
         .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
@@ -277,7 +277,7 @@ describe('Factory Loader container', () => {
           v: '4.0',
           source: 'devfile.yaml',
           devfile: workspace.devfile,
-          location: location.split('&')[0],
+          location,
           links: [],
         })
         .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -25,6 +25,7 @@ import { convertWorkspace, Workspace, WorkspaceAdapter } from '../../services/wo
 import { DevWorkspaceBuilder } from '../../store/__mocks__/devWorkspaceBuilder';
 import devfileApi from '../../services/devfileApi';
 import { safeDump } from 'js-yaml';
+import { CheWorkspaceBuilder } from '../../store/__mocks__/cheWorkspaceBuilder';
 
 const showAlertMock = jest.fn();
 const setWorkspaceQualifiedName = jest.fn();
@@ -48,7 +49,6 @@ jest.mock('../../store/Workspaces/index', () => {
         (devfile, namespace, infrastructureNamespace, attributes) =>
         async (): Promise<Workspace> => {
           createWorkspaceFromDevfileMock(devfile, namespace, infrastructureNamespace, attributes);
-          jest.runOnlyPendingTimers();
           return convertWorkspace({
             id: 'id-wksp-test',
             attributes,
@@ -131,6 +131,188 @@ describe('Factory Loader container', () => {
     jest.resetAllMocks();
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+  });
+
+  describe('converting devfiles', () => {
+    it('should NOT convert devfile v1 in Che Server mode', async () => {
+      const location = 'http://test-location';
+      const workspaceV1 = new CheWorkspaceBuilder()
+        .withId('my-workspace-id')
+        .withName('my-project')
+        .build();
+      const workspace = convertWorkspace(workspaceV1);
+
+      const store = new FakeStoreBuilder()
+        .withCheWorkspaces({
+          workspaces: [workspaceV1],
+        })
+        .withWorkspaces({
+          workspaceId: workspace.id,
+          namespace: workspace.namespace,
+          workspaceName: workspace.name,
+        })
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'false',
+        } as che.WorkspaceSettings)
+        .withFactoryResolver({
+          v: '4.0',
+          source: 'devfile.yaml',
+          devfile: workspace.devfile,
+          location: location.split('&')[0],
+          links: [],
+        })
+        .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
+        .build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: location });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      await waitFor(() => expect(startWorkspaceMock).toHaveBeenCalled());
+
+      const convertingMessage = screen.queryByText(
+        `Devfile 2.x version found, converting it to devfile version 1.`,
+        { exact: false },
+      );
+      // the message should not appear
+      expect(convertingMessage).toBeNull();
+
+      // the correct devfile should be passed
+      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+        workspace.devfile,
+        undefined,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('should convert devfile v2 to v1 in Che Server mode', async () => {
+      const location = 'http://test-location';
+      const workspaceV2 = new DevWorkspaceBuilder()
+        .withId('my-workspace-id')
+        .withName('my-project')
+        .build();
+      const workspace = convertWorkspace(workspaceV2);
+      const workspaceV1 = new CheWorkspaceBuilder()
+        .withId(workspace.id)
+        .withName(workspace.name)
+        .build();
+
+      const store = new FakeStoreBuilder()
+        .withCheWorkspaces({
+          workspaces: [workspaceV1],
+        })
+        .withWorkspaces({
+          workspaceId: workspace.id,
+          namespace: workspace.namespace,
+          workspaceName: workspace.name,
+        })
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'false',
+        } as che.WorkspaceSettings)
+        .withFactoryResolver({
+          v: '4.0',
+          source: 'devfile.yaml',
+          devfile: workspace.devfile,
+          location: location.split('&')[0],
+          links: [],
+        })
+        .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
+        .build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: location });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      await waitFor(() => expect(startWorkspaceMock).toHaveBeenCalled());
+
+      const convertingMessage = screen.queryByText(
+        `Devfile 2.x version found, converting it to devfile version 1.`,
+        { exact: false },
+      );
+      // the message should appear
+      expect(convertingMessage).not.toBeNull();
+
+      // the correct devfile should be passed
+      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiVersion: workspaceV1.devfile.apiVersion,
+          metadata: expect.objectContaining({
+            name: expect.stringMatching(workspaceV1.devfile.metadata.name as string),
+          }),
+        } as che.WorkspaceDevfile),
+        undefined,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('should NOT convert devfile v2 in devworkspaces mode', async () => {
+      const location = 'http://test-location';
+      const workspaceV2 = new DevWorkspaceBuilder()
+        .withId('my-workspace-id')
+        .withName('my-project')
+        .build();
+      const workspace = convertWorkspace(workspaceV2);
+
+      const store = new FakeStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [workspaceV2],
+        })
+        .withWorkspaces({
+          workspaceId: workspace.id,
+          namespace: workspace.namespace,
+          workspaceName: workspace.name,
+        })
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'true',
+        } as che.WorkspaceSettings)
+        .withFactoryResolver({
+          v: '4.0',
+          source: 'devfile.yaml',
+          devfile: workspace.devfile,
+          location: location.split('&')[0],
+          links: [],
+        })
+        .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
+        .build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: location });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      await waitFor(() => expect(startWorkspaceMock).toHaveBeenCalled());
+
+      const convertingMessage = screen.queryByText(
+        `Devfile 2.x version found, converting it to devfile version 1.`,
+        { exact: false },
+      );
+      // the message should not appear
+      expect(convertingMessage).toBeNull();
+
+      // the correct devfile should be passed
+      const devfile = workspace.devfile as devfileApi.Devfile;
+      expect(createWorkspaceFromDevfileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schemaVersion: devfile.schemaVersion,
+          metadata: expect.objectContaining({
+            name: expect.stringMatching(devfile.metadata.name),
+          }),
+        } as devfileApi.Devfile),
+        undefined,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
   });
 
   describe('Use a devfile V1', () => {
@@ -656,7 +838,7 @@ function renderComponentV1(
     .withFactoryResolver({
       v: '4.0',
       source: 'devfile.yaml',
-      devfile: workspace.devfile as api.che.workspace.devfile.Devfile,
+      devfile: workspace.devfile as che.WorkspaceDevfile,
       location: url.split('&')[0],
       links: [],
     })


### PR DESCRIPTION
For the factory flow, covert any devfile v2 to v1 when Che is running in che-server mode

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes when the dashboard should convert devfiles v2 to v1 while performing factory flow in che-server mode.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-2411?focusedCommentId=19350430&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-19350430

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

Create workspaces using factory flow with following devfiles:
`https://raw.githubusercontent.com/crw-samples/quarkus-quickstarts/devfilev2/devfile.yaml`
`https://raw.githubusercontent.com/che-samples/java-spring-petclinic/devfilev2/devfile.yaml`
