### PR TITLE
fix: default plugins support for devworkspaces created with resources

### DIFF
--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -466,6 +466,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
   private async createDevWorkspaceFromResources(
     devWorkspacePrebuiltResources: string,
     factoryParams: string,
+    editorId?: string,
   ): Promise<Workspace | undefined> {
     let workspace: Workspace | undefined;
 
@@ -507,7 +508,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
           resource => resource.kind === 'DevWorkspaceTemplate',
         ) as devfileApi.DevWorkspaceTemplate;
 
-        await this.props.createWorkspaceFromResources(devworkspace, devworkspaceTemplate);
+        await this.props.createWorkspaceFromResources(devworkspace, devworkspaceTemplate, editorId);
 
         const namespace = this.props.defaultNamespace?.name;
         this.props.setWorkspaceQualifiedName(namespace, devworkspace.metadata.name as string);
@@ -624,6 +625,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       workspace = await this.createDevWorkspaceFromResources(
         attrs.devWorkspace,
         attrs.factoryParams,
+        attrs['che-editor'],
       );
     } else {
       // create workspace using a devfile

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -13,8 +13,12 @@
 import { V1alpha2DevWorkspaceMetadata } from '@devfile/api';
 
 export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'che.eclipse.org/last-updated-timestamp';
+
+export const DEVWORKSPACE_CHE_EDITOR = 'che.eclipse.org/che-editor';
+
 type DevWorkspaceMetadataAnnotation = {
-  DEVWORKSPACE_UPDATING_TIME_ANNOTATION?: string;
+  [DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]?: string;
+  [DEVWORKSPACE_CHE_EDITOR]?: string;
 };
 
 export type DevWorkspaceMetadata = V1alpha2DevWorkspaceMetadata &

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -157,7 +157,7 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
     } else {
       if (this.workspace.metadata.annotations?.[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]) {
         return new Date(
-          this.workspace.metadata.annotations[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION],
+          this.workspace.metadata.annotations[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]!,
         ).getTime();
       }
     }

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -60,7 +60,7 @@ describe('DevWorkspace client, create', () => {
       .mockResolvedValueOnce(testWorkspace);
     jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
 
-    await client.createFromDevfile(testDevfile, namespace, [], undefined, undefined, {});
+    await client.createFromDevfile(testDevfile, namespace, [], undefined, undefined, undefined, {});
 
     expect(spyCreateWorkspace).toBeCalledWith(
       expect.objectContaining({
@@ -68,6 +68,42 @@ describe('DevWorkspace client, create', () => {
           annotations: {
             'che.eclipse.org/last-updated-timestamp': timestampNew,
           },
+        }),
+      }),
+    );
+  });
+
+  it('should add editor annotation', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testDevfile: devfileApi.Devfile = {
+      schemaVersion: '2.1.0',
+      metadata: {
+        namespace,
+        name,
+      },
+    };
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .build();
+
+    const spyCreateWorkspace = jest
+      .spyOn(DwApi, 'createWorkspace')
+      .mockResolvedValueOnce(testWorkspace);
+    jest.spyOn(DwApi, 'patchWorkspace').mockResolvedValueOnce(testWorkspace);
+
+    const editorId = 'eclipse/theia/next';
+    await client.createFromDevfile(testDevfile, namespace, [], undefined, undefined, editorId, {});
+
+    expect(spyCreateWorkspace).toBeCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          annotations: expect.objectContaining({
+            'che.eclipse.org/che-editor': editorId,
+          }),
         }),
       }),
     );

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -32,7 +32,10 @@ import { AppAlerts } from '../../alerts/appAlerts';
 import { AlertVariant } from '@patternfly/react-core';
 import { WorkspaceAdapter } from '../../workspace-adapter';
 import { safeLoad } from 'js-yaml';
