### PR TITLE
fix: generateName is not executed if devfile v2

### DIFF
--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -423,11 +423,11 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       if (isCheDevfile(devfile)) {
         attrs.stackName = stackName;
         delete attrs.factoryParams;
-        if (!devfile.metadata.name && devfile.metadata.generateName) {
-          const name = devfile.metadata.generateName + getRandomString(4).toLowerCase();
-          delete devfile.metadata.generateName;
-          devfile.metadata.name = name;
-        }
+      }
+      if (!devfile.metadata.name && devfile.metadata.generateName) {
+        const name = devfile.metadata.generateName + getRandomString(4).toLowerCase();
+        delete devfile.metadata.generateName;
+        devfile.metadata.name = name;
       }
       const namespace = this.props.defaultNamespace?.name;
       try {

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/metadata.ts
@@ -14,6 +14,7 @@ import { V220DevfileMetadata } from '@devfile/api';
 
 export type DevfileMetadataLike = V220DevfileMetadata & {
   namespace?: string;
+  generateName?: string;
 };
 
 export type DevfileMetadata = DevfileMetadataLike &

--- a/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
@@ -24,7 +24,11 @@ export function isDevfileV2(devfile: unknown): devfile is devfileApi.Devfile {
 }
 
 export function isDevfileV2Metadata(metadata: unknown): metadata is devfileApi.DevfileMetadata {
-  return metadata !== undefined && (metadata as devfileApi.DevfileMetadata).name !== undefined;
+  return (
+    metadata !== undefined &&
+    ((metadata as devfileApi.DevfileMetadata).name !== undefined ||
+      (metadata as devfileApi.DevfileMetadata).generateName !== undefined)
+  );
 }
 
 export function isDevWorkspaceLike(workspace: unknown): workspace is devfileApi.DevWorkspaceLike {


### PR DESCRIPTION
See discussion here: https://github.com/eclipse/che/issues/21067

---

If starting a devfile v2 that has generateName instead of name v2 checks fail since they only check for `name`. See: https://github.com/nils-mosbach/che-dashboard/blob/f9c2a7c087871c6095b033729c51729f779f252c/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts#L19-L24

This leads to the following message:

``` 
Failed to create a workspace. Failed to create a new workspace from the devfile, reason: Failed to create a new workspace. Unable to create devworkspace: DevWorkspace.workspace.devfile.io "devfile-test" is invalid: [<nil>: Invalid value: "": "spec.template.components" must validate one and only one schema (oneOf). Found none valid, spec.template.components.container: Required value, spec.template.components.name: Invalid value: "": spec.template.components.name in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$']
```

This pull request executes generateName to name conversion on all Devfiles (not just v1).
