### PR TITLE
feat: fix v2.2.0 -> v1 devWorkspaces

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -10,7 +10,7 @@
 | [`@eclipse-che/common@7.37.0-SNAPSHOT`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-backend@7.37.0-SNAPSHOT`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-frontend@7.37.0-SNAPSHOT`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | N/A |
-| [`@eclipse-che/devfile-converter@0.0.1-69851f8`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | clearlydefined |
+| [`@eclipse-che/devfile-converter@0.0.1-ba9d381`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/workspace-client@0.0.1-1632305737`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | clearlydefined |
 | [`@fastify/ajv-compiler@1.1.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
 | [`@kubernetes/client-node@0.14.3`](https://github.com/kubernetes-client/javascript.git) | Apache-2.0 | clearlydefined |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@eclipse-che/che-code-devworkspace-handler": "1.63.0-dev-2c23dcf",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1637592995",
-    "@eclipse-che/devfile-converter": "0.0.1-69851f8",
+    "@eclipse-che/devfile-converter": "0.0.1-ba9d381",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,10 +382,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/devfile-converter@0.0.1-69851f8":
-  version "0.0.1-69851f8"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-69851f8.tgz#6ef4e94d20a7263a065b39b5c8dec0ed758d9c2f"
-  integrity sha512-KmcZ6wrJYs3vtcLXYXoaw1/qtkEyNHD8XjprqHiK2NhW6+NY/pdisg1od22ACd4jPIbC9PPgZZ+e79L36VqUUA==
+"@eclipse-che/devfile-converter@0.0.1-ba9d381":
+  version "0.0.1-ba9d381"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-ba9d381.tgz#3c59ce517d0678b2b7ff2f23d3dc2f0fde47016b"
+  integrity sha512-30iGKhVWrURUUDWZavFU93Jb/cYKqnzJ/tdXB2J04GlhpR/d1qKABMu42Yxqx3UKG1mKeEZliTD6d5hUUIEbQQ==
   dependencies:
     "@devfile/api" "2.2.0-alpha-1637255314"
     "@eclipse-che/api" "^7.39.2"


### PR DESCRIPTION
### What does this PR do?
Handle v2.2.0 -> v1 devfiles (even invalid devfiles like the one in OpenShift console)

For che-server workspaces. Do not try with devWorkspace mode

depends on https://github.com/eclipse-che/che-server/pull/189

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/20856


### Is it tested? How?
2.2.0 example with invalid workingdirectory
https://che-server#https://github.com/devfile-samples/devfile-sample-code-with-quarkus

2.2.0 example with invalid workingdirectory
https://che-server#https://github.com/devfile-samples/devfile-sample-java-springboot-basic 

invalid place-holder image and invalid image
https://che-server#https://github.com/devfile-samples/devfile-sample-java-springboot-basic/tree/03d097ddbe0c8b4e6a413c75199b48a3086b7afd


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