-import { DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION } from '../../devfileApi/devWorkspace/metadata';
+import {
+  DEVWORKSPACE_CHE_EDITOR,
+  DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION,
+} from '../../devfileApi/devWorkspace/metadata';
 import { AxiosInstance } from 'axios';
 import {
   V1alpha2DevWorkspaceTemplateSpec,
@@ -105,8 +108,6 @@ export const DEVWORKSPACE_NEXT_START_ANNOTATION = 'che.eclipse.org/next-start-cf
 export const DEVWORKSPACE_DEBUG_START_ANNOTATION = 'controller.devfile.io/debug-start';
 
 export const DEVWORKSPACE_DEVFILE_SOURCE = 'che.eclipse.org/devfile-source';
-
-export const DEVWORKSPACE_CHE_EDITOR = 'che.eclipse.org/che-editor';
 
 export const DEVWORKSPACE_METADATA_ANNOTATION = 'dw.metadata.annotations';
 
@@ -251,6 +252,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     defaultNamespace: string,
     devworkspace: devfileApi.DevWorkspace,
     devworkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+    editorId: string | undefined,
   ): Promise<any> {
     // create DWT
     devworkspaceTemplate.metadata.namespace = defaultNamespace;
@@ -265,6 +267,10 @@ export class DevWorkspaceClient extends WorkspaceClient {
     devworkspace.metadata.annotations[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION] =
       new Date().toISOString();
 
+    if (editorId) {
+      devworkspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR] = editorId;
+    }
+
     return DwApi.createWorkspace(devworkspace);
   }
 
