### PR TITLE
Prevent infinite reloads loop

### DIFF
--- a/packages/dashboard-backend/src/local-run/che-server.ts
+++ b/packages/dashboard-backend/src/local-run/che-server.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FastifyInstance, RouteShorthandOptions } from 'fastify';
+import { FastifyInstance, FastifyReply, FastifyRequest, RouteShorthandOptions } from 'fastify';
 import fastifyHttpProxy from 'fastify-http-proxy';
 
 export function registerCheApiProxy(
@@ -59,5 +59,11 @@ export function registerCheApiProxy(
       });
     }
     done();
+  });
+
+  // redirect to the Dashboard factory flow
+  server.get('/f', async (request: FastifyRequest, reply: FastifyReply) => {
+    const queryStr = request.url.replace('/f', '');
+    return reply.redirect('/dashboard/#/load-factory' + queryStr);
   });
 }

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.privateRepo.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.privateRepo.spec.tsx
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, waitFor } from '@testing-library/react';
+import { ROUTE } from '../../../route.enum';
+import { getMockRouterProps } from '../../../services/__mocks__/router';
+import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
+import FactoryLoaderContainer, { LoadFactorySteps } from '..';
+import { AlertOptions } from '../../../pages/IdeLoader';
+import { constructWorkspace, Devfile } from '../../../services/workspace-adapter';
+import { actionCreators as workspacesActionCreators } from '../../../store/Workspaces';
+import {
+  actionCreators as factoryResolverActionCreators,
+  isOAuthResponse,
+} from '../../../store/FactoryResolver';
+import SessionStorageService, { SessionStorageKey } from '../../../services/session-storage';
+import { RouterProps } from 'react-router';
+import { Store } from 'redux';
+
+const showAlertMock = jest.fn();
+const setWorkspaceQualifiedName = jest.fn();
+const createWorkspaceFromDevfileMock = jest.fn().mockResolvedValue(undefined);
+const requestWorkspaceMock = jest.fn().mockResolvedValue(undefined);
+const startWorkspaceMock = jest.fn().mockResolvedValue(undefined);
+const requestFactoryResolverMock = jest.fn().mockResolvedValue(undefined);
+const setWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
+const clearWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
+
+const createWorkspaceFromResourcesMock = jest.fn().mockReturnValue(undefined);
+jest.mock('../../../store/Workspaces/devWorkspaces/index', () => {
+  return {
+    actionCreators: {
+      createWorkspaceFromResources:
+        (devworkspace: string, devworkspaceTemplate: string) => async (): Promise<void> => {
+          createWorkspaceFromResourcesMock(devworkspace, devworkspaceTemplate);
+        },
+    },
+  };
+});
+
+jest.mock('../../../store/Workspaces');
+(workspacesActionCreators.requestWorkspace as jest.Mock).mockImplementation(
+  (id: string) => async () => requestWorkspaceMock(id),
+);
+(workspacesActionCreators.startWorkspace as jest.Mock).mockImplementation(
+  (workspace: string) => async () => startWorkspaceMock(workspace),
+);
+(workspacesActionCreators.createWorkspaceFromDevfile as jest.Mock).mockImplementation(
+  (
+      devfile: Devfile,
+      namespace: string,
+      infrastructureNamespace: string,
+      attributes: { [key: string]: string },
+    ) =>
+    async () => {
+      createWorkspaceFromDevfileMock(devfile, namespace, infrastructureNamespace, attributes);
+      return constructWorkspace({
+        id: 'id-wksp-test',
+        attributes: attributes as che.WorkspaceAttributes,
+        namespace,
+        devfile: devfile as che.WorkspaceDevfile,
+        temporary: false,
+        status: 'STOPPED',
+      });
+    },
+);
+(workspacesActionCreators.setWorkspaceId as jest.Mock).mockImplementation(
+  (id: string) => async () => setWorkspaceIdMock(id),
+);
+(workspacesActionCreators.clearWorkspaceId as jest.Mock).mockImplementation(
+  () => async () => clearWorkspaceIdMock(),
+);
+(workspacesActionCreators.setWorkspaceQualifiedName as jest.Mock).mockImplementation(
+  (namespace: string, workspaceName: string) => async () =>
+    setWorkspaceQualifiedName(namespace, workspaceName),
+);
+
+jest.mock('../../../store/FactoryResolver');
+const actualModule = jest.requireActual('../../../store/FactoryResolver');
+(isOAuthResponse as unknown as jest.Mock).mockImplementation(actualModule.isOAuthResponse);
+(factoryResolverActionCreators.requestFactoryResolver as jest.Mock).mockImplementation(
+  (
+      location: string,
+      overrideParams?: {
+        [params: string]: string;
+      },
+    ) =>
+    async () => {
+      if (!overrideParams) {
+        requestFactoryResolverMock(location);
+      } else {
+        requestFactoryResolverMock(location, overrideParams);
+      }
+    },
+);
+
+jest.mock('../../../pages/FactoryLoader', () => {
+  return function DummyWizard(props: {
+    hasError: boolean;
+    currentStep: LoadFactorySteps;
+    workspaceName: string;
+    workspaceId: string;
+    resolvedDevfileMessage?: string;
+    callbacks?: {
+      showAlert?: (alertOptions: AlertOptions) => void;
+    };
+  }): React.ReactElement {
+    if (props.callbacks) {
+      props.callbacks.showAlert = showAlertMock;
+    }
+    return (
+      <div>
+        Dummy Wizard
+        <div data-testid="factory-loader-has-error">{props.hasError.toString()}</div>
+        <div data-testid="factory-loader-current-step">{props.currentStep}</div>
+        <div data-testid="factory-loader-workspace-name">{props.workspaceName}</div>
+        <div data-testid="factory-loader-workspace-id">{props.workspaceId}</div>
+        <div data-testid="factory-loader-devfile-location-info">{props.resolvedDevfileMessage}</div>
+      </div>
+    );
+  };
+});
+
+describe('Factory Loader container', () => {
+  const privateRepoUrl = 'https://my-private.repo';
+  const oauthAuthenticationUrl = 'https://oauth_authentication_url';
+  const host = 'che-host';
+  const protocol = 'http://';
+
+  let spyWindowLocation: jest.SpyInstance;
+
+  beforeEach(() => {
+    (factoryResolverActionCreators.requestFactoryResolver as jest.Mock).mockImplementation(
+      () => async () => {
+        throw {
+          attributes: {
+            oauth_provider: 'oauth_provider',
+            oauth_authentication_url: oauthAuthenticationUrl,
+          },
+        };
+      },
+    );
+    spyWindowLocation = createWindowLocationSpy(host, protocol);
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    spyWindowLocation.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  describe('Resolving a private repository devfile', () => {
+    it('should handle the the namespace absence', async () => {
+      const store = new FakeStoreBuilder().build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: privateRepoUrl });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      await waitFor(() =>
+        expect(showAlertMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: expect.stringMatching('The infrastructure namespace is required to be created.'),
+          }),
+        ),
+      );
+    });
+
+    it('should redirect to login page', async () => {
+      const store = new FakeStoreBuilder()
+        .withInfrastructureNamespace([{ name: 'user-che', attributes: { phase: 'Active' } }])
+        .build();
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: privateRepoUrl });
+
+      render(
+        <Provider store={store}>
+          <FactoryLoaderContainer {...props} />
+        </Provider>,
+      );
+
+      const expectedRedirectUrl = `${oauthAuthenticationUrl}/&redirect_after_login=${protocol}${host}/f?url=${encodeURIComponent(
+        privateRepoUrl,
+      )}`;
+
+      await waitFor(() => expect(spyWindowLocation).toHaveBeenCalledWith(expectedRedirectUrl));
+    });
+
+    describe('prevent reloading loop', () => {
+      let store: Store;
+      let props: RouterProps;
+
+      beforeEach(() => {
+        store = new FakeStoreBuilder()
+          .withInfrastructureNamespace([{ name: 'user-che', attributes: { phase: 'Active' } }])
+          .build();
+        props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: privateRepoUrl });
+      });
+
+      test('page reloads number is less than the limit', async () => {
+        const spyStorageGet = jest.spyOn(SessionStorageService, 'get');
+        const spyStorageUpdate = jest.spyOn(SessionStorageService, 'update');
+
+        render(
+          <Provider store={store}>
+            <FactoryLoaderContainer {...props} />
+          </Provider>,
+        );
+
+        const expectedRedirectUrl = `${oauthAuthenticationUrl}/&redirect_after_login=${protocol}${host}/f?url=${encodeURIComponent(
+          privateRepoUrl,
+        )}`;
+
+        await waitFor(() => expect(spyWindowLocation).toHaveBeenCalledWith(expectedRedirectUrl));
+
+        expect(spyStorageGet).toHaveBeenCalled();
+
+        expect(spyStorageUpdate).toHaveBeenCalledTimes(1);
+        expect(spyStorageUpdate).toHaveBeenCalledWith(
+          SessionStorageKey.PRIVATE_FACTORY_RELOADS,
+          expect.stringContaining(privateRepoUrl),
+        );
+        expect(spyStorageUpdate).toHaveBeenCalledWith(
+          SessionStorageKey.PRIVATE_FACTORY_RELOADS,
+          expect.stringContaining('1'),
+        );
+      });
+
+      test('page reloads number equals the limit', async () => {
+        const spyStorageGet = jest
+          .spyOn(SessionStorageService, 'get')
+          .mockImplementationOnce(() => {
+            return JSON.stringify({
+              [privateRepoUrl]: 2,
+            });
+          });
+        const spyStorageUpdate = jest.spyOn(SessionStorageService, 'update');
+
+        render(
+          <Provider store={store}>
+            <FactoryLoaderContainer {...props} />
+          </Provider>,
+        );
+
+        await waitFor(() => expect(showAlertMock).toHaveBeenCalled());
+
+        expect(spyWindowLocation).not.toHaveBeenCalledWith();
+
+        expect(spyStorageGet).toHaveBeenCalled();
+        expect(spyStorageUpdate).not.toHaveBeenCalled();
+      });
+
+      test('page reloads number is more than the limit', async () => {
+        const spyStorageGet = jest
+          .spyOn(SessionStorageService, 'get')
+          .mockImplementationOnce(() => {
+            return JSON.stringify({
+              [privateRepoUrl]: 2,
+            });
+          });
+        const spyStorageUpdate = jest.spyOn(SessionStorageService, 'update');
+
+        render(
+          <Provider store={store}>
+            <FactoryLoaderContainer {...props} />
+          </Provider>,
+        );
+
+        await waitFor(() => expect(showAlertMock).toHaveBeenCalled());
+
+        expect(spyWindowLocation).not.toHaveBeenCalledWith();
+
+        expect(spyStorageGet).toHaveBeenCalled();
+        expect(spyStorageUpdate).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+function createWindowLocationSpy(host: string, protocol: string): jest.SpyInstance {
+  delete (window as any).location;
+  (window.location as any) = {
+    host,
+    protocol,
+  };
+  Object.defineProperty(window.location, 'href', {
+    set: () => {
+      // no-op
+    },
+    configurable: true,
+  });
+  return jest.spyOn(window.location, 'href', 'set');
+}

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.spec.tsx
@@ -33,6 +33,7 @@ import {
   actionCreators as factoryResolverActionCreators,
   isOAuthResponse,
 } from '../../../store/FactoryResolver';
+import SessionStorageService, { SessionStorageKey } from '../../../services/session-storage';
 
 const showAlertMock = jest.fn();
 const setWorkspaceQualifiedName = jest.fn();
@@ -44,7 +45,7 @@ const setWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
 const clearWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
 
 const createWorkspaceFromResourcesMock = jest.fn().mockReturnValue(undefined);
-jest.mock('../../store/Workspaces/devWorkspaces/index', () => {
+jest.mock('../../../store/Workspaces/devWorkspaces/index', () => {
   return {
     actionCreators: {
       createWorkspaceFromResources:
@@ -55,7 +56,7 @@ jest.mock('../../store/Workspaces/devWorkspaces/index', () => {
   };
 });
 
-jest.mock('../../store/Workspaces');
+jest.mock('../../../store/Workspaces');
 (workspacesActionCreators.requestWorkspace as jest.Mock).mockImplementation(
   (id: string) => async () => requestWorkspaceMock(id),
 );
@@ -92,8 +93,8 @@ jest.mock('../../store/Workspaces');
     setWorkspaceQualifiedName(namespace, workspaceName),
 );
 
-jest.mock('../../store/FactoryResolver');
-const actualModule = jest.requireActual('../../store/FactoryResolver');
+jest.mock('../../../store/FactoryResolver');
+const actualModule = jest.requireActual('../../../store/FactoryResolver');
 (isOAuthResponse as unknown as jest.Mock).mockImplementation(actualModule.isOAuthResponse);
 (factoryResolverActionCreators.requestFactoryResolver as jest.Mock).mockImplementation(
   (
@@ -111,7 +112,7 @@ const actualModule = jest.requireActual('../../store/FactoryResolver');
     },
 );
 
-jest.mock('../../pages/FactoryLoader', () => {
+jest.mock('../../../pages/FactoryLoader', () => {
   return function DummyWizard(props: {
     hasError: boolean;
     currentStep: LoadFactorySteps;
@@ -950,74 +951,41 @@ metadata:
         `Devfile version 1 found, converting it to devfile version 1.`,
       );
     });
-  });
 
-  describe('Resolving a private repository devfile', () => {
-    it('should handle the the namespace absence', async () => {
-      const location = 'private-repository-location';
+    it('should not store number of reloads', async () => {
+      const location = 'https://my-repository-location';
 
       (factoryResolverActionCreators.requestFactoryResolver as jest.Mock).mockImplementation(
         () => async () => {
-          throw {
-            attributes: {
-              oauth_provider: 'oauth_provider',
-              oauth_authentication_url: 'oauth_authentication_url',
-            },
-          };
+          requestFactoryResolverMock();
         },
       );
 
-      const store = new FakeStoreBuilder().build();
-      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: location });
-
-      render(
-        <Provider store={store}>
-          <FactoryLoaderContainer {...props} />
-        </Provider>,
-      );
-
-      await waitFor(() =>
-        expect(showAlertMock).toHaveBeenCalledWith(
-          expect.objectContaining({
-            title: expect.stringMatching('The infrastructure namespace is required to be created.'),
-          }),
-        ),
-      );
-    });
-
-    it('should redirect to login page', async () => {
-      const privateRepoUrl = 'https://my-private.repo';
-      const oauthAuthenticationUrl = 'https://oauth_authentication_url';
-      const host = 'che-host';
-      const protocol = 'http://';
-      delete (window as any).location;
-      (window.location as any) = {
-        host,
-        protocol,
-      };
-      Object.defineProperty(window.location, 'href', {
-        set: () => {
-          // no-op
+      const devfile = {
+        schemaVersion: '2.3.4',
+        metadata: {
+          name: 'my-project',
         },
-        configurable: true,
-      });
-      const spy = jest.spyOn(window.location, 'href', 'set');
-
-      (factoryResolverActionCreators.requestFactoryResolver as jest.Mock).mockImplementation(
-        () => async () => {
-          throw {
-            attributes: {
-              oauth_provider: 'oauth_provider',
-              oauth_authentication_url: oauthAuthenticationUrl,
-            },
-          };
-        },
-      );
+      } as devfileApi.Devfile;
 
       const store = new FakeStoreBuilder()
-        .withInfrastructureNamespace([{ name: 'user-che', attributes: { phase: 'Active' } }])
+        .withFactoryResolver(
+          {
+            devfile,
+            location,
+          } as ResolverState,
+          {
+            isConverted: false,
+          } as ConvertedState,
+        )
+        .withWorkspacesSettings({
+          'che.devworkspaces.enabled': 'true',
+        })
         .build();
-      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: privateRepoUrl });
+      const props = getMockRouterProps(ROUTE.LOAD_FACTORY_URL, { url: location });
+
+      const spyStorageGet = jest.spyOn(SessionStorageService, 'get');
+      const spyStorageUpdate = jest.spyOn(SessionStorageService, 'update');
 
       render(
         <Provider store={store}>
@@ -1025,11 +993,14 @@ metadata:
         </Provider>,
       );
 
-      const expectedRedirectUrl = `${oauthAuthenticationUrl}/&redirect_after_login=${protocol}${host}/f?url=${encodeURIComponent(
-        privateRepoUrl,
-      )}`;
+      await waitFor(() => expect(requestFactoryResolverMock).toHaveBeenCalled());
 
-      await waitFor(() => expect(spy).toHaveBeenCalledWith(expectedRedirectUrl));
+      expect(spyStorageGet).not.toHaveBeenCalled();
+      expect(spyStorageUpdate).toHaveBeenCalledTimes(1);
+      expect(spyStorageUpdate).toHaveBeenCalledWith(
+        SessionStorageKey.PRIVATE_FACTORY_RELOADS,
+        '{}',
+      );
     });
   });
 });

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.spec.tsx
@@ -15,24 +15,24 @@ import { Provider } from 'react-redux';
 import { AlertVariant } from '@patternfly/react-core';
 import { RenderResult, render, screen, waitFor } from '@testing-library/react';
 import mockAxios from 'axios';
-import { ROUTE } from '../../route.enum';
-import { getMockRouterProps } from '../../services/__mocks__/router';
-import { FakeStoreBuilder } from '../../store/__mocks__/storeBuilder';
-import { createFakeCheWorkspace } from '../../store/__mocks__/workspace';
-import { WorkspaceStatus } from '../../services/helpers/types';
-import FactoryLoaderContainer, { LoadFactorySteps } from '../FactoryLoader';
-import { AlertOptions } from '../../pages/IdeLoader';
-import { constructWorkspace, Devfile, WorkspaceAdapter } from '../../services/workspace-adapter';
-import { DevWorkspaceBuilder } from '../../store/__mocks__/devWorkspaceBuilder';
-import devfileApi from '../../services/devfileApi';
+import { ROUTE } from '../../../route.enum';
+import { getMockRouterProps } from '../../../services/__mocks__/router';
+import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
+import { createFakeCheWorkspace } from '../../../store/__mocks__/workspace';
+import { WorkspaceStatus } from '../../../services/helpers/types';
+import FactoryLoaderContainer, { LoadFactorySteps } from '../../FactoryLoader';
+import { AlertOptions } from '../../../pages/IdeLoader';
+import { constructWorkspace, Devfile, WorkspaceAdapter } from '../../../services/workspace-adapter';
+import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
+import devfileApi from '../../../services/devfileApi';
 import { safeDump } from 'js-yaml';
-import { CheWorkspaceBuilder } from '../../store/__mocks__/cheWorkspaceBuilder';
-import { ConvertedState, ResolverState } from '../../store/FactoryResolver';
-import { actionCreators as workspacesActionCreators } from '../../store/Workspaces';
+import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilder';
+import { ConvertedState, ResolverState } from '../../../store/FactoryResolver';
+import { actionCreators as workspacesActionCreators } from '../../../store/Workspaces';
 import {
   actionCreators as factoryResolverActionCreators,
   isOAuthResponse,
-} from '../../store/FactoryResolver';
+} from '../../../store/FactoryResolver';
 
 const showAlertMock = jest.fn();
 const setWorkspaceQualifiedName = jest.fn();

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -440,12 +440,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       }
       const fullOauthUrl =
         oauthUrlTmp.toString() + '&redirect_after_login=' + redirectUrl.toString();
-
-      if (isDevEnvironment(env)) {
-        window.open(fullOauthUrl);
-      } else {
-        window.location.href = fullOauthUrl;
-      }
+      window.location.href = fullOauthUrl;
     } catch (e) {
       this.showAlert('Failed to open authentication page.');
       throw e;

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -49,6 +49,7 @@ import { DEVWORKSPACE_DEVFILE_SOURCE } from '../../services/workspace-client/dev
 import devfileApi from '../../services/devfileApi';
 import getRandomString from '../../services/helpers/random';
 import { isDevworkspacesEnabled } from '../../services/helpers/devworkspace';
+import SessionStorageService, { SessionStorageKey } from '../../services/session-storage';
 
 const WS_ATTRIBUTES_TO_SAVE: string[] = [
   'workspaceDeploymentLabels',
@@ -73,6 +74,11 @@ export enum LoadFactorySteps {
   START_WORKSPACE,
   OPEN_IDE,
 }
+
+const RELOADS_LIMIT = 2;
+type ReloadsInfo = {
+  [url: string]: number;
+};
 
 type Props = MappedProps & { history: History };
 
@@ -289,8 +295,16 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       : undefined;
     try {
       await this.props.requestFactoryResolver(location, override);
+      this.clearNumberOfTries();
     } catch (e) {
       if (isOAuthResponse(e)) {
+        const isOk = this.checkNumberOfTries(location);
+        if (isOk) {
+          this.increaseNumberOfTries(location);
+        } else {
+          return;
+        }
+
         this.resolvePrivateDevfile(e.attributes.oauth_authentication_url, location);
         return;
       }
@@ -342,17 +356,75 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
     return devfile;
   }
 
-  private resolvePrivateDevfile(oauthUrl: string, location: string): void {
-    try {
-      // looking for a pre-created infrastructure namespace
-      const namespaces = this.props.infrastructureNamespaces;
-      if (namespaces.length === 0 || (namespaces.length === 1 && !namespaces[0].attributes.phase)) {
-        this.showAlert(
-          'Failed to accept the factory URL. The infrastructure namespace is required to be created. Please create a regular workspace to workaround the issue and open factory URL again.',
-        );
-        return;
-      }
+  private getNumberOfTries(location: string): number {
+    const reloads = this.getReloadsInfo();
+    return reloads[location] || 0;
+  }
 
+  private increaseNumberOfTries(location: string): void {
+    const reloads = this.getReloadsInfo();
+    if (!reloads[location]) {
+      reloads[location] = 0;
+    }
+    reloads[location]++;
+    this.setReloadsInfo(reloads);
+  }
+
+  private clearNumberOfTries(): void {
+    const reloads = {};
+    this.setReloadsInfo(reloads);
+  }
+
+  private getReloadsInfo(): ReloadsInfo {
+    const strReloads = SessionStorageService.get(SessionStorageKey.PRIVATE_FACTORY_RELOADS);
+    if (!strReloads) {
+      return {};
+    }
+    try {
+      return JSON.parse(strReloads);
+    } catch (e) {
+      return {};
+    }
+  }
+
+  private setReloadsInfo(reloads: ReloadsInfo): void {
+    const strReloads = JSON.stringify(reloads);
+    SessionStorageService.update(SessionStorageKey.PRIVATE_FACTORY_RELOADS, strReloads);
+  }
+
+  /**
+   * Checks if page reloads number for given private repo URL is less than the limit.
+   * @param location
+   * @returns `true` if reloads limit is not reached yet. Otherwise, returns `false` and shows an alert notification.
+   */
+  private checkNumberOfTries(location: string): boolean {
+    // check how many times this factory was tried to be resolved.
+    // if the number of tries is too high that may be the infinite reloading loop. Show alert notification and ask user to take an action.
+    const reloadsNumber = this.getNumberOfTries(location);
+    if (reloadsNumber < RELOADS_LIMIT) {
+      return true;
+    }
+
+    this.showAlert({
+      alertActionLinks: this.errorActionLinks(),
+      title:
+        'The Dashboard reached a limit of reloads while trying to resolve a devfile in a private repo. Please contact admin to check if OAuth is configured correctly.',
+      alertVariant: AlertVariant.danger,
+    });
+    return false;
+  }
+
+  private resolvePrivateDevfile(oauthUrl: string, location: string): void {
+    // looking for a pre-created infrastructure namespace
+    const namespaces = this.props.infrastructureNamespaces;
+    if (namespaces.length === 0 || (namespaces.length === 1 && !namespaces[0].attributes.phase)) {
+      this.showAlert(
+        'Failed to accept the factory URL. The infrastructure namespace is required to be created. Please create a regular workspace to workaround the issue and open factory URL again.',
+      );
+      return;
+    }
+
+    try {
       const env = getEnvironment();
       // build redirect URL
       let redirectHost = window.location.protocol + '//' + window.location.host;

--- a/packages/dashboard-frontend/src/services/session-storage/index.ts
+++ b/packages/dashboard-frontend/src/services/session-storage/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export enum SessionStorageKey {
+  PRIVATE_FACTORY_RELOADS = 'private-factory-reloads-number',
+}
+
+export default class SessionStorageService {
+  static update(key: SessionStorageKey, value: string): void {
+    window.sessionStorage.setItem(key, value);
+  }
+
+  static get(key: SessionStorageKey): string | undefined {
+    return window.sessionStorage.getItem(key) || undefined;
+  }
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR makes the dashboard limit the number of reloads during factory flow. If there happen two reloads in a row then the dashboard stops resolving the devfile.


https://user-images.githubusercontent.com/16220722/152542768-06db0482-757a-4398-9f97-9a549430fc5d.mp4



### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/21077


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. [Configure GitHub OAuth](https://www.eclipse.org/che/docs/che-7/administration-guide/configuring-authorization/#configuring-github-oauth_che) with a wrong secret
2. Create factory using a private repo url

