### PR TITLE
feat: Hiding devfile v1 che-server based workspaces if DevWorkspace engine is enabled

### DIFF
--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -136,17 +136,16 @@ export const actionCreators: ActionCreators = {
       try {
         const state = getState();
         const cheDevworkspaceEnabled = isDevworkspacesEnabled(state.workspacesSettings.settings);
-        let requestDevWorkspaces: Promise<any>;
+        let requestWorkspaces: Promise<any>;
+
+        // Hide devfile v1 workspaces if the DevWorkspace engine is enabled - https://github.com/eclipse/che/issues/20900
         if (cheDevworkspaceEnabled) {
-          requestDevWorkspaces = dispatch(DevWorkspacesStore.actionCreators.requestWorkspaces());
+          requestWorkspaces = dispatch(DevWorkspacesStore.actionCreators.requestWorkspaces());
         } else {
-          requestDevWorkspaces = Promise.resolve([]);
+          requestWorkspaces = dispatch(CheWorkspacesStore.actionCreators.requestWorkspaces());
         }
 
-        await Promise.all([
-          dispatch(CheWorkspacesStore.actionCreators.requestWorkspaces()),
-          requestDevWorkspaces,
-        ]);
+        await requestWorkspaces;
 
         dispatch({ type: 'RECEIVE_WORKSPACES' });
       } catch (e) {


### PR DESCRIPTION
### What does this PR do?

https://github.com/eclipse/che/issues/20900

### What issues does this PR fix or reference?

Hiding devfile v1 che-server based workspaces if DevWorkspace engine is enabled

### Is it tested? How?
Before:  

![image](https://user-images.githubusercontent.com/1461122/145799925-e44b5f72-b749-4a9c-b565-7f7d5c12e48e.png)


After:

![image](https://user-images.githubusercontent.com/1461122/145801154-ba32929c-9f0c-4143-b1d8-b321ba5b5f7b.png)


#### Release Notes
Hiding devfile v1 che-server based workspaces if DevWorkspace engine is enabled

#### Docs PR
N / A