@@ -274,6 +280,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     dwEditorsPlugins: { devfile: devfileApi.Devfile; url: string }[],
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
+    editorId: string | undefined,
     optionalFilesContent: { [fileName: string]: string },
   ): Promise<devfileApi.DevWorkspace> {
     if (!devfile.components) {
@@ -291,6 +298,10 @@ export class DevWorkspaceClient extends WorkspaceClient {
     }
     devworkspace.metadata.annotations[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION] =
       new Date().toISOString();
+
+    if (editorId) {
+      devworkspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR] = editorId;
+    }
 
     const createdWorkspace = await DwApi.createWorkspace(devworkspace);
     const namespace = createdWorkspace.metadata.namespace;

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -19,8 +19,6 @@ import { DevWorkspaceStatus } from '../../../services/helpers/types';
 import { createObject } from '../../helpers';
 import {
   DevWorkspaceClient,
-  DEVWORKSPACE_CHE_EDITOR,
-  DEVWORKSPACE_METADATA_ANNOTATION,
   DEVWORKSPACE_NEXT_START_ANNOTATION,
   IStatusUpdate,
 } from '../../../services/workspace-client/devworkspace/devWorkspaceClient';
@@ -31,7 +29,10 @@ import { DisposableCollection } from '../../../services/helpers/disposable';
 import { selectDwEditorsPluginsList } from '../../Plugins/devWorkspacePlugins/selectors';
 import { devWorkspaceKind } from '../../../services/devfileApi/devWorkspace';
 import { WorkspaceAdapter } from '../../../services/workspace-adapter';
-import { DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION } from '../../../services/devfileApi/devWorkspace/metadata';
+import {
+  DEVWORKSPACE_CHE_EDITOR,
+  DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION,
+} from '../../../services/devfileApi/devWorkspace/metadata';
 import * as DwPluginsStore from '../../Plugins/devWorkspacePlugins';
 import { selectDefaultNamespace } from '../../InfrastructureNamespaces/selectors';
 import { injectKubeConfig } from '../../../services/dashboard-backend-client/devWorkspaceApi';
@@ -143,6 +144,7 @@ export type ActionCreators = {
   createWorkspaceFromResources: (
     devworkspace: devfileApi.DevWorkspace,
     devworkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+    editor?: string,
   ) => AppThunk<KnownAction, Promise<void>>;
 
   deleteWorkspaceLogs: (workspaceId: string) => AppThunk<DeleteWorkspaceLogsAction, void>;
@@ -441,17 +443,27 @@ export const actionCreators: ActionCreators = {
     (
       devworkspace: devfileApi.DevWorkspace,
       devworkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+      editorId?: string,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       const defaultKubernetesNamespace = selectDefaultNamespace(getState());
       const defaultNamespace = defaultKubernetesNamespace.name;
       try {
+        const cheEditor = editorId ? editorId : getState().dwPlugins.defaultEditorName;
         const workspace = await devWorkspaceClient.createFromResources(
           defaultNamespace,
           devworkspace,
           devworkspaceTemplate,
+          cheEditor,
         );
 
+        if (workspace.spec.started) {
+          const editor = workspace.metadata.annotations
+            ? workspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR]
+            : undefined;
+          const defaultPlugins = getState().dwPlugins.defaultPlugins;
+          await devWorkspaceClient.onStart(workspace, defaultPlugins, editor);
+        }
         dispatch({
           type: 'ADD_DEVWORKSPACE',
           workspace,
@@ -514,25 +526,20 @@ export const actionCreators: ActionCreators = {
         const devWorkspaceDevfile = devfile as devfileApi.Devfile;
         const defaultNamespace = selectDefaultNamespace(state);
         const dwEditorsList = selectDwEditorsPluginsList(cheEditor)(state);
-
-        if (!devWorkspaceDevfile.metadata.attributes) {
-          devWorkspaceDevfile.metadata.attributes = {};
-        }
-        devWorkspaceDevfile.metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION] = {
-          [DEVWORKSPACE_CHE_EDITOR]: cheEditor,
-        };
-
         const workspace = await devWorkspaceClient.createFromDevfile(
           devWorkspaceDevfile,
           defaultNamespace.name,
           dwEditorsList,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
+          cheEditor,
           optionalFilesContent,
         );
 
-        const defaultPlugins = getState().dwPlugins.defaultPlugins;
-        await devWorkspaceClient.onStart(workspace, defaultPlugins, cheEditor as string);
+        if (workspace.spec.started) {
+          const defaultPlugins = getState().dwPlugins.defaultPlugins;
+          await devWorkspaceClient.onStart(workspace, defaultPlugins, cheEditor as string);
+        }
         dispatch({
           type: 'ADD_DEVWORKSPACE',
           workspace,

--- a/run/local-run.sh
+++ b/run/local-run.sh
@@ -48,10 +48,10 @@ parse_args() {
 FORCE_BUILD="false"
 # Init Che Namespace with the default value if it's not set
 CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
-CHECLUSTER_CR_NAMESPACE="${CHE_NAMESPACE}"
+export CHECLUSTER_CR_NAMESPACE="${CHE_NAMESPACE}"
 
 # Init Che CRD object name with the default value if it's not set
-CHECLUSTER_CR_NAME="${CHECLUSTER_CR_NAME:-eclipse-che}"
+export CHECLUSTER_CR_NAME="${CHECLUSTER_CR_NAME:-eclipse-che}"
 
 # guide backend to use the current cluster from kubeconfig
 export LOCAL_RUN="true"


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds default plugins support for devworkspaces created with resources.

### Is it tested? How?
1. Deploy Che with the dashboard image for this PR: quay.io/dkwon17/che-dashboard:default-plugins

2. Add this field to the existing CheCluster CR:
```
  server:
    workspacesDefaultPlugins:
      - editor: 'eclipse/che-theia/next'
        plugins: ['https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/containers/buildah/latest/devfile.yaml']
```
4. Start a sample devworkspace from the che-dashboard. 
5. Verify that the devworkspace has a plugin component for the default plugin
![image](https://user-images.githubusercontent.com/83611742/145871537-0e11fb82-e8ff-494a-a041-b9fdbe2abed2.png)

6. Remove `server.workspacesDefaultPlugins` from the CheCluster CR.
7. Start the same devworkspace from step 4, and verify that the devworkspace does not have the default plugin anymore
![image](https://user-images.githubusercontent.com/83611742/145871558-bfeebb93-7798-4fb7-a088-53310acf618f.png)