### PR TITLE
fix: Fix some devfile v1 to v2 conversions

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -10,7 +10,7 @@
 | [`@eclipse-che/common@7.43.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-backend@7.43.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
 | [`@eclipse-che/dashboard-frontend@7.43.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | N/A |
-| [`@eclipse-che/devfile-converter@0.0.1-14c62ee`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | clearlydefined |
+| [`@eclipse-che/devfile-converter@0.0.1-ca41630`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/workspace-client@0.0.1-1632305737`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | clearlydefined |
 | [`@fastify/ajv-compiler@1.1.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
 | [`@hapi/address@2.1.4`](git://github.com/hapijs/address) | BSD-3-Clause | clearlydefined |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@eclipse-che/che-code-devworkspace-handler": "1.64.0-dev-210b722",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1642670698",
-    "@eclipse-che/devfile-converter": "0.0.1-14c62ee",
+    "@eclipse-che/devfile-converter": "0.0.1-ca41630",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,10 +383,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/devfile-converter@0.0.1-14c62ee":
-  version "0.0.1-14c62ee"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-14c62ee.tgz#45cc18ef554ef1fc5653e73c5de0cc6bc1a7ed34"
-  integrity sha512-Hg/P8Un6RI3VuNSw5OTL/5IAs0TXmfmeJVdWon2Hz3Ns9e6M7fOFYr1oqhzARa0ivXQkPJxPblTvNpZCC5zQHA==
+"@eclipse-che/devfile-converter@0.0.1-ca41630":
+  version "0.0.1-ca41630"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-ca41630.tgz#305e23161fafd6a4b32021da795d036dfd65974a"
+  integrity sha512-gb4O9njmdBELDlPFq5ZfzRXEhfDXfes3Nf/rhxxjUV0wlc0jwvz+ECABqsRU82oJCyALPBYVTneT5YHMesZO5A==
   dependencies:
     "@devfile/api" "2.2.0-alpha-1637255314"
     "@eclipse-che/api" "^7.39.2"


### PR DESCRIPTION
### What does this PR do?
Fix some devfile v1 to v2 conversions

che-server engine was more permissive on rules
- handle invalid project name (needs to be lowercase with devWorkspace engine)
- handle multiple volume mount
- handle duplicated endpoints (it's an error with devWorkspace engine)


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/21167
Fixes https://github.com/eclipse/che/issues/21121
1 out of 3 issues of https://github.com/eclipse/che/issues/21120 (other issues are not related to this converter lib)


### Is it tested? How?
Unit tests added on the converter library


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
