### PR TITLE
feat: change default policy and add ?new for starting a new workspace using short syntax

### DIFF
--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -57,8 +57,6 @@ const WS_ATTRIBUTES_TO_SAVE: string[] = [
   'che-editor',
 ];
 
-const DEFAULT_CREATE_POLICY = 'perclick';
-
 export type CreatePolicy = 'perclick' | 'peruser';
 
 enum ErrorCodes {
@@ -102,14 +100,19 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
 
     const { search } = this.props.history.location;
     const cheDevworkspaceEnabled = isDevworkspacesEnabled(this.props.workspacesSettings);
-
+    const createPolicy = this.getDefaultCreatePolicy();
     this.state = {
       currentStep: LoadFactorySteps.INITIALIZING,
       hasError: false,
-      createPolicy: DEFAULT_CREATE_POLICY,
+      createPolicy,
       search,
       cheDevworkspaceEnabled,
     };
+  }
+
+  private getDefaultCreatePolicy(): CreatePolicy {
+    const devWorkspaceMode = isDevworkspacesEnabled(this.props.workspacesSettings);
+    return devWorkspaceMode ? 'peruser' : 'perclick';
   }
 
   private resetOverrideParams(): void {
@@ -220,7 +223,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
   }
 
   private getCreatePolicy(attrs: { [key: string]: string }): CreatePolicy | undefined {
-    const policy = attrs['policies.create'] || DEFAULT_CREATE_POLICY;
+    const policy = attrs['policies.create'] || this.getDefaultCreatePolicy();
     if (this.isCreatePolicy(policy)) {
       return policy;
     }

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -696,34 +696,6 @@ describe('Factory Loader container', () => {
   });
 
   describe('Use a devfile V2', () => {
-    it('should resolve the factory with default policy and open existing workspace', async () => {
-      const location = 'http://test-location?new';
-      const name = 'test-name';
-      const devWorkspace = new DevWorkspaceBuilder()
-        .withId('id-wksp-test')
-        .withName(name)
-        .withNamespace('test')
-        .build();
-      renderComponentV2(location, devWorkspace);
-
-      const elementCurrentStep = screen.getByTestId('factory-loader-current-step');
-      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(
-        LoadFactorySteps[LoadFactorySteps.LOOKING_FOR_DEVFILE],
-      );
-
-      jest.runOnlyPendingTimers();
-      await waitFor(() =>
-        expect(requestFactoryResolverMock).toHaveBeenCalledWith(location.split('&')[0]),
-      );
-      expect(LoadFactorySteps[elementCurrentStep.innerHTML]).toEqual(
-        LoadFactorySteps[LoadFactorySteps.APPLYING_DEVFILE],
-      );
-
-      jest.runOnlyPendingTimers();
-
-      await waitFor(() => expect(createWorkspaceFromDevfileMock).not.toBeCalled());
-    });
-
     it('should resolve the factory with create policie "peruser" and open existing workspace', async () => {
       const location = 'http://test-location&policies.create=peruser';
       const name = 'test-name';

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/location.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/location.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { buildFactoryLoaderLocation } from '../location';
+
+describe('Location test', () => {
+  test('new policy', () => {
+    const result = buildFactoryLoaderLocation(
+      'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?new=',
+    );
+    expect(result.search).toBe(
+      '?url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2&policies.create=perclick',
+    );
+  });
+
+  test('che-editor parameter', () => {
+    const result = buildFactoryLoaderLocation(
+      'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=che-incubator/checode/insiders',
+    );
+    expect(result.search).toBe(
+      '?url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2&che-editor=che-incubator/checode/insiders',
+    );
+  });
+
+  test('devfilePath parameter', () => {
+    const result = buildFactoryLoaderLocation(
+      'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?devfilePath=devfilev2.yaml',
+    );
+    expect(result.search).toBe(
+      '?url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2&override.devfileFilename=devfilev2.yaml',
+    );
+  });
+});

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -52,6 +52,8 @@ export function buildFactoryLoaderLocation(url?: string): Location {
       devfilePath = extractUrlParam(fullUrl, 'df');
     }
 
+    // creation policy
+    const newWorkspace = extractUrlParam(fullUrl, 'new');
     const encodedUrl = encodeURIComponent(fullUrl.toString());
 
     // if editor specified, add it as a new parameter
@@ -61,6 +63,9 @@ export function buildFactoryLoaderLocation(url?: string): Location {
     }
     if (devfilePath) {
       pathAndQuery = `${pathAndQuery}&override.devfileFilename=${devfilePath}`;
+    }
+    if (newWorkspace) {
+      pathAndQuery = `${pathAndQuery}&policies.create=perclick`;
     }
   }
   return _buildLocationObject(pathAndQuery);
@@ -72,6 +77,11 @@ function extractUrlParam(fullUrl: URL, paramName: string): string | undefined {
   let value;
   if (param && typeof param === 'string') {
     value = param.slice();
+  } else if (!param) {
+    // boolean parameter
+    if (fullUrl.searchParams.has(paramName)) {
+      value = true;
+    }
   }
   fullUrl.searchParams.delete(paramName);
   return value;


### PR DESCRIPTION
### What does this PR do?

**only for devWorkspace mode* Change default policy to only create only one workspace when we click on a link

To create a new workspace, allow to use `?new` at the end of the short URL

ie: 
```
http://che-server#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2 : only one workspace
http://che-server#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?new ==> create a new workspace
```

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/20867


### Is it tested? How?
yes clicking first
http://localhost:3000#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2

then clicking on http://localhost:3000#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2 is reopening the same workspace

and http://localhost:3000#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?new is creating a new one

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
