### PR TITLE
Fix KubeConfig API error messages

### DIFF
--- a/packages/dashboard-backend/src/api/authorizeInfo.ts
+++ b/packages/dashboard-backend/src/api/authorizeInfo.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance } from 'fastify';
+import { baseApiPath } from '../constants/config';
+import { getSchema } from '../services/helpers';
+
+const tags = ['authorize'];
+
+export function authorizeInfo(server: FastifyInstance) {
+  server.get(`${baseApiPath}/token`, getSchema({ tags }), async () => {
+    const clusterAccessToken = process.env.CLUSTER_ACCESS_TOKEN as string;
+    const authorization = clusterAccessToken ? 'Bearer ' + clusterAccessToken : undefined;
+    return { authorization };
+  });
+}

--- a/packages/dashboard-backend/src/api/kubeConfigAPI.ts
+++ b/packages/dashboard-backend/src/api/kubeConfigAPI.ts
@@ -15,23 +15,20 @@ import { baseApiPath } from '../constants/config';
 import { getDevWorkspaceClient } from './helper';
 import { getSchema } from '../services/helpers';
 import { restParams } from '../typings/models';
+import { namespacedKubeConfigSchema } from '../constants/schemas';
 
 const tags = ['kubeconfig'];
 
 export function registerKubeConfigApi(server: FastifyInstance) {
   server.post(
     `${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig`,
-    getSchema({ tags }),
+    getSchema({ tags, params: namespacedKubeConfigSchema }),
     async function (request: FastifyRequest, reply: FastifyReply) {
-      try {
-        const { kubeConfigApi } = await getDevWorkspaceClient(request);
-        const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParam;
-        await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
-        reply.code(204);
-        return reply.send();
-      } catch (e) {
-        return reply.send(e);
-      }
+      const { kubeConfigApi } = await getDevWorkspaceClient(request);
+      const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParam;
+      await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
+      reply.code(204);
+      return reply.send();
     },
   );
 }

--- a/packages/dashboard-backend/src/api/templateApi.ts
+++ b/packages/dashboard-backend/src/api/templateApi.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { FastifyInstance, FastifyRequest } from 'fastify';
 import { baseApiPath } from '../constants/config';
 import {
   namespacedSchema,

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -22,6 +22,19 @@ export const authenticationHeaderSchema: JSONSchema7 = {
   },
 };
 
