### PR TITLE
[feat] Implement editor agnostic kubeconfig injection

### DIFF
--- a/packages/dashboard-backend/src/api/kubeConfigAPI.ts
+++ b/packages/dashboard-backend/src/api/kubeConfigAPI.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { baseApiPath } from '../constants/config';
+import { getDevWorkspaceClient } from './helper';
+import { getSchema } from '../services/helpers';
+import { restParams } from '../typings/models';
+
+const tags = ['kubeconfig'];
+
+export function registerKubeConfigApi(server: FastifyInstance) {
+  server.post(
+    `${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig`,
+    getSchema({ tags }),
+    async function (request: FastifyRequest, reply: FastifyReply) {
+      try {
+        const { kubeConfigApi } = await getDevWorkspaceClient(request);
+        const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParam;
+        await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
+        reply.code(204);
+        return reply.send();
+      } catch (e) {
+        return reply.send(e);
+      }
+    },
+  );
+}

--- a/packages/dashboard-backend/src/devworkspace-client/index.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/index.ts
@@ -17,6 +17,7 @@ import {
   IDevWorkspaceClient,
   IDevWorkspaceTemplateApi,
   IDockerConfigApi,
+  IKubeConfigApi,
 } from './types';
 import { findApi } from './services/helpers';
 import { DevWorkspaceTemplateApi } from './services/api/template-api';
@@ -24,6 +25,7 @@ import { DevWorkspaceApi } from './services/api/workspace-api';
 import { devworkspaceGroup, devworkspaceLatestVersion } from '@devfile/api';
 import { DockerConfigApi } from './services/api/dockerConfigApi';
 import { ServerConfigApi } from './services/api/serverConfigApi';
+import { KubeConfigAPI } from './services/api/kubeConfigApi';
 
 export * from './types';
 
