### PR TITLE
feat: Adds vscode library processing into dashboard

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,6 +5,7 @@
 | [`@babel/runtime@7.15.4`](https://github.com/babel/babel.git) | MIT | clearlydefined |
 | [`@devfile/api@2.2.0-alpha-1633545768`](https://github.com/devfile/api.git) | EPL-2.0 | clearlydefined |
 | `@eclipse-che/api@7.36.0` | EPL-2.0 | clearlydefined |
+| [`@eclipse-che/che-code-devworkspace-handler@1.63.0-dev-2c23dcf`](git+https://github.com/che-incubator/che-code.git) | EPL-2.0 | N/A |
 | [`@eclipse-che/che-theia-devworkspace-handler@0.0.1-1637592995`](git+https://github.com/eclipse-che/che-theia.git) | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/common@7.37.0-SNAPSHOT`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-backend@7.37.0-SNAPSHOT`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -36,6 +36,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@eclipse-che/che-code-devworkspace-handler": "1.63.0-dev-2c23dcf",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1637592995",
     "@eclipse-che/devfile-converter": "0.0.1-69851f8",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",

--- a/packages/dashboard-frontend/src/inversify.config.ts
+++ b/packages/dashboard-frontend/src/inversify.config.ts
@@ -24,6 +24,7 @@ import {
   IDevWorkspaceEditorProcess,
 } from './services/workspace-client/devworkspace/devWorkspaceClient';
 import { DevWorkspaceEditorProcessTheia } from './services/workspace-client/devworkspace/DevWorkspaceEditorProcessTheia';
+import { DevWorkspaceEditorProcessCode } from './services/workspace-client/devworkspace/DevWorkspaceEditorProcessCode';
 
 const container = new Container();
 const { lazyInject } = getDecorators(container);
@@ -35,6 +36,7 @@ container.bind(Debounce).toSelf();
 container.bind(CheWorkspaceClient).toSelf().inSingletonScope();
 container.bind(DevWorkspaceClient).toSelf().inSingletonScope();
 container.bind(IDevWorkspaceEditorProcess).to(DevWorkspaceEditorProcessTheia).inSingletonScope();
+container.bind(IDevWorkspaceEditorProcess).to(DevWorkspaceEditorProcessCode).inSingletonScope();
 container.bind(AppAlerts).toSelf().inSingletonScope();
 
 export { container, lazyInject };

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceEditorProcessCode.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceEditorProcessCode.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { InversifyBinding } from '@eclipse-che/che-code-devworkspace-handler/lib/inversify/inversify-binding';
+import { CheCodeDevfileResolver } from '@eclipse-che/che-code-devworkspace-handler/lib/api/che-code-devfile-resolver';
+import common from '@eclipse-che/common';
+import { injectable } from 'inversify';
+import {
+  IDevWorkspaceEditorProcess,
+  IDevWorkspaceEditorProcessingContext,
+} from './devWorkspaceClient';
+
+/**
+ * This class manages what needs to be added on devfile/devworkspace template for Che-Code
+ */
+@injectable()
+export class DevWorkspaceEditorProcessCode implements IDevWorkspaceEditorProcess {
+  /**
+   * Match if the editor metadata name contains the name theia
+   */
+  match(context: IDevWorkspaceEditorProcessingContext): boolean {
+    return context.editorsDevfile.some(editor =>
+      editor.metadata.name.toLowerCase().includes('che-code'),
+    );
+  }
+
+  /**
+   * Do the theia stuff
+   */
+  public async apply(context: IDevWorkspaceEditorProcessingContext): Promise<void> {
+    console.log(
+      'DevWorkspaceEditorProcessTheia: Applying CheCode processor on top of the Devfile.',
+    );
+    // call che-code library to insert all the logic
+    const inversifyBindings = new InversifyBinding();
+    const container = await inversifyBindings.initBindings({
+      insertDevWorkspaceTemplatesAsPlugin: false,
+    });
+
+    const cheCodeDevfileResolver = container.get(CheCodeDevfileResolver);
+
+    // call library to update devWorkspace and add optional templates
+    try {
+      await cheCodeDevfileResolver.update({
+        devfile: context.devfile,
+        devWorkspace: context.devWorkspace,
+        devWorkspaceTemplates: context.devWorkspaceTemplates,
+        suffix: context.workspaceId,
+      });
+    } catch (e) {
+      console.error(e);
+      const errorMessage = common.helpers.errors.getMessage(e);
+      throw new Error(`Unable to resolve che-code plugins: ${errorMessage}`);
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,6 +357,18 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.39.2.tgz#a49d8a56345cbb52da7829652ffcad612e5f0391"
   integrity sha512-13zSFY4+YjYBQOzQTXE71fAX37HMQm/3rkMHN8c7Ejg1UF8ILXwC3Z28xzlMv4kSxtecn0/frqbwoZN8wRjc/g==
 
+"@eclipse-che/che-code-devworkspace-handler@1.63.0-dev-2c23dcf":
+  version "1.63.0-dev-2c23dcf"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-code-devworkspace-handler/-/che-code-devworkspace-handler-1.63.0-dev-2c23dcf.tgz#83ff92a57a4913b79b509d25c84537e79b80e54a"
+  integrity sha512-r2iUfk780cpE9km5hMMqaCfIkE99LxEBDGPEcHYeJy8zHSMCnU/yr6DPGQcjFZCJui9VYDEb9HTpu7PqECGjxA==
+  dependencies:
+    "@devfile/api" latest
+    axios "0.21.2"
+    inversify "^5.0.1"
+    js-yaml "^4.0.0"
+    jsonc-parser "^3.0.0"
+    reflect-metadata "^0.1.13"
+
 "@eclipse-che/che-theia-devworkspace-handler@0.0.1-1637592995":
   version "0.0.1-1637592995"
   resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1637592995.tgz#cc584fa11b06dc19f9c5b33d33334d29abd07a1e"


### PR DESCRIPTION
### What does this PR do?
Adds VS code devfile enhancement into dashboard

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/20679

### Is it tested? How?

Using the image built by this PR:

Clicking with the che-editor link to the current editor devfile from the plug-in registry
```
https://<che-cluster>#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
```

https://user-images.githubusercontent.com/436777/144198130-f73a69c8-f452-4790-ba82-2b9a70b8f459.mp4




#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
