### PR TITLE
Add annotation with workspace ID

### DIFF
--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
@@ -24,7 +24,10 @@ import {
 } from '../../../store/Workspaces';
 import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
 import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilder';
-import { ORIGINAL_WORKSPACE_ID_ANNOTATION } from '../../../services/devfileApi/devWorkspace/metadata';
+import {
+  DEVWORKSPACE_ID_OVERRIDE_ANNOTATION,
+  ORIGINAL_WORKSPACE_ID_ANNOTATION,
+} from '../../../services/devfileApi/devWorkspace/metadata';
 import userEvent from '@testing-library/user-event';
 import devfileApi from '../../../services/devfileApi';
 import { DEVWORKSPACE_METADATA_ANNOTATION } from '../../../services/workspace-client/devworkspace/devWorkspaceClient';
@@ -303,6 +306,7 @@ describe('Workspace Details container', () => {
               attributes: expect.objectContaining({
                 [DEVWORKSPACE_METADATA_ANNOTATION]: {
                   [ORIGINAL_WORKSPACE_ID_ANNOTATION]: cheWorkspaceId,
+                  [DEVWORKSPACE_ID_OVERRIDE_ANNOTATION]: cheWorkspaceId,
                 },
               }),
             }),

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
@@ -27,6 +27,7 @@ import * as WorkspacesStore from '../../store/Workspaces';
 import { selectAllWorkspaces, selectIsLoading } from '../../store/Workspaces/selectors';
 import { isDevWorkspace } from '../../services/devfileApi';
 import { ORIGINAL_WORKSPACE_ID_ANNOTATION } from '../../services/devfileApi/devWorkspace/metadata';
+import { DEVWORKSPACE_ID_OVERRIDE_ANNOTATION } from '../../services/devfileApi/devWorkspace/metadata';
 import { convertDevfileV1toDevfileV2 } from '../../services/devfile/converters';
 import { DEVWORKSPACE_METADATA_ANNOTATION } from '../../services/workspace-client/devworkspace/devWorkspaceClient';
 import { selectDefaultNamespace } from '../../store/InfrastructureNamespaces/selectors';
@@ -173,6 +174,9 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
     }
     devfileV2.metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION][
       ORIGINAL_WORKSPACE_ID_ANNOTATION
+    ] = oldWorkspace.id;
+    devfileV2.metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION][
+      DEVWORKSPACE_ID_OVERRIDE_ANNOTATION
     ] = oldWorkspace.id;
     const defaultNamespace = this.props.defaultNamespace.name;
     // create a new workspace

--- a/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
@@ -71,10 +71,11 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
       if (isDevWorkspace(workspace.ref)) {
         return true;
       }
