### PR TITLE
feat: manage default uri plugins for DevWorkspaces

### DIFF
--- a/packages/dashboard-frontend/src/inversify.config.ts
+++ b/packages/dashboard-frontend/src/inversify.config.ts
@@ -25,6 +25,7 @@ import {
 } from './services/workspace-client/devworkspace/devWorkspaceClient';
 import { DevWorkspaceEditorProcessTheia } from './services/workspace-client/devworkspace/DevWorkspaceEditorProcessTheia';
 import { DevWorkspaceEditorProcessCode } from './services/workspace-client/devworkspace/DevWorkspaceEditorProcessCode';
+import { DevWorkspaceDefaultPluginsHandler } from './services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler';
 
 const container = new Container();
 const { lazyInject } = getDecorators(container);
@@ -38,5 +39,6 @@ container.bind(DevWorkspaceClient).toSelf().inSingletonScope();
 container.bind(IDevWorkspaceEditorProcess).to(DevWorkspaceEditorProcessTheia).inSingletonScope();
 container.bind(IDevWorkspaceEditorProcess).to(DevWorkspaceEditorProcessCode).inSingletonScope();
 container.bind(AppAlerts).toSelf().inSingletonScope();
+container.bind(DevWorkspaceDefaultPluginsHandler).toSelf().inSingletonScope();
 
 export { container, lazyInject };

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/serverConfigApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/serverConfigApi.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import axios from 'axios';
+import common from '@eclipse-che/common';
+import { prefix } from './const';
+
+/**
+ * Returns an array of default plug-ins for the specified editor
+ * 
+ * @param editorId The editor id to get default plug-ins for
+ * @returns Promise resolving with the array of default plug-ins for the specified editor
+ */
+export async function getDefaultPlugins(editorId: string): Promise<string[]> {
+  const url = `${prefix}/server-config/default-plugins`;
+  try {
+    const response = await axios.get(url);
+    const editorPlugins = response.data.find((element: { editor: string; plugins: string[] }) =>
+      element.editor.toLowerCase() === editorId,
+    );
+    return editorPlugins ? editorPlugins.plugins : [];
+  } catch (e) {
+    throw `Failed to fetch default plugins. ${common.helpers.errors.getMessage(e)}`;
+  }
+}

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { injectable } from 'inversify';
+import { api } from '@eclipse-che/common';
+import * as ServerConfigApi from '../../dashboard-backend-client/serverConfigApi';
+import { createHash } from 'crypto';
+import devfileApi from '../../devfileApi';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import * as DwApi from '../../dashboard-backend-client/devWorkspaceApi';
+
+const DEFAULT_PLUGIN_ATTRIBUTE = 'che.eclipse.org/default-plugin';
+
+/**
+ * This class manages the default plugins defined in
+ * the DevWorkspace's spec.template.components array.
+ */
+@injectable()
+export class DevWorkspaceDefaultPluginsHandler {
+  public async handle(workspace: devfileApi.DevWorkspace, editor: string): Promise<void> {
+    const defaultPlugins = await ServerConfigApi.getDefaultPlugins(editor);
+    this.handleUriPlugins(workspace, defaultPlugins);
+    this.patchWorkspaceComponents(workspace);
+  }
+
+  private async handleUriPlugins(workspace: devfileApi.DevWorkspace, defaultPlugins: string[]) {
+    const defaultUriPlugins = new Set(
+      defaultPlugins.filter(plugin => {
+        if (this.isUri(plugin)) {
+          return true;
+        }
+        console.log(`Default plugin ${plugin} is not a uri. Ignoring.`);
+        return false;
+      }),
+    );
+
+    this.removeOldDefaultUriPlugins(workspace, defaultUriPlugins);
+
+    defaultUriPlugins.forEach(plugin => {
+      const hash = createHash('MD5').update(plugin).digest('hex').substring(0, 20).toLowerCase();
+      this.addDefaultPluginByUri(workspace, 'default-' + hash, plugin);
+    });
+  }
+
+  private isUri(str: string): boolean {
+    try {
+      new URL(str);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if there are default plugins in the workspace that are not
+   * specified in defaultUriPlugins. If such plugins are found, this function
+   * removes them.
+   * @param workspace A devworkspace to remove old default plugins for
+   * @param defaultUriPlugins The set of current default plugins
+   */
+  private removeOldDefaultUriPlugins(
+    workspace: devfileApi.DevWorkspace,
+    defaultUriPlugins: Set<string>,
+  ) {
+    if (!workspace.spec.template.components) {
+      return;
+    }
+    const components = workspace.spec.template.components.filter(component => {
+      if (!this.isDefaultPluginComponent(component) || !component.plugin?.uri) {
+        // component is not a default uri plugin, keep component.
+        return true;
+      }
+      return defaultUriPlugins.has(component.plugin.uri);
+    });
+    workspace.spec.template.components = components;
+  }
+
+  /**
+   * Returns true if component is a default plugin managed by this class
+   * @param component The component to check
+   * @returns true if component is a default plugin managed by this class
+   */
+  private isDefaultPluginComponent(component: V1alpha2DevWorkspaceSpecTemplateComponents): boolean {
+    return component.attributes && component.attributes[DEFAULT_PLUGIN_ATTRIBUTE]
+      ? component.attributes[DEFAULT_PLUGIN_ATTRIBUTE].toString() === 'true'
+      : false;
+  }
+
+  /**
+   * Add a default plugin to the workspace by uri
+   * @param workspace A devworkspace
+   * @param pluginName The name of the plugin
+   * @param pluginUri The uri of the plugin
+   */
+  private addDefaultPluginByUri(
+    workspace: devfileApi.DevWorkspace,
+    pluginName: string,
+    pluginUri: string,
+  ) {
+    if (!workspace.spec.template.components) {
+      workspace.spec.template.components = [];
+    }
+
+    if (workspace.spec.template.components.find(component => component.name === pluginName)) {
+      // plugin already exists
+      return;
+    }
+
+    workspace.spec.template.components.push({
+      name: pluginName,
+      attributes: { [DEFAULT_PLUGIN_ATTRIBUTE]: true },
+      plugin: { uri: pluginUri },
+    });
+  }
+
+  private async patchWorkspaceComponents(workspace: devfileApi.DevWorkspace) {
+    const patch: api.IPatch[] = [
+      {
+        op: 'replace',
+        path: '/spec/template/components',
+        value: workspace.spec.template.components,
+      },
+    ];
+    return DwApi.patchWorkspace(workspace.metadata.namespace, workspace.metadata.name, patch);
+  }
+}

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '../../../../inversify.config';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import { DevWorkspaceClient } from '../devWorkspaceClient';
+import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
+import * as ServerConfigApi from '../../../dashboard-backend-client/serverConfigApi';
+
+describe('DevWorkspace client, start', () => {
+  let client: DevWorkspaceClient;
+
+  beforeEach(() => {
+    client = container.get(DevWorkspaceClient);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should add default plugin uri', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .build();
+
+    const defaultPluginUri = 'https://test.com/devfile.yaml';
+    const getDefaultPlugins = jest
+      .spyOn(ServerConfigApi, 'getDefaultPlugins')
+      .mockResolvedValueOnce([defaultPluginUri]);
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    await client.onStart(testWorkspace, '');
+    expect(testWorkspace.spec.template.components!.length).toBe(1);
+    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(defaultPluginUri);
+    expect(
+      testWorkspace.spec.template.components![0].attributes!['che.eclipse.org/default-plugin'],
+    ).toBe(true);
+    expect(getDefaultPlugins).toHaveBeenCalled();
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+
+  it('should remove default plugin uri when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withTemplate({
+        components: [
+          {
+            name: 'default',
+            attributes: { 'che.eclipse.org/default-plugin': true },
+            plugin: { uri: 'https://test.com/devfile.yaml' },
+          },
+        ],
+      })
+      .build();
+
+    // No default plugins
+    const getDefaultPlugins = jest
+      .spyOn(ServerConfigApi, 'getDefaultPlugins')
+      .mockResolvedValueOnce([]);
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    await client.onStart(testWorkspace, '');
+    expect(testWorkspace.spec.template.components!.length).toBe(0);
+    expect(getDefaultPlugins).toHaveBeenCalled();
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+
+  it('should not remove non default plugin uri when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const uri = 'https://test.com/devfile.yaml';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withTemplate({
+        components: [
+          {
+            name: 'my-plugin',
+            plugin: { uri },
+          },
+        ],
+      })
+      .build();
+
+    // No default plugins
+    const getDefaultPlugins = jest
+      .spyOn(ServerConfigApi, 'getDefaultPlugins')
+      .mockResolvedValueOnce([]);
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    await client.onStart(testWorkspace, '');
+    expect(testWorkspace.spec.template.components!.length).toBe(1);
+    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
+    expect(testWorkspace.spec.template.components![0].attributes).toBeUndefined();
+    expect(getDefaultPlugins).toHaveBeenCalled();
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+
+  it('should not remove non default plugin uri if attribute is false', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const uri = 'https://test.com/devfile.yaml';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withTemplate({
+        components: [
+          {
+            name: 'default',
+            attributes: { 'che.eclipse.org/default-plugin': false },
+            plugin: { uri: 'https://test.com/devfile.yaml' },
+          },
+        ],
+      })
+      .build();
+
+    // No default plugins
+    const getDefaultPlugins = jest
+      .spyOn(ServerConfigApi, 'getDefaultPlugins')
+      .mockResolvedValueOnce([]);
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    await client.onStart(testWorkspace, '');
+    expect(testWorkspace.spec.template.components!.length).toBe(1);
+    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
+    expect(getDefaultPlugins).toHaveBeenCalled();
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -273,6 +273,10 @@ export const actionCreators: ActionCreators = {
         } else {
           updatedWorkspace = await devWorkspaceClient.changeWorkspaceStatus(workspace, true, true);
         }
+        await devWorkspaceClient.onStart(
+          updatedWorkspace,
+          getState().dwPlugins.defaultEditorName as string,
+        );
         dispatch({
           type: 'UPDATE_DEVWORKSPACE',
           workspace: updatedWorkspace,
@@ -466,6 +470,7 @@ export const actionCreators: ActionCreators = {
           optionalFilesContent,
         );
 
+        await devWorkspaceClient.onStart(workspace, cheEditor as string);
         dispatch({
           type: 'ADD_DEVWORKSPACE',
           workspace,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR provides support for adding/deleting default plugins for DevWorkspaces. This PR only supports managing plugins specified by url to a v2 devfile / DW / DWT.

Example plugin urls:
* https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/moby/buildkit/latest/devfile.yaml
* https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/containers/buildah/latest/devfile.yaml

Default plugin urls are to be added to the Che CR's `server.workspaceDefaultPlugins` field, which is introduced in this PR: https://github.com/eclipse-che/che-operator/pull/1248.

Example:
```
  server:
    workspacesDefaultPlugins:
      - editor: 'eclipse/che-theia/latest'
        plugins: ['https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/containers/buildah/latest/devfile.yaml']
```
 
### What issues does this PR fix or reference?
This PR brings support for specifying default plugins by url in the CR for: https://github.com/eclipse/che/issues/20090

### Is it tested? How?
1. Deploy Che using the chectl command from this PR: [eclipse-che/che-operator#1248](https://github.com/eclipse/che/issues/20090), with this patch:
```
spec:
 devWorkspace:
   enabled: true
 server:
    dashboardImagePullPolicy: Always
    dashboardImage: 'quay.io/dkwon17/che-dashboard:che-20090'
```
2. Add this field to the existing CheCluster CR:
```
  server:
    workspacesDefaultPlugins:
      - editor: 'eclipse/che-theia/next'
        plugins: ['https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/containers/buildah/latest/devfile.yaml']
```
4. Start a devworkspace from the che-dashboard. For the screenshot below, I created a Go devworkspace.
5. Verify that the devworkspace has a plugin component for the default plugin
![image](https://user-images.githubusercontent.com/83611742/145871537-0e11fb82-e8ff-494a-a041-b9fdbe2abed2.png)

6. Remove `server.workspacesDefaultPlugins` from the CheCluster CR.
7. Start the same devworkspace from step 4, and verify that the devworkspace does not have the default plugin anymore
![image](https://user-images.githubusercontent.com/83611742/145871558-bfeebb93-7798-4fb7-a088-53310acf618f.png)



#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
TODO