### PR TITLE
Add owner references into devWorkspace templates

### DIFF
--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -33,6 +33,7 @@ import {
   actionCreators as factoryResolverActionCreators,
   isOAuthResponse,
 } from '../../store/FactoryResolver';
+import getRandomString from '../../services/helpers/random';
 
 const showAlertMock = jest.fn();
 const setWorkspaceQualifiedName = jest.fn();
@@ -181,6 +182,78 @@ describe('Factory Loader container', () => {
   });
 
   describe('with prebuilt resources', () => {
+    it('should not try to create a new workspace and show an error if prebuilt resources are empty', async () => {
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({ 'che.devworkspaces.enabled': 'true' } as che.WorkspaceSettings)
+        .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
+        .build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: 'http://test-location' });
+      props.location.search += '&devWorkspace=devWorkspace.yaml';
+
+      (mockAxios.get as jest.Mock).mockResolvedValueOnce({ data: '' });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      const elementHasError = screen.getByTestId('factory-loader-has-error');
+      await waitFor(() => expect(elementHasError.innerHTML).toEqual('true'));
+      await waitFor(() => expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled());
+    });
+
+    it('should not try to create a new workspace and show an error if prebuilt resources does not include a Template', async () => {
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({ 'che.devworkspaces.enabled': 'true' } as che.WorkspaceSettings)
+        .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
+        .build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: 'http://test-location' });
+      props.location.search += '&devWorkspace=devWorkspace.yaml';
+
+      const yamlContent = `apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  name: project
+  namespace: test-dev`;
+      (mockAxios.get as jest.Mock).mockResolvedValueOnce({ data: yamlContent });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      const elementHasError = screen.getByTestId('factory-loader-has-error');
+      await waitFor(() => expect(elementHasError.innerHTML).toEqual('true'));
+      await waitFor(() => expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled());
+    });
+
+    it('should not try to create a new workspace and show an error if prebuilt resources does not include a DevWorkspace', async () => {
+      const store = new FakeStoreBuilder()
+        .withWorkspacesSettings({ 'che.devworkspaces.enabled': 'true' } as che.WorkspaceSettings)
+        .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
+        .build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: 'http://test-location' });
+      props.location.search += '&devWorkspace=devWorkspace.yaml';
+
+      const yamlContent = `apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  name: theia-ide-project`;
+      (mockAxios.get as jest.Mock).mockResolvedValueOnce({ data: yamlContent });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      const elementHasError = screen.getByTestId('factory-loader-has-error');
+      await waitFor(() => expect(elementHasError.innerHTML).toEqual('true'));
+      await waitFor(() => expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled());
+    });
+
     it('should start creating a devworkspace using pre-generated resources', async () => {
       const store = new FakeStoreBuilder()
         .withWorkspacesSettings({
@@ -203,8 +276,9 @@ metadata:
 apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspace
 metadata:
-  name: project`;
-      (mockAxios.get as jest.Mock).mockResolvedValueOnce(yamlContent);
+  name: project
+  namespace: test-dev`;
+      (mockAxios.get as jest.Mock).mockResolvedValueOnce({ data: yamlContent });
 
       render(
         <Provider store={store}>
@@ -212,7 +286,30 @@ metadata:
         </Provider>,
       );
 
-      await waitFor(() => expect(createWorkspaceFromResourcesMock).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(createWorkspaceFromResourcesMock).toHaveBeenCalledWith(
+          {
+            apiVersion: 'workspace.devfile.io/v1alpha2',
+            kind: 'DevWorkspace',
+            metadata: {
+              name: 'project',
+              namespace: 'test-dev',
+              annotations: {
+                'che.eclipse.org/devfile-source': `factory:
+  params: 'url=http://test-location&devWorkspace=devWorkspace.yaml'
+`,
+              },
+            },
+          },
+          {
+            apiVersion: 'workspace.devfile.io/v1alpha2',
+            kind: 'DevWorkspaceTemplate',
+            metadata: {
+              name: 'theia-ide-project',
+            },
+          },
+        ),
+      );
     });
   });
 

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -33,7 +33,6 @@ import {
   actionCreators as factoryResolverActionCreators,
   isOAuthResponse,
 } from '../../store/FactoryResolver';
