### PR TITLE
feat: manage default uri plugins for DevWorkspaces

### DIFF
--- a/local-start.sh
+++ b/local-start.sh
@@ -17,7 +17,7 @@ Arguments:
 Env vars:
   KUBECONFIG    : Kubeconfig file location. Default: "$HOME/.kube/config"
   CHE_NAMESPACE : kubernetes namespace where Che Cluster should be looked into. Default: "eclipse-che"
-  CHE_CRD_OBJECT_NAME : kubernetes CRD object name. Default: "eclipse-che"
+  CHECLUSTER_CR_NAME : kubernetes CRD object name. Default: "eclipse-che"
 Examples:
 $0
 $0 --force-build
@@ -38,9 +38,10 @@ parse_args() {
 FORCE_BUILD="false"
 # Init Che Namespace with the default value if it's not set
 CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
+CHECLUSTER_CR_NAMESPACE="${CHE_NAMESPACE}"
 
 # Init Che CRD object name with the default value if it's not set
-CHE_CRD_OBJECT_NAME="${CHE_CRD_OBJECT_NAME:-eclipse-che}"
+CHECLUSTER_CR_NAME="${CHECLUSTER_CR_NAME:-eclipse-che}"
 
 # guide backend to use the current cluster from kubeconfig
 export LOCAL_RUN="true"

--- a/packages/dashboard-backend/src/devworkspace-client/services/api/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/api/serverConfigApi.ts
@@ -21,8 +21,8 @@ const GROUP = 'org.eclipse.che';
 const VERSION = 'v1';
 const PLURAL = 'checlusters';
 
-const NAME = process.env.CHE_CRD_OBJECT_NAME;
-const NAMESPACE = process.env.CHE_NAMESPACE;
+const NAME = process.env.CHECLUSTER_CR_NAME;
+const NAMESPACE = process.env.CHECLUSTER_CR_NAMESPACE;
 
 export class ServerConfigApi implements IServerConfigApi {
   private readonly customObjectAPI: k8s.CustomObjectsApi;
@@ -36,7 +36,7 @@ export class ServerConfigApi implements IServerConfigApi {
       throw createError(
         undefined,
         CUSTOM_RECOURSE_DEFINITIONS_API_ERROR_LABEL,
-        'Mandatory environment variables are not defined: $CHE_NAMESPACE, $CHE_CRD_OBJECT_NAME',
+        'Mandatory environment variables are not defined: $CHECLUSTER_CR_NAMESPACE, $CHECLUSTER_CR_NAME',
       );
     }
 

--- a/packages/dashboard-frontend/src/inversify.config.ts
+++ b/packages/dashboard-frontend/src/inversify.config.ts
@@ -25,6 +25,7 @@ import {
 } from './services/workspace-client/devworkspace/devWorkspaceClient';
 import { DevWorkspaceEditorProcessTheia } from './services/workspace-client/devworkspace/DevWorkspaceEditorProcessTheia';
 import { DevWorkspaceEditorProcessCode } from './services/workspace-client/devworkspace/DevWorkspaceEditorProcessCode';
+import { DevWorkspaceDefaultPluginsHandler } from './services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler';
 
 const container = new Container();
 const { lazyInject } = getDecorators(container);
@@ -38,5 +39,6 @@ container.bind(DevWorkspaceClient).toSelf().inSingletonScope();
 container.bind(IDevWorkspaceEditorProcess).to(DevWorkspaceEditorProcessTheia).inSingletonScope();
 container.bind(IDevWorkspaceEditorProcess).to(DevWorkspaceEditorProcessCode).inSingletonScope();
 container.bind(AppAlerts).toSelf().inSingletonScope();
+container.bind(DevWorkspaceDefaultPluginsHandler).toSelf().inSingletonScope();
 
 export { container, lazyInject };

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -74,6 +74,7 @@ export default class Bootstrap {
         return this.fetchDevfileSchema();
       }),
       this.fetchDwPlugins(settings),
+      this.fetchDefaultDwPlugins(settings),
       this.fetchRegistriesMetadata(settings),
       this.updateDevWorkspaceTemplates(settings),
       this.fetchWorkspaces(),
@@ -172,6 +173,18 @@ export default class Bootstrap {
       addBanner(message)(this.store.dispatch, this.store.getState, undefined);
 
       throw e;
+    }
+  }
+
+  private async fetchDefaultDwPlugins(settings: che.WorkspaceSettings): Promise<void> {
+    if (!isDevworkspacesEnabled(settings)) {
+      return;
+    }
+    const { requestDwDefaultPlugins } = DwPluginsStore.actionCreators;
+    try {
+      await requestDwDefaultPlugins()(this.store.dispatch, this.store.getState, undefined);
+    } catch (e) {
+      console.error('Failed to retrieve default plug-ins.', e);
     }
   }
 

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/serverConfigApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/serverConfigApi.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import axios from 'axios';
+import common from '@eclipse-che/common';
+import { prefix } from './const';
+import { api } from '@eclipse-che/common';
+
+/**
+ * Returns an array of default plug-ins per editor
+ *
+ * @returns Promise resolving with the array of default plug-ins for the specified editor
+ */
+export async function getDefaultPlugins(): Promise<api.IWorkspacesDefaultPlugins[]> {
+  const url = `${prefix}/server-config/default-plugins`;
+  try {
+    const response = await axios.get(url);
+    return response.data ? response.data : [];
+  } catch (e) {
+    throw `Failed to fetch default plugins. ${common.helpers.errors.getMessage(e)}`;
+  }
+}

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as DwApi from '../../dashboard-backend-client/devWorkspaceApi';
+import devfileApi from '../../devfileApi';
+import { api } from '@eclipse-che/common';
+import { createHash } from 'crypto';
+import { injectable } from 'inversify';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { WorkspacesDefaultPlugins } from 'dashboard-frontend/src/store/Plugins/devWorkspacePlugins';
+
+const DEFAULT_PLUGIN_ATTRIBUTE = 'che.eclipse.org/default-plugin';
+
+/**
+ * This class manages the default plugins defined in
+ * the DevWorkspace's spec.template.components array.
+ */
+@injectable()
+export class DevWorkspaceDefaultPluginsHandler {
+  public async handle(
+    workspace: devfileApi.DevWorkspace,
+    editorId: string,
+    defaultPlugins: WorkspacesDefaultPlugins,
+  ): Promise<void> {
+    if (!defaultPlugins[editorId]) {
+      return;
+    }
+
+    const componentsUpdated = this.handleUriPlugins(workspace, defaultPlugins[editorId]);
+    if (componentsUpdated) {
+      this.patchWorkspaceComponents(workspace);
+    }
+  }
+
+  /**
+   * Manages the default uri plugins from the devworkspace's spec.template.components
+   * @param workspace A devworkspace to manage default plugins for
+   * @param defaultPlugins The set of current default plugins uris
+   * @returns true if the devworkspace's spec.template.components has been updated
+   */
+  private handleUriPlugins(workspace: devfileApi.DevWorkspace, defaultPlugins: string[]): boolean {
+    const defaultUriPlugins = new Set(
+      defaultPlugins.filter(plugin => {
+        if (this.isUri(plugin)) {
+          return true;
+        }
+        console.log(`Default plugin ${plugin} is not a uri. Ignoring.`);
+        return false;
+      }),
+    );
+
+    let componentsUpdated = this.removeOldDefaultUriPlugins(workspace, defaultUriPlugins);
+    defaultUriPlugins.forEach(plugin => {
+      const hash = createHash('MD5').update(plugin).digest('hex').substring(0, 20).toLowerCase();
+      const added = this.addDefaultPluginByUri(workspace, 'default-' + hash, plugin);
+      componentsUpdated = added || componentsUpdated;
+    });
+
+    return componentsUpdated;
+  }
+
+  private isUri(str: string): boolean {
+    try {
+      new URL(str);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if there are default plugins in the workspace that are not
+   * specified in defaultUriPlugins. If such plugins are found, this function
+   * removes them.
+   * @param workspace A devworkspace to remove old default plugins for
+   * @param defaultUriPlugins The set of current default plugins
+   * @returns true if a plugin has been removed, false otherwise
+   */
+  private removeOldDefaultUriPlugins(
+    workspace: devfileApi.DevWorkspace,
+    defaultUriPlugins: Set<string>,
+  ): boolean {
+    if (!workspace.spec.template.components) {
+      return false;
+    }
+
+    const components = workspace.spec.template.components.filter(component => {
+      if (!this.isDefaultPluginComponent(component) || !component.plugin?.uri) {
+        // component is not a default uri plugin, keep component.
+        return true;
+      }
+      return defaultUriPlugins.has(component.plugin.uri);
+    });
+
+    const removed = workspace.spec.template.components.length !== components.length;
+    workspace.spec.template.components = components;
+    return removed;
+  }
+
+  /**
+   * Returns true if component is a default plugin managed by this class
+   * @param component The component to check
+   * @returns true if component is a default plugin managed by this class
+   */
+  private isDefaultPluginComponent(component: V1alpha2DevWorkspaceSpecTemplateComponents): boolean {
+    return component.attributes && component.attributes[DEFAULT_PLUGIN_ATTRIBUTE]
+      ? component.attributes[DEFAULT_PLUGIN_ATTRIBUTE].toString() === 'true'
+      : false;
+  }
+
+  /**
+   * Adds a default plugin to the workspace by uri if the default plugin does not
+   * already exist
+   * @param workspace A devworkspace
+   * @param pluginName The name of the plugin
+   * @param pluginUri The uri of the plugin
+   * @returns true if the default plugin has been added
+   */
+  private addDefaultPluginByUri(
+    workspace: devfileApi.DevWorkspace,
+    pluginName: string,
+    pluginUri: string,
+  ): boolean {
+    if (!workspace.spec.template.components) {
+      workspace.spec.template.components = [];
+    }
+
+    if (workspace.spec.template.components.find(component => component.name === pluginName)) {
+      // plugin already exists
+      return false;
+    }
+
+    workspace.spec.template.components.push({
+      name: pluginName,
+      attributes: { [DEFAULT_PLUGIN_ATTRIBUTE]: true },
+      plugin: { uri: pluginUri },
+    });
+    return true;
+  }
+
+  private async patchWorkspaceComponents(workspace: devfileApi.DevWorkspace) {
+    const patch: api.IPatch[] = [
+      {
+        op: 'replace',
+        path: '/spec/template/components',
+        value: workspace.spec.template.components,
+      },
+    ];
+    return DwApi.patchWorkspace(workspace.metadata.namespace, workspace.metadata.name, patch);
+  }
+}

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '../../../../inversify.config';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import { DevWorkspaceClient } from '../devWorkspaceClient';
+import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
+import * as ServerConfigApi from '../../../dashboard-backend-client/serverConfigApi';
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+describe('DevWorkspace client, start', () => {
+  let client: DevWorkspaceClient;
+
+  beforeEach(() => {
+    client = container.get(DevWorkspaceClient);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should add default plugin uri', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .build();
+    const defaultPluginUri = 'https://test.com/devfile.yaml';
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+
+    const defaults = { 'eclipse/theia/next': [defaultPluginUri] };
+    const editor = 'eclipse/theia/next';
+    await client.onStart(testWorkspace, defaults, editor);
+    expect(testWorkspace.spec.template.components!.length).toBe(1);
+    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(defaultPluginUri);
+    expect(
+      (testWorkspace.spec.template.components![0].attributes as any)[
+        'che.eclipse.org/default-plugin'
+      ],
+    ).toBe(true);
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+
+  it('should remove default plugin uri when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withTemplate({
+        components: [
+          {
+            name: 'default',
+            attributes: { 'che.eclipse.org/default-plugin': true },
+            plugin: { uri: 'https://test.com/devfile.yaml' },
+          },
+        ],
+      })
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = { 'eclipse/theia/next': [] };
+    const editor = 'eclipse/theia/next';
+    await client.onStart(testWorkspace, defaults, editor);
+    expect(testWorkspace.spec.template.components!.length).toBe(0);
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+
+  it('should not remove non default plugin uri when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const uri = 'https://test.com/devfile.yaml';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withTemplate({
+        components: [
+          {
+            name: 'my-plugin',
+            plugin: { uri },
+          },
+        ],
+      })
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = { 'eclipse/theia/next': [] };
+    const editor = 'eclipse/theia/next';
+    await client.onStart(testWorkspace, defaults, editor);
+    expect(testWorkspace.spec.template.components!.length).toBe(1);
+    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
+    expect(testWorkspace.spec.template.components![0].attributes).toBeUndefined();
+    expect(patchWorkspace).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not remove non default plugin uri if attribute is false', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const uri = 'https://test.com/devfile.yaml';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withTemplate({
+        components: [
+          {
+            name: 'default',
+            attributes: { 'che.eclipse.org/default-plugin': false },
+            plugin: { uri },
+          },
+        ],
+      })
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = { 'eclipse/theia/next': [] };
+    const editor = 'eclipse/theia/next';
+    await client.onStart(testWorkspace, defaults, editor);
+    expect(testWorkspace.spec.template.components!.length).toBe(1);
+    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
+    expect(patchWorkspace).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not call ServerConfigApi.getDefaultPlugins', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .build();
+
+    const getDefaultPlugins = jest.spyOn(ServerConfigApi, 'getDefaultPlugins');
+    const defaults = {};
+    const editor = 'eclipse/theia/next';
+    await client.onStart(testWorkspace, defaults, editor);
+    expect(getDefaultPlugins).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
@@ -11,6 +11,7 @@
  */
 
 import devfileApi from '../../../devfileApi';
+import { DEVWORKSPACE_METADATA_ANNOTATION } from '../devWorkspaceClient';
 
 export const devworkspaceVersion = 'v1alpha2';
 export const devWorkspaceApiGroup = 'workspace.devfile.io';
@@ -22,7 +23,7 @@ export function devfileToDevWorkspace(
   started: boolean,
 ): devfileApi.DevWorkspace {
   const devfileAttributes = devfile.metadata.attributes || {};
-  const devWorkspaceAnnotations = devfileAttributes['dw.metadata.annotations'] || {};
+  const devWorkspaceAnnotations = devfileAttributes[DEVWORKSPACE_METADATA_ANNOTATION] || {};
   const template: devfileApi.DevWorkspace = {
     apiVersion: `${devWorkspaceApiGroup}/${devworkspaceVersion}`,
     kind: 'DevWorkspace',

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -40,6 +40,8 @@ import {
 } from '@devfile/api';
 import { isEqual } from 'lodash';
 import { fetchData } from '../../registry/devfiles';
+import { DevWorkspaceDefaultPluginsHandler } from './DevWorkspaceDefaultPluginsHandler';
+import { WorkspacesDefaultPlugins } from 'dashboard-frontend/src/store/Plugins/devWorkspacePlugins';
 
 export interface IStatusUpdate {
   status: string;
@@ -104,6 +106,8 @@ export const DEVWORKSPACE_DEBUG_START_ANNOTATION = 'controller.devfile.io/debug-
 
 export const DEVWORKSPACE_DEVFILE_SOURCE = 'che.eclipse.org/devfile-source';
 
+export const DEVWORKSPACE_CHE_EDITOR = 'che.eclipse.org/che-editor';
+
 export const DEVWORKSPACE_METADATA_ANNOTATION = 'dw.metadata.annotations';
 
 export interface ICheEditorOverrideContainer extends V220DevfileComponentsItemsContainer {
@@ -135,10 +139,13 @@ export class DevWorkspaceClient extends WorkspaceClient {
   private readonly webSocketEventName: string;
   private readonly _failingWebSockets: string[];
   private readonly showAlert: (alert: AlertItem) => void;
+  private readonly defaultPluginsHandler: DevWorkspaceDefaultPluginsHandler;
 
   constructor(
     @inject(KeycloakSetupService) keycloakSetupService: KeycloakSetupService,
     @inject(AppAlerts) appAlerts: AppAlerts,
+    @inject(DevWorkspaceDefaultPluginsHandler)
+    defaultPluginsHandler: DevWorkspaceDefaultPluginsHandler,
     @multiInject(IDevWorkspaceEditorProcess) private editorProcesses: IDevWorkspaceEditorProcess[],
   ) {
     super(keycloakSetupService);
@@ -150,6 +157,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     this.webSocketEventEmitter = new EventEmitter();
     this.webSocketEventName = 'websocketClose';
     this._failingWebSockets = [];
+    this.defaultPluginsHandler = defaultPluginsHandler;
 
     this.showAlert = (alert: AlertItem) => appAlerts.showAlert(alert);
 
@@ -466,6 +474,22 @@ export class DevWorkspaceClient extends WorkspaceClient {
         ' and templates updated to',
         context.devWorkspaceTemplates,
       );
+    }
+  }
+
+  /**
+   * Called when a DevWorkspace has started.
+   *
+   * @param workspace The DevWorkspace that was started
+   * @param editorId The editor id of the DevWorkspace that was started
+   */
+  async onStart(
+    workspace: devfileApi.DevWorkspace,
+    defaultPlugins: WorkspacesDefaultPlugins,
+    editorId?: string,
+  ) {
+    if (editorId) {
+      await this.defaultPluginsHandler.handle(workspace, editorId, defaultPlugins);
     }
   }
 

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
@@ -32,7 +32,7 @@ const plugin = {
 
 describe('dwPlugins store', () => {
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   describe('actions', () => {
@@ -295,6 +295,37 @@ describe('dwPlugins store', () => {
       ];
       expect(actions).toEqual(expectedActions);
     });
+
+    it('should create REQUEST_DW_DEFAULT_EDITOR and RECEIVE_DW_DEFAULT_EDITOR when fetching default plugins', async () => {
+      (mockAxios.get as jest.Mock).mockResolvedValueOnce({
+        data: [{ editor: 'eclipse/theia/next', plugins: ['https://test.com/devfile.yaml'] }],
+      });
+
+      const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, dwPluginsStore.KnownAction>
+      >;
+
+      const settings = {
+        'che.devworkspaces.enabled': 'true',
+      } as che.WorkspaceSettings;
+      await store.dispatch(dwPluginsStore.actionCreators.requestDwDefaultPlugins());
+
+      const actions = store.getActions();
+
+      const expectedActions: dwPluginsStore.KnownAction[] = [
+        {
+          type: 'REQUEST_DW_DEFAULT_PLUGINS',
+        },
+        {
+          type: 'RECEIVE_DW_DEFAULT_PLUGINS',
+          defaultPlugins: {
+            'eclipse/theia/next': ['https://test.com/devfile.yaml'],
+          },
+        },
+      ];
+      expect(actions).toEqual(expectedActions);
+    });
   });
 
   describe('reducers', () => {
@@ -309,6 +340,7 @@ describe('dwPlugins store', () => {
         isLoading: false,
         plugins: {},
         editors: {},
+        defaultPlugins: {},
       };
 
       expect(initialState).toEqual(expectedState);
@@ -319,6 +351,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       } as dwPluginsStore.State;
       const incomingAction = {
         type: 'OTHER_ACTION',
@@ -329,6 +362,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         plugins: {},
         editors: {},
+        defaultPlugins: {},
       };
       expect(newState).toEqual(expectedState);
     });
@@ -343,6 +377,7 @@ describe('dwPlugins store', () => {
             url: 'devfile-location',
           },
         },
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.RequestDwPluginAction = {
         type: 'REQUEST_DW_PLUGIN',
@@ -359,6 +394,7 @@ describe('dwPlugins store', () => {
             url: 'devfile-location',
           },
         },
+        defaultPlugins: {},
       };
 
       expect(newState).toEqual(expectedState);
@@ -374,6 +410,7 @@ describe('dwPlugins store', () => {
           },
         },
         plugins: {},
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.RequestDwEditorAction = {
         type: 'REQUEST_DW_EDITOR',
@@ -392,6 +429,7 @@ describe('dwPlugins store', () => {
           },
         },
         plugins: {},
+        defaultPlugins: {},
       };
 
       expect(newState).toEqual(expectedState);
@@ -402,6 +440,7 @@ describe('dwPlugins store', () => {
         isLoading: false,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
         defaultEditorError: 'unexpected error',
       };
       const incomingAction: dwPluginsStore.RequestDwDefaultEditorAction = {
@@ -414,6 +453,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       };
 
       expect(newState).toEqual(expectedState);
@@ -424,6 +464,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwPluginAction = {
         type: 'RECEIVE_DW_PLUGIN',
@@ -442,6 +483,7 @@ describe('dwPlugins store', () => {
             plugin,
           },
         },
+        defaultPlugins: {},
       };
 
       expect(newState).toEqual(expectedState);
@@ -452,6 +494,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwEditorAction = {
         type: 'RECEIVE_DW_EDITOR',
@@ -471,6 +514,7 @@ describe('dwPlugins store', () => {
           },
         },
         plugins: {},
+        defaultPlugins: {},
       };
 
       expect(newState).toEqual(expectedState);
@@ -481,6 +525,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwPluginErrorAction = {
         type: 'RECEIVE_DW_PLUGIN_ERROR',
@@ -499,6 +544,7 @@ describe('dwPlugins store', () => {
             error: 'unexpected error',
           },
         },
+        defaultPlugins: {},
       };
 
       expect(newState).toEqual(expectedState);
@@ -509,6 +555,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.RequestDwEditorErrorAction = {
         type: 'RECEIVE_DW_EDITOR_ERROR',
@@ -528,6 +575,7 @@ describe('dwPlugins store', () => {
           },
         },
         plugins: {},
+        defaultPlugins: {},
       };
 
       expect(newState).toEqual(expectedState);
@@ -538,6 +586,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwDefaultEditorErrorAction = {
         type: 'RECEIVE_DW_DEFAULT_EDITOR_ERROR',
@@ -550,6 +599,7 @@ describe('dwPlugins store', () => {
         isLoading: false,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
         defaultEditorError: 'unexpected error',
       };
 
@@ -561,6 +611,7 @@ describe('dwPlugins store', () => {
         isLoading: true,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
       };
       const incomingAction: dwPluginsStore.ReceiveDwDefaultEditorAction = {
         type: 'RECEIVE_DW_DEFAULT_EDITOR',
@@ -574,9 +625,59 @@ describe('dwPlugins store', () => {
         isLoading: false,
         editors: {},
         plugins: {},
+        defaultPlugins: {},
         defaultEditorName: 'hello',
       };
 
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle REQUEST_DW_DEFAULT_PLUGINS', () => {
+      const initialState: dwPluginsStore.State = {
+        isLoading: false,
+        editors: {},
+        plugins: {},
+        defaultPlugins: {},
+      };
+      const incomingAction: dwPluginsStore.RequestDwDefaultPluginsAction = {
+        type: 'REQUEST_DW_DEFAULT_PLUGINS',
+      };
+
+      const newState = dwPluginsStore.reducer(initialState, incomingAction);
+
+      const expectedState: dwPluginsStore.State = {
+        isLoading: true,
+        editors: {},
+        plugins: {},
+        defaultPlugins: {},
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVE_DW_DEFAULT_PLUGINS', () => {
+      const initialState: dwPluginsStore.State = {
+        isLoading: true,
+        editors: {},
+        plugins: {},
+        defaultPlugins: {},
+      };
+
+      const defaultPlugins = { 'eclipse/theia/next': ['https://test.com/devfile.yaml'] };
+
+      const incomingAction: dwPluginsStore.ReceiveDwDefaultPluginsAction = {
+        type: 'RECEIVE_DW_DEFAULT_PLUGINS',
+        defaultPlugins,
+      };
+
+      const newState = dwPluginsStore.reducer(initialState, incomingAction);
+
+      const expectedState: dwPluginsStore.State = {
+        isLoading: false,
+        editors: {},
+        plugins: {},
+        defaultPlugins,
+      };
       expect(newState).toEqual(expectedState);
     });
   });

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -96,6 +96,7 @@ export class FakeStoreBuilder {
       isLoading: false,
       editors: {},
       plugins: {},
+      defaultPlugins: {},
     },
     dwDockerConfig: {
       isLoading: false,


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR is the same PR as https://github.com/eclipse-che/che-dashboard/pull/425, except, its source branch is in the `eclipse-che/che-dashboard` repository rather than `dkwon17/che-dashboard`.

### What issues does this PR fix or reference?
eclipse/che#20090