### PR TITLE
Convert che-server workspaces into devworkspaces

### DIFF
--- a/.deps/EXCLUDED/dev.md
+++ b/.deps/EXCLUDED/dev.md
@@ -3,5 +3,5 @@ This file contains a manual contribution to .deps/dev.md and it's needed because
 | Packages | Resolved CQs |
 | --- | --- |
 | `keycloak-js@10.0.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/keycloak-js/10.0.2) |
-| `x-is-string@0.1.0` | [CQ22418](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22418) |
 | `postcss-syntax@0.36.2` | [CQ22418](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22418) |
+| `x-is-string@0.1.0` | [CQ22418](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22418) |

--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -6,7 +6,7 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `@eclipse-che/common@7.43.0-next` | N/A |
 | `@eclipse-che/dashboard-backend@7.43.0-next` | N/A |
 | `@eclipse-che/dashboard-frontend@7.43.0-next` | N/A |
+| `fastify-swagger@4.11.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify-swagger/4.11.0) |
 | `fsevents@2.3.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fsevents/2.3.2) |
 | `jsdom@16.7.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsdom/16.7.0) |
 | `node-notifier@8.0.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/node-notifier/8.0.2) |
-| `fastify-swagger@4.11.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify-swagger/4.11.0) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,12 +5,12 @@
 | [`@babel/runtime@7.15.4`](https://github.com/babel/babel.git) | MIT | clearlydefined |
 | [`@devfile/api@2.2.0-alpha-1633545768`](https://github.com/devfile/api.git) | EPL-2.0 | clearlydefined |
 | `@eclipse-che/api@7.36.0` | EPL-2.0 | clearlydefined |
-| [`@eclipse-che/che-code-devworkspace-handler@1.64.0-dev-7ba5d3e`](git+https://github.com/che-incubator/che-code.git) | EPL-2.0 | clearlydefined |
-| [`@eclipse-che/che-theia-devworkspace-handler@0.0.1-1639587602`](git+https://github.com/eclipse-che/che-theia.git) | EPL-2.0 | clearlydefined |
+| [`@eclipse-che/che-code-devworkspace-handler@1.64.0-dev-210b722`](git+https://github.com/che-incubator/che-code.git) | EPL-2.0 | clearlydefined |
+| [`@eclipse-che/che-theia-devworkspace-handler@0.0.1-1642670698`](git+https://github.com/eclipse-che/che-theia.git) | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/common@7.43.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-backend@7.43.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-frontend@7.43.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | N/A |
-| [`@eclipse-che/devfile-converter@0.0.1-437a239`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | clearlydefined |
+| [`@eclipse-che/devfile-converter@0.0.1-14c62ee`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/workspace-client@0.0.1-1632305737`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | clearlydefined |
 | [`@fastify/ajv-compiler@1.1.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
 | [`@hapi/address@2.1.4`](git://github.com/hapijs/address) | BSD-3-Clause | clearlydefined |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -36,8 +36,8 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@eclipse-che/che-code-devworkspace-handler": "1.64.0-dev-7ba5d3e",
-    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1639587602",
+    "@eclipse-che/che-code-devworkspace-handler": "1.64.0-dev-210b722",
+    "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1642670698",
     "@eclipse-che/devfile-converter": "0.0.1-14c62ee",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",

--- a/packages/dashboard-frontend/src/Layout/Navigation/MainList.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/MainList.tsx
@@ -17,7 +17,7 @@ import { NavigationItemObject } from '.';
 import { ROUTE } from '../../route.enum';
 import { AppState } from '../../store';
 import { connect, ConnectedProps } from 'react-redux';
-import { selectAllWorkspacesNumber } from '../../store/Workspaces/selectors';
+import { selectAllWorkspaces } from '../../store/Workspaces/selectors';
 
 type Props = MappedProps & {
   activePath: string;
@@ -25,7 +25,14 @@ type Props = MappedProps & {
 
 export class NavigationMainList extends React.PureComponent<Props> {
   private get items(): NavigationItemObject[] {
-    const { allWorkspacesNumber } = this.props;
+    const { allWorkspaces } = this.props;
+
+    const allWorkspacesNumber = allWorkspaces.filter(workspace => {
+      if (workspace.isDevWorkspace) {
+        return true;
+      }
+      return (workspace.ref as che.Workspace).attributes?.converted === undefined;
+    }).length;
 
     return [
       { to: ROUTE.GET_STARTED, label: 'Create Workspace' },
@@ -45,7 +52,7 @@ export class NavigationMainList extends React.PureComponent<Props> {
 }
 
 const mapStateToProps = (state: AppState) => ({
-  allWorkspacesNumber: selectAllWorkspacesNumber(state),
+  allWorkspaces: selectAllWorkspaces(state),
 });
 
 const connector = connect(mapStateToProps);

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentItemWorkspaceActions.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentItemWorkspaceActions.tsx
@@ -98,11 +98,7 @@ class NavigationItemWorkspaceActions extends React.PureComponent<Props, State> {
         createAction(WorkspaceAction.START_DEBUG_AND_OPEN_LOGS),
         createAction(WorkspaceAction.START_IN_BACKGROUND),
       );
-    } else if (
-      status !== WorkspaceStatus.STOPPING &&
-      status !== DevWorkspaceStatus.TERMINATING &&
-      status !== DevWorkspaceStatus.FAILED
-    ) {
+    } else if (status !== WorkspaceStatus.STOPPING && status !== DevWorkspaceStatus.TERMINATING) {
       dropdownItems.push(createAction(WorkspaceAction.STOP_WORKSPACE));
     }
     if (

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/MainList.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/MainList.spec.tsx
@@ -11,25 +11,29 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, RenderResult, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { Nav } from '@patternfly/react-core';
 
 import NavigationMainList from '../MainList';
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { Provider } from 'react-redux';
-import { createFakeCheWorkspace } from '../../../store/__mocks__/workspace';
+import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
+import { Store } from 'redux';
+import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilder';
 
 describe('Navigation Main List', () => {
   it('should have correct number of main navigation items', () => {
-    render(buildElement());
+    const store = new FakeStoreBuilder().build();
+    renderComponent(store);
 
     const navLinks = screen.getAllByRole('link');
     expect(navLinks.length).toEqual(2);
   });
 
   it('should have correct navigation item labels', () => {
-    render(buildElement());
+    const store = new FakeStoreBuilder().build();
+    renderComponent(store);
 
     const navLinks = screen.getAllByRole('link');
 
@@ -38,20 +42,63 @@ describe('Navigation Main List', () => {
   });
 
   it('should have correct navigation item workspaces quantity', () => {
-    let workspaces = [0, 1, 2, 3, 4].map(i => createFakeCheWorkspace('works-' + i, 'works-' + i));
-    const { rerender } = render(buildElement(workspaces));
+    let workspaces = [0, 1, 2, 3, 4].map(i =>
+      new DevWorkspaceBuilder()
+        .withId('wksp-' + i)
+        .withName('wksp-' + i)
+        .build(),
+    );
+    let store = new FakeStoreBuilder().withDevWorkspaces({ workspaces }).build();
+    const { rerender } = renderComponent(store);
 
     expect(screen.queryByRole('link', { name: 'Workspaces (5)' })).toBeInTheDocument();
 
-    workspaces = [0, 1, 2].map(i => createFakeCheWorkspace('works-' + i, 'works-' + i));
-    rerender(buildElement(workspaces));
+    workspaces = [0, 1, 2].map(i =>
+      new DevWorkspaceBuilder()
+        .withId('wksp-' + i)
+        .withName('wksp-' + i)
+        .build(),
+    );
+    store = new FakeStoreBuilder().withDevWorkspaces({ workspaces }).build();
+    rerender(buildElement(store));
 
     expect(screen.queryByRole('link', { name: 'Workspaces (3)' })).toBeInTheDocument();
   });
+
+  describe('with deprecated workspaces', () => {
+    it('should count all workspaces but converted', () => {
+      const cheworkspaces = [
+        new CheWorkspaceBuilder().withId('wksp-1').withName('wksp-1').build(),
+        new CheWorkspaceBuilder()
+          .withId('wksp-2')
+          .withName('wksp-2')
+          .withAttributes({
+            converted: new Date().toISOString(),
+          } as che.WorkspaceAttributes)
+          .build(),
+      ];
+      const devworkspaces = [0, 1].map(i =>
+        new DevWorkspaceBuilder()
+          .withId('devwksp-' + i)
+          .withName('wksp-' + i)
+          .build(),
+      );
+      const store = new FakeStoreBuilder()
+        .withCheWorkspaces({ workspaces: cheworkspaces })
+        .withDevWorkspaces({ workspaces: devworkspaces })
+        .build();
+      renderComponent(store);
+
+      expect(screen.queryByRole('link', { name: 'Workspaces (3)' })).toBeInTheDocument();
+    });
+  });
 });
 
-function buildElement(workspaces: che.Workspace[] = []): JSX.Element {
-  const store = new FakeStoreBuilder().withCheWorkspaces({ workspaces }).build();
+function renderComponent(store: Store): RenderResult {
+  return render(buildElement(store));
+}
+
+function buildElement(store: Store): React.ReactElement {
   return (
     <Provider store={store}>
       <MemoryRouter>

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentItem.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentItem.spec.tsx
@@ -30,7 +30,7 @@ jest.mock('../../../components/Workspace/Indicator', () => {
 
 describe('Navigation Item', () => {
   const item: NavigationRecentItemObject = {
-    status: '',
+    status: WorkspaceStatus.STOPPED,
     label: 'workspace',
     to: '/namespace/workspace',
     isDevWorkspace: false,

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentList.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentList.spec.tsx
@@ -18,7 +18,7 @@ import { RenderResult, render, screen } from '@testing-library/react';
 import { Store } from 'redux';
 
 import NavigationRecentList from '../RecentList';
-import { convertWorkspace, Workspace } from '../../../services/workspace-adapter';
+import { constructWorkspace, Workspace } from '../../../services/workspace-adapter';
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { createHashHistory } from 'history';
 import { createFakeCheWorkspace } from '../../../store/__mocks__/workspace';
@@ -30,7 +30,7 @@ jest.mock('react-tooltip', () => {
 });
 
 const cheWorkspaces = [1, 2, 3].map(i => createFakeCheWorkspace('wksp-' + i, 'wksp-' + i));
-const workspaces = cheWorkspaces.map(workspace => convertWorkspace(workspace));
+const workspaces = cheWorkspaces.map(workspace => constructWorkspace(workspace));
 
 describe('Navigation Recent List', () => {
   function renderComponent(store: Store, workspaces: Workspace[]): RenderResult {

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentList.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentList.spec.tsx
@@ -21,7 +21,7 @@ import NavigationRecentList from '../RecentList';
 import { constructWorkspace, Workspace } from '../../../services/workspace-adapter';
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { createHashHistory } from 'history';
-import { createFakeCheWorkspace } from '../../../store/__mocks__/workspace';
+import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilder';
 
 jest.mock('react-tooltip', () => {
   return function DummyTooltip(): React.ReactElement {
@@ -29,10 +29,20 @@ jest.mock('react-tooltip', () => {
   };
 });
 
-const cheWorkspaces = [1, 2, 3].map(i => createFakeCheWorkspace('wksp-' + i, 'wksp-' + i));
-const workspaces = cheWorkspaces.map(workspace => constructWorkspace(workspace));
+let cheWorkspaces: che.Workspace[];
+let workspaces: Workspace[];
 
 describe('Navigation Recent List', () => {
+  beforeEach(() => {
+    cheWorkspaces = [1, 2, 3].map(i =>
+      new CheWorkspaceBuilder()
+        .withId('wksp-' + i)
+        .withName('wksp-' + i)
+        .build(),
+    );
+    workspaces = cheWorkspaces.map(workspace => constructWorkspace(workspace));
+  });
+
   function renderComponent(store: Store, workspaces: Workspace[]): RenderResult {
     const history = createHashHistory();
     return render(

--- a/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
@@ -27,6 +27,11 @@ import {
   buildWorkspacesLocation,
   sanitizeLocation,
 } from '../../services/helpers/location';
+import {
+  DeprecatedWorkspaceStatus,
+  DevWorkspaceStatus,
+  WorkspaceStatus,
+} from '../../services/helpers/types';
 
 export interface NavigationItemObject {
   to: string;
@@ -36,7 +41,7 @@ export interface NavigationItemObject {
 export interface NavigationRecentItemObject {
   to: string;
   label: string;
-  status: string;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   workspaceId: string;
   isDevWorkspace: boolean;
 }
@@ -111,8 +116,6 @@ export class Navigation extends React.PureComponent<Props, State> {
     const { theme, recentWorkspaces, history } = this.props;
     const { activeLocation } = this.state;
 
-    const recent = recentWorkspaces || [];
-
     return (
       <Nav
         aria-label="Navigation"
@@ -121,7 +124,7 @@ export class Navigation extends React.PureComponent<Props, State> {
       >
         <NavigationMainList activePath={activeLocation.pathname} />
         <NavigationRecentList
-          workspaces={recent}
+          workspaces={recentWorkspaces}
           activePath={activeLocation.pathname}
           history={history}
         />

--- a/packages/dashboard-frontend/src/Routes/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Routes/__tests__/index.spec.tsx
@@ -27,7 +27,7 @@ import {
   buildWorkspacesLocation,
 } from '../../services/helpers/location';
 import { IdeLoaderTab, WorkspaceDetailsTab } from '../../services/helpers/types';
-import { convertWorkspace, Workspace } from '../../services/workspace-adapter';
+import { constructWorkspace, Workspace } from '../../services/workspace-adapter';
 import { CheWorkspaceBuilder } from '../../store/__mocks__/cheWorkspaceBuilder';
 
 jest.mock('../../pages/GetStarted', () => {
@@ -140,7 +140,7 @@ describe('Routes', () => {
     let workspace: Workspace;
 
     beforeEach(() => {
-      workspace = convertWorkspace(new CheWorkspaceBuilder().withNamespace('namespace').build());
+      workspace = constructWorkspace(new CheWorkspaceBuilder().withNamespace('namespace').build());
     });
 
     it('should handle "/workspace/namespace/name"', async () => {
@@ -184,7 +184,7 @@ describe('Routes', () => {
     let workspace: Workspace;
 
     beforeEach(() => {
-      workspace = convertWorkspace(new CheWorkspaceBuilder().withNamespace('namespace').build());
+      workspace = constructWorkspace(new CheWorkspaceBuilder().withNamespace('namespace').build());
     });
 
     it('should handle "/ide/namespace/name"', async () => {

--- a/packages/dashboard-frontend/src/components/Header/index.tsx
+++ b/packages/dashboard-frontend/src/components/Header/index.tsx
@@ -21,11 +21,16 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import WorkspaceStatusLabel from '../WorkspaceStatusLabel';
+import {
+  DeprecatedWorkspaceStatus,
+  DevWorkspaceStatus,
+  WorkspaceStatus,
+} from '../../services/helpers/types';
 
 const SECTION_THEME = PageSectionVariants.light;
 
 type Props = {
-  status?: string;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   title: string;
 };
 
@@ -41,11 +46,9 @@ class Header extends React.PureComponent<Props> {
               <Text component={TextVariants.h1}>{title}</Text>
             </TextContent>
           </FlexItem>
-          {status && (
-            <FlexItem>
-              <WorkspaceStatusLabel status={status} />
-            </FlexItem>
-          )}
+          <FlexItem>
+            <WorkspaceStatusLabel status={status} />
+          </FlexItem>
         </Flex>
       </PageSection>
     );

--- a/packages/dashboard-frontend/src/components/Progress/__tests__/__snapshots__/Progress.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Progress/__tests__/__snapshots__/Progress.spec.tsx.snap
@@ -4,12 +4,12 @@ exports[`Progress component should render progress with loading correctly 1`] = 
 <span>
   <div
     className="pf-c-progress pf-m-sm pf-m-singleline"
-    id="che-progress-ind"
+    id="progress-indicator"
   >
     <div
       aria-hidden="true"
       className="pf-c-progress__description"
-      id="che-progress-ind-description"
+      id="progress-indicator-description"
       onMouseEnter={null}
     >
       
@@ -19,6 +19,7 @@ exports[`Progress component should render progress with loading correctly 1`] = 
       className="pf-c-progress__status"
     />
     <div
+      aria-label="Action is in progress"
       aria-valuemax={100}
       aria-valuemin={0}
       aria-valuenow={0}

--- a/packages/dashboard-frontend/src/components/Progress/index.tsx
+++ b/packages/dashboard-frontend/src/components/Progress/index.tsx
@@ -23,7 +23,7 @@ type State = {
   progressVal: number;
 };
 
-class CheProgress extends React.PureComponent<Props, State> {
+class ProgressIndicator extends React.PureComponent<Props, State> {
   private intervalId: any;
   private readonly onProgressInc: () => void;
 
@@ -78,10 +78,11 @@ class CheProgress extends React.PureComponent<Props, State> {
       <span className={styles.progressLine}>
         {this.props.isLoading || this.state.progressVal !== 0 ? (
           <Progress
-            id="che-progress-ind"
+            id="progress-indicator"
             value={progressVal}
             size={ProgressSize.sm}
             measureLocation={ProgressMeasureLocation.none}
+            aria-label="Action is in progress"
           />
         ) : (
           ''
@@ -91,4 +92,4 @@ class CheProgress extends React.PureComponent<Props, State> {
   }
 }
 
-export default CheProgress;
+export default ProgressIndicator;

--- a/packages/dashboard-frontend/src/components/Workspace/Indicator/__tests__/Indicator.spec.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Indicator/__tests__/Indicator.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('react-tooltip', () => {
 
 describe('Workspace indicator component', () => {
   it('should render default status correctly', () => {
-    const element = <WorkspaceIndicator status={'undefined'} />;
+    const element = <WorkspaceIndicator status={WorkspaceStatus.STOPPING} />;
     expect(renderer.create(element).toJSON()).toMatchSnapshot();
   });
 
@@ -72,6 +72,13 @@ describe('Workspace indicator component', () => {
 
     it('should render FAILING status correctly', () => {
       const element = <WorkspaceIndicator status={DevWorkspaceStatus.FAILING} />;
+      expect(getComponentSnapshot(element)).toMatchSnapshot();
+    });
+  });
+
+  describe('Deprecated workspaces', () => {
+    it('should render "Deprecated" status correctly', () => {
+      const element = <WorkspaceIndicator status={'Deprecated'} />;
       expect(getComponentSnapshot(element)).toMatchSnapshot();
     });
   });

--- a/packages/dashboard-frontend/src/components/Workspace/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Workspace/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
@@ -161,6 +161,37 @@ Array [
 ]
 `;
 
+exports[`Workspace indicator component Deprecated workspaces should render "Deprecated" status correctly 1`] = `
+Array [
+  <span
+    data-testid="workspace-status-indicator"
+    data-tip="Deprecated workspace"
+  >
+    <svg
+      aria-hidden={true}
+      aria-labelledby={null}
+      fill="var(--pf-global--warning-color--100)"
+      height="1em"
+      role="img"
+      style={
+        Object {
+          "verticalAlign": "-0.125em",
+        }
+      }
+      viewBox="0 0 576 512"
+      width="1em"
+    >
+      <path
+        d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+      />
+    </svg>
+  </span>,
+  <div>
+    Dummy Tooltip
+  </div>,
+]
+`;
+
 exports[`Workspace indicator component DevWorkspaces should render FAILED status correctly 1`] = `
 Array [
   <span
@@ -295,7 +326,7 @@ exports[`Workspace indicator component should render default status correctly 1`
 Array [
   <span
     data-testid="workspace-status-indicator"
-    data-tip="UNDEFINED"
+    data-tip="STOPPING"
   >
     <svg
       aria-hidden={true}

--- a/packages/dashboard-frontend/src/components/Workspace/Indicator/index.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Indicator/index.tsx
@@ -14,16 +14,21 @@ import {
   ExclamationCircleIcon,
   InProgressIcon,
   ResourcesFullIcon,
+  ExclamationTriangleIcon,
 } from '@patternfly/react-icons/dist/js/icons';
 import React from 'react';
-import { DevWorkspaceStatus, WorkspaceStatus } from '../../../services/helpers/types';
+import ReactTooltip from 'react-tooltip';
+import {
+  DevWorkspaceStatus,
+  WorkspaceStatus,
+  DeprecatedWorkspaceStatus,
+} from '../../../services/helpers/types';
 import { ColorType, StoppedIcon } from '../../WorkspaceStatusLabel';
 
 import styles from './index.module.css';
-import ReactTooltip from 'react-tooltip';
 
 type Props = {
-  status: string;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
 };
 
 class WorkspaceIndicator extends React.PureComponent<Props> {
@@ -57,21 +62,31 @@ class WorkspaceIndicator extends React.PureComponent<Props> {
         color = '#0e6fe0';
         icon = <InProgressIcon className={styles.rotate} color={color} />;
         break;
+      case 'Deprecated':
+        icon = <ExclamationTriangleIcon color="var(--pf-global--warning-color--100)" />;
+        break;
       default:
         color = 'grey';
         icon = <InProgressIcon className={styles.rotate} color={color} />;
     }
 
+    const tooltip = status === 'Deprecated' ? 'Deprecated workspace' : status.toLocaleUpperCase();
+
     return (
       <>
         <span
-          data-tip={status.toUpperCase()}
+          data-tip={tooltip}
           className={styles.statusIndicator}
           data-testid="workspace-status-indicator"
         >
           {icon}
         </span>
-        <ReactTooltip backgroundColor="black" textColor="white" effect="solid" />
+        <ReactTooltip
+          backgroundColor="black"
+          textColor="white"
+          effect="solid"
+          offset={{ right: 20 }}
+        />
       </>
     );
   }

--- a/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/__tests__/__snapshots__/index.spec.tsx.snap
@@ -126,6 +126,46 @@ Array [
 ]
 `;
 
+exports[`The workspace status label component Deprecated workspaces should render "Deprecated" status correctly 1`] = `
+Array [
+  <span
+    className="pf-c-label pf-m-orange"
+    data-tip=""
+  >
+    <span
+      className="pf-c-label__content"
+    >
+      <span
+        className="pf-c-label__icon"
+      >
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="var(--pf-global--warning-color--100)"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 576 512"
+          width="1em"
+        >
+          <path
+            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+          />
+        </svg>
+      </span>
+      Deprecated
+    </span>
+  </span>,
+  <div>
+    Dummy Tooltip
+  </div>,
+]
+`;
+
 exports[`The workspace status label component DevWorkspaces should render FAILED status correctly 1`] = `
 Array [
   <span
@@ -323,7 +363,7 @@ Array [
           />
         </svg>
       </span>
-      undefined
+      stopping
     </span>
   </span>,
   <div>

--- a/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/__tests__/index.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('react-tooltip', () => {
 
 describe('The workspace status label component', () => {
   it('should render default status correctly', () => {
-    const element = <WorkspaceStatusLabel status={'undefined'} />;
+    const element = <WorkspaceStatusLabel status={WorkspaceStatus.STOPPING} />;
     expect(renderer.create(element).toJSON()).toMatchSnapshot();
   });
 
@@ -62,6 +62,13 @@ describe('The workspace status label component', () => {
 
     it('should render FAILING status correctly', () => {
       const element = <WorkspaceStatusLabel status={DevWorkspaceStatus.FAILING} />;
+      expect(renderer.create(element).toJSON()).toMatchSnapshot();
+    });
+  });
+
+  describe('Deprecated workspaces', () => {
+    it('should render "Deprecated" status correctly', () => {
+      const element = <WorkspaceStatusLabel status={'Deprecated'} />;
       expect(renderer.create(element).toJSON()).toMatchSnapshot();
     });
   });

--- a/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceStatusLabel/index.tsx
@@ -17,8 +17,13 @@ import {
 } from '@patternfly/react-icons/dist/js/icons';
 import React from 'react';
 import { Label } from '@patternfly/react-core';
-import { DevWorkspaceStatus, WorkspaceStatus } from '../../services/helpers/types';
+import {
+  DevWorkspaceStatus,
+  WorkspaceStatus,
+  DeprecatedWorkspaceStatus,
+} from '../../services/helpers/types';
 import ReactTooltip from 'react-tooltip';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import styles from './index.module.css';
 
@@ -54,7 +59,7 @@ export const StoppedIcon = (props: { color?: ColorType }): React.ReactElement =>
 };
 
 type Props = {
-  status: string | undefined;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
 };
 
 class WorkspaceStatusLabel extends React.PureComponent<Props> {
@@ -65,7 +70,7 @@ class WorkspaceStatusLabel extends React.PureComponent<Props> {
 
     const tooltip = (
       <ReactTooltip
-        getContent={() => status}
+        getContent={() => (status === 'Deprecated' ? 'Deprecated workspace' : status)}
         backgroundColor="black"
         textColor="white"
         effect="solid"
@@ -162,6 +167,20 @@ class WorkspaceStatusLabel extends React.PureComponent<Props> {
               icon={<InProgressIcon className={styles.rotate} />}
             >
               Starting
+            </Label>
+            {tooltip}
+          </>
+        );
+      case 'Deprecated':
+        return (
+          <>
+            <Label
+              data-tip=""
+              className={styles.statusLabel}
+              color="orange"
+              icon={<ExclamationTriangleIcon color="var(--pf-global--warning-color--100)" />}
+            >
+              Deprecated
             </Label>
             {tooltip}
           </>

--- a/packages/dashboard-frontend/src/containers/IdeLoader.tsx
+++ b/packages/dashboard-frontend/src/containers/IdeLoader.tsx
@@ -20,7 +20,12 @@ import { lazyInject } from '../inversify.config';
 import IdeLoader, { AlertOptions } from '../pages/IdeLoader';
 import { Debounce } from '../services/helpers/debounce';
 import { delay } from '../services/helpers/delay';
-import { IdeLoaderTab } from '../services/helpers/types';
+import {
+  DeprecatedWorkspaceStatus,
+  DevWorkspaceStatus,
+  IdeLoaderTab,
+  WorkspaceStatus,
+} from '../services/helpers/types';
 import { AppState } from '../store';
 import { getEnvironment, isDevEnvironment } from '../services/helpers/environment';
 import * as WorkspaceStore from '../store/Workspaces';
@@ -57,7 +62,7 @@ type State = {
   hasStarted: boolean;
   isWaitingForRestart: boolean;
   isDevWorkspace: boolean;
-  status?: string;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
 };
 
 class IdeLoaderContainer extends React.PureComponent<Props, State> {
@@ -94,6 +99,9 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
       workspace =>
         workspace.namespace === params.namespace && workspace.name === this.workspaceName,
     );
+    const status =
+      workspace?.status ||
+      (this.props.devworkspacesEnabled ? DevWorkspaceStatus.STOPPED : WorkspaceStatus.STOPPED);
     this.state = {
       currentStep: LoadIdeSteps.INITIALIZING,
       namespace,
@@ -103,6 +111,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
       preselectedTabKey: this.preselectedTabKey,
       isWaitingForRestart: false,
       hasStarted: false,
+      status,
     };
 
     this.debounce.subscribe(async onStart => {

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
@@ -97,7 +97,7 @@ class WorkspaceDetailsContainer extends React.Component<Props> {
     if (!oldWorkspace) {
       return;
     }
-    return buildDetailsLocation(oldWorkspace);
+    return buildDetailsLocation(oldWorkspace, WorkspaceDetailsTab.DEVFILE);
   }
 
   public componentDidMount(): void {

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
@@ -11,7 +11,7 @@
  */
 
 import { AlertVariant } from '@patternfly/react-core';
-import { History } from 'history';
+import { History, Location } from 'history';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
@@ -31,6 +31,8 @@ import {
   selectIsLoading,
   selectWorkspaceById,
 } from '../store/Workspaces/selectors';
+import { isDevWorkspace } from '../services/devfileApi';
+import { ORIGINAL_WORKSPACE_ID } from './WorkspaceActions';
 
 type Props = MappedProps & { history: History } & RouteComponentProps<{
     namespace: string;
@@ -80,6 +82,24 @@ class WorkspaceDetailsContainer extends React.Component<Props> {
     }
   }
 
+  private getOldWorkspacePath(workspace: Workspace): Location | undefined {
+    if (!workspace || !isDevWorkspace(workspace.ref)) {
+      return;
+    }
+    const oldWorkspaceId = workspace.ref.metadata.annotations?.[ORIGINAL_WORKSPACE_ID];
+    if (!oldWorkspaceId) {
+      return;
+    }
+    // check if the old workspace is still available
+    const oldWorkspace = this.props.allWorkspaces.find(
+      workspace => workspace.id === oldWorkspaceId,
+    );
+    if (!oldWorkspace) {
+      return;
+    }
+    return buildDetailsLocation(oldWorkspace);
+  }
+
   public componentDidMount(): void {
     this.init();
     const showAlert = this.workspaceDetailsPageRef.current?.showAlert;
@@ -115,10 +135,16 @@ class WorkspaceDetailsContainer extends React.Component<Props> {
   }
 
   render() {
+    let oldWorkspacePath: Location | undefined;
+    if (this.props.workspace && isDevWorkspace(this.props.workspace.ref)) {
+      oldWorkspacePath = this.getOldWorkspacePath(this.props.workspace);
+    }
+
     return (
       <WorkspaceDetails
         ref={this.workspaceDetailsPageRef}
         workspacesLink={this.workspacesLink}
+        oldWorkspacePath={oldWorkspacePath}
         onSave={(workspace: Workspace, activeTab?: WorkspaceDetailsTab) =>
           this.onSave(workspace, activeTab)
         }

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
@@ -32,7 +32,7 @@ import {
   selectWorkspaceById,
 } from '../store/Workspaces/selectors';
 import { isDevWorkspace } from '../services/devfileApi';
-import { ORIGINAL_WORKSPACE_ID } from './WorkspaceActions';
+import { ORIGINAL_WORKSPACE_ID_ANNOTATION } from '../services/devfileApi/devWorkspace/metadata';
 
 type Props = MappedProps & { history: History } & RouteComponentProps<{
     namespace: string;
@@ -86,7 +86,7 @@ class WorkspaceDetailsContainer extends React.Component<Props> {
     if (!workspace || !isDevWorkspace(workspace.ref)) {
       return;
     }
-    const oldWorkspaceId = workspace.ref.metadata.annotations?.[ORIGINAL_WORKSPACE_ID];
+    const oldWorkspaceId = workspace.ref.metadata.annotations?.[ORIGINAL_WORKSPACE_ID_ANNOTATION];
     if (!oldWorkspaceId) {
       return;
     }

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails.tsx
@@ -93,7 +93,10 @@ class WorkspaceDetailsContainer extends React.Component<Props> {
   }
 
   public shouldComponentUpdate(nextProps: Props): boolean {
-    return this.props.workspace?.id !== nextProps.workspace?.id;
+    return (
+      this.props.workspace?.id !== nextProps.workspace?.id ||
+      this.props.location.pathname !== nextProps.location.pathname
+    );
   }
 
   public componentDidUpdate(): void {

--- a/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
@@ -28,6 +28,7 @@ import { lazyInject } from '../inversify.config';
 import { AppAlerts } from '../services/alerts/appAlerts';
 import { AlertVariant } from '@patternfly/react-core';
 import { selectBranding } from '../store/Branding/selectors';
+import { isDevWorkspace } from '../services/devfileApi';
 
 type Props = MappedProps & { history: History };
 
@@ -62,6 +63,16 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
       return Fallback;
     }
 
+    const filteredWorkspaces = allWorkspaces.filter(workspace => {
+      if (workspace.isDeprecated === false) {
+        return true;
+      }
+      if (isDevWorkspace(workspace.ref)) {
+        return true;
+      }
+      return workspace.ref.attributes?.converted === undefined;
+    });
+
     return (
       <WorkspaceActionsProvider history={history}>
         <WorkspaceActionsConsumer>
@@ -69,7 +80,7 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
             <WorkspacesList
               branding={branding}
               history={history}
-              workspaces={allWorkspaces}
+              workspaces={filteredWorkspaces}
               onAction={(action, id) => context.handleAction(action, id)}
               showConfirmation={wantDelete => context.showConfirmation(wantDelete)}
               toDelete={context.toDelete}

--- a/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/FactoryLoader.spec.tsx
@@ -22,7 +22,7 @@ import { createFakeCheWorkspace } from '../../store/__mocks__/workspace';
 import { WorkspaceStatus } from '../../services/helpers/types';
 import FactoryLoaderContainer, { LoadFactorySteps } from '../FactoryLoader';
 import { AlertOptions } from '../../pages/IdeLoader';
-import { convertWorkspace, Devfile, WorkspaceAdapter } from '../../services/workspace-adapter';
+import { constructWorkspace, Devfile, WorkspaceAdapter } from '../../services/workspace-adapter';
 import { DevWorkspaceBuilder } from '../../store/__mocks__/devWorkspaceBuilder';
 import devfileApi from '../../services/devfileApi';
 import { safeDump } from 'js-yaml';
@@ -71,7 +71,7 @@ jest.mock('../../store/Workspaces');
     ) =>
     async () => {
       createWorkspaceFromDevfileMock(devfile, namespace, infrastructureNamespace, attributes);
-      return convertWorkspace({
+      return constructWorkspace({
         id: 'id-wksp-test',
         attributes: attributes as che.WorkspaceAttributes,
         namespace,
@@ -319,7 +319,7 @@ metadata:
         .withId('wrksp-test-id')
         .withName('wrksp-test-name')
         .build();
-      const workspaceAdapter = convertWorkspace(workspace);
+      const workspaceAdapter = constructWorkspace(workspace);
 
       renderComponentV1(location, workspace);
 
@@ -361,7 +361,7 @@ metadata:
     it('should resolve the factory, create a new workspace and open IDE', async () => {
       const location = 'http://test-location';
       const workspace = createFakeWorkspaceWithRuntimeV1('id-wksp-test');
-      const workspaceAdapter = convertWorkspace(workspace);
+      const workspaceAdapter = constructWorkspace(workspace);
 
       renderComponentV1(location, workspace);
 
@@ -494,7 +494,7 @@ metadata:
         'id-wksp-test',
         'http://test-location/?policies.create=peruser',
       );
-      const workspaceAdapter = convertWorkspace(workspace);
+      const workspaceAdapter = constructWorkspace(workspace);
 
       renderComponentV1(location, workspace);
 
@@ -1035,7 +1035,7 @@ metadata:
 });
 
 function renderComponentV2(url: string, workspace: devfileApi.DevWorkspace): RenderResult {
-  const wrks = convertWorkspace(workspace);
+  const wrks = constructWorkspace(workspace);
   (wrks.ref as devfileApi.DevWorkspace).metadata.annotations = {
     'che.eclipse.org/devfile-source': safeDump({
       factory: { params: 'url=http://test-location&policies.create=peruser' },
@@ -1057,7 +1057,7 @@ function renderComponentV2(url: string, workspace: devfileApi.DevWorkspace): Ren
       {
         v: '4.0',
         source: 'devfile.yaml',
-        devfile: convertWorkspace(workspace).devfile,
+        devfile: constructWorkspace(workspace).devfile,
         location: url.split('&')[0],
         scm_info: {
           clone_url: 'http://github.com/clone-url',

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Flex, FlexItem, PageSection, PageSectionVariants } from '@patternfly/react-core';
 import { AppState } from '../../../store';
-import CheProgress from '../../../components/Progress';
+import ProgressIndicator from '../../../components/Progress';
 import { SamplesListHeader } from './SamplesListHeader';
 import SamplesListToolbar from './SamplesListToolbar';
 import SamplesListGallery from './SamplesListGallery';
@@ -115,7 +115,7 @@ export class SamplesListTab extends React.PureComponent<Props, State> {
 
     return (
       <>
-        <CheProgress isLoading={isLoading} />
+        <ProgressIndicator isLoading={isLoading} />
         <PageSection variant={PageSectionVariants.default} style={{ background: '#f0f0f0' }}>
           <PageSection variant={PageSectionVariants.light}>
             <ImportFromGit

--- a/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import GetStarted from '..';
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { BrandingData } from '../../../services/bootstrap/branding.constant';
-import { convertWorkspace, Devfile, Workspace } from '../../../services/workspace-adapter';
+import { constructWorkspace, Devfile, Workspace } from '../../../services/workspace-adapter';
 import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilder';
 
 const setWorkspaceQualifiedName = jest.fn();
@@ -45,7 +45,7 @@ jest.mock('../../../store/Workspaces/index', () => {
         (devfile, namespace, infrastructureNamespace, attributes) =>
         async (): Promise<Workspace> => {
           createWorkspaceFromDevfileMock(devfile, namespace, infrastructureNamespace, attributes);
-          return convertWorkspace({
+          return constructWorkspace({
             id: 'id-wksp-test',
             attributes,
             namespace,

--- a/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/IdeLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/IdeLoader.spec.tsx
@@ -16,7 +16,7 @@ import { Store } from 'redux';
 import { Provider } from 'react-redux';
 import IdeLoaderTabs from '..';
 import { LoadIdeSteps } from '../../../containers/IdeLoader';
-import { WorkspaceStatus } from '../../../services/helpers/types';
+import { DeprecatedWorkspaceStatus, WorkspaceStatus } from '../../../services/helpers/types';
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { createFakeCheWorkspace } from '../../../store/__mocks__/workspace';
 
@@ -53,7 +53,7 @@ describe('The Ide Loader page  component', () => {
       workspaceName,
       workspaceId,
       hasError,
-      workspace.status,
+      workspace.status as WorkspaceStatus,
     );
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -80,7 +80,7 @@ describe('The Ide Loader page  component', () => {
       workspaceName,
       workspaceId,
       hasError,
-      workspace.status,
+      workspace.status as WorkspaceStatus,
     );
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -107,7 +107,7 @@ describe('The Ide Loader page  component', () => {
       workspaceName,
       workspaceId,
       false,
-      workspace.status,
+      workspace.status as WorkspaceStatus,
     );
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -162,7 +162,7 @@ describe('The Ide Loader page  component', () => {
       workspaceName,
       workspaceId,
       false,
-      workspace.status,
+      workspace.status as WorkspaceStatus,
     );
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -216,7 +216,7 @@ describe('The Ide Loader page  component', () => {
       workspaceName,
       workspaceId,
       false,
-      workspace.status,
+      workspace.status as WorkspaceStatus,
       ideUrl,
     );
 
@@ -230,7 +230,7 @@ function renderComponent(
   workspaceName: string,
   workspaceId: string,
   hasError: boolean,
-  workspaceStatus: string | undefined,
+  workspaceStatus: WorkspaceStatus | DeprecatedWorkspaceStatus,
   ideUrl?: string,
 ): ReactTestRenderer {
   return renderer.create(

--- a/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
@@ -30,7 +30,12 @@ import Header from '../../components/Header';
 import WorkspaceLogs from '../../components/LogsTab';
 import { LoadIdeSteps } from '../../containers/IdeLoader';
 import { delay } from '../../services/helpers/delay';
-import { WorkspaceStatus, DevWorkspaceStatus, IdeLoaderTab } from '../../services/helpers/types';
+import {
+  WorkspaceStatus,
+  DevWorkspaceStatus,
+  IdeLoaderTab,
+  DeprecatedWorkspaceStatus,
+} from '../../services/helpers/types';
 
 import workspaceStatusLabelStyles from '../../components/WorkspaceStatusLabel/index.module.css';
 import './IdeLoader.styl';
@@ -42,7 +47,7 @@ type Props = {
   hasError: boolean;
   ideUrl?: string;
   preselectedTabKey?: IdeLoaderTab;
-  status: string | undefined;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   workspaceId: string;
   workspaceName: string;
   isDevWorkspace: boolean;

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/index.tsx
@@ -24,7 +24,7 @@ import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { History } from 'history';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import CheProgress from '../../../components/Progress';
+import ProgressIndicator from '../../../components/Progress';
 import { lazyInject } from '../../../inversify.config';
 import { AppAlerts } from '../../../services/alerts/appAlerts';
 import { AlertItem } from '../../../services/helpers/types';
@@ -297,7 +297,7 @@ export class ContainerRegistriesTab extends React.PureComponent<Props, State> {
 
     return (
       <React.Fragment>
-        <CheProgress isLoading={isLoading} />
+        <ProgressIndicator isLoading={isLoading} />
         <EditRegistryModal
           onCancel={() => this.setEditModalStatus(false)}
           onChange={_registry => this.handleRegistryChange(_registry)}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WorkspaceConversionButton render 1`] = `
+<button
+  aria-disabled={false}
+  aria-label={null}
+  className="pf-c-button pf-m-warning"
+  data-ouia-component-id="OUIA-Generated-Button-warning-1"
+  data-ouia-component-type="PF4/Button"
+  data-ouia-safe={true}
+  disabled={false}
+  onClick={[Function]}
+  role={null}
+  type="button"
+>
+  Convert
+</button>
+`;

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/__tests__/index.spec.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router';
+import { Store } from 'redux';
+import { createHashHistory } from 'history';
+import { render, RenderResult, screen, waitFor } from '@testing-library/react';
+import renderer, { ReactTestRendererJSON } from 'react-test-renderer';
+import WorkspaceConversionButton from '..';
+import { constructWorkspace, Workspace } from '../../../../services/workspace-adapter';
+import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
+import { CheWorkspaceBuilder } from '../../../../store/__mocks__/cheWorkspaceBuilder';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import devfileApi from '../../../../services/devfileApi';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('../../../../store/Workspaces', () => {
+  return {
+    actionCreators: {
+      createWorkspaceFromDevfile: () => async (): Promise<void> => Promise.resolve(),
+      updateWorkspace: () => async () => Promise.resolve(),
+    },
+  };
+});
+
+jest.mock('../../../../store/Workspaces/devWorkspaces', () => {
+  return {
+    actionCreators: {
+      updateWorkspaceAnnotation: () => async () => Promise.resolve(),
+    },
+  };
+});
+
+const mockCleanupError = jest.fn();
+const mockOnError = jest.fn();
+
+describe('WorkspaceConversionButton', () => {
+  let cheWorkspace: che.Workspace;
+  let devWorkspace: devfileApi.DevWorkspace;
+  let store: Store;
+
+  beforeEach(() => {
+    cheWorkspace = new CheWorkspaceBuilder()
+      .withId('old-workspace-id')
+      .withName('workspace-name')
+      .withNamespace('user')
+      .withDevfile({
+        apiVersion: '1.0.0',
+        metadata: {
+          name: 'workspace-name',
+        },
+        components: [],
+      })
+      .build();
+    devWorkspace = new DevWorkspaceBuilder()
+      .withId('dev-workspace-id')
+      .withName('workspace-name')
+      .withNamespace('user-dev')
+      .build();
+    store = new FakeStoreBuilder()
+      .withCheWorkspaces({ workspaces: [cheWorkspace] })
+      .withDevWorkspaces({ workspaces: [devWorkspace] })
+      .withInfrastructureNamespace([
+        {
+          name: 'user-dev',
+          attributes: {
+            default: 'true',
+            displayName: 'user-dev',
+            phase: 'Active',
+          },
+        },
+      ])
+      .build();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('render', () => {
+    const oldWorkspace = constructWorkspace(cheWorkspace);
+    const component = getComponent(oldWorkspace);
+    const snapshot = createSnapshot(component);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should emit cleanupError on conversion start', async () => {
+    const oldWorkspace = constructWorkspace(cheWorkspace);
+    const component = getComponent(oldWorkspace);
+    renderComponent(component);
+
+    const convertButton = screen.getByRole('button', { name: 'Convert' });
+    userEvent.click(convertButton);
+
+    await waitFor(() => expect(mockCleanupError).toBeCalled());
+  });
+
+  it('should emit onError if devworkspace', async () => {
+    // try to convert an devworkspace
+    const oldWorkspace = constructWorkspace(devWorkspace);
+    const component = getComponent(oldWorkspace);
+    renderComponent(component);
+
+    const convertButton = screen.getByRole('button', { name: 'Convert' });
+    userEvent.click(convertButton);
+
+    await waitFor(() =>
+      expect(mockOnError).toBeCalledWith('This workspace cannot be converted to DevWorkspaces.'),
+    );
+  });
+
+  it('should emit onError if new workspace is not in the store', async () => {
+    // no devworkspace in the store
+    store = new FakeStoreBuilder()
+      .withCheWorkspaces({ workspaces: [cheWorkspace] })
+      .withInfrastructureNamespace([
+        {
+          name: 'user-dev',
+          attributes: {
+            default: 'true',
+            displayName: 'user-dev',
+            phase: 'Active',
+          },
+        },
+      ])
+      .build();
+    const oldWorkspace = constructWorkspace(cheWorkspace);
+    const component = getComponent(oldWorkspace);
+    renderComponent(component);
+
+    const convertButton = screen.getByRole('button', { name: 'Convert' });
+    userEvent.click(convertButton);
+
+    await waitFor(() =>
+      expect(mockOnError).toBeCalledWith(
+        'The new DevWorkspace has been created but cannot be obtained.',
+      ),
+    );
+  });
+
+  it('should redirect to new workspace page', async () => {
+    const oldWorkspace = constructWorkspace(cheWorkspace);
+    const component = getComponent(oldWorkspace);
+    renderComponent(component);
+
+    const convertButton = screen.getByRole('button', { name: 'Convert' });
+    userEvent.click(convertButton);
+
+    await waitFor(() => expect(window.location.href).toMatch(/user-dev\/workspace-name/));
+  });
+
+  function getComponent(oldWorkspace: Workspace): React.ReactElement {
+    const history = createHashHistory();
+    return (
+      <Router history={history}>
+        <Provider store={store}>
+          <WorkspaceConversionButton
+            history={history}
+            oldWorkspace={oldWorkspace}
+            cleanupError={mockCleanupError}
+            onError={mockOnError}
+          />
+        </Provider>
+      </Router>
+    );
+  }
+
+  function renderComponent(component: React.ReactElement): RenderResult {
+    return render(component);
+  }
+
+  function createSnapshot(
+    component: React.ReactElement,
+  ): null | ReactTestRendererJSON | ReactTestRendererJSON[] {
+    return renderer.create(component).toJSON();
+  }
+});

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/index.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { Location, History } from 'history';
+import { connect, ConnectedProps } from 'react-redux';
+import { Button } from '@patternfly/react-core';
+import common from '@eclipse-che/common';
+import devfileApi, { isDevWorkspace } from '../../../services/devfileApi';
+import { ORIGINAL_WORKSPACE_ID_ANNOTATION } from '../../../services/devfileApi/devWorkspace/metadata';
+import { convertDevfileV1toDevfileV2 } from '../../../services/devfile/converters';
+import { Workspace } from '../../../services/workspace-adapter';
+import { AppState } from '../../../store';
+import { selectDefaultNamespace } from '../../../store/InfrastructureNamespaces/selectors';
+import {
+  selectAllWorkspaces,
+  selectWorkspaceByQualifiedName,
+} from '../../../store/Workspaces/selectors';
+import * as WorkspacesStore from '../../../store/Workspaces';
+import * as DevWorkspacesStore from '../../../store/Workspaces/devWorkspaces';
+import { buildDetailsLocation } from '../../../services/helpers/location';
+import { WorkspaceDetailsTab } from '../../../services/helpers/types';
+
+type Props = MappedProps & {
+  history: History;
+  oldWorkspace: Workspace;
+  onError: (errorMessage: string) => void;
+  cleanupError: () => void;
+};
+
+type State = {
+  isDisabled: boolean;
+};
+
+export class WorkspaceConversionButton extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      isDisabled: false,
+    };
+  }
+
+  private async handleConversion(): Promise<void> {
+    this.setState({
+      isDisabled: true,
+    });
+    this.props.cleanupError();
+
+    const { oldWorkspace } = this.props;
+
+    try {
+      const newWorkspaceLocation = await this.convert(oldWorkspace);
+      this.props.history.replace(newWorkspaceLocation);
+    } catch (e) {
+      const errorMessage = common.helpers.errors.getMessage(e);
+      this.props.onError(errorMessage);
+    }
+
+    this.setState({
+      isDisabled: false,
+    });
+  }
+
+  private async convert(oldWorkspace: Workspace): Promise<Location> {
+    if (isDevWorkspace(oldWorkspace.ref)) {
+      throw new Error('This workspace cannot be converted to DevWorkspaces.');
+    }
+
+    const devfileV1 = oldWorkspace.devfile as che.WorkspaceDevfile;
+    const devfileV2 = await convertDevfileV1toDevfileV2(devfileV1);
+    const defaultNamespace = this.props.defaultNamespace.name;
+    // create a new workspace
+    await this.props.createWorkspaceFromDevfile(
+      devfileV2,
+      undefined,
+      defaultNamespace,
+      {},
+      {},
+      false,
+    );
+
+    const newWorkspace = this.props.allWorkspaces.find(
+      workspace => workspace.namespace === defaultNamespace && workspace.name === oldWorkspace.name,
+    );
+    if (!newWorkspace) {
+      throw new Error('The new DevWorkspace has been created but cannot be obtained.');
+    }
+
+    // add annotation to the new workspace
+    // so then we can figure out the original workspace
+    const newDevworkspace = newWorkspace.ref as devfileApi.DevWorkspace;
+    if (!newDevworkspace.metadata.annotations) {
+      newDevworkspace.metadata.annotations = {};
+    }
+    newDevworkspace.metadata.annotations[ORIGINAL_WORKSPACE_ID_ANNOTATION] = oldWorkspace.id;
+    await this.props.updateWorkspaceAnnotation(newDevworkspace);
+
+    // add 'converted' attribute to the old workspace
+    // to be able to hide it on the Workspaces page
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    oldWorkspace.ref.attributes!.converted = new Date().toISOString();
+    await this.props.updateWorkspace(oldWorkspace);
+
+    // return the new workspace page location
+    const nextLocation = buildDetailsLocation(newWorkspace, WorkspaceDetailsTab.DEVFILE);
+    return nextLocation;
+  }
+
+  render() {
+    const { isDisabled } = this.state;
+    return (
+      <Button
+        variant="warning"
+        isDisabled={isDisabled}
+        onClick={async () => await this.handleConversion()}
+      >
+        Convert
+      </Button>
+    );
+  }
+}
+
+const mapStateToProps = (state: AppState) => ({
+  allWorkspaces: selectAllWorkspaces(state),
+  defaultNamespace: selectDefaultNamespace(state),
+  workspaceByQualifiedName: selectWorkspaceByQualifiedName(state),
+});
+
+const connector = connect(mapStateToProps, {
+  ...WorkspacesStore.actionCreators,
+  updateWorkspaceAnnotation: DevWorkspacesStore.actionCreators.updateWorkspaceAnnotation,
+});
+
+type MappedProps = ConnectedProps<typeof connector>;
+export default connector(WorkspaceConversionButton);

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/__tests__/index.spec.tsx
@@ -19,7 +19,7 @@ import userEvent from '@testing-library/user-event';
 import { dump } from 'js-yaml';
 import devfileApi from '../../../../services/devfileApi';
 import EditorTab from '..';
-import { Workspace, convertWorkspace } from '../../../../services/workspace-adapter';
+import { Workspace, constructWorkspace } from '../../../../services/workspace-adapter';
 import { CheWorkspaceBuilder } from '../../../../store/__mocks__/cheWorkspaceBuilder';
 import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
 import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
@@ -66,7 +66,7 @@ describe('Editor Tab', () => {
           workspaces: [cheWorkspace],
         })
         .build();
-      workspace = convertWorkspace(cheWorkspace);
+      workspace = constructWorkspace(cheWorkspace);
       component = getComponent(store, workspace);
     });
 
@@ -141,7 +141,7 @@ describe('Editor Tab', () => {
           workspaces: [devWorkspace],
         })
         .build();
-      workspace = convertWorkspace(devWorkspace);
+      workspace = constructWorkspace(devWorkspace);
       component = getComponent(store, workspace);
     });
 

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/index.tsx
@@ -210,26 +210,28 @@ export class EditorTab extends React.PureComponent<Props, State> {
             onChange={(newValue, isValid) => this.onDevfileChange(newValue, isValid)}
             isReadonly={isReadonly}
           />
-          <Flex direction={{ default: 'column' }}>
-            <FlexItem align={{ default: 'alignRight' }} className={styles.buttonsGroup}>
-              <Button
-                onClick={() => this.onSave()}
-                variant="primary"
-                className={styles.saveButton}
-                isDisabled={!this.state.hasChanges || !this.state.isDevfileValid}
-              >
-                Save
-              </Button>
-              <Button
-                onClick={() => this.cancelChanges()}
-                variant="secondary"
-                className={styles.cancelButton}
-                isDisabled={!this.state.hasChanges && this.state.isDevfileValid}
-              >
-                Cancel
-              </Button>
-            </FlexItem>
-          </Flex>
+          {isReadonly === false && (
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem align={{ default: 'alignRight' }} className={styles.buttonsGroup}>
+                <Button
+                  onClick={() => this.onSave()}
+                  variant="primary"
+                  className={styles.saveButton}
+                  isDisabled={!this.state.hasChanges || !this.state.isDevfileValid}
+                >
+                  Save
+                </Button>
+                <Button
+                  onClick={() => this.cancelChanges()}
+                  variant="secondary"
+                  className={styles.cancelButton}
+                  isDisabled={!this.state.hasChanges && this.state.isDevfileValid}
+                >
+                  Cancel
+                </Button>
+              </FlexItem>
+            </Flex>
+          )}
         </TextContent>
       </React.Fragment>
     );

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/index.tsx
@@ -29,7 +29,7 @@ import { safeLoad } from 'js-yaml';
 import common from '@eclipse-che/common';
 import DevfileEditor, { DevfileEditor as Editor } from '../../../components/DevfileEditor';
 import EditorTools from './EditorTools';
-import { convertWorkspace, isCheWorkspace, Workspace } from '../../../services/workspace-adapter';
+import { constructWorkspace, isCheWorkspace, Workspace } from '../../../services/workspace-adapter';
 import devfileApi, { isDevfileV2, isDevWorkspace } from '../../../services/devfileApi';
 import {
   DevWorkspaceClient,
@@ -245,7 +245,7 @@ export class EditorTab extends React.PureComponent<Props, State> {
     try {
       await this.checkForModifiedClusterDevWorkspace();
       const devworkspace = this.props.workspace.ref as devfileApi.DevWorkspace;
-      const convertedDevWorkspace = convertWorkspace(devworkspace);
+      const convertedDevWorkspace = constructWorkspace(devworkspace);
       convertedDevWorkspace.devfile = devfile;
       // Store the devfile in here
       (convertedDevWorkspace.ref as devfileApi.DevWorkspace).metadata.annotations = {
@@ -333,7 +333,7 @@ export class EditorTab extends React.PureComponent<Props, State> {
     if (!devfile) {
       return;
     }
-    const workspaceCopy = convertWorkspace(this.props.workspace.ref);
+    const workspaceCopy = constructWorkspace(this.props.workspace.ref);
     if (!devfile.metadata) {
       devfile.metadata = {};
     }

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/EditorTab/index.tsx
@@ -141,6 +141,7 @@ export class EditorTab extends React.PureComponent<Props, State> {
   public render(): React.ReactElement {
     const originDevfile = this.props.workspace.devfile;
     const { devfile, additionSchema } = this.state;
+    const isReadonly = this.props.workspace.isDeprecated;
 
     return (
       <React.Fragment>
@@ -207,6 +208,7 @@ export class EditorTab extends React.PureComponent<Props, State> {
             devfile={originDevfile}
             decorationPattern="location[ \t]*(.*)[ \t]*$"
             onChange={(newValue, isValid) => this.onDevfileChange(newValue, isValid)}
+            isReadonly={isReadonly}
           />
           <Flex direction={{ default: 'column' }}>
             <FlexItem align={{ default: 'alignRight' }} className={styles.buttonsGroup}>

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Actions.styl
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Actions.styl
@@ -1,5 +1,0 @@
-.workspace-action-selector
-  button
-    border-radius 3px
-  ul
-    padding 0

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
@@ -46,6 +46,9 @@ jest.mock('../../../../../store/Workspaces/index', () => {
 });
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
+const mockOnConversionAlert = jest.fn();
+const mockCloseConversionAlert = jest.fn();
+
 const namespace = 'che';
 const workspaceName = 'test-workspace-name';
 const workspaceId = 'test-workspace-id';
@@ -103,8 +106,9 @@ describe('Workspace WorkspaceAction widget', () => {
     actionDropdown.click();
 
     const menuitems = screen.getAllByRole('menuitem');
-    expect(menuitems.length).toEqual(1);
-    expect(menuitems[0]).toHaveTextContent('Delete Workspace');
+    expect(menuitems.length).toEqual(2);
+    expect(menuitems[0]).toHaveTextContent('Convert');
+    expect(menuitems[1]).toHaveTextContent('Delete Workspace');
   });
 
   it('should call the callback with OPEN action', async () => {
@@ -209,6 +213,8 @@ function createComponent(
       workspaceName={workspaceName}
       history={history}
       status={status}
+      onConversionAlert={mockOnConversionAlert}
+      closeConversionAlert={mockCloseConversionAlert}
     />
   );
 }

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
@@ -46,9 +46,6 @@ jest.mock('../../../../../store/Workspaces/index', () => {
 });
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
-const mockOnConversionAlert = jest.fn();
-const mockCloseConversionAlert = jest.fn();
-
 const namespace = 'che';
 const workspaceName = 'test-workspace-name';
 const workspaceId = 'test-workspace-id';
@@ -106,9 +103,8 @@ describe('Workspace WorkspaceAction widget', () => {
     actionDropdown.click();
 
     const menuitems = screen.getAllByRole('menuitem');
-    expect(menuitems.length).toEqual(2);
-    expect(menuitems[0]).toHaveTextContent('Convert');
-    expect(menuitems[1]).toHaveTextContent('Delete Workspace');
+    expect(menuitems.length).toEqual(1);
+    expect(menuitems[0]).toHaveTextContent('Delete Workspace');
   });
 
   it('should call the callback with OPEN action', async () => {
@@ -213,8 +209,6 @@ function createComponent(
       workspaceName={workspaceName}
       history={history}
       status={status}
-      onConversionAlert={mockOnConversionAlert}
-      closeConversionAlert={mockCloseConversionAlert}
     />
   );
 }

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.module.css
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+.workspaceActionSelector button {
+  border-radius: 3px;
+}
+
+.workspaceActionSelector ul {
+  padding: 0;
+}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
@@ -101,12 +101,11 @@ export class HeaderActionSelect extends React.PureComponent<Props, State> {
       isExpanded: false,
     });
     try {
-      // todo implement redirecting to the new workspace page
-      const nextPath = await context.handleAction(selectedAction, this.props.workspaceId);
-      if (!nextPath) {
+      const nextLocation = await context.handleAction(selectedAction, this.props.workspaceId);
+      if (!nextLocation) {
         return;
       }
-      this.props.history.push(nextPath);
+      this.props.history.replace(nextLocation);
     } catch (e) {
       const errorMessage = common.helpers.errors.getMessage(e);
       this.props.onConversionAlert(errorMessage);

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
@@ -37,8 +37,6 @@ type Props = {
   workspaceName: string;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   history: History;
-  onConversionAlert: (errorMessage: string) => void;
-  closeConversionAlert: () => void;
 };
 
 type State = {
@@ -93,26 +91,6 @@ export class HeaderActionSelect extends React.PureComponent<Props, State> {
     }
   }
 
-  private async handleConversion(
-    selectedAction: WorkspaceAction,
-    context: ActionContextType,
-  ): Promise<void> {
-    this.setState({
-      isExpanded: false,
-    });
-    try {
-      const nextLocation = await context.handleAction(selectedAction, this.props.workspaceId);
-      if (!nextLocation) {
-        return;
-      }
-      this.props.history.replace(nextLocation);
-    } catch (e) {
-      const errorMessage = common.helpers.errors.getMessage(e);
-      this.props.onConversionAlert(errorMessage);
-      console.warn(errorMessage);
-    }
-  }
-
   private showAlert(message: string): void {
     this.appAlerts.showAlert({
       key: 'workspace-details-' + getRandomString(4),
@@ -127,23 +105,9 @@ export class HeaderActionSelect extends React.PureComponent<Props, State> {
     if (status === 'Deprecated') {
       return [
         <DropdownItem
-          key={`action-${WorkspaceAction.CONVERT}`}
-          // todo isDisabled={isConverted}
-          isDisabled={false}
-          onClick={async () => {
-            this.props.closeConversionAlert();
-            this.handleConversion(WorkspaceAction.CONVERT, context);
-          }}
-        >
-          <div>{WorkspaceAction.CONVERT}</div>
-        </DropdownItem>,
-        <DropdownItem
           key={`action-${WorkspaceAction.DELETE_WORKSPACE}`}
           isDisabled={false}
-          onClick={async () => {
-            this.props.closeConversionAlert();
-            this.handleSelectedAction(WorkspaceAction.CONVERT, context);
-          }}
+          onClick={async () => this.handleSelectedAction(WorkspaceAction.DELETE_WORKSPACE, context)}
         >
           <div>{WorkspaceAction.DELETE_WORKSPACE}</div>
         </DropdownItem>,

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
@@ -20,6 +20,7 @@ import {
   WorkspaceAction,
   WorkspaceStatus,
   DevWorkspaceStatus,
+  DeprecatedWorkspaceStatus,
 } from '../../../../services/helpers/types';
 import {
   ActionContextType,
@@ -29,12 +30,12 @@ import { lazyInject } from '../../../../inversify.config';
 import { AppAlerts } from '../../../../services/alerts/appAlerts';
 import getRandomString from '../../../../services/helpers/random';
 
-import './Actions.styl';
+import styles from './index.module.css';
 
 type Props = {
   workspaceId: string;
   workspaceName: string;
-  status: string | undefined;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   history: History;
 };
 
@@ -104,6 +105,18 @@ export class HeaderActionSelect extends React.PureComponent<Props, State> {
   private getDropdownItems(context: ActionContextType): React.ReactNode[] {
     const { status } = this.props;
 
+    if (status === 'Deprecated') {
+      return [
+        <DropdownItem
+          key={`action-${WorkspaceAction.DELETE_WORKSPACE}`}
+          isDisabled={false}
+          onClick={async () => this.handleSelect(WorkspaceAction.DELETE_WORKSPACE, context)}
+        >
+          <div>{WorkspaceAction.DELETE_WORKSPACE}</div>
+        </DropdownItem>,
+      ];
+    }
+
     return [
       <DropdownItem
         key={`action-${WorkspaceAction.OPEN_IDE}`}
@@ -163,7 +176,7 @@ export class HeaderActionSelect extends React.PureComponent<Props, State> {
         <WorkspaceActionsConsumer>
           {context => (
             <Dropdown
-              className="workspace-action-selector"
+              className={styles.workspaceActionSelector}
               toggle={
                 <DropdownToggle
                   data-testid={`${workspaceId}-action-dropdown`}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.module.css
@@ -17,3 +17,7 @@
 .breadcrumb li:first-child a {
   margin-right: 8px;
 }
+
+.actionButtons > * {
+  margin-left: 10px;
+}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.tsx
@@ -61,7 +61,9 @@ class Header extends React.PureComponent<Props> {
               <FlexItem>
                 <WorkspaceStatusLabel status={status} />
               </FlexItem>
-              <FlexItem align={{ default: 'alignRight' }}>{children}</FlexItem>
+              <FlexItem className={styles.actionButtons} align={{ default: 'alignRight' }}>
+                {children}
+              </FlexItem>
             </Flex>
           </StackItem>
         </Stack>

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.tsx
@@ -26,10 +26,15 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import WorkspaceStatusLabel from '../../../components/WorkspaceStatusLabel';
 
 import styles from './index.module.css';
+import {
+  DeprecatedWorkspaceStatus,
+  DevWorkspaceStatus,
+  WorkspaceStatus,
+} from '../../../services/helpers/types';
 
 type Props = {
   workspacesLink: string;
-  status: string | undefined;
+  status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   workspaceName: string;
 };
 

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/__tests__/index.spec.tsx
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { render, RenderResult, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WorkspaceInlineAlerts } from '..';
+import {
+  constructWorkspace,
+  Workspace,
+  WorkspaceAdapter,
+} from '../../../../services/workspace-adapter';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import { CheWorkspaceBuilder } from '../../../../store/__mocks__/cheWorkspaceBuilder';
+
+const mockOnCloseConversionError = jest.fn();
+const mockOnCloseRestartAlert = jest.fn();
+
+describe('Inline alerts', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should render empty alert group', () => {
+    const workspace = constructWorkspace(
+      new DevWorkspaceBuilder().withName('wksp').withNamespace('user').build(),
+    );
+    renderComponent({ workspace });
+
+    const alertHeadings = screen.queryAllByRole('heading');
+    expect(alertHeadings.length).toEqual(0);
+  });
+
+  it('should render the deprecation warning', () => {
+    const deprecatedId = 'wksp-id';
+    WorkspaceAdapter.setDeprecatedIds([deprecatedId]);
+    const workspace = constructWorkspace(
+      new CheWorkspaceBuilder().withId(deprecatedId).withName('wksp').withNamespace('user').build(),
+    );
+    renderComponent({ workspace });
+
+    const alertHeading = screen.queryByRole('heading');
+    expect(alertHeading).toBeTruthy();
+    expect(alertHeading).toBeInTheDocument();
+    expect(alertHeading).toHaveTextContent('This workspace is deprecated.');
+  });
+
+  it('should render the conversion error', () => {
+    const deprecatedId = 'wksp-id';
+    WorkspaceAdapter.setDeprecatedIds([deprecatedId]);
+    const workspace = constructWorkspace(
+      new CheWorkspaceBuilder().withId(deprecatedId).withName('wksp').withNamespace('user').build(),
+    );
+    const conversionError = 'An error happened during devfiles conversion.';
+    renderComponent({ workspace, conversionError });
+
+    const alertHeading = screen.queryByRole('heading', {
+      name: /workspace conversion failed/i,
+    });
+    expect(alertHeading).toBeTruthy();
+    expect(alertHeading).toBeInTheDocument();
+    expect(screen.queryByText(conversionError)).toBeTruthy();
+    expect(screen.queryByText(/instructions for converting/i)).toBeTruthy();
+  });
+
+  it('should render the restart warning', () => {
+    const workspace = constructWorkspace(
+      new DevWorkspaceBuilder().withName('wksp').withNamespace('user').build(),
+    );
+    renderComponent({ workspace, restartWarning: true });
+
+    const alertHeading = screen.queryByRole('heading');
+    expect(alertHeading).toBeTruthy();
+    expect(alertHeading).toBeInTheDocument();
+    expect(alertHeading).toHaveTextContent(/should be restarted to apply changes/i);
+  });
+
+  describe('workspace failures', () => {
+    it('should render no alerts if status message was not set', () => {
+      const workspace = constructWorkspace(
+        new DevWorkspaceBuilder()
+          .withName('wksp')
+          .withNamespace('user')
+          .withStatus({ phase: 'FAILED' })
+          .build(),
+      );
+      renderComponent({ workspace });
+
+      const alertHeading = screen.queryByRole('heading');
+      expect(alertHeading).toBeFalsy();
+    });
+
+    it('should initially render a failure error', () => {
+      const failureMessage = 'The workspace failed to start.';
+      const workspace = constructWorkspace(
+        new DevWorkspaceBuilder()
+          .withName('wksp')
+          .withNamespace('user')
+          .withStatus({ phase: 'FAILED', message: failureMessage })
+          .build(),
+      );
+      renderComponent({ workspace });
+
+      const alertHeading = screen.queryByRole('heading');
+      expect(alertHeading).toBeTruthy();
+      expect(alertHeading).toBeInTheDocument();
+      expect(alertHeading).toHaveTextContent(failureMessage);
+    });
+
+    it('should re-render a failure error', () => {
+      const failureMessage = 'The workspace failed to start.';
+      const initWorkspace = constructWorkspace(
+        new DevWorkspaceBuilder()
+          .withName('wksp')
+          .withNamespace('user')
+          .withStatus({ phase: 'FAILED' })
+          .build(),
+      );
+      const { rerender } = renderComponent({ workspace: initWorkspace });
+
+      const prevAlertHeading = screen.queryByRole('heading');
+      expect(prevAlertHeading).toBeFalsy();
+
+      const nextWorkspace = constructWorkspace(
+        new DevWorkspaceBuilder()
+          .withName('wksp')
+          .withNamespace('user')
+          .withStatus({ phase: 'FAILED', message: failureMessage })
+          .build(),
+      );
+      reRenderComponent({ workspace: nextWorkspace }, rerender);
+
+      const nextAlertHeading = screen.queryByRole('heading');
+      expect(nextAlertHeading).toBeTruthy();
+      expect(nextAlertHeading).toBeInTheDocument();
+      expect(nextAlertHeading).toHaveTextContent(failureMessage);
+    });
+
+    // the alert should remain closed if until the workspace status is changed
+    it('should close a failure error', () => {
+      const failureMessage = 'The workspace failed to start.';
+      const devworkspace = new DevWorkspaceBuilder()
+        .withName('wksp')
+        .withNamespace('user')
+        .withStatus({ phase: 'FAILED', message: failureMessage })
+        .build();
+      const prevWorkspace = constructWorkspace(devworkspace);
+      const { rerender } = renderComponent({ workspace: prevWorkspace });
+
+      // alert visible
+      let prevAlertHeading = screen.queryByRole('heading');
+      expect(prevAlertHeading).toBeTruthy();
+
+      const closeButton = screen.getByRole('button', {
+        name: /workspace failed/i,
+      });
+      userEvent.click(closeButton);
+
+      // alert closed
+      prevAlertHeading = screen.queryByRole('heading');
+      expect(prevAlertHeading).toBeFalsy();
+
+      const nextWorkspace = constructWorkspace(devworkspace);
+      reRenderComponent({ workspace: nextWorkspace }, rerender);
+
+      // alert remains closed
+      const nextAlertHeading = screen.queryByRole('heading');
+      expect(nextAlertHeading).toBeFalsy();
+    });
+
+    // the alert should be reopened if the workspace status is changed
+    it('should reopen a failure error alert', () => {
+      const failureMessage = 'The workspace failed to start.';
+      const failedWorkspace = constructWorkspace(
+        new DevWorkspaceBuilder()
+          .withName('wksp')
+          .withNamespace('user')
+          .withStatus({ phase: 'FAILED', message: failureMessage })
+          .build(),
+      );
+      const startingWorkspace = constructWorkspace(
+        new DevWorkspaceBuilder()
+          .withName('wksp')
+          .withNamespace('user')
+          .withStatus({ phase: 'STARTING' })
+          .build(),
+      );
+
+      const { rerender } = renderComponent({ workspace: failedWorkspace });
+
+      // alert visible
+      let prevAlertHeading = screen.queryByRole('heading');
+      expect(prevAlertHeading).toBeTruthy();
+
+      const closeButton = screen.getByRole('button', {
+        name: /workspace failed/i,
+      });
+      userEvent.click(closeButton);
+
+      // alert closed
+      prevAlertHeading = screen.queryByRole('heading');
+      expect(prevAlertHeading).toBeFalsy();
+
+      // render the workspace in 'starting' phase
+      reRenderComponent({ workspace: startingWorkspace }, rerender);
+
+      // render the workspace in 'failed' phase again
+      reRenderComponent({ workspace: failedWorkspace }, rerender);
+
+      // alert should be visible
+      const nextAlertHeading = screen.queryByRole('heading');
+      expect(nextAlertHeading).toBeTruthy();
+    });
+  });
+});
+
+function renderComponent(options: {
+  workspace: Workspace;
+  conversionError?: string;
+  restartWarning?: boolean;
+}): RenderResult {
+  options.restartWarning = !!options.restartWarning;
+
+  return render(
+    <WorkspaceInlineAlerts
+      workspace={options.workspace}
+      conversionError={options.conversionError}
+      showRestartWarning={options.restartWarning}
+      onCloseConversionAlert={mockOnCloseConversionError}
+      onCloseRestartAlert={mockOnCloseRestartAlert}
+    />,
+  );
+}
+function reRenderComponent(
+  options: {
+    workspace: Workspace;
+    conversionError?: string;
+    restartWarning?: boolean;
+  },
+  rerender: (ui: React.ReactElement) => void,
+): void {
+  options.restartWarning = !!options.restartWarning;
+
+  rerender(
+    <WorkspaceInlineAlerts
+      workspace={options.workspace}
+      conversionError={options.conversionError}
+      showRestartWarning={options.restartWarning}
+      onCloseConversionAlert={mockOnCloseConversionError}
+      onCloseRestartAlert={mockOnCloseRestartAlert}
+    />,
+  );
+}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/index.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import {
+  AlertGroup,
+  Alert,
+  AlertVariant,
+  AlertActionCloseButton,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import devfileApi from '../../../services/devfileApi';
+import { DevWorkspaceStatus } from '../../../services/helpers/types';
+import { Workspace } from '../../../services/workspace-adapter';
+
+const migratingDocs =
+  'https://devfile.io/docs/devfile/2.1.0/user-guide/migrating-to-devfile-v2.html';
+
+type Props = {
+  workspace: Workspace;
+  conversionError: string | undefined;
+  onCloseConversionAlert: () => void;
+  showRestartWarning: boolean;
+  onCloseRestartAlert: () => void;
+};
+
+type State = {
+  showFailureAlert: boolean;
+};
+
+export class WorkspaceInlineAlerts extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      showFailureAlert: true,
+    };
+  }
+
+  private buildDeprecationAlert(): React.ReactElement {
+    return (
+      <Alert
+        variant={AlertVariant.warning}
+        isInline
+        title="This workspace is deprecated. Please refer the document below to see next steps."
+      >
+        <a href={migratingDocs} rel="noreferrer" target="_blank">
+          Migrating to devfile v2
+        </a>
+      </Alert>
+    );
+  }
+
+  private buildConversionAlert(): React.ReactElement {
+    const { conversionError } = this.props;
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        isInline
+        title="Workspace conversion failed."
+        actionClose={<AlertActionCloseButton onClose={() => this.props.onCloseConversionAlert()} />}
+      >
+        <TextContent>
+          {conversionError}
+          <Text component={TextVariants.small}>
+            Find manual instructions for converting devfile v1 to devfile v2 in the{' '}
+            <a href={migratingDocs} rel="noreferrer" target="_blank">
+              documentation
+            </a>
+            .
+          </Text>
+        </TextContent>
+      </Alert>
+    );
+  }
+
+  private buildRestartAlert(): React.ReactElement {
+    const { workspace } = this.props;
+    return (
+      <Alert
+        variant={AlertVariant.warning}
+        isInline
+        title={
+          <React.Fragment>
+            The workspace <em>{workspace.name}&nbsp;</em> should be restarted to apply changes.
+          </React.Fragment>
+        }
+        actionClose={<AlertActionCloseButton onClose={() => this.props.onCloseRestartAlert()} />}
+      />
+    );
+  }
+
+  private buildFailureAlert(): React.ReactElement {
+    const { workspace } = this.props;
+    if (!workspace.isDevWorkspace) {
+      return <></>;
+    }
+    const { status } = workspace.ref as devfileApi.DevWorkspace;
+    if (!status) {
+      return <></>;
+    }
+    const title = status.message;
+    if (!title) {
+      return <></>;
+    }
+
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        isInline
+        title={title}
+        actionClose={<AlertActionCloseButton onClose={() => this.handleCloseFailureAlert()} />}
+      />
+    );
+  }
+
+  private handleCloseFailureAlert(): void {
+    this.setState({
+      showFailureAlert: false,
+    });
+  }
+
+  public componentDidUpdate(prevProps: Props): void {
+    if (this.state.showFailureAlert === false) {
+      const showFailureAlert = this.props.workspace.status !== prevProps.workspace.status;
+      this.setState({
+        showFailureAlert,
+      });
+    }
+  }
+
+  render(): React.ReactElement {
+    const { workspace, conversionError, showRestartWarning: restartWarning } = this.props;
+    const { showFailureAlert } = this.state;
+
+    return (
+      <AlertGroup className={spacing.mbLg}>
+        {workspace.isDeprecated && this.buildDeprecationAlert()}
+        {conversionError && this.buildConversionAlert()}
+        {restartWarning && this.buildRestartAlert()}
+        {showFailureAlert &&
+          workspace.status === DevWorkspaceStatus.FAILED &&
+          this.buildFailureAlert()}
+      </AlertGroup>
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
@@ -17,7 +17,7 @@ import { WorkspaceNameFormGroup } from './WorkspaceName';
 import InfrastructureNamespaceFormGroup from './InfrastructureNamespace';
 import ProjectsFormGroup from './Projects';
 import { constructWorkspace, Workspace } from '../../../services/workspace-adapter';
-import devfileApi, { isDevWorkspace } from '../../../services/devfileApi';
+import devfileApi from '../../../services/devfileApi';
 
 type Props = {
   onSave: (workspace: Workspace) => Promise<void>;

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
@@ -76,7 +76,7 @@ export class OverviewTab extends React.Component<Props, State> {
     const workspaceName = this.props.workspace.name;
     const namespace = this.state.infrastructureNamespace;
     const projects = this.props.workspace.projects;
-    const readonly = isDevWorkspace(this.props.workspace.ref);
+    const readonly = this.props.workspace.isDeprecated || this.props.workspace.isDevWorkspace;
 
     return (
       <React.Fragment>

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
@@ -16,7 +16,7 @@ import StorageTypeFormGroup from './StorageType';
 import { WorkspaceNameFormGroup } from './WorkspaceName';
 import InfrastructureNamespaceFormGroup from './InfrastructureNamespace';
 import ProjectsFormGroup from './Projects';
-import { convertWorkspace, Workspace } from '../../../services/workspace-adapter';
+import { constructWorkspace, Workspace } from '../../../services/workspace-adapter';
 import devfileApi, { isDevWorkspace } from '../../../services/devfileApi';
 
 type Props = {
@@ -105,7 +105,7 @@ export class OverviewTab extends React.Component<Props, State> {
   }
 
   private async onSave(devfile: che.WorkspaceDevfile | devfileApi.Devfile): Promise<void> {
-    const workspaceCopy = convertWorkspace(this.props.workspace.ref);
+    const workspaceCopy = constructWorkspace(this.props.workspace.ref);
     workspaceCopy.devfile = devfile;
     await this.props.onSave(workspaceCopy);
   }

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { Link } from 'react-router-dom';
 import {
   Alert,
   AlertActionCloseButton,
@@ -37,9 +38,7 @@ import { selectIsLoading, selectWorkspaceById } from '../../store/Workspaces/sel
 import { History, UnregisterCallback, Location } from 'history';
 import { isCheWorkspace, Workspace } from '../../services/workspace-adapter';
 import UnsavedChangesModal from '../../components/UnsavedChangesModal';
-import { Link } from 'react-router-dom';
-import { isDevWorkspace } from '../../services/devfileApi';
-import { ORIGINAL_WORKSPACE_ID } from '../../containers/WorkspaceActions';
+import WorkspaceConversionButton from './ConversionButton';
 
 import './WorkspaceDetails.styl';
 
@@ -256,13 +255,19 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
               Show Original Devfile
             </Button>
           )}
+          {workspace.isDeprecated && (
+            <WorkspaceConversionButton
+              history={history}
+              oldWorkspace={workspace}
+              cleanupError={() => this.handleCloseConversionAlert()}
+              onError={errorMessage => this.handleConversionAlert(errorMessage)}
+            />
+          )}
           <HeaderActionSelect
             workspaceId={workspace.id}
             workspaceName={workspaceName}
             status={workspace.status}
             history={this.props.history}
-            onConversionAlert={errorMessage => this.handleConversionAlert(errorMessage)}
-            closeConversionAlert={() => this.handleCloseConversionAlert()}
           />
         </Header>
         <PageSection variant={SECTION_THEME} className="workspace-details-tabs">

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
@@ -23,6 +23,9 @@ import {
   PageSectionVariants,
   Tab,
   Tabs,
+  Text,
+  TextContent,
+  TextVariants,
 } from '@patternfly/react-core';
 import Head from '../../components/Head';
 import { WorkspaceDetailsTab, WorkspaceStatus } from '../../services/helpers/types';
@@ -41,6 +44,7 @@ import UnsavedChangesModal from '../../components/UnsavedChangesModal';
 import WorkspaceConversionButton from './ConversionButton';
 
 import './WorkspaceDetails.styl';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 export const SECTION_THEME = PageSectionVariants.light;
 
@@ -138,8 +142,22 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
     const { inlineAlertConversionError, inlineAlertRestartWarning } = this.state;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const workspaceName = this.props.workspace!.name;
+    const isDeprecated = this.props.workspace?.isDeprecated;
+    const migratingDocs =
+      'https://devfile.io/docs/devfile/2.1.0/user-guide/migrating-to-devfile-v2.html';
     return (
-      <AlertGroup>
+      <AlertGroup className={spacing.mbLg}>
+        {isDeprecated && (
+          <Alert
+            variant={AlertVariant.warning}
+            isInline
+            title="This workspace is deprecated. Please refer the document below to see next steps."
+          >
+            <a href={migratingDocs} rel="noreferrer" target="_blank">
+              Migrating to devfile v2
+            </a>
+          </Alert>
+        )}
         {inlineAlertConversionError && (
           <Alert
             variant={AlertVariant.danger}
@@ -149,7 +167,16 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
               <AlertActionCloseButton onClose={() => this.handleCloseConversionAlert()} />
             }
           >
-            {inlineAlertConversionError}
+            <TextContent>
+              {inlineAlertConversionError}
+              <Text component={TextVariants.small}>
+                Find manual instructions for converting devfile v1 to devfile v2 in the{' '}
+                <a href={migratingDocs} rel="noreferrer" target="_blank">
+                  documentation
+                </a>
+                .
+              </Text>
+            </TextContent>
           </Alert>
         )}
         {inlineAlertRestartWarning && (

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
@@ -30,7 +30,7 @@ import {
 import Head from '../../components/Head';
 import { WorkspaceDetailsTab, WorkspaceStatus } from '../../services/helpers/types';
 import Header from './Header';
-import CheProgress from '../../components/Progress';
+import ProgressIndicator from '../../components/Progress';
 import { AppState } from '../../store';
 import { HeaderActionSelect } from './Header/Actions';
 import { lazyInject } from '../../inversify.config';
@@ -301,7 +301,7 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
           {inlineAlerts}
           <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
             <Tab eventKey={WorkspaceDetailsTab.OVERVIEW} title={WorkspaceDetailsTab.OVERVIEW}>
-              <CheProgress isLoading={this.props.isLoading} />
+              <ProgressIndicator isLoading={this.props.isLoading} />
               <OverviewTab
                 ref={this.overviewTabPageRef}
                 workspace={workspace}
@@ -309,7 +309,7 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
               />
             </Tab>
             <Tab eventKey={WorkspaceDetailsTab.DEVFILE} title={WorkspaceDetailsTab.DEVFILE}>
-              <CheProgress isLoading={this.props.isLoading} />
+              <ProgressIndicator isLoading={this.props.isLoading} />
               <EditorTab
                 ref={this.editorTabPageRef}
                 workspace={workspace}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
@@ -17,6 +17,7 @@ import {
   AlertActionCloseButton,
   AlertGroup,
   AlertVariant,
+  Button,
   PageSection,
   PageSectionVariants,
   Tab,
@@ -33,16 +34,20 @@ import { AppAlerts } from '../../services/alerts/appAlerts';
 import OverviewTab, { OverviewTab as Overview } from './OverviewTab';
 import EditorTab, { EditorTab as Editor } from './EditorTab';
 import { selectIsLoading, selectWorkspaceById } from '../../store/Workspaces/selectors';
-import { History, UnregisterCallback } from 'history';
-
-import './WorkspaceDetails.styl';
+import { History, UnregisterCallback, Location } from 'history';
 import { isCheWorkspace, Workspace } from '../../services/workspace-adapter';
 import UnsavedChangesModal from '../../components/UnsavedChangesModal';
+import { Link } from 'react-router-dom';
+import { isDevWorkspace } from '../../services/devfileApi';
+import { ORIGINAL_WORKSPACE_ID } from '../../containers/WorkspaceActions';
+
+import './WorkspaceDetails.styl';
 
 export const SECTION_THEME = PageSectionVariants.light;
 
 type Props = {
   workspacesLink: string;
+  oldWorkspacePath?: Location;
   onSave: (workspace: Workspace, activeTab: WorkspaceDetailsTab | undefined) => Promise<void>;
   history: History;
 } & MappedProps;
@@ -228,7 +233,7 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { workspace, workspacesLink, history } = this.props;
+    const { workspace, workspacesLink, history, oldWorkspacePath } = this.props;
 
     if (!workspace) {
       return <div>Workspace not found.</div>;
@@ -246,6 +251,11 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
           workspaceName={workspaceName}
           status={workspace.status}
         >
+          {oldWorkspacePath && (
+            <Button variant="link" component={props => <Link {...props} to={oldWorkspacePath} />}>
+              Show Original Devfile
+            </Button>
+          )}
           <HeaderActionSelect
             workspaceId={workspace.id}
             workspaceName={workspaceName}

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
@@ -151,7 +151,9 @@ export function buildRow(
 
   /* Open IDE link */
   let open: React.ReactElement | string;
-  if (isDeleted || workspace.status === DevWorkspaceStatus.TERMINATING) {
+  if (workspace.isDeprecated) {
+    open = <></>;
+  } else if (isDeleted || workspace.status === DevWorkspaceStatus.TERMINATING) {
     open = 'deleting...';
   } else {
     if (isDevWorkspace) {

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
@@ -11,18 +11,16 @@
  */
 
 import React from 'react';
-import { History } from 'history';
+import { Link } from 'react-router-dom';
+import { Location } from 'history';
 import { IRow, SortByDirection } from '@patternfly/react-table';
+import { Button } from '@patternfly/react-core';
 import WorkspaceIndicator from '../../components/Workspace/Indicator';
 import { formatDate, formatRelativeDate } from '../../services/helpers/date';
-import {
-  buildDetailsLocation,
-  toHref,
-  buildIdeLoaderLocation,
-} from '../../services/helpers/location';
+import { buildDetailsLocation, buildIdeLoaderLocation } from '../../services/helpers/location';
 import { isCheWorkspace, Workspace } from '../../services/workspace-adapter';
 import devfileApi from '../../services/devfileApi';
-import { DevWorkspaceStatus } from '../../services/helpers/types';
+import { DevWorkspaceStatus, WorkspaceDetailsTab } from '../../services/helpers/types';
 
 export interface RowData extends IRow {
   props: {
@@ -31,7 +29,6 @@ export interface RowData extends IRow {
 }
 
 export function buildRows(
-  history: History,
   workspaces: Workspace[],
   toDelete: string[],
   filtered: string[],
@@ -59,11 +56,10 @@ export function buildRows(
       const isSelected = selected.includes(workspace.id);
       const isDeleted = toDelete.includes(workspace.id);
 
-      const locationToDetails = buildDetailsLocation(workspace);
-      const linkToDetails = toHref(history, locationToDetails);
+      const overviewPageLocation = buildDetailsLocation(workspace);
+      const devfilePageLocation = buildDetailsLocation(workspace, WorkspaceDetailsTab.DEVFILE);
 
-      const locationToIde = buildIdeLoaderLocation(workspace);
-      const linkToIde = toHref(history, locationToIde);
+      const ideLoaderLocation = buildIdeLoaderLocation(workspace);
 
       try {
         rows.push(
@@ -71,9 +67,9 @@ export function buildRows(
             workspace,
             isSelected,
             isDeleted,
-            linkToDetails,
-            linkToIde,
-            workspace.isDevWorkspace,
+            overviewPageLocation,
+            devfilePageLocation,
+            ideLoaderLocation,
           ),
         );
       } catch (e) {
@@ -96,9 +92,9 @@ export function buildRow(
   workspace: Workspace,
   isSelected: boolean,
   isDeleted: boolean,
-  linkToDetails: string,
-  linkToIde: string,
-  isDevWorkspace: boolean,
+  overviewPageLocation: Location,
+  devfilePageLocation: Location,
+  ideLoaderLocation: Location,
 ): RowData {
   if (!workspace.name) {
     throw new Error('Empty workspace name.');
@@ -113,7 +109,9 @@ export function buildRow(
   const details = (
     <span>
       {statusIndicator}
-      <a href={linkToDetails}>{workspace.name}</a>
+      <Button variant="link" component={props => <Link {...props} to={overviewPageLocation} />}>
+        {workspace.name}
+      </Button>
     </span>
   );
 
@@ -149,21 +147,45 @@ export function buildRow(
   }
   const projectsList = projects.join(', \n') || '-';
 
-  /* Open IDE link */
-  let open: React.ReactElement | string;
+  let action: React.ReactElement | string;
   if (workspace.isDeprecated) {
-    open = <></>;
+    action = (
+      <Button
+        variant="link"
+        isInline
+        isSmall
+        component={props => <Link {...props} to={devfilePageLocation} />}
+      >
+        Convert
+      </Button>
+    );
   } else if (isDeleted || workspace.status === DevWorkspaceStatus.TERMINATING) {
-    open = 'deleting...';
+    action = 'deleting...';
   } else {
-    if (isDevWorkspace) {
-      open = (
-        <a href={linkToIde} target={workspace.id} rel="noreferrer">
+    if (workspace.isDevWorkspace) {
+      action = (
+        <Button
+          variant="link"
+          isInline
+          isSmall
+          component={props => (
+            <Link {...props} to={ideLoaderLocation} rel="noreferrer" target={workspace.id} />
+          )}
+        >
           Open
-        </a>
+        </Button>
       );
     } else {
-      open = <a href={linkToIde}>Open</a>;
+      action = (
+        <Button
+          variant="link"
+          isInline
+          isSmall
+          component={props => <Link {...props} to={ideLoaderLocation} />}
+        >
+          Open
+        </Button>
+      );
     }
   }
 
@@ -183,12 +205,12 @@ export function buildRow(
       },
       {
         // Cell is visible only on Sm
-        title: open,
+        title: action,
         key: 'open-ide-visible-sm',
       },
       {
         // Cell is hidden only on Sm
-        title: open,
+        title: action,
         key: 'open-ide-hidden-sm',
       },
     ],

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/__tests__/index.spec.tsx
@@ -17,7 +17,7 @@ import { render, screen, RenderResult, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import WorkspacesListToolbar from '..';
 import { createFakeCheWorkspace } from '../../../../store/__mocks__/workspace';
-import { convertWorkspace, Workspace } from '../../../../services/workspace-adapter';
+import { constructWorkspace, Workspace } from '../../../../services/workspace-adapter';
 
 let workspaces: Workspace[];
 let isSelectedAll: boolean;
@@ -45,7 +45,7 @@ describe('Workspaces List Toolbar', () => {
   beforeEach(() => {
     workspaces = [0, 1, 2, 3, 4]
       .map(i => createFakeCheWorkspace('workspace-' + i, 'workspace-' + i))
-      .map(workspace => convertWorkspace(workspace));
+      .map(workspace => constructWorkspace(workspace));
     isSelectedAll = false;
     isEnabledDelete = false;
   });

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
@@ -20,7 +20,7 @@ import WorkspacesList from '..';
 import { BrandingData } from '../../../services/bootstrap/branding.constant';
 import { createFakeCheWorkspace } from '../../../store/__mocks__/workspace';
 import { WorkspaceAction, WorkspaceStatus } from '../../../services/helpers/types';
-import { convertWorkspace, Workspace } from '../../../services/workspace-adapter';
+import { constructWorkspace, Workspace } from '../../../services/workspace-adapter';
 
 jest.mock('../../../components/Head', () => {
   const FakeHead = () => {
@@ -55,7 +55,7 @@ describe('Workspaces List Page', () => {
   beforeEach(() => {
     workspaces = [0, 1, 2, 3, 4]
       .map(i => createFakeCheWorkspace('workspace-' + i, 'workspace-' + i))
-      .map(workspace => convertWorkspace(workspace));
+      .map(workspace => constructWorkspace(workspace));
     isDeleted = [];
   });
 
@@ -352,7 +352,7 @@ describe('Workspaces List Page', () => {
         status: WorkspaceStatus.RUNNING,
         activeEnv: 'default',
       };
-      workspaces[0] = convertWorkspace(
+      workspaces[0] = constructWorkspace(
         createFakeCheWorkspace(
           'workspace-' + 0,
           'workspace-' + 0,

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
@@ -26,7 +26,6 @@ import {
   WorkspaceAdapter,
 } from '../../../services/workspace-adapter';
 import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilder';
-import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
 
 jest.mock('../../../components/Head', () => {
   const FakeHead = () => {

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -160,6 +160,13 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
     if (workspace.isDeprecated) {
       return [
         {
+          title: 'Convert',
+          onClick: (event, rowId, rowData) => {
+            this.handleConversion(WorkspaceAction.CONVERT, rowData);
+          },
+          isDisabled: false === this.isEnabledAction(WorkspaceAction.CONVERT, workspace),
+        },
+        {
           title: 'Delete Workspace',
           onClick: (event, rowId, rowData) =>
             this.handleAction(WorkspaceAction.DELETE_WORKSPACE, rowData),
@@ -242,14 +249,24 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
       }
       this.props.history.push(nextPath);
     } catch (e) {
-      const workspace = this.props.workspaces.find(workspace => id === workspace.id);
-      const workspaceName = workspace?.name ? ` "${workspace?.name}"` : '';
       const errorMessage = common.helpers.errors.getMessage(e);
-      const message =
-        `Unable to ${action.toLocaleLowerCase()}${workspaceName}. ` +
-        errorMessage.replace('Error: ', '');
-      this.showAlert(message);
-      console.warn(message);
+      this.showAlert(errorMessage);
+      console.warn(errorMessage);
+    }
+  }
+
+  private async handleConversion(action: WorkspaceAction, rowData: IRowData): Promise<void> {
+    const id = (rowData as RowData).props.workspaceId;
+    try {
+      const nextLocation = await this.props.onAction(action, id);
+      if (!nextLocation) {
+        return;
+      }
+      this.props.history.replace(nextLocation);
+    } catch (e) {
+      const errorMessage = common.helpers.errors.getMessage(e);
+      this.showAlert(errorMessage);
+      console.warn(errorMessage);
     }
   }
 

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -142,10 +142,10 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
   }
 
   private buildRows(): RowData[] {
-    const { history, toDelete, workspaces } = this.props;
+    const { toDelete, workspaces } = this.props;
     const { filtered, selected, sortBy } = this.state;
 
-    return buildRows(history, workspaces, toDelete, filtered, selected, sortBy);
+    return buildRows(workspaces, toDelete, filtered, selected, sortBy);
   }
 
   private actionResolver(rowData: IRowData): IAction[] {
@@ -159,13 +159,6 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
 
     if (workspace.isDeprecated) {
       return [
-        {
-          title: 'Convert',
-          onClick: (event, rowId, rowData) => {
-            this.handleConversion(WorkspaceAction.CONVERT, rowData);
-          },
-          isDisabled: false === this.isEnabledAction(WorkspaceAction.CONVERT, workspace),
-        },
         {
           title: 'Delete Workspace',
           onClick: (event, rowId, rowData) =>
@@ -248,21 +241,6 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
         return;
       }
       this.props.history.push(nextPath);
-    } catch (e) {
-      const errorMessage = common.helpers.errors.getMessage(e);
-      this.showAlert(errorMessage);
-      console.warn(errorMessage);
-    }
-  }
-
-  private async handleConversion(action: WorkspaceAction, rowData: IRowData): Promise<void> {
-    const id = (rowData as RowData).props.workspaceId;
-    try {
-      const nextLocation = await this.props.onAction(action, id);
-      if (!nextLocation) {
-        return;
-      }
-      this.props.history.replace(nextLocation);
     } catch (e) {
       const errorMessage = common.helpers.errors.getMessage(e);
       this.showAlert(errorMessage);

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -157,6 +157,17 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
       return [];
     }
 
+    if (workspace.isDeprecated) {
+      return [
+        {
+          title: 'Delete Workspace',
+          onClick: (event, rowId, rowData) =>
+            this.handleAction(WorkspaceAction.DELETE_WORKSPACE, rowData),
+          isDisabled: false === this.isEnabledAction(WorkspaceAction.DELETE_WORKSPACE, workspace),
+        },
+      ];
+    }
+
     return [
       {
         title: 'Open in Verbose mode',

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -36,6 +36,8 @@ import { selectDwEditorsPluginsList } from '../../store/Plugins/devWorkspacePlug
 import devfileApi from '../devfileApi';
 import { selectDefaultNamespace } from '../../store/InfrastructureNamespaces/selectors';
 import { selectDevWorkspacesResourceVersion } from '../../store/Workspaces/devWorkspaces/selectors';
+import { WorkspaceAdapter } from '../workspace-adapter';
+import { selectDeprecatedWorkspacesIds } from '../../store/Workspaces/selectors';
 
 /**
  * This class executes a few initial instructions
@@ -144,6 +146,8 @@ export default class Bootstrap {
   private async fetchWorkspaces(): Promise<void> {
     const { requestWorkspaces } = WorkspacesStore.actionCreators;
     await requestWorkspaces()(this.store.dispatch, this.store.getState, undefined);
+    const deprecatedIds = selectDeprecatedWorkspacesIds(this.store.getState());
+    WorkspaceAdapter.setDeprecatedIds(deprecatedIds);
   }
 
   private async fetchPlugins(settings: che.WorkspaceSettings): Promise<void> {

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -13,12 +13,12 @@
 import { V1alpha2DevWorkspaceMetadata } from '@devfile/api';
 
 export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'che.eclipse.org/last-updated-timestamp';
-
 export const DEVWORKSPACE_CHE_EDITOR = 'che.eclipse.org/che-editor';
-
+export const ORIGINAL_WORKSPACE_ID_ANNOTATION = 'che.eclipse.org/original-workspace-id';
 type DevWorkspaceMetadataAnnotation = {
   [DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]?: string;
   [DEVWORKSPACE_CHE_EDITOR]?: string;
+  [ORIGINAL_WORKSPACE_ID_ANNOTATION]?: string;
 };
 
 export type DevWorkspaceMetadata = V1alpha2DevWorkspaceMetadata &

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -107,16 +107,34 @@ export function buildGettingStartedLocation(tab?: CreateWorkspaceTab): Location 
   return _buildLocationObject(pathAndQuery);
 }
 
-export function buildDetailsLocation(workspace: Workspace, tab?: WorkspaceDetailsTab): Location {
+export function buildDetailsLocation(
+  ...args:
+    | [namespace: string, workspaceName: string, pageTab?: WorkspaceDetailsTab]
+    | [workspace: Workspace, pageTab?: WorkspaceDetailsTab]
+): Location {
+  let workspaceName: string;
+  let namespace: string;
+  let tab: WorkspaceDetailsTab | undefined;
+  if (typeof args[0] === 'string') {
+    namespace = args[0];
+    workspaceName = args[1] as string;
+    tab = args[2];
+  } else {
+    const workspace = args[0];
+    namespace = workspace.namespace;
+    workspaceName = workspace.name;
+    tab = args[1] as WorkspaceDetailsTab | undefined;
+  }
+
   let pathAndQuery: string;
   if (!tab) {
-    pathAndQuery = ROUTE.WORKSPACE_DETAILS.replace(':namespace', workspace.namespace).replace(
+    pathAndQuery = ROUTE.WORKSPACE_DETAILS.replace(':namespace', namespace).replace(
       ':workspaceName',
-      workspace.name,
+      workspaceName,
     );
   } else {
-    pathAndQuery = ROUTE.WORKSPACE_DETAILS_TAB.replace(':namespace', workspace.namespace)
-      .replace(':workspaceName', workspace.name)
+    pathAndQuery = ROUTE.WORKSPACE_DETAILS_TAB.replace(':namespace', namespace)
+      .replace(':workspaceName', workspaceName)
       .replace(':tabId', tab);
   }
   return _buildLocationObject(pathAndQuery);

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -44,6 +44,8 @@ export type DevfileV2ProjectSource = {
   };
 };
 
+export type DeprecatedWorkspaceStatus = 'Deprecated';
+
 export enum WorkspaceStatus {
   RUNNING = 'RUNNING',
   STOPPING = 'STOPPING',

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -87,7 +87,6 @@ export enum WorkspaceAction {
   ADD_CUSTOM_WORKSPACE = 'Add Workspace',
   RESTART_WORKSPACE = 'Restart Workspace',
   EDIT_WORKSPACE = 'Edit Workspace',
-  CONVERT = 'Convert',
 }
 
 export type UserPreferencesTab = 'container-registries';

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -87,6 +87,7 @@ export enum WorkspaceAction {
   ADD_CUSTOM_WORKSPACE = 'Add Workspace',
   RESTART_WORKSPACE = 'Restart Workspace',
   EDIT_WORKSPACE = 'Edit Workspace',
+  CONVERT = 'Convert',
 }
 
 export type UserPreferencesTab = 'container-registries';

--- a/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
@@ -11,7 +11,7 @@
  */
 
 import { cloneDeep } from 'lodash';
-import { convertWorkspace } from '..';
+import { constructWorkspace } from '..';
 import {
   CheWorkspaceBuilder,
   CHE_DEVFILE_STUB,
@@ -40,14 +40,14 @@ describe('Workspace adapter', () => {
     it('should not throw when convert Che workspace', () => {
       const cheWorkspace = new CheWorkspaceBuilder().build();
       expect(() => {
-        convertWorkspace(cheWorkspace);
+        constructWorkspace(cheWorkspace);
       }).not.toThrow();
     });
 
     it('should not throw when convert Dev workspace', () => {
       const devWorkspace = new DevWorkspaceBuilder().build();
       expect(() => {
-        convertWorkspace(devWorkspace);
+        constructWorkspace(devWorkspace);
       }).not.toThrow();
     });
 
@@ -58,7 +58,7 @@ describe('Workspace adapter', () => {
         field: 'value',
       } as any;
       expect(() => {
-        convertWorkspace(obj);
+        constructWorkspace(obj);
       }).toThrow();
     });
   });
@@ -66,28 +66,28 @@ describe('Workspace adapter', () => {
   describe('for Che workspace', () => {
     it('should return reference to the workspace', () => {
       const cheWorkspace = new CheWorkspaceBuilder().build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.ref).toMatchObject(cheWorkspace);
     });
 
     it('should return ID', () => {
       const id = 'workspace1234asdf';
       const cheWorkspace = new CheWorkspaceBuilder().withId(id).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.id).toEqual(id);
     });
 
     it('should return name', () => {
       const name = 'wksp-1234';
       const cheWorkspace = new CheWorkspaceBuilder().withName(name).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.name).toEqual(name);
     });
 
     it('should return namespace', () => {
       const namespace = 'test-namespace';
       const cheWorkspace = new CheWorkspaceBuilder().withNamespace(namespace).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.namespace).toEqual(namespace);
     });
 
@@ -98,7 +98,7 @@ describe('Workspace adapter', () => {
           infrastructureNamespace,
         } as che.WorkspaceAttributes)
         .build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.infrastructureNamespace).toEqual(infrastructureNamespace);
     });
 
@@ -109,7 +109,7 @@ describe('Workspace adapter', () => {
           created,
         } as che.WorkspaceAttributes)
         .build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.created.toString()).toEqual(created);
     });
 
@@ -120,14 +120,14 @@ describe('Workspace adapter', () => {
           updated,
         } as che.WorkspaceAttributes)
         .build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.updated.toString()).toEqual(updated);
     });
 
     it('should return status', () => {
       const status = 'STARTING';
       const cheWorkspace = new CheWorkspaceBuilder().withStatus(status).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.status).toEqual(status);
     });
 
@@ -136,7 +136,7 @@ describe('Workspace adapter', () => {
       const runtime = CHE_RUNTIME_STUB;
       runtime.machines['theia-ide'].servers.theia.url = ideUrl;
       const cheWorkspace = new CheWorkspaceBuilder().withRuntime(runtime).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.ideUrl).toEqual(ideUrl);
     });
 
@@ -146,7 +146,7 @@ describe('Workspace adapter', () => {
         asyncPersist: 'false',
       };
       const cheWorkspace = new CheWorkspaceBuilder().withDevfile(cheDevfile).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.storageType).toEqual(StorageTypeTitle.ephemeral.toLowerCase());
     });
 
@@ -156,7 +156,7 @@ describe('Workspace adapter', () => {
         asyncPersist: 'false',
       };
       const cheWorkspace = new CheWorkspaceBuilder().withDevfile(cheDevfile).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.devfile).toMatchObject(cheDevfile);
     });
 
@@ -178,13 +178,13 @@ describe('Workspace adapter', () => {
         },
       ];
       const cheWorkspace = new CheWorkspaceBuilder().withProjects(projects).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
       expect(workspace.projects).toEqual([projects[0].name, projects[1].name]);
     });
 
     it('should set "ephemeral" storage type', () => {
       const cheWorkspace = new CheWorkspaceBuilder().withDevfile(cheDevfile).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
 
       expect(workspace.storageType).toEqual('persistent');
       expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual(undefined);
@@ -199,7 +199,7 @@ describe('Workspace adapter', () => {
 
     it('should set "async" storage type', () => {
       const cheWorkspace = new CheWorkspaceBuilder().withDevfile(cheDevfile).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
 
       expect(workspace.storageType).toEqual('persistent');
       expect((workspace.devfile as che.WorkspaceDevfile).attributes).toEqual(undefined);
@@ -218,7 +218,7 @@ describe('Workspace adapter', () => {
         persistVolumes: 'false',
       };
       const cheWorkspace = new CheWorkspaceBuilder().withDevfile(cheDevfile).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
 
       expect(workspace.storageType).toEqual('ephemeral');
 
@@ -235,7 +235,7 @@ describe('Workspace adapter', () => {
         asyncPersist: 'true',
       };
       const cheWorkspace = new CheWorkspaceBuilder().withDevfile(cheDevfile).build();
-      const workspace = convertWorkspace(cheWorkspace);
+      const workspace = constructWorkspace(cheWorkspace);
 
       expect(workspace.storageType).toEqual('async');
 
@@ -251,35 +251,35 @@ describe('Workspace adapter', () => {
   describe('for Dev workspace', () => {
     it('should return reference to the workspace', () => {
       const devWorkspace = new DevWorkspaceBuilder().build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.ref).toMatchObject(devWorkspace);
     });
 
     it('should return ID', () => {
       const id = '1234asdf';
       const devWorkspace = new DevWorkspaceBuilder().withId(id).build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.id).toEqual(id);
     });
 
     it('should return name', () => {
       const name = 'wksp-1234';
       const devWorkspace = new DevWorkspaceBuilder().withName(name).build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.name).toEqual(name);
     });
 
     it('should return namespace', () => {
       const namespace = 'test-namespace';
       const devWorkspace = new DevWorkspaceBuilder().withNamespace(namespace).build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.namespace).toEqual(namespace);
     });
 
     it('should return infrastructure namespace', () => {
       const infrastructureNamespace = 'infrastructure-namespace';
       const devWorkspace = new DevWorkspaceBuilder().withNamespace(infrastructureNamespace).build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.infrastructureNamespace).toEqual(infrastructureNamespace);
     });
 
@@ -288,7 +288,7 @@ describe('Workspace adapter', () => {
       const created = new Date(timestamp);
       const devWorkspace = new DevWorkspaceBuilder().build();
       devWorkspace.metadata.creationTimestamp = created;
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.created).toEqual(timestamp);
     });
 
@@ -299,27 +299,27 @@ describe('Workspace adapter', () => {
       devWorkspace.metadata.annotations = {
         [DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]: updated,
       };
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.updated).toEqual(timestamp);
     });
 
     it('should return status', () => {
       const status = 'STARTING';
       const devWorkspace = new DevWorkspaceBuilder().withStatus({ phase: status }).build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.status).toEqual(DevWorkspaceStatus[status]);
     });
 
     it('should return ideUrl', () => {
       const ideUrl = 'my/ide/url';
       const devWorkspace = new DevWorkspaceBuilder().withIdeUrl(ideUrl).build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.ideUrl).toEqual(ideUrl);
     });
 
     it('should return storage type', () => {
       const devWorkspace = new DevWorkspaceBuilder().build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.storageType).toEqual(StorageTypeTitle.persistent.toLowerCase());
     });
 
@@ -335,7 +335,7 @@ describe('Workspace adapter', () => {
         .withName('my-wksp')
         .withNamespace('my-namespace')
         .build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.devfile).toMatchObject(devfile);
     });
 
@@ -359,7 +359,7 @@ describe('Workspace adapter', () => {
         },
       ];
       const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
-      const workspace = convertWorkspace(devWorkspace);
+      const workspace = constructWorkspace(devWorkspace);
       expect(workspace.projects).toEqual([projects[0].name, projects[1].name]);
     });
   });

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -168,10 +168,10 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
         return new Date(parseInt(this.workspace.attributes.updated, 10)).getTime();
       }
     } else {
-      const timestampAnnotation =
+      const updated =
         this.workspace.metadata.annotations?.[DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION];
-      if (timestampAnnotation) {
-        return new Date(timestampAnnotation).getTime();
+      if (updated) {
+        return new Date(updated).getTime();
       }
     }
     return new Date().getTime();

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -334,7 +334,7 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
   }
 }
 
-export function convertWorkspace<T extends che.Workspace | devfileApi.DevWorkspace>(
+export function constructWorkspace<T extends che.Workspace | devfileApi.DevWorkspace>(
   workspace: T,
 ): Workspace {
   return new WorkspaceAdapter(workspace);

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -43,6 +43,7 @@ export interface Workspace {
   readonly isRunning: boolean;
   readonly hasError: boolean;
   readonly isDevWorkspace: boolean;
+  readonly isDeprecated: boolean;
 }
 
 export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -334,6 +334,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     pluginRegistryInternalUrl: string | undefined,
     editorId: string | undefined,
     optionalFilesContent: { [fileName: string]: string },
+    start = true,
   ): Promise<devfileApi.DevWorkspace> {
     if (!devfile.components) {
       devfile.components = [];
@@ -526,7 +527,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
       }),
     );
 
-    createdWorkspace.spec.started = true;
+    createdWorkspace.spec.started = start;
     const patch = [
       {
         op: 'replace',

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -665,6 +665,15 @@ export class DevWorkspaceClient extends WorkspaceClient {
     return DwApi.patchWorkspace(namespace, name, patch);
   }
 
+  async updateAnnotation(workspace: devfileApi.DevWorkspace): Promise<devfileApi.DevWorkspace> {
+    const patch: api.IPatch = {
+      op: 'replace',
+      path: '/metadata/annotations',
+      value: workspace.metadata.annotations || {},
+    };
+    return DwApi.patchWorkspace(workspace.metadata.namespace, workspace.metadata.name, [patch]);
+  }
+
   private escape(key: string): string {
     // We have to escape the slash and use ~1 instead. See https://tools.ietf.org/html/rfc6902#appendix-A.14
     return key.replace(/\//g, '~1');

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -140,6 +140,7 @@ export type ActionCreators = {
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
     attributes: { [key: string]: string },
+    start?: boolean,
   ) => AppThunk<KnownAction, Promise<void>>;
   createWorkspaceFromResources: (
     devworkspace: devfileApi.DevWorkspace,
@@ -496,6 +497,7 @@ export const actionCreators: ActionCreators = {
       pluginRegistryUrl: string | undefined,
       pluginRegistryInternalUrl: string | undefined,
       attributes: { [key: string]: string },
+      start = true,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       let state = getState();
@@ -541,6 +543,7 @@ export const actionCreators: ActionCreators = {
           pluginRegistryInternalUrl,
           cheEditor,
           optionalFilesContent,
+          start,
         );
 
         if (workspace.spec.started) {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -131,6 +131,9 @@ export type ActionCreators = {
   restartWorkspace: (workspace: devfileApi.DevWorkspace) => AppThunk<KnownAction, Promise<void>>;
   stopWorkspace: (workspace: devfileApi.DevWorkspace) => AppThunk<KnownAction, Promise<void>>;
   terminateWorkspace: (workspace: devfileApi.DevWorkspace) => AppThunk<KnownAction, Promise<void>>;
+  updateWorkspaceAnnotation: (
+    workspace: devfileApi.DevWorkspace,
+  ) => AppThunk<KnownAction, Promise<void>>;
   updateWorkspace: (workspace: devfileApi.DevWorkspace) => AppThunk<KnownAction, Promise<void>>;
   createWorkspaceFromDevfile: (
     devfile: devfileApi.Devfile,
@@ -414,6 +417,29 @@ export const actionCreators: ActionCreators = {
         });
 
         throw resMessage;
+      }
+    },
+
+  updateWorkspaceAnnotation:
+    (workspace: devfileApi.DevWorkspace): AppThunk<KnownAction, Promise<void>> =>
+    async (dispatch): Promise<void> => {
+      dispatch({ type: 'REQUEST_DEVWORKSPACE' });
+
+      try {
+        const updated = await devWorkspaceClient.updateAnnotation(workspace);
+        dispatch({
+          type: 'UPDATE_DEVWORKSPACE',
+          workspace: updated,
+        });
+      } catch (e) {
+        const errorMessage =
+          `Failed to update the workspace ${workspace.metadata.name}, reason: ` +
+          common.helpers.errors.getMessage(e);
+        dispatch({
+          type: 'RECEIVE_DEVWORKSPACE_ERROR',
+          error: errorMessage,
+        });
+        throw errorMessage;
       }
     },
 

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -116,6 +116,7 @@ export type ActionCreators = {
     optionalFilesContent?: {
       [fileName: string]: string;
     },
+    start?: boolean,
   ) => AppThunk<KnownAction, Promise<void>>;
 
   setWorkspaceQualifiedName: (
@@ -292,6 +293,7 @@ export const actionCreators: ActionCreators = {
       optionalFilesContent?: {
         [fileName: string]: string;
       },
+      start = true,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_WORKSPACES' });
@@ -311,6 +313,7 @@ export const actionCreators: ActionCreators = {
               pluginRegistryUrl,
               pluginRegistryInternalUrl,
               attributes,
+              start,
             ),
           );
           dispatch({ type: 'ADD_WORKSPACE' });

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -136,14 +136,12 @@ export const actionCreators: ActionCreators = {
       try {
         const state = getState();
         const cheDevworkspaceEnabled = isDevworkspacesEnabled(state.workspacesSettings.settings);
-        let requestWorkspaces: Promise<any>;
+        let requestWorkspaces: Promise<any> = Promise.resolve();
 
-        // Hide devfile v1 workspaces if the DevWorkspace engine is enabled - https://github.com/eclipse/che/issues/20900
         if (cheDevworkspaceEnabled) {
           requestWorkspaces = dispatch(DevWorkspacesStore.actionCreators.requestWorkspaces());
-        } else {
-          requestWorkspaces = dispatch(CheWorkspacesStore.actionCreators.requestWorkspaces());
         }
+        requestWorkspaces = dispatch(CheWorkspacesStore.actionCreators.requestWorkspaces());
 
         await requestWorkspaces;
 

--- a/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
@@ -12,7 +12,7 @@
 
 import { createSelector } from 'reselect';
 import { AppState } from '..';
-import { convertWorkspace, Workspace } from '../../services/workspace-adapter';
+import { constructWorkspace, Workspace } from '../../services/workspace-adapter';
 import { selectCheWorkspacesError } from './cheWorkspaces/selectors';
 import { selectDevWorkspacesError } from './devWorkspaces/selectors';
 
@@ -35,7 +35,7 @@ export const selectAllWorkspaces = createSelector(
   selectDevWorkspacesState,
   (cheWorkspacesState, devWorkspacesState) => {
     return [...cheWorkspacesState.workspaces, ...devWorkspacesState.workspaces].map(workspace =>
-      convertWorkspace(workspace),
+      constructWorkspace(workspace),
     );
   },
 );

--- a/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
@@ -126,10 +126,6 @@ export const selectRecentWorkspaces = createSelector(
       .sort(sortByUpdatedTimeFn)
       .slice(0, recentNumber),
 );
-export const selectAllWorkspacesNumber = createSelector(
-  selectAllWorkspaces,
-  allWorkspaces => allWorkspaces.length,
-);
 
 export const selectWorkspacesError = createSelector(
   selectCheWorkspacesError,

--- a/packages/dashboard-frontend/src/typings/che.d.ts
+++ b/packages/dashboard-frontend/src/typings/che.d.ts
@@ -64,6 +64,7 @@ declare namespace che {
     stackName?: string;
     errorMessage?: string;
     infrastructureNamespace: string;
+    converted?: string;
 
     [propName: string]: string | number | undefined;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,10 +357,10 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.39.2.tgz#a49d8a56345cbb52da7829652ffcad612e5f0391"
   integrity sha512-13zSFY4+YjYBQOzQTXE71fAX37HMQm/3rkMHN8c7Ejg1UF8ILXwC3Z28xzlMv4kSxtecn0/frqbwoZN8wRjc/g==
 
-"@eclipse-che/che-code-devworkspace-handler@1.64.0-dev-7ba5d3e":
-  version "1.64.0-dev-7ba5d3e"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-code-devworkspace-handler/-/che-code-devworkspace-handler-1.64.0-dev-7ba5d3e.tgz#f247e7959a7db2b0539238bcfbe5cb1cb6c59542"
-  integrity sha512-EQq/db7+MQsZm4D+XLnskQOkZjzyXWx/rTaNLTOHG51zE26GkJWgsDu9NrUADxuqZ3CMqO8GIlk9j91UfNL73Q==
+"@eclipse-che/che-code-devworkspace-handler@1.64.0-dev-210b722":
+  version "1.64.0-dev-210b722"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-code-devworkspace-handler/-/che-code-devworkspace-handler-1.64.0-dev-210b722.tgz#185625439849bb733e97eb2e34e1f415e0dcd0ed"
+  integrity sha512-QGDwuXZwxgt68dStE0JTMGB/GBnp6Q7EsDLuUZMR3yTswc44ZxAafvBS3K3pWtenErGManCwNJ+6FM8yP0Q7/A==
   dependencies:
     "@devfile/api" latest
     axios "0.21.2"
@@ -370,10 +370,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1639587602":
-  version "0.0.1-1639587602"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1639587602.tgz#ce26a00b7c668a3e2aa03a298c716354329ec4f9"
-  integrity sha512-vCzirEnaul87XaXXRGtr+wCJjJSM0M1BO4rdN7EazzdOLiucIF8kjvIk9Qjzbty2Pfx2ntveXI0wjnWFJ4l4UA==
+"@eclipse-che/che-theia-devworkspace-handler@0.0.1-1642670698":
+  version "0.0.1-1642670698"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-theia-devworkspace-handler/-/che-theia-devworkspace-handler-0.0.1-1642670698.tgz#c64f57b66b40b5e1f211eba7855609d71182a290"
+  integrity sha512-nRS7n/X+PV7S6o/KjPbI/OH35eUArQ4MBiBX7+SvlwEqyVk/8Fac+/zg1h/A3mT23DN6X47ooBT+eYNLGNSitg==
   dependencies:
     "@devfile/api" latest
     axios "0.21.2"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

With `devworkspaces.enabled: 'true'`, the dashboard :

- shows che-server workspaces as deprecated
- hides them from recent workspacspaces list
- don't allow to start/edit old workspaces
- and adds the ability to convert them into devworkspaces.

The conversion means that the old workspace devfile v1 is converted into devfile v2 and the new devfile is used to create a new devworkspace. When the conversion is done, the old workspace gets hidden from the workspaces list. In case it's necessary users still can view the old devfile.


### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/20845

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