-import getRandomString from '../../services/helpers/random';
 
 const showAlertMock = jest.fn();
 const setWorkspaceQualifiedName = jest.fn();
@@ -200,7 +199,7 @@ describe('Factory Loader container', () => {
 
       const elementHasError = screen.getByTestId('factory-loader-has-error');
       await waitFor(() => expect(elementHasError.innerHTML).toEqual('true'));
-      await waitFor(() => expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled());
+      expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled();
     });
 
     it('should not try to create a new workspace and show an error if prebuilt resources does not include a Template', async () => {
@@ -226,7 +225,7 @@ metadata:
 
       const elementHasError = screen.getByTestId('factory-loader-has-error');
       await waitFor(() => expect(elementHasError.innerHTML).toEqual('true'));
-      await waitFor(() => expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled());
+      expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled();
     });
 
     it('should not try to create a new workspace and show an error if prebuilt resources does not include a DevWorkspace', async () => {
@@ -251,7 +250,7 @@ metadata:
 
       const elementHasError = screen.getByTestId('factory-loader-has-error');
       await waitFor(() => expect(elementHasError.innerHTML).toEqual('true'));
-      await waitFor(() => expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled());
+      expect(createWorkspaceFromResourcesMock).not.toHaveBeenCalled();
     });
 
     it('should start creating a devworkspace using pre-generated resources', async () => {

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.module.css
@@ -23,10 +23,10 @@
 }
 
 .openIdeCell {
-  text-align: right;
   width: 80px !important;
   max-width: 80px !important;
   overflow: hidden !important;
   white-space: nowrap !important;
+  text-align: right;
   text-overflow: ellipsis !important;
 }

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -266,13 +266,12 @@ export class DevWorkspaceClient extends WorkspaceClient {
     const components = devworkspace.spec.template.components;
     devworkspace.spec.template.components = [];
 
-    const createdWorkspace = await DwApi.createWorkspace(devworkspace);
-
     if (editorId) {
       devworkspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR] = editorId;
     }
 
-    return DwApi.createWorkspace(devworkspace);
+    const createdWorkspace = await DwApi.createWorkspace(devworkspace);
+
     // create DWT
     devworkspaceTemplate.metadata.namespace = defaultNamespace;
     // update owner reference (to allow automatic cleanup)

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
@@ -306,9 +306,6 @@ describe('dwPlugins store', () => {
         ThunkDispatch<AppState, undefined, dwPluginsStore.KnownAction>
       >;
 
-      const settings = {
-        'che.devworkspaces.enabled': 'true',
-      } as che.WorkspaceSettings;
       await store.dispatch(dwPluginsStore.actionCreators.requestDwDefaultPlugins());
 
       const actions = store.getActions();

--- a/run/prepare-local-run.sh
+++ b/run/prepare-local-run.sh
@@ -52,7 +52,7 @@ if [[ ! -z "$GATEWAY" &&
     echo 'Found the staticClient for localStart'
   else
     echo 'Patching dex config map...'
-    UPDATED_CONFIG_YAML=$(kubectl get -n dex configMaps/dex -o jsonpath="{.data['config\.yaml']}" | yq e ".staticClients[0].redirectURIs = [\"$CHE_HOST/oauth/callback\"]" -)
+    UPDATED_CONFIG_YAML=$(kubectl get -n dex configMaps/dex -o jsonpath="{.data['config\.yaml']}" | yq e ".staticClients[0].redirectURIs[0] = \"$CHE_HOST/oauth/callback\"" -)
     dq_mid=\\\"
     yaml_esc="${UPDATED_CONFIG_YAML//\"/$dq_mid}"
     kubectl get configMaps/dex -n dex -o json | jq ".data[\"config.yaml\"] |= \"${yaml_esc}\"" | kubectl replace -f -

--- a/run/prepare-local-run.sh
+++ b/run/prepare-local-run.sh
@@ -52,7 +52,7 @@ if [[ ! -z "$GATEWAY" &&
     echo 'Found the staticClient for localStart'
   else
     echo 'Patching dex config map...'
-    UPDATED_CONFIG_YAML=$(kubectl get -n dex configMaps/dex -o jsonpath="{.data['config\.yaml']}" | yq e ".staticClients[0].redirectURIs = .staticClients[0].redirectURIs + \"$CHE_HOST/oauth/callback\"" -)
+    UPDATED_CONFIG_YAML=$(kubectl get -n dex configMaps/dex -o jsonpath="{.data['config\.yaml']}" | yq e ".staticClients[0].redirectURIs = [\"$CHE_HOST/oauth/callback\"]" -)
     dq_mid=\\\"
     yaml_esc="${UPDATED_CONFIG_YAML//\"/$dq_mid}"
     kubectl get configMaps/dex -n dex -o json | jq ".data[\"config.yaml\"] |= \"${yaml_esc}\"" | kubectl replace -f -

--- a/run/revert-local-run.sh
+++ b/run/revert-local-run.sh
@@ -58,7 +58,7 @@ fi
 
 if kubectl get configMaps/dex -o jsonpath="{.data['config\.yaml']}" -n dex | yq e ".staticClients[0].redirectURIs" - | grep $CHE_HOST/oauth/callback; then
   echo 'Patching dex config map...'
-  UPDATED_CONFIG_YAML=$(kubectl get -n dex configMaps/dex -o jsonpath="{.data['config\.yaml']}" | yq e ".staticClients[0].redirectURIs = [\"$CHE_HOST_ORIGIN/oauth/callback\"]" -)
+  UPDATED_CONFIG_YAML=$(kubectl get -n dex configMaps/dex -o jsonpath="{.data['config\.yaml']}" | yq e ".staticClients[0].redirectURIs[0] = \"$CHE_HOST_ORIGIN/oauth/callback\"" -)
   dq_mid=\\\"
   yaml_esc="${UPDATED_CONFIG_YAML//\"/$dq_mid}"
   kubectl get configMaps/dex -n dex -o json | jq ".data[\"config.yaml\"] |= \"${yaml_esc}\"" | kubectl replace -f -

--- a/run/revert-local-run.sh
+++ b/run/revert-local-run.sh
@@ -56,6 +56,20 @@ if kubectl get configMaps che-gateway-config-oauth-proxy -o jsonpath="{.data}" -
   echo 'Done.'
 fi
 
+if kubectl get configMaps/dex -o jsonpath="{.data['config\.yaml']}" -n dex | yq e ".staticClients[0].redirectURIs" - | grep $CHE_HOST/oauth/callback; then
+  echo 'Patching dex config map...'
+  UPDATED_CONFIG_YAML=$(kubectl get -n dex configMaps/dex -o jsonpath="{.data['config\.yaml']}" | yq e ".staticClients[0].redirectURIs = [\"$CHE_HOST_ORIGIN/oauth/callback\"]" -)
+  dq_mid=\\\"
+  yaml_esc="${UPDATED_CONFIG_YAML//\"/$dq_mid}"
+  kubectl get configMaps/dex -n dex -o json | jq ".data[\"config.yaml\"] |= \"${yaml_esc}\"" | kubectl replace -f -
+
+  # rollout Dex deployment
+  echo 'Rolling out Dex deployment...'
+  oc patch deployment/dex --patch "{\"spec\":{\"replicas\":0}}" -n dex
+  oc patch deployment/dex --patch "{\"spec\":{\"replicas\":1}}" -n dex
+  echo 'Done.'
+fi
+
 if kubectl get deployment/che-operator -n $CHE_NAMESPACE -o jsonpath="{.spec.replicas}" | grep 0; then
   echo 'Turning on Che-operator deployment...'
   oc patch deployment/che-operator --patch "{\"spec\":{\"replicas\":1}}" -n $CHE_NAMESPACE


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add owner references templates and source information into devWorkspace

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21013
fixes https://github.com/eclipse/che/issues/21022

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Click on a sample to create a workspace
2. Delete the workspace
3. Try to create a workspace from the previous sample
4. Click on the same sample one more time - the existing workspace would be opened