+export const namespacedKubeConfigSchema: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    namespace: {
+      type: 'string',
+    },
+    devworkspaceId: {
+      type: 'string',
+    },
+  },
+  required: ['namespace', 'devworkspaceId'],
+};
+
 export const namespacedDockerConfigSchema: JSONSchema7 = {
   type: 'object',
   properties: {

--- a/packages/dashboard-backend/src/devworkspace-client/services/api/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/api/kubeConfigApi.ts
@@ -13,6 +13,7 @@
 import * as k8s from '@kubernetes/client-node';
 import { IKubeConfigApi } from '../../types';
 import { StdStream } from '../helpers/stream';
+import { helpers } from '@eclipse-che/common';
 
 export class KubeConfigAPI implements IKubeConfigApi {
   private readonly execAPI: k8s.Exec;
@@ -35,31 +36,35 @@ export class KubeConfigAPI implements IKubeConfigApi {
     const podName = currentPod.metadata?.name || '';
     const currentPodContainers = currentPod.spec?.containers || [];
 
-    for (const container of currentPodContainers) {
-      const containerName = container.name;
+    try {
+      for (const container of currentPodContainers) {
+        const containerName = container.name;
 
-      // find the directory where we should create the kubeconfig
-      const kubeConfigDirectory = await this.resolveDirectory(podName, namespace, containerName);
-      if (kubeConfigDirectory === '') {
-        console.log(
-          `Could not find appropriate kubeconfig directory for ${namespace}/${podName}/${containerName}`,
-        );
-        continue;
+        // find the directory where we should create the kubeconfig
+        const kubeConfigDirectory = await this.resolveDirectory(podName, namespace, containerName);
+        if (kubeConfigDirectory === '') {
+          console.log(
+            `Could not find appropriate kubeconfig directory for ${namespace}/${podName}/${containerName}`,
+          );
+          continue;
+        }
+
+        // then create the directory if it doesn't exist
+        await this.exec(podName, namespace, containerName, [
+          'sh',
+          '-c',
+          `mkdir -p ${kubeConfigDirectory}`,
+        ]);
+
+        // if -f ${kubeConfigDirectory}/config is not found then sync kubeconfig to the container
+        await this.exec(podName, namespace, containerName, [
+          'sh',
+          '-c',
+          `[ -f ${kubeConfigDirectory}/config ] || echo '${this.kubeConfig}' > ${kubeConfigDirectory}/config`,
+        ]);
       }
-
-      // then create the directory if it doesn't exist
-      await this.exec(podName, namespace, containerName, [
-        'sh',
-        '-c',
-        `mkdir -p ${kubeConfigDirectory}`,
-      ]);
-
-      // if -f ${kubeConfigDirectory}/config is not found then sync kubeconfig to the container
-      await this.exec(podName, namespace, containerName, [
-        'sh',
-        '-c',
-        `[ -f ${kubeConfigDirectory}/config ] || echo '${this.kubeConfig}' > ${kubeConfigDirectory}/config`,
-      ]);
+    } catch (e) {
+      throw `Failed to inject kubeconfig. ${helpers.errors.getMessage(e)}`;
     }
   }
 
@@ -89,7 +94,9 @@ export class KubeConfigAPI implements IKubeConfigApi {
       }
       return resp.body.items[0];
     } catch (e: any) {
-      throw new Error(`Error occured when attempting to retrieve pod. ${e.message}`);
+      throw new Error(
+        `Error occurred when attempting to retrieve pod. ${helpers.errors.getMessage(e)}`,
+      );
     }
   }
 
@@ -106,30 +113,41 @@ export class KubeConfigAPI implements IKubeConfigApi {
     namespace: string,
     containerName: string,
   ): Promise<string> {
-    // attempt to resolve the kubeconfig env variable
-    const kubeConfigEnvResolver = await this.exec(name, namespace, containerName, [
-      'sh',
-      '-c',
-      'echo $KUBECONFIG',
-    ]);
+    try {
+      // attempt to resolve the kubeconfig env variable
+      const kubeConfigEnvResolver = await this.exec(name, namespace, containerName, [
+        'sh',
+        '-c',
+        'echo $KUBECONFIG',
+      ]);
 
-    if (kubeConfigEnvResolver.stdOut !== '') {
-      return kubeConfigEnvResolver.stdOut.replace(new RegExp('/config$'), '');
+      if (kubeConfigEnvResolver.stdOut) {
+        return kubeConfigEnvResolver.stdOut.replace(new RegExp('/config$'), '');
+      }
+    } catch (e) {
+      console.log(
+        `Could not resolve the kubeconfig env variable in ${namespace}/${name}/${containerName}`,
+      );
     }
 
-    // attempt to resolve the home directory
-    const homeEnvResolution = await this.exec(name, namespace, containerName, [
-      'sh',
-      '-c',
-      'echo $HOME',
-    ]);
+    try {
+      // attempt to resolve the home directory
+      const homeEnvResolution = await this.exec(name, namespace, containerName, [
+        'sh',
+        '-c',
+        'echo $HOME',
+      ]);
 
-    if (homeEnvResolution.stdOut !== '' && homeEnvResolution.stdOut !== '/') {
-      if (homeEnvResolution.stdOut.substr(-1) === '/') {
-        return homeEnvResolution.stdOut + '.kube';
-      } else {
-        return homeEnvResolution.stdOut + '/.kube';
+      if (homeEnvResolution.stdOut) {
+        if (homeEnvResolution.stdOut.substr(-1) === '/') {
+          return homeEnvResolution.stdOut + '.kube';
+        } else {
+          return homeEnvResolution.stdOut + '/.kube';
+        }
       }
+    } catch (e) {
+      const message = helpers.errors.getMessage(e);
+      throw `Failed to run command 'echo $HOME' in '${namespace}/${name}/${containerName}' with message: '${message}'`;
     }
     return '';
   }
@@ -149,44 +167,35 @@ export class KubeConfigAPI implements IKubeConfigApi {
     containerName: string,
     command: string[],
   ): Promise<{ stdOut: string }> {
-    try {
-      const stdOutStream = new StdStream();
+    const stdOutStream = new StdStream();
 
-      // Wait until the exec request is done and reject if the final status is a failure, otherwise
-      // everything went OK and stdOutStream contains the response
-      await new Promise((resolve, reject) => {
-        this.execAPI.exec(
-          namespace,
-          name,
-          containerName,
-          command,
-          stdOutStream,
-          null,
-          null,
-          true,
-          status => {
-            if (status.status === 'Failure') {
-              reject(status);
-            } else {
-              resolve(status);
-            }
-          },
-        );
-      });
-      return {
-        stdOut: stdOutStream.chunks,
-      };
-    } catch (e: any) {
-      // swallow this error message and log it out instead because not all containers have a shell that you can use to inject
-      // and will fail by default
-      console.log(
-        `Failed trying to run command: ${command.join(
-          ' ',
-        )} in ${namespace}/${name}/${containerName} with message: ${e.message}`,
+    // Wait until the exec request is done and reject if the final status is a failure, otherwise
+    // everything went OK and stdOutStream contains the response
+    await new Promise((resolve, reject) => {
+      const promise = this.execAPI.exec(
+        namespace,
+        name,
+        containerName,
+        command,
+        stdOutStream,
+        null,
+        null,
+        true,
+        (status: k8s.V1Status) => {
+          if (status.status === 'Failure') {
+            reject(status);
+          } else {
+            resolve(status);
+          }
+        },
       );
-      return {
-        stdOut: '',
-      };
-    }
+      promise.catch(error => {
+        reject(error);
+      });
+    });
+
+    return {
+      stdOut: stdOutStream.chunks,
+    };
   }
 }

--- a/packages/dashboard-backend/src/index.ts
+++ b/packages/dashboard-backend/src/index.ts
@@ -27,6 +27,7 @@ import { CLUSTER_CONSOLE_URL } from './devworkspace-client/services/cluster-info
 import { registerDockerConfigApi } from './api/dockerConfigApi';
 import { registerServerConfigApi } from './api/serverConfigApi';
 import { registerKubeConfigApi } from './api/kubeConfigAPI';
+import { authorizeInfo } from './api/authorizeInfo';
 import fastifyWebsocket from 'fastify-websocket';
 import {
   addDexProxy,
@@ -78,6 +79,10 @@ if (isLocalRun) {
 registerStaticServer(publicFolder, server);
 
 registerSwagger(server);
+
+if (isLocalRun) {
+  authorizeInfo(server);
+}
 
 registerDevworkspaceApi(server);
 

--- a/run/prepare-local-run.sh
+++ b/run/prepare-local-run.sh
@@ -71,7 +71,8 @@ if [[ ! -z "$GATEWAY" &&
     if kubectl get deployment/che-operator -n $CHE_NAMESPACE -o jsonpath="{.spec.replicas}" | grep 1; then
       echo 'Turn off Che-operator deployment...'
       oc patch deployment/che-operator --patch "{\"spec\":{\"replicas\":0}}" -n $CHE_NAMESPACE
-      sleep 3
+      echo 'Waiting 10 seconds to operator shut down...'
+      sleep 10
       echo 'Done.'
     fi
 


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix kubeConfigApi error messages.

In addition, this PR includes:
- Increasing delay for the prepare-local-run script.
- Add authorized info API (for development mode only).
- Fix swagger schema for kubeConfig API.

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Ensure that Che is running with devworkspaces enabled then either create a new devworkspace from the dashboard.
2. Wait for the workspace to start.
2. Open  swagger ```/dashboard/api/swagger``` and use 'kubeconfig'. 
3. Stop workspace and try it one more time. It should throw an error:
```
{
  "statusCode": 500,
  "error": "Internal Server Error",
  "message": "Error occurred when attempting to retrieve pod. Could not find the requested devworkspace with id... "
}
```