@@ -35,12 +37,14 @@ export class DevWorkspaceClient implements IDevWorkspaceClient {
   private readonly _devworkspaceApi: IDevWorkspaceApi;
   private readonly _dockerConfigApi: IDockerConfigApi;
   private readonly _serverConfigApi: IServerConfigApi;
+  private readonly _kubeConfigApi: IKubeConfigApi;
 
   constructor(kc: k8s.KubeConfig) {
     this._templateApi = new DevWorkspaceTemplateApi(kc);
     this._devworkspaceApi = new DevWorkspaceApi(kc);
     this._dockerConfigApi = new DockerConfigApi(kc);
     this._serverConfigApi = new ServerConfigApi(kc);
+    this._kubeConfigApi = new KubeConfigAPI(kc);
     this._apisApi = kc.makeApiClient(k8s.ApisApi);
   }
 
@@ -58,6 +62,10 @@ export class DevWorkspaceClient implements IDevWorkspaceClient {
 
   get serverConfigApi(): IServerConfigApi {
     return this._serverConfigApi;
+  }
+
+  get kubeConfigApi(): IKubeConfigApi {
+    return this._kubeConfigApi;
   }
 
   async isDevWorkspaceApiEnabled(): Promise<boolean> {

--- a/packages/dashboard-backend/src/devworkspace-client/services/api/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/api/kubeConfigApi.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import { IKubeConfigApi } from '../../types';
+import { StdStream } from '../helpers/stream';
+
+export class KubeConfigAPI implements IKubeConfigApi {
+  private readonly execAPI: k8s.Exec;
+  private readonly corev1API: k8s.CoreV1Api;
+  private readonly kubeConfig: string;
+
+  constructor(kc: k8s.KubeConfig) {
+    this.execAPI = new k8s.Exec(kc);
+    this.corev1API = kc.makeApiClient(k8s.CoreV1Api);
+    this.kubeConfig = kc.exportConfig();
+  }
+
+  /**
+   * Inject the kubeconfig into all containers with the given name in the namespace
+   * @param namespace The namespace where the pod lives
+   * @param devworkspaceId The id of the devworkspace
+   */
+  async injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void> {
+    const currentPod = await this.getPodByDevWorkspaceId(namespace, devworkspaceId);
+    const podName = currentPod.metadata?.name || '';
+    const currentPodContainers = currentPod.spec?.containers || [];
+
+    for (const container of currentPodContainers) {
+      const containerName = container.name;
+
+      // find the directory where we should create the kubeconfig
+      const kubeConfigDirectory = await this.resolveDirectory(podName, namespace, containerName);
+      if (kubeConfigDirectory === '') {
+        console.log(
+          `Could not find appropriate kubeconfig directory for ${namespace}/${podName}/${containerName}`,
+        );
+        continue;
+      }
+
+      // then create the directory if it doesn't exist
+      await this.exec(podName, namespace, containerName, [
+        'sh',
+        '-c',
+        `mkdir -p ${kubeConfigDirectory}`,
+      ]);
+
+      // if -f ${kubeConfigDirectory}/config is not found then sync kubeconfig to the container
+      await this.exec(podName, namespace, containerName, [
+        'sh',
+        '-c',
+        `[ -f ${kubeConfigDirectory}/config ] || echo '${this.kubeConfig}' > ${kubeConfigDirectory}/config`,
+      ]);
+    }
+  }
+
+  /**
+   * Given a namespace, find a pod that has the label controller.devfile.io/devworkspace_id=${devworkspaceId}
+   * @param namespace The namespace to look in
+   * @param devworkspaceId The id of the devworkspace
+   * @returns The containers for the first pod with given devworkspaceId
+   */
+  private async getPodByDevWorkspaceId(
+    namespace: string,
+    devworkspaceId: string,
+  ): Promise<k8s.V1Pod> {
+    try {
+      const resp = await this.corev1API.listNamespacedPod(
+        namespace,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        `controller.devfile.io/devworkspace_id=${devworkspaceId}`,
+      );
+      if (resp.body.items.length === 0) {
+        throw new Error(
+          `Could not find requested devworkspace with id ${devworkspaceId} in ${namespace}`,
+        );
+      }
+      return resp.body.items[0];
+    } catch (e: any) {
+      throw new Error(`Error occured when attempting to retrieve pod. ${e.message}`);
+    }
+  }
+
+  /**
+   * Resolve the directory where the kubeconfig is going to live. First it looks for the $KUBECONFIG env variable if
+   * that is found then use that. If that is not found then the default directory is $HOME/.kube
+   * @param name The name of the pod
+   * @param namespace The namespace where the pod lives
+   * @param containerName The name of the container to resolve the directory for
+   * @returns A promise of the directory where the kubeconfig is going to live
+   */
+  private async resolveDirectory(
+    name: string,
+    namespace: string,
+    containerName: string,
+  ): Promise<string> {
+    // attempt to resolve the kubeconfig env variable
+    const kubeConfigEnvResolver = await this.exec(name, namespace, containerName, [
+      'sh',
+      '-c',
+      'echo $KUBECONFIG',
+    ]);
+
+    if (kubeConfigEnvResolver.stdOut !== '') {
+      return kubeConfigEnvResolver.stdOut.replace(new RegExp('/config$'), '');
+    }
+
+    // attempt to resolve the home directory
+    const homeEnvResolution = await this.exec(name, namespace, containerName, [
+      'sh',
+      '-c',
+      'echo $HOME',
+    ]);
+
+    if (homeEnvResolution.stdOut !== '' && homeEnvResolution.stdOut !== '/') {
+      if (homeEnvResolution.stdOut.substr(-1) === '/') {
+        return homeEnvResolution.stdOut + '.kube';
+      } else {
+        return homeEnvResolution.stdOut + '/.kube';
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Execute the given command inside of a given container in a pod with a name and namespace and return the
+   * stdout and stderr responses
+   * @param name The name of the pod
+   * @param namespace The namespace where the pod lives
+   * @param containerName The name of the container
+   * @param command The command to return
+   * @returns The strings containing the stdout and stderr of running the command in the container
+   */
+  private async exec(
+    name: string,
+    namespace: string,
+    containerName: string,
+    command: string[],
+  ): Promise<{ stdOut: string }> {
+    try {
+      const stdOutStream = new StdStream();
+
+      // Wait until the exec request is done and reject if the final status is a failure, otherwise
+      // everything went OK and stdOutStream contains the response
+      await new Promise((resolve, reject) => {
+        this.execAPI.exec(
+          namespace,
+          name,
+          containerName,
+          command,
+          stdOutStream,
+          null,
+          null,
+          true,
+          status => {
+            if (status.status === 'Failure') {
+              reject(status);
+            } else {
+              resolve(status);
+            }
+          },
+        );
+      });
+      return {
+        stdOut: stdOutStream.chunks,
+      };
+    } catch (e: any) {
+      // swallow this error message and log it out instead because not all containers have a shell that you can use to inject
+      // and will fail by default
+      console.log(
+        `Failed trying to run command: ${command.join(
+          ' ',
+        )} in ${namespace}/${name}/${containerName} with message: ${e.message}`,
+      );
+      return {
+        stdOut: '',
+      };
+    }
+  }
+}

--- a/packages/dashboard-backend/src/devworkspace-client/services/helpers/stream.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/helpers/stream.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Writable } from 'stream';
+
+export class StdStream extends Writable {
+  private _chunks;
+
+  constructor() {
+    super();
+    this._chunks = '';
+  }
+
+  _write(chunk: string, encoding: BufferEncoding, done: (error?: Error | null) => void): void {
+    this._chunks += chunk.toString();
+    done();
+  }
+
+  get chunks() {
+    return this._chunks.trim();
+  }
+}

--- a/packages/dashboard-backend/src/devworkspace-client/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/types/index.ts
@@ -92,6 +92,13 @@ export interface IServerConfigApi {
   getDefaultPlugins(): Promise<api.IWorkspacesDefaultPlugins[]>;
 }
 
+export interface IKubeConfigApi {
+  /**
+   * Inject the kubeconfig into all containers with the given devworkspaceId in a namespace
+   */
+  injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void>;
+}
+
 export type IDevWorkspaceCallbacks = {
   onModified: (workspace: V1alpha2DevWorkspace) => void;
   onDeleted: (workspaceId: string) => void;
@@ -104,6 +111,7 @@ export interface IDevWorkspaceClient {
   templateApi: IDevWorkspaceTemplateApi;
   dockerConfigApi: IDockerConfigApi;
   serverConfigApi: IServerConfigApi;
+  kubeConfigApi: IKubeConfigApi;
   isDevWorkspaceApiEnabled(): Promise<boolean>;
 }
 

--- a/packages/dashboard-backend/src/index.ts
+++ b/packages/dashboard-backend/src/index.ts
@@ -26,6 +26,7 @@ import { registerClusterInfo } from './api/clusterInfo';
 import { CLUSTER_CONSOLE_URL } from './devworkspace-client/services/cluster-info';
 import { registerDockerConfigApi } from './api/dockerConfigApi';
 import { registerServerConfigApi } from './api/serverConfigApi';
+import { registerKubeConfigApi } from './api/kubeConfigAPI';
 
 const CHE_HOST = process.env.CHE_HOST as string;
 
@@ -69,6 +70,8 @@ registerTemplateApi(server);
 registerDockerConfigApi(server);
 
 registerServerConfigApi(server);
+
+registerKubeConfigApi(server);
 
 if (CLUSTER_CONSOLE_URL) {
   registerClusterInfo(server);

--- a/packages/dashboard-backend/src/typings/models.d.ts
+++ b/packages/dashboard-backend/src/typings/models.d.ts
@@ -31,6 +31,10 @@ declare namespace restParams {
     templateName: string;
   }
 
+  export interface INamespacedPodParam extends INamespacedParam {
+    devworkspaceId: string;
+  }
+
   export interface IStatusUpdate {
     error?: string;
     message?: string;

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
@@ -98,3 +98,13 @@ export async function putDockerConfig(
     throw `Failed to put dockerconfig. ${helpers.errors.getMessage(e)}`;
   }
 }
+
+export async function injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void> {
+  try {
+    await axios.post(
+      `${prefix}/namespace/${namespace}/devworkspaceId/${devworkspaceId}/kubeconfig`,
+    );
+  } catch (e) {
+    throw `Failed to inject kubeconfig. ${helpers.errors.getMessage(e)}`;
+  }
+}


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR implements editor agnostic kubeconfig injection for devworkspaces by calling a new endpoint `/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig` everytime a devworkspace is loaded. This new API injects the kubeconfig into all containers associated with a devworkspaceId.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20782

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Ensure that Che is running with devworkspaces enabled then either create a new devworkspace from the dashboard itself or use `https://gist.githubusercontent.com/JPinkney/d4f6e665d1239a5fc4caefbe20bf4f56/raw/96faebbd51b3bba209f8a8de8b448327f385c779/a.yaml` with a factory url (that gist has vscode-kubernetes-tools and vscode-yaml pre-installed). Wait for the workspace to start and then observe that the kubeconfig is located at `$HOME/.kube/config`. If you are using the gist with vscode-kubernetes-tools then you can also observe that the kubeconfig is automatically loaded into vscode-kubernetes-tools when you open up the side panel.


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
