### PR TITLE
 Provide devfile parent section to a new devworkspace

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/converter.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/converter.spec.ts
@@ -26,6 +26,7 @@ describe('testing sample conversions', () => {
       expect(devfileToDevWorkspace(input, 'che', true)).toStrictEqual(output);
     });
   });
+
   describe('devworkspace to devfile', () => {
     test('the sample-devworkspace fixture should convert into sample-devfile fixture', () => {
       const input: any = yaml.load(
@@ -33,6 +34,28 @@ describe('testing sample conversions', () => {
       );
       const output = yaml.load(
         fs.readFileSync(__dirname + '/fixtures/sample-devfile.yaml', 'utf-8'),
+      );
+      delete (output as any).metadata.attributes;
+      expect(devWorkspaceToDevfile(input)).toStrictEqual(output);
+    });
+  });
+  describe('parent section', () => {
+    test('the test-devfile-parent fixture should convert into test-devworkspace-parent fixture', () => {
+      const input: any = yaml.load(
+        fs.readFileSync(__dirname + '/fixtures/test-devfile-parent.yaml', 'utf-8'),
+      );
+      const output = yaml.load(
+        fs.readFileSync(__dirname + '/fixtures/test-devworkspace-parent.yaml', 'utf-8'),
+      );
+      expect(devfileToDevWorkspace(input, 'che', true)).toStrictEqual(output);
+    });
+
+    test('the test-devworkspace-parent fixture should convert into test-devfile-parent fixture', () => {
+      const input: any = yaml.load(
+        fs.readFileSync(__dirname + '/fixtures/test-devworkspace-parent.yaml', 'utf-8'),
+      );
+      const output = yaml.load(
+        fs.readFileSync(__dirname + '/fixtures/test-devfile-parent.yaml', 'utf-8'),
       );
       delete (output as any).metadata.attributes;
       expect(devWorkspaceToDevfile(input)).toStrictEqual(output);

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devfile-parent.yaml
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devfile-parent.yaml
@@ -1,0 +1,12 @@
+schemaVersion: 2.1.0
+metadata:
+  name: nodejs-stack
+  namespace: dwclient-test
+  attributes:
+    author: Somebody
+    dw.metadata.annotations:
+      any.custom.settings: 'true'
+parent:
+  id: nodejs
+  registryUrl: "https://registry.devfile.io"
+components: []

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devworkspace-parent.yaml
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devworkspace-parent.yaml
@@ -1,0 +1,17 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  labels: {}
+  name: nodejs-stack
+  namespace: dwclient-test
+  annotations:
+    any.custom.settings: 'true'
+  uid: ''
+spec:
+  routingClass: che
+  started: true
+  template:
+    parent:
+      id: nodejs
+      registryUrl: "https://registry.devfile.io"
+    components: []

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
@@ -42,6 +42,9 @@ export function devfileToDevWorkspace(
       },
     },
   };
+  if (devfile.parent) {
+    template.spec.template.parent = devfile.parent;
+  }
   if (devfile.projects) {
     template.spec.template.projects = devfile.projects;
   }
@@ -66,6 +69,9 @@ export function devWorkspaceToDevfile(devworkspace: devfileApi.DevWorkspace): de
     },
     components: [],
   } as devfileApi.Devfile;
+  if (devworkspace.spec.template.parent) {
+    template.parent = devworkspace.spec.template.parent;
+  }
   if (devworkspace.spec.template.projects) {
     template.projects = devworkspace.spec.template.projects;
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

With this fix, the dashboard will not ignore `parent` section of a devfile while creating new workspaces.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/21098