-      if (workspace.ref.attributes?.convertedId === undefined) {
+      const convertedId = workspace.ref.attributes?.convertedId;
+      if (convertedId === undefined) {
         return true;
       }
-      return ids.indexOf(workspace.ref.attributes?.convertedId) === -1;
+      return ids.includes(convertedId) === false;
     });
 
     return (

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
@@ -103,6 +103,19 @@ describe('Workspace WorkspaceAction widget', () => {
     expect(actionButton).toBeTruthy();
   });
 
+  it('should not not show actions nor button', () => {
+    const history = createHashHistory();
+    const component = createComponent(history, 'Deprecated', false);
+
+    renderComponent(component);
+
+    const actionButton = screen.queryByRole('button', { name: /delete/i });
+    expect(actionButton).toBe(null);
+
+    const actionDropdown = screen.queryByTestId(`${workspaceId}-action-dropdown`);
+    expect(actionDropdown).toBe(null);
+  });
+
   it('should call the callback with OPEN action', async () => {
     const action = WorkspaceAction.OPEN_IDE;
     const history = createHashHistory();
@@ -198,11 +211,13 @@ describe('Workspace WorkspaceAction widget', () => {
 function createComponent(
   history: History,
   status: WorkspaceStatus | DeprecatedWorkspaceStatus = WorkspaceStatus.STOPPED,
+  canDelete = true,
 ): React.ReactElement {
   return (
     <HeaderActionSelect
       workspaceId={workspaceId}
       workspaceName={workspaceName}
+      canDelete={canDelete}
       history={history}
       status={status}
     />

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
@@ -34,6 +34,7 @@ import ButtonAction from './Button';
 type Props = {
   workspaceId: string;
   workspaceName: string;
+  canDelete: boolean;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   history: History;
 };
@@ -79,19 +80,23 @@ export class HeaderActionSelect extends React.PureComponent<Props> {
   }
 
   render(): React.ReactNode {
-    const { history, status } = this.props;
+    const { canDelete, history, status } = this.props;
 
     return (
       <WorkspaceActionsProvider history={history}>
         <WorkspaceActionsConsumer>
           {context => {
             if (status === 'Deprecated') {
-              return (
-                <ButtonAction
-                  context={context}
-                  onAction={(action, context) => this.handleSelectedAction(action, context)}
-                />
-              );
+              if (canDelete) {
+                return (
+                  <ButtonAction
+                    context={context}
+                    onAction={(action, context) => this.handleSelectedAction(action, context)}
+                  />
+                );
+              } else {
+                return <></>;
+              }
             }
             const { ...props } = this.props;
             return (

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/__tests__/index.spec.tsx
@@ -22,17 +22,12 @@ import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilde
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { constructWorkspace } from '../../../services/workspace-adapter';
 import devfileApi from '../../../services/devfileApi';
-import { container } from '../../../inversify.config';
-import { AppAlerts } from '../../../services/alerts/appAlerts';
 
 const mockOnConvert = jest.fn();
 const mockOnSave = jest.fn();
 
 jest.mock('../EditorTab');
 jest.mock('../OverviewTab/StorageType');
-
-const appAlerts = container.get(AppAlerts);
-const spyShowAlert = jest.spyOn(appAlerts, 'showAlert');
 
 let history: History;
 

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
@@ -216,6 +216,9 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
     const workspaceName = workspace.name;
     const { inlineAlertConversionError, showInlineAlertRestartWarning } = this.state;
 
+    // show the Delete button for a deprecated workspace until it's converted
+    const canDelete = showConvertButton;
+
     return (
       <React.Fragment>
         <Head pageName={workspaceName} />
@@ -238,6 +241,7 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
           <HeaderActionSelect
             workspaceId={workspace.id}
             workspaceName={workspaceName}
+            canDelete={canDelete}
             status={workspace.status}
             history={this.props.history}
           />

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -12,13 +12,17 @@
 
 import { V1alpha2DevWorkspaceMetadata } from '@devfile/api';
 
-export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'che.eclipse.org/last-updated-timestamp';
 export const DEVWORKSPACE_CHE_EDITOR = 'che.eclipse.org/che-editor';
+// used by UD to get the original Che7 workspace ID
 export const ORIGINAL_WORKSPACE_ID_ANNOTATION = 'che.eclipse.org/original-workspace-id';
+// used by devworkspace-controller to allow to mount the corresponding Che7 workspace folder
+export const DEVWORKSPACE_ID_OVERRIDE_ANNOTATION = 'controller.devfile.io/devworkspace_id_override';
+export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'che.eclipse.org/last-updated-timestamp';
 type DevWorkspaceMetadataAnnotation = {
-  [DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]?: string;
   [DEVWORKSPACE_CHE_EDITOR]?: string;
   [ORIGINAL_WORKSPACE_ID_ANNOTATION]?: string;
+  [DEVWORKSPACE_ID_OVERRIDE_ANNOTATION]?: string;
+  [DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]?: string;
 };
 
 export type DevWorkspaceMetadata = V1alpha2DevWorkspaceMetadata &


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Each new workspace created via converting an old Che7 workspace will have a new annotation (`controller.devfile.io/devworkspace_id_override`) added so Che7 workspace folder can be mounted and reused after migrating to DevWorkspace.
Additionally, the dashboard hides the "Delete" button for those old workspaces that were converted. This should prevent accidentally deleting a Che7 workspace with all related resources while they are in use by a new devworkspace.

### What issues does this PR fix or reference?

fix https://github.com/eclipse/che/issues/21153

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

unit tests

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
