### PR TITLE
fix: skip DevWorkspaceTemplate updates for sidecarless editors (che-code)

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -927,6 +927,11 @@ export class DevWorkspaceClient extends WorkspaceClient {
         pluginsByUrl[url] = plugin;
       }
 
+      if (plugin.metadata.name.toLowerCase().includes('che-code')) {
+        // skip updates for editors in sidecarless mode
+        continue;
+      }
+
       const spec: Partial<V1alpha2DevWorkspaceTemplateSpec> = {};
       for (const key in plugin) {
         if (key !== 'schemaVersion' && key !== 'metadata') {

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -927,7 +927,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
         pluginsByUrl[url] = plugin;
       }
 
-      if (plugin.metadata.name.toLowerCase().includes('che-code')) {
+      const skipEditors = ['che-code', 'idea', 'pycharm'];
+      if (skipEditors.some(e => plugin?.metadata?.name?.toLowerCase().includes(e))) {
         // skip updates for editors in sidecarless mode
         continue;
       }

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -458,10 +458,16 @@ export class DevWorkspaceClient extends WorkspaceClient {
         },
         spec: pluginDevfile,
       };
+
+      const unmanagedEditors = ['che-code', 'idea', 'pycharm'];
       dwEditorsPlugins.forEach(plugin => {
         if (plugin.devfile === pluginDevfile && editorDWT.metadata) {
+          const isUnmanaged = unmanagedEditors.some(e =>
+            editorDWT.metadata?.name?.toLowerCase().includes(e),
+          );
+
           editorDWT.metadata.annotations = {
-            [COMPONENT_UPDATE_POLICY]: 'managed',
+            [COMPONENT_UPDATE_POLICY]: isUnmanaged ? 'unmanaged' : 'managed',
             [REGISTRY_URL]: plugin.url,
           };
         }
@@ -925,12 +931,6 @@ export class DevWorkspaceClient extends WorkspaceClient {
         const pluginContent = await fetchData<string>(url);
         plugin = safeLoad(pluginContent) as devfileApi.Devfile;
         pluginsByUrl[url] = plugin;
-      }
-
-      const skipEditors = ['che-code', 'idea', 'pycharm'];
-      if (skipEditors.some(e => plugin?.metadata?.name?.toLowerCase().includes(e))) {
-        // skip updates for editors in sidecarless mode
-        continue;
       }
 
       const spec: Partial<V1alpha2DevWorkspaceTemplateSpec> = {};


### PR DESCRIPTION
After Che-Dashboard is loaded DevWorkspaceTemplates are automatically updated to their latest plugins definition. This breaks existing workspaces for editors (e.g. che-code) that use sidecarless mode.

While starting new workspaces Che-Dashboard will remove editor definitions from DevWorkspaceTemplate since these get merged to the users dev container. If DevWorkspaceTemplate get updated, DevWorkspaceTemplate and DevWorkspace both contain editor definitions. Workspace therefore will fail to start due to duplicate ports.

Quick fix is skipping the update in case of `che-code`. Maybe `intellij` and `pycharm` would also make sense.

See also: https://github.com/eclipse/che/issues/21085