### PR TITLE
fix: factory resolver to respect the OAuth response

### DIFF
--- a/packages/common/src/helpers/errors.ts
+++ b/packages/common/src/helpers/errors.ts
@@ -44,7 +44,7 @@ export function getMessage(error: unknown): string {
     return `"${statusCode}" returned by "${error.response.url}".`;
   }
 
-  if (isAxiosError(error) && isAxiosResponse(error.response)) {
+  if (includesAxiosResponse(error)) {
     const response = error.response;
     if (response.data.message) {
       return response.data.message;
@@ -88,6 +88,21 @@ export function isAxiosResponse(response: unknown): response is AxiosResponse {
     (response as AxiosResponse).config !== undefined &&
     (response as AxiosResponse).data !== undefined
   );
+}
+
+type ObjectWithAxiosResponse = {
+  response: AxiosResponse;
+};
+export function includesAxiosResponse(
+  obj: unknown,
+): obj is ObjectWithAxiosResponse {
+  if (
+    obj !== undefined &&
+    isAxiosResponse((obj as ObjectWithAxiosResponse).response)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export function isAxiosError(object: unknown): object is AxiosError {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -155,7 +155,10 @@ describe('FactoryResolver store', () => {
           isAxiosError: true,
           code: '401',
           response: {
+            headers: {},
             status: 401,
+            statusText: 'Unauthorized',
+            config: {},
             data: {
               attributes: {
                 oauth_provider: 'oauth_provider',

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -170,13 +170,10 @@ export const actionCreators: ActionCreators = {
         });
         return;
       } catch (e) {
-        if (
-          common.helpers.errors.isAxiosError(e) &&
-          common.helpers.errors.isAxiosResponse(e.response)
-        ) {
-          const responseData = e.response.data;
-          if (e.response.status === 401 && isOAuthResponse(responseData)) {
-            throw responseData;
+        if (common.helpers.errors.isAxiosResponse((e as any).response)) {
+          const response = (e as any).response;
+          if (response.status === 401 && isOAuthResponse(response.data)) {
+            throw response.data;
           }
         }
         const errorMessage =

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -170,8 +170,8 @@ export const actionCreators: ActionCreators = {
         });
         return;
       } catch (e) {
-        if (common.helpers.errors.isAxiosResponse((e as any).response)) {
-          const response = (e as any).response;
+        if (common.helpers.errors.includesAxiosResponse(e)) {
+          const response = e.response;
           if (response.status === 401 && isOAuthResponse(response.data)) {
             throw response.data;
           }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes the regression caused by https://github.com/eclipse-che/che-dashboard/commit/61f0902c6305c35e6496e194d31c7d5e689dc596. 

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/20835

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

see https://github.com/eclipse-che/che-server/pull/178
