### PR TITLE
Convert devfiles in accordance to mode which Che is running

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,17 +1,10 @@
 apiVersion: 1.0.0
 metadata:
-  generateName: che-dashboard-react-
+  generateName: che-dashboard-
 attributes:
   persistVolumes: 'false'
 components:
   - mountSources: true
-    endpoints:
-      - attributes:
-          public: 'true'
-          protocol: http
-          path: /
-        name: dashboard-dev-server
-        port: 3000
     command:
       - tail
       - '-f'
@@ -19,31 +12,23 @@ components:
     memoryLimit: 3Gi
     type: dockerimage
     alias: dashboard-dev
-    image: 'docker.io/node:12.20.1-alpine3.12'
-  - id: vscode/typescript-language-features/latest
-    type: chePlugin
+    image: 'quay.io/eclipse/che-nodejs12-community:next'
 commands:
   - name: '[UD] install dependencies'
     actions:
       - workdir: /projects/che-dashboard
         type: exec
-        command: yarn install
+        command: yarn install --non-interactive --modules-folder /tmp/node_modules && ln -s /tmp/node_modules /projects/che-dashboard/node_modules
         component: dashboard-dev
-  - name: '[UD] compile'
+  - name: '[UD] build'
     actions:
       - workdir: /projects/che-dashboard
         type: exec
-        command: yarn install && yarn compile
+        command: yarn build
         component: dashboard-dev
   - name: '[UD] test'
     actions:
       - workdir: /projects/che-dashboard
         type: exec
-        command: yarn install && yarn test
-        component: dashboard-dev
-  - name: '[UD] start'
-    actions:
-      - workdir: /projects/che-dashboard
-        type: exec
-        command: 'yarn install && yarn start --port=3000 --host=0.0.0.0 --env.server=${CHE_API_INTERNAL%????} --env.token=${CHE_MACHINE_TOKEN}'
+        command: yarn test
         component: dashboard-dev

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@eclipse-che/che-code-devworkspace-handler": "1.63.0-dev-2c23dcf",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1637592995",
-    "@eclipse-che/devfile-converter": "0.0.1-eb20432",
+    "@eclipse-che/devfile-converter": "0.0.1-8de908e",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@eclipse-che/che-code-devworkspace-handler": "1.63.0-dev-2c23dcf",
-    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1637592995",
+    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1639587602",
     "@eclipse-che/devfile-converter": "0.0.1-8de908e",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@eclipse-che/che-code-devworkspace-handler": "1.63.0-dev-2c23dcf",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1637592995",
-    "@eclipse-che/devfile-converter": "0.0.1-ba9d381",
+    "@eclipse-che/devfile-converter": "0.0.1-eb20432",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@eclipse-che/che-code-devworkspace-handler": "1.63.0-dev-2c23dcf",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1639587602",
-    "@eclipse-che/devfile-converter": "0.0.1-8de908e",
+    "@eclipse-che/devfile-converter": "0.0.1-437a239",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/__tests__/index.spec.tsx
@@ -25,6 +25,7 @@ import { toTitle } from '../../../../services/storageTypes';
 import CustomWorkspaceTab from '..';
 import { FactoryResolver } from '../../../../services/helpers/types';
 import { Devfile } from '../../../../services/workspace-adapter';
+import { ConvertedState } from '../../../../store/FactoryResolver';
 
 jest.mock('../../../../components/DevfileEditor', () => {
   return forwardRef(function DummyEditor(...args: any[]): React.ReactElement {
@@ -384,12 +385,17 @@ function createStore(
         },
       },
     })
-    .withFactoryResolver({
-      devfile: {
-        apiVersion: '1.0.0',
-        metadata: { name: 'Custom Devfile' },
-      } as Devfile,
-    } as FactoryResolver)
+    .withFactoryResolver(
+      {
+        devfile: {
+          apiVersion: '1.0.0',
+          metadata: { name: 'Custom Devfile' },
+        } as Devfile,
+      } as FactoryResolver,
+      {
+        isConverted: false,
+      } as ConvertedState,
+    )
     .withBranding({
       docs: {
         storageTypes: 'https://che-docs/storage-types',

--- a/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/CustomWorkspaceTab/index.tsx
@@ -30,7 +30,7 @@ import {
   selectPreferredStorageType,
   selectWorkspacesSettings,
 } from '../../../store/Workspaces/Settings/selectors';
-import { attributesToType, updateDevfile } from '../../../services/storageTypes';
+import { attributesToType, updateDevfileStorageType } from '../../../services/storageTypes';
 import { safeLoad } from 'js-yaml';
 import { updateDevfileMetadata } from '../updateDevfileMetadata';
 import { Devfile, isCheDevfile } from '../../../services/workspace-adapter';
@@ -112,7 +112,7 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
       return;
     }
 
-    const newDevfile = updateDevfile(devfile, storageType);
+    const newDevfile = updateDevfileStorageType(devfile, storageType);
 
     this.setState({
       storageType,
@@ -131,7 +131,7 @@ export class CustomWorkspaceTab extends React.PureComponent<Props, State> {
       devfileContent?.attributes?.asyncPersist === undefined &&
       this.props.preferredStorageType
     ) {
-      devfile = updateDevfile(devfileContent, this.props.preferredStorageType);
+      devfile = updateDevfileStorageType(devfileContent, this.props.preferredStorageType);
     } else {
       devfile = devfileContent;
     }

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
@@ -20,6 +20,7 @@ import mockMetadata from '../../__tests__/devfileMetadata.json';
 import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
 import { BrandingData } from '../../../../services/bootstrap/branding.constant';
 import { Devfile } from '../../../../services/workspace-adapter';
+import { ConvertedState } from '../../../../store/FactoryResolver';
 
 const requestFactoryResolverMock = jest.fn().mockResolvedValue(undefined);
 
@@ -137,13 +138,18 @@ describe('Samples List Gallery', () => {
 });
 
 function createFakeStore(metadata?: che.DevfileMetaData[], devWorkspaceEnabled?: boolean): Store {
-  const registries = {};
+  const registries = {} as {
+    [location: string]: {
+      metadata?: che.DevfileMetaData[];
+      error?: string;
+    };
+  };
   if (metadata) {
     registries['registry-location'] = {
       metadata,
     };
   }
-  const workspaceSettings = {};
+  const workspaceSettings = {} as che.WorkspaceSettings;
   if (devWorkspaceEnabled) {
     workspaceSettings['che.devworkspaces.enabled'] = 'true';
   }
@@ -153,18 +159,23 @@ function createFakeStore(metadata?: che.DevfileMetaData[], devWorkspaceEnabled?:
         storageTypes: 'https://docs.location',
       },
     } as BrandingData)
-    .withWorkspacesSettings(workspaceSettings as che.WorkspaceSettings)
-    .withFactoryResolver({
-      v: '4.0',
-      source: 'devfile.yaml',
-      devfile: {} as Devfile,
-      location: 'http://fake-location',
-      scm_info: {
-        clone_url: 'http://github.com/clone-url',
-        scm_provider: 'github',
+    .withWorkspacesSettings(workspaceSettings)
+    .withFactoryResolver(
+      {
+        v: '4.0',
+        source: 'devfile.yaml',
+        devfile: {} as Devfile,
+        location: 'http://fake-location',
+        scm_info: {
+          clone_url: 'http://github.com/clone-url',
+          scm_provider: 'github',
+        },
+        links: [],
       },
-      links: [],
-    })
+      {
+        isConverted: false,
+      } as ConvertedState,
+    )
     .withDevfileRegistries({ registries })
     .build();
 }

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
@@ -24,7 +24,7 @@ import {
   selectWorkspacesSettings,
 } from '../../../store/Workspaces/Settings/selectors';
 import { load } from 'js-yaml';
-import { updateDevfile } from '../../../services/storageTypes';
+import { updateDevfileStorageType } from '../../../services/storageTypes';
 import stringify from '../../../services/helpers/editor';
 import ImportFromGit from './ImportFromGit';
 import { ResolverState } from '../../../store/FactoryResolver';
@@ -77,14 +77,17 @@ export class SamplesListTab extends React.PureComponent<Props, State> {
     let devfile = load(devfileContent);
 
     if (this.state.temporary === undefined) {
-      devfile = updateDevfile(devfile, this.props.preferredStorageType);
+      devfile = updateDevfileStorageType(devfile, this.props.preferredStorageType);
     } else if (this.props.preferredStorageType === 'async') {
-      devfile = updateDevfile(
+      devfile = updateDevfileStorageType(
         devfile,
         this.state.temporary ? 'ephemeral' : this.props.preferredStorageType,
       );
     } else {
-      devfile = updateDevfile(devfile, this.state.temporary ? 'ephemeral' : 'persistent');
+      devfile = updateDevfileStorageType(
+        devfile,
+        this.state.temporary ? 'ephemeral' : 'persistent',
+      );
     }
     this.isLoading = true;
     try {
@@ -97,7 +100,7 @@ export class SamplesListTab extends React.PureComponent<Props, State> {
 
   private handleDevfileResolver(resolverState: ResolverState, stackName: string): Promise<void> {
     const devfile: Devfile = resolverState.devfile;
-    const updatedDevfile = updateDevfile(devfile, this.props.preferredStorageType);
+    const updatedDevfile = updateDevfileStorageType(devfile, this.props.preferredStorageType);
     const devfileContent = stringify(updatedDevfile);
 
     return this.props.onDevfile(

--- a/packages/dashboard-frontend/src/services/__tests__/storageTypes.spec.ts
+++ b/packages/dashboard-frontend/src/services/__tests__/storageTypes.spec.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { updateDevfile } from '../storageTypes';
+import { updateDevfileStorageType } from '../storageTypes';
 import { DevfileBuilder } from '../../store/__mocks__/devfile';
 
 describe('Storage Types Service', () => {
@@ -20,7 +20,7 @@ describe('Storage Types Service', () => {
 
       it('should correctly update a devfile without volumes', () => {
         const devfile = getDevfileWithoutAttributes();
-        const newDevfile = updateDevfile(devfile, 'persistent');
+        const newDevfile = updateDevfileStorageType(devfile, 'persistent');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
         expect(newDevfile).toEqual(devfile);
@@ -28,21 +28,21 @@ describe('Storage Types Service', () => {
 
       it('should correctly update a devfile with "persistent" storage', () => {
         const devfile = getDevfileWithPersistentStorage();
-        const newDevfile = updateDevfile(devfile, 'persistent');
+        const newDevfile = updateDevfileStorageType(devfile, 'persistent');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
 
       it('should correctly update a devfile with "ephemeral" storage', () => {
         const devfile = getDevfileWithEphemeralStorage();
-        const newDevfile = updateDevfile(devfile, 'persistent');
+        const newDevfile = updateDevfileStorageType(devfile, 'persistent');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
 
       it('should correctly update a devfile with "async" storage', () => {
         const devfile = getDevfileWithAsyncStorage();
-        const newDevfile = updateDevfile(devfile, 'persistent');
+        const newDevfile = updateDevfileStorageType(devfile, 'persistent');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
@@ -55,21 +55,21 @@ describe('Storage Types Service', () => {
 
       it('should correctly update a devfile without volumes', () => {
         const devfile = getDevfileWithoutAttributes();
-        const newDevfile = updateDevfile(devfile, 'ephemeral');
+        const newDevfile = updateDevfileStorageType(devfile, 'ephemeral');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
 
       it('should correctly update a devfile with "persistent" storage', () => {
         const devfile = getDevfileWithPersistentStorage();
-        const newDevfile = updateDevfile(devfile, 'ephemeral');
+        const newDevfile = updateDevfileStorageType(devfile, 'ephemeral');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
 
       it('should correctly update a devfile with "ephemeral" storage', () => {
         const devfile = getDevfileWithEphemeralStorage();
-        const newDevfile = updateDevfile(devfile, 'ephemeral');
+        const newDevfile = updateDevfileStorageType(devfile, 'ephemeral');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
         expect(newDevfile).toEqual(devfile);
@@ -77,7 +77,7 @@ describe('Storage Types Service', () => {
 
       it('should correctly update a devfile with "async" storage', () => {
         const devfile = getDevfileWithAsyncStorage();
-        const newDevfile = updateDevfile(devfile, 'ephemeral');
+        const newDevfile = updateDevfileStorageType(devfile, 'ephemeral');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
@@ -91,28 +91,28 @@ describe('Storage Types Service', () => {
 
       it('should correctly update a devfile without volumes', () => {
         const devfile = getDevfileWithoutAttributes();
-        const newDevfile = updateDevfile(devfile, 'async');
+        const newDevfile = updateDevfileStorageType(devfile, 'async');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
 
       it('should correctly update a devfile with "persistent" storage', () => {
         const devfile = getDevfileWithPersistentStorage();
-        const newDevfile = updateDevfile(devfile, 'async');
+        const newDevfile = updateDevfileStorageType(devfile, 'async');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
 
       it('should correctly update a devfile with "ephemeral" storage', () => {
         const devfile = getDevfileWithEphemeralStorage();
-        const newDevfile = updateDevfile(devfile, 'async');
+        const newDevfile = updateDevfileStorageType(devfile, 'async');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
       });
 
       it('should correctly update a devfile with "async" storage', () => {
         const devfile = getDevfileWithAsyncStorage();
-        const newDevfile = updateDevfile(devfile, 'async');
+        const newDevfile = updateDevfileStorageType(devfile, 'async');
 
         expect(newDevfile.attributes).toEqual(expectedAttr);
         expect(newDevfile).toEqual(devfile);

--- a/packages/dashboard-frontend/src/services/devfile/converters.ts
+++ b/packages/dashboard-frontend/src/services/devfile/converters.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as devfileConverter from '@eclipse-che/devfile-converter';
+import devfileApi from '../devfileApi';
+
+export async function convertDevfileV2toDevfileV1(
+  devfile: devfileApi.Devfile,
+  optionalFilesContent:
+    | {
+        [fileName: string]: string;
+      }
+    | undefined,
+): Promise<che.WorkspaceDevfile> {
+  const externalAccess = async function (file: string): Promise<string> {
+    return optionalFilesContent?.[file] || '';
+  };
+  return (await devfileConverter.v2ToV1(devfile, externalAccess)) as che.WorkspaceDevfile;
+}
+
+export async function convertDevfileV1toDevfileV2(
+  devfile: che.WorkspaceDevfile,
+): Promise<devfileApi.Devfile> {
+  return (await devfileConverter.v1ToV2(devfile)) as devfileApi.Devfile;
+}

--- a/packages/dashboard-frontend/src/services/devfileApi/__mocks__/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/__mocks__/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+const devfileApiMock = jest.genMockFromModule('..');
+export default devfileApiMock;
+
+export * from '../typeguards';

--- a/packages/dashboard-frontend/src/services/helpers/getDefaultDevfile.ts
+++ b/packages/dashboard-frontend/src/services/helpers/getDefaultDevfile.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { updateDevfile } from '../storageTypes';
+import { updateDevfileStorageType } from '../storageTypes';
 import { Devfile } from '../workspace-adapter';
 import devfileApi from '../devfileApi';
 
@@ -23,9 +23,9 @@ export function getDefaultDevfileV1(
     metadata: {
       generateName,
     },
-  };
+  } as che.WorkspaceDevfile;
 
-  return updateDevfile(devfile as Devfile, preferredStorageType) as che.WorkspaceDevfile;
+  return updateDevfileStorageType(devfile, preferredStorageType) as che.WorkspaceDevfile;
 }
 
 export function getDefaultDevfileV2(name = 'wksp'): devfileApi.Devfile {

--- a/packages/dashboard-frontend/src/services/storageTypes.ts
+++ b/packages/dashboard-frontend/src/services/storageTypes.ts
@@ -87,12 +87,15 @@ export function attributesToType(
   return 'persistent';
 }
 
-export function updateDevfile(devfile: Devfile, storageType: che.WorkspaceStorageType): Devfile {
+export function updateDevfileStorageType(
+  devfile: Devfile,
+  storageType: che.WorkspaceStorageType,
+): Devfile {
   if (isDevfileV2(devfile)) {
     return devfile;
   }
 
-  const newDevfile = Object.assign({}, devfile) as che.WorkspaceDevfile;
+  const newDevfile = Object.assign({}, devfile);
   const attributes = newDevfile.attributes;
   switch (storageType) {
     case 'persistent':

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -21,30 +21,214 @@ import { CheWorkspaceClient } from '../../../services/workspace-client/cheworksp
 import * as factoryResolverStore from '..';
 import { AxiosError } from 'axios';
 import { KubernetesNamespace } from '@eclipse-che/workspace-client/dist/rest/resources';
+import normalizeDevfileV1 from '../normalizeDevfileV1';
+import normalizeDevfileV2 from '../normalizeDevfileV2';
+import {
+  convertDevfileV2toDevfileV1,
+  convertDevfileV1toDevfileV2,
+} from '../../../services/devfile/converters';
+
+jest.mock('../normalizeDevfileV1.ts');
+(normalizeDevfileV1 as jest.Mock).mockImplementation(devfile => {
+  return devfile;
+});
+jest.mock('../normalizeDevfileV2.ts');
+(normalizeDevfileV2 as jest.Mock).mockImplementation(devfile => {
+  return devfile;
+});
+
+jest.mock('../../../services/devfile/converters');
+(convertDevfileV2toDevfileV1 as jest.Mock).mockImplementation(async () => {
+  return {
+    apiVersion: '1.0.0',
+  } as che.WorkspaceDevfile;
+});
+(convertDevfileV1toDevfileV2 as jest.Mock).mockImplementation(async () => {
+  return {
+    schemaVersion: '2.0.0',
+  } as devfileApi.Devfile;
+});
+
+jest.mock('../../../services/devfileApi');
+jest.mock('../../../services/devfileApi/typeguards.ts', () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    ...(jest.requireActual('../../../services/devfileApi/typeguards.ts') as Object),
+    isDevfileV2: (devfile: unknown): boolean => {
+      return (devfile as devfileApi.Devfile).schemaVersion !== undefined;
+    },
+  };
+});
+
+// mute the error outputs
+console.error = jest.fn();
 
 const cheWorkspaceClient = container.get(CheWorkspaceClient);
 jest
   .spyOn(cheWorkspaceClient.restApiClient, 'provisionKubernetesNamespace')
   .mockResolvedValue({} as KubernetesNamespace);
 
+const getFactoryResolverSpy = jest.spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver');
+
 describe('FactoryResolver store', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
+  describe('requestFactoryResolver action', () => {
+    it('should NOT convert resolved devfile v1 with devworkspace mode DISABLED', async () => {
+      const resolver = {
+        devfile: {
+          apiVersion: '1.0.0',
+        } as che.WorkspaceDevfile,
+      } as factoryResolverStore.ResolverState;
+
+      getFactoryResolverSpy.mockResolvedValueOnce(resolver);
+
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'false',
+          'che.workspace.storage.preferred_type': 'ephemeral',
+        })
+        .build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const location = 'factory-link';
+      await store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location));
+
+      const actions = store.getActions();
+      expect(actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'RECEIVE_FACTORY_RESOLVER',
+            converted: expect.objectContaining({
+              isConverted: false,
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it('should convert resolved devfile v1 with devworkspace mode ENABLED', async () => {
+      const resolver = {
+        devfile: {
+          apiVersion: '1.0.0',
+        } as che.WorkspaceDevfile,
+      } as factoryResolverStore.ResolverState;
+
+      getFactoryResolverSpy.mockResolvedValueOnce(resolver);
+
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'true',
+          'che.workspace.storage.preferred_type': 'ephemeral',
+        })
+        .build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const location = 'factory-link';
+      await store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location));
+
+      const actions = store.getActions();
+      expect(actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'RECEIVE_FACTORY_RESOLVER',
+            converted: expect.objectContaining({
+              isConverted: true,
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it('should NOT convert resolved devfile v2.x.x with devworkspace mode ENABLED', async () => {
+      const resolver = {
+        devfile: {
+          schemaVersion: '2.0.0',
+        } as devfileApi.Devfile,
+      } as factoryResolverStore.ResolverState;
+
+      getFactoryResolverSpy.mockResolvedValueOnce(resolver);
+
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'true',
+          'che.workspace.storage.preferred_type': 'ephemeral',
+        })
+        .build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const location = 'factory-link';
+      await store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location));
+
+      const actions = store.getActions();
+      expect(actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'RECEIVE_FACTORY_RESOLVER',
+            converted: expect.objectContaining({
+              isConverted: false,
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it('should convert resolved devfile v2.x.x with devworkspace mode DISABLED', async () => {
+      const resolver = {
+        devfile: {
+          schemaVersion: '2.0.0',
+        } as devfileApi.Devfile,
+      } as factoryResolverStore.ResolverState;
+
+      getFactoryResolverSpy.mockResolvedValueOnce(resolver);
+
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'false',
+          'che.workspace.storage.preferred_type': 'ephemeral',
+        })
+        .build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
+      >;
+
+      const location = 'factory-link';
+      await store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location));
+
+      const actions = store.getActions();
+      expect(actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'RECEIVE_FACTORY_RESOLVER',
+            converted: expect.objectContaining({
+              isConverted: true,
+            }),
+          }),
+        ]),
+      );
+    });
   });
 
   describe('actions', () => {
     it('should create REQUEST_FACTORY_RESOLVER and RECEIVE_FACTORY_RESOLVER', async () => {
-      const resolver: factoryResolverStore.ResolverState = {
+      const resolver = {
         devfile: {
-          schemaVersion: '2.0.0',
-        } as devfileApi.Devfile,
-      };
+          apiVersion: '1.0.0',
+        } as che.WorkspaceDevfile,
+      } as factoryResolverStore.ResolverState;
 
-      const getFactoryResolverSpy = jest
-        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
-        .mockResolvedValue(resolver);
+      getFactoryResolverSpy.mockResolvedValueOnce(resolver);
 
-      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'false',
+          'che.workspace.storage.preferred_type': 'ephemeral',
+        })
+        .build() as MockStoreEnhanced<
         AppState,
         ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
       >;
@@ -60,27 +244,22 @@ describe('FactoryResolver store', () => {
         {
           type: 'RECEIVE_FACTORY_RESOLVER',
           resolver: expect.objectContaining(resolver),
+          converted: expect.objectContaining({ isConverted: false }),
         },
       ];
       expect(actions).toEqual(expectedActions);
-
-      getFactoryResolverSpy.mockRestore();
     });
 
     it('should create REQUEST_FACTORY_RESOLVER and RECEIVE_FACTORY_RESOLVER_ERROR', async () => {
-      const spyGetFactoryResolver = jest
-        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
-        .mockRejectedValue({
-          isAxiosError: true,
-          code: '500',
-          response: {
-            data: {
-              message: 'Something unexpected happened.',
-            },
+      getFactoryResolverSpy.mockRejectedValueOnce({
+        isAxiosError: true,
+        code: '500',
+        response: {
+          data: {
+            message: 'Something unexpected happened.',
           },
-        } as AxiosError);
-      // mute the error outputs
-      console.error = jest.fn();
+        },
+      } as AxiosError);
 
       const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
         AppState,
@@ -98,10 +277,10 @@ describe('FactoryResolver store', () => {
         },
       ];
 
-      const spyIsAxiosError = jest
+      const isAxiosErrorMock = jest
         .spyOn(common.helpers.errors, 'isAxiosError')
         .mockImplementation(() => true);
-      const spyIsAxiosResponse = jest
+      const isAxiosResponseMock = jest
         .spyOn(common.helpers.errors, 'isAxiosResponse')
         .mockImplementation(() => true);
 
@@ -111,17 +290,14 @@ describe('FactoryResolver store', () => {
       ).rejects.toMatch('Failed to request factory resolver');
       expect(actions).toEqual(expectedActions);
 
-      spyGetFactoryResolver.mockRestore();
-      spyIsAxiosError.mockRestore();
-      spyIsAxiosResponse.mockRestore();
+      isAxiosErrorMock.mockRestore();
+      isAxiosResponseMock.mockRestore();
     });
 
     it('should throw if it resolves no devfile', async () => {
       const resolver = {} as factoryResolverStore.ResolverState;
 
-      const spyGetFactoryResolver = jest
-        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
-        .mockResolvedValue(resolver);
+      getFactoryResolverSpy.mockResolvedValueOnce(resolver);
 
       const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
         AppState,
@@ -144,39 +320,35 @@ describe('FactoryResolver store', () => {
         store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
       ).rejects.toMatch('The specified link does not contain a valid Devfile.');
       expect(actions).toEqual(expectedActions);
-
-      spyGetFactoryResolver.mockRestore();
     });
 
     it('should reject if authentication is needed', async () => {
-      const spyGetFactoryResolver = jest
-        .spyOn(cheWorkspaceClient.restApiClient, 'getFactoryResolver')
-        .mockRejectedValue({
-          isAxiosError: true,
-          code: '401',
-          response: {
-            headers: {},
-            status: 401,
-            statusText: 'Unauthorized',
-            config: {},
-            data: {
-              attributes: {
-                oauth_provider: 'oauth_provider',
-                oauth_authentication_url: 'oauth_authentication_url',
-              },
+      getFactoryResolverSpy.mockRejectedValueOnce({
+        isAxiosError: true,
+        code: '401',
+        response: {
+          headers: {},
+          status: 401,
+          statusText: 'Unauthorized',
+          config: {},
+          data: {
+            attributes: {
+              oauth_provider: 'oauth_provider',
+              oauth_authentication_url: 'oauth_authentication_url',
             },
           },
-        } as AxiosError);
+        },
+      } as AxiosError);
 
       const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
         AppState,
         ThunkDispatch<AppState, undefined, factoryResolverStore.KnownAction>
       >;
 
-      const spyIsAxiosError = jest
+      const isAxiosErrorMock = jest
         .spyOn(common.helpers.errors, 'isAxiosError')
         .mockReturnValue(true);
-      const spyIsAxiosResponse = jest
+      const isAxiosResponseMock = jest
         .spyOn(common.helpers.errors, 'isAxiosResponse')
         .mockReturnValue(true);
 
@@ -190,9 +362,8 @@ describe('FactoryResolver store', () => {
         },
       });
 
-      spyGetFactoryResolver.mockRestore();
-      spyIsAxiosError.mockRestore();
-      spyIsAxiosResponse.mockRestore();
+      isAxiosErrorMock.mockRestore();
+      isAxiosResponseMock.mockRestore();
     });
   });
 
@@ -246,20 +417,25 @@ describe('FactoryResolver store', () => {
       const initialState: factoryResolverStore.State = {
         isLoading: true,
       };
-      const resolver: factoryResolverStore.ResolverState = {
+      const resolver = {
         devfile: {
           schemaVersion: '2.0.0',
         } as devfileApi.Devfile,
-      };
+      } as factoryResolverStore.ResolverState;
+      const converted: factoryResolverStore.ConvertedState = {
+        isConverted: false,
+      } as any;
       const incomingAction: factoryResolverStore.KnownAction = {
         type: 'RECEIVE_FACTORY_RESOLVER',
         resolver,
+        converted,
       };
 
       const newState = factoryResolverStore.reducer(initialState, incomingAction);
       const expectedState: factoryResolverStore.State = {
         isLoading: false,
         resolver,
+        converted,
       };
 
       expect(newState).toEqual(expectedState);

--- a/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV1.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV1.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { updateDevfileStorageType } from '../../services/storageTypes';
+
+export default function normalizeDevfileV1(
+  devfile: che.WorkspaceDevfile,
+  preferredStorageType: che.WorkspaceStorageType,
+): che.WorkspaceDevfile {
+  if (
+    devfile?.attributes?.persistVolumes === undefined &&
+    devfile?.attributes?.asyncPersist === undefined &&
+    preferredStorageType
+  ) {
+    devfile = updateDevfileStorageType(devfile, preferredStorageType) as che.WorkspaceDevfile;
+  }
+
+  return devfile;
+}

--- a/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FactoryResolver, DevfileV2ProjectSource } from '../../services/helpers/types';
+import devfileApi from '../../services/devfileApi';
+import { getProjectName } from '../../services/helpers/getProjectName';
+import { safeDump } from 'js-yaml';
+import {
+  DEVWORKSPACE_DEVFILE_SOURCE,
+  DEVWORKSPACE_METADATA_ANNOTATION,
+} from '../../services/workspace-client/devworkspace/devWorkspaceClient';
+
+/**
+ * Returns a devfile from the FactoryResolver object.
+ * @param data a FactoryResolver object.
+ * @param location a source location.
+ * @param isDevworkspacesEnabled indicates if devworkspace engine is enabled.
+ */
+export default function normalizeDevfileV2(
+  devfile: devfileApi.Devfile,
+  data: FactoryResolver,
+  location: string,
+): devfileApi.Devfile {
+  const scmInfo = data['scm_info'];
+
+  devfile = devfile as devfileApi.Devfile;
+  if (!devfile.components) {
+    devfile.components = [];
+  }
+
+  // temporary solution for fix che-server serialization bug with empty volume
+  const components =
+    devfile.components.map(component => {
+      if (Object.keys(component).length === 1 && component.name) {
+        component.volume = {};
+      }
+      return component;
+    }) || [];
+  devfile = Object.assign(devfile, { components });
+
+  // add a default project
+  const projects: DevfileV2ProjectSource[] = [];
+  if (!devfile.projects?.length && scmInfo) {
+    const origin = scmInfo.clone_url;
+    const name = getProjectName(origin);
+    const revision = scmInfo.branch;
+    const project: DevfileV2ProjectSource = { name, git: { remotes: { origin } } };
+    if (revision) {
+      project.git.checkoutFrom = { revision };
+    }
+    projects.push(project);
+    devfile = Object.assign({ projects }, devfile);
+  }
+
+  // provide metadata about the origin of the devfile with DevWorkspace
+  let devfileSource = '';
+  if (data.source && scmInfo) {
+    if (scmInfo.branch) {
+      devfileSource = safeDump({
+        scm: {
+          repo: scmInfo['clone_url'],
+          revision: scmInfo.branch,
+          fileName: data.source,
+        },
+      });
+    } else {
+      devfileSource = safeDump({
+        scm: {
+          repo: scmInfo['clone_url'],
+          fileName: data.source,
+        },
+      });
+    }
+  } else if (location) {
+    devfileSource = safeDump({ url: { location } });
+  }
+  const metadata = devfile.metadata;
+  if (!metadata.attributes) {
+    metadata.attributes = {};
+  }
+  if (!metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION]) {
+    metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION] = {};
+  }
+  metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION][DEVWORKSPACE_DEVFILE_SOURCE] =
+    devfileSource;
+  devfile = Object.assign({}, devfile, { metadata });
+
+  return devfile;
+}

--- a/packages/dashboard-frontend/src/store/__mocks__/cheWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/cheWorkspaceBuilder.ts
@@ -46,7 +46,11 @@ export const CHE_RUNTIME_STUB: che.WorkspaceRuntime = {
 export class CheWorkspaceBuilder {
   private workspace: che.Workspace = {
     id: getRandomString(4),
+    attributes: {
+      infrastructureNamespace: 'che',
+    } as che.WorkspaceAttributes,
     status: WorkspaceStatus.STOPPED,
+    namespace: 'admin',
     devfile: CHE_DEVFILE_STUB,
   };
 

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -13,13 +13,12 @@
 import { Store } from 'redux';
 import createMockStore from 'redux-mock-store';
 import { BrandingData } from '../../services/bootstrap/branding.constant';
-import { FactoryResolver } from '../../services/helpers/types';
 import { AppState } from '..';
 import { State as DevfileRegistriesState } from '../DevfileRegistries/index';
 import { RegistryEntry } from '../DockerConfig/types';
 import { State as WorkspacesState } from '../Workspaces/index';
 import { State as BrandingState } from '../Branding';
-import { State as FactoryResolverState } from '../FactoryResolver';
+import { ConvertedState, ResolverState, State as FactoryResolverState } from '../FactoryResolver';
 import { State as InfrastructureNamespaceState } from '../InfrastructureNamespaces';
 import { State as PluginsState } from '../Plugins/chePlugins';
 import { State as UserState } from '../User';
@@ -164,8 +163,13 @@ export class FakeStoreBuilder {
     return this;
   }
 
-  public withFactoryResolver(resolver: FactoryResolver, isLoading = false): FakeStoreBuilder {
+  public withFactoryResolver(
+    resolver: ResolverState,
+    converted: ConvertedState,
+    isLoading = false,
+  ): FakeStoreBuilder {
     this.state.factoryResolver.resolver = Object.assign({}, resolver);
+    this.state.factoryResolver.converted = Object.assign({}, converted);
     this.state.factoryResolver.isLoading = isLoading;
     return this;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,10 +382,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/devfile-converter@0.0.1-8de908e":
-  version "0.0.1-8de908e"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-8de908e.tgz#f1f170832c4f5062dd47227cd4c921b12652a927"
-  integrity sha512-/nwqpbjT5bHkcY+d7mGjkXafgNJ9UCcTK/snj5u+DTXbi+eE5MQMJgf7cEsO8FQcIXwaWKnJnoQF6y849IGCjA==
+"@eclipse-che/devfile-converter@0.0.1-437a239":
+  version "0.0.1-437a239"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-437a239.tgz#95f8973437b7b3b5e0daa2ee4a6ce07b8be1e2b2"
+  integrity sha512-zUVVw97dqZ4zodZnGdzhDilmqlyfNJ8AXPh9TRhgE7CoIlAtcPwcsvRGvLFyCtwQ35nXh+90ZffTQCc438NIcQ==
   dependencies:
     "@devfile/api" "2.2.0-alpha-1637255314"
     "@eclipse-che/api" "^7.39.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,10 +382,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/devfile-converter@0.0.1-eb20432":
-  version "0.0.1-eb20432"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-eb20432.tgz#e02b7e5baa4c7aab67db1d1062998da0d60df9bd"
-  integrity sha512-VH6J/gaT4LOc8QpXvSf9W5FcilRmlc4FnGhLx+iwF/1/LgAyOnUOt24/hPUtPwskDoAEETpF2dE61ScwwT0QPA==
+"@eclipse-che/devfile-converter@0.0.1-8de908e":
+  version "0.0.1-8de908e"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-8de908e.tgz#f1f170832c4f5062dd47227cd4c921b12652a927"
+  integrity sha512-/nwqpbjT5bHkcY+d7mGjkXafgNJ9UCcTK/snj5u+DTXbi+eE5MQMJgf7cEsO8FQcIXwaWKnJnoQF6y849IGCjA==
   dependencies:
     "@devfile/api" "2.2.0-alpha-1637255314"
     "@eclipse-che/api" "^7.39.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,10 +369,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1637592995":
-  version "0.0.1-1637592995"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1637592995.tgz#cc584fa11b06dc19f9c5b33d33334d29abd07a1e"
-  integrity sha512-TP6lSNf1g9aLHHIZWoK/GJU2fO8sqpEXfI+TnS+ZaYXggJLuK+t87waGZCij42227iRsX4tUx1P6XFOJrk/SCw==
+"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1639587602":
+  version "0.0.1-1639587602"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1639587602.tgz#ce26a00b7c668a3e2aa03a298c716354329ec4f9"
+  integrity sha512-vCzirEnaul87XaXXRGtr+wCJjJSM0M1BO4rdN7EazzdOLiucIF8kjvIk9Qjzbty2Pfx2ntveXI0wjnWFJ4l4UA==
   dependencies:
     "@devfile/api" latest
     axios "0.21.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,10 +382,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/devfile-converter@0.0.1-ba9d381":
-  version "0.0.1-ba9d381"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-ba9d381.tgz#3c59ce517d0678b2b7ff2f23d3dc2f0fde47016b"
-  integrity sha512-30iGKhVWrURUUDWZavFU93Jb/cYKqnzJ/tdXB2J04GlhpR/d1qKABMu42Yxqx3UKG1mKeEZliTD6d5hUUIEbQQ==
+"@eclipse-che/devfile-converter@0.0.1-eb20432":
+  version "0.0.1-eb20432"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-eb20432.tgz#e02b7e5baa4c7aab67db1d1062998da0d60df9bd"
+  integrity sha512-VH6J/gaT4LOc8QpXvSf9W5FcilRmlc4FnGhLx+iwF/1/LgAyOnUOt24/hPUtPwskDoAEETpF2dE61ScwwT0QPA==
   dependencies:
     "@devfile/api" "2.2.0-alpha-1637255314"
     "@eclipse-che/api" "^7.39.2"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

With this PR it's possible to start devworkspaces using factory flow for repositories with devfile v1. 

### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/20784
fixes https://github.com/eclipse/che/issues/20893

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

Deploy Eclipse Che with devworkspaces mode enabled and create workspaces using factory links below:

*devfiles v1*:
1.  ✅ `[che-host]#https://github.com/eclipse-che/che-dashboard/tree/da713f90d68b22c339dbef9404c27dcd882da642` 
2. ✅ `[che-host]#https://github.com/eclipse-che/che-devfile-registry/raw/main/devfiles/nodejs-react/devfile.yaml`
3. ✅ `[che-host]#https://raw.githubusercontent.com/eclipse-che/che-devfile-registry/main/devfiles/java-web-spring/devfile.yaml` 

*devfiles v2*:
1. ✅ `[che-host]#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2` 
2. ✅ `[che-host]#https://github.com/che-samples/quarkus-quickstarts/tree/devfilev2`


*no devfiles in repository* 
1. ✅ `[che-host]#https://github.com/eclipse/che`
2. ✅ `[che-host]#https://github.com/spring-projects/spring-petclinic`

