### PR TITLE
Add ability to show a warning banner by configuring CheCluster CR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/eclipse/che-dashboard/workflows/CI/badge.svg)](https://github.com/eclipse/che-dashboard/actions/workflows/ci.yaml)
-[![Codecov](https://img.shields.io/codecov/c/github/eclipse/che-dashboard)](https://app.codecov.io/gh/eclipse/che-dashboard)
+[![codecov](https://codecov.io/gh/eclipse-che/che-dashboard/branch/main/graph/badge.svg?token=ao9sqdlXeT)](https://codecov.io/gh/eclipse-che/che-dashboard)
 
 ## About Eclipse Che
 

--- a/packages/common/src/dto/cluster-config.ts
+++ b/packages/common/src/dto/cluster-config.ts
@@ -10,16 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import helpers from './helpers';
-import * as api from './dto/api';
-
-export * from './dto/cluster-info';
-export * from './dto/cluster-config';
-
-export { helpers, api };
-
-const common = {
-  helpers,
-  api,
-};
-export default common;
+export interface ClusterConfig {
+  dashboardWarning?: string;
+}

--- a/packages/common/src/dto/cluster-info.ts
+++ b/packages/common/src/dto/cluster-info.ts
@@ -10,6 +10,10 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+export interface ClusterInfo {
+  applications: ApplicationInfo[];
+}
+
 export interface ApplicationInfo {
   url: string;
   title: string;

--- a/packages/dashboard-backend/src/api/clusterConfig.ts
+++ b/packages/dashboard-backend/src/api/clusterConfig.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance } from 'fastify';
+import { ClusterConfig } from '@eclipse-che/common';
+import { baseApiPath } from '../constants/config';
+import { getSchema } from '../services/helpers';
+import { getDevWorkspaceClient, getServiceAccountToken } from './helper';
+
+const tags = ['clusterConfig'];
+
+export function registerClusterConfig(server: FastifyInstance) {
+  server.get(`${baseApiPath}/cluster-config`, getSchema({ tags }), async () =>
+    buildClusterConfig(),
+  );
+}
+
+async function buildClusterConfig(): Promise<ClusterConfig> {
+  const token = getServiceAccountToken();
+  const { serverConfigApi } = await getDevWorkspaceClient(token);
+
+  return {
+    dashboardWarning: await serverConfigApi.getDashboardWarning(),
+  };
+}

--- a/packages/dashboard-backend/src/api/clusterInfo.ts
+++ b/packages/dashboard-backend/src/api/clusterInfo.ts
@@ -10,8 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { ApplicationInfo } from '@eclipse-che/common';
 import { FastifyInstance } from 'fastify';
+import { ApplicationInfo, ClusterInfo } from '@eclipse-che/common';
 import { baseApiPath } from '../constants/config';
 import {
   CLUSTER_CONSOLE_GROUP,
@@ -24,15 +24,20 @@ import { getSchema } from '../services/helpers';
 const tags = ['clusterInfo'];
 
 export function registerClusterInfo(server: FastifyInstance) {
-  server.get(
-    `${baseApiPath}/cluster-info`,
-    getSchema({ tags }),
-    async () =>
-      ({
-        icon: CLUSTER_CONSOLE_ICON,
-        title: CLUSTER_CONSOLE_TITLE,
-        url: CLUSTER_CONSOLE_URL,
-        group: CLUSTER_CONSOLE_GROUP,
-      } as ApplicationInfo),
+  server.get(`${baseApiPath}/cluster-info`, getSchema({ tags }), async () =>
+    buildApplicationInfo(),
   );
+}
+
+function buildApplicationInfo(): ClusterInfo {
+  const applications: ApplicationInfo[] = [];
+  if (CLUSTER_CONSOLE_URL) {
+    applications.push({
+      icon: CLUSTER_CONSOLE_ICON,
+      title: CLUSTER_CONSOLE_TITLE,
+      url: CLUSTER_CONSOLE_URL,
+      group: CLUSTER_CONSOLE_GROUP,
+    });
+  }
+  return { applications };
 }

--- a/packages/dashboard-backend/src/devworkspace-client/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/types/index.ts
@@ -87,9 +87,14 @@ export interface IDevWorkspaceTemplateApi {
 
 export interface IServerConfigApi {
   /**
-   * Get server config from custom resources
+   * Returns default plugins
    */
   getDefaultPlugins(): Promise<api.IWorkspacesDefaultPlugins[]>;
+
+  /**
+   * Returns a maintenance warning
+   */
+  getDashboardWarning(): Promise<string>;
 }
 
 export interface IKubeConfigApi {

--- a/packages/dashboard-backend/src/index.ts
+++ b/packages/dashboard-backend/src/index.ts
@@ -23,7 +23,7 @@ import { registerSwagger } from './swagger';
 import { helpers } from '@eclipse-che/common';
 import { isLocalRun } from './local-run';
 import { registerClusterInfo } from './api/clusterInfo';
-import { CLUSTER_CONSOLE_URL } from './devworkspace-client/services/cluster-info';
+import { registerClusterConfig } from './api/clusterConfig';
 import { registerDockerConfigApi } from './api/dockerConfigApi';
 import { registerServerConfigApi } from './api/serverConfigApi';
 import { registerKubeConfigApi } from './api/kubeConfigAPI';
@@ -99,9 +99,9 @@ registerServerConfigApi(server);
 
 registerKubeConfigApi(server);
 
-if (CLUSTER_CONSOLE_URL) {
-  registerClusterInfo(server);
-}
+registerClusterInfo(server);
+
+registerClusterConfig(server);
 
 registerCors(isLocalRun, server);
 

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/ApplicationsMenu/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/ApplicationsMenu/__tests__/index.spec.tsx
@@ -17,7 +17,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { Store } from 'redux';
 import { ApplicationsMenu } from '..';
 import { FakeStoreBuilder } from '../../../../../store/__mocks__/storeBuilder';
-import { selectApplications } from '../../../../../store/ExternalApplications/selectors';
+import { selectApplications } from '../../../../../store/ClusterInfo/selectors';
 
 describe('About Menu', () => {
   global.open = jest.fn();
@@ -91,25 +91,27 @@ describe('About Menu', () => {
 
 function createStore(): Store {
   return new FakeStoreBuilder()
-    .withApplications([
-      {
-        title: 'External App #1',
-        url: 'http://example.com/ext/app/1',
-        icon: 'http://example.com/ext/app/1/assets/logo.png',
-        group: 'Group 1',
-      },
-      {
-        title: 'External App #2',
-        url: 'http://example.com/ext/app/2',
-        icon: 'http://example.com/ext/app/2/assets/logo.png',
-        group: 'Group 1',
-      },
-      {
-        title: 'External App #3',
-        url: 'http://example.com/ext/app/3',
-        icon: 'http://example.com/ext/app/3/assets/logo.png',
-        group: 'Group 2',
-      },
-    ])
+    .withClusterInfo({
+      applications: [
+        {
+          title: 'External App #1',
+          url: 'http://example.com/ext/app/1',
+          icon: 'http://example.com/ext/app/1/assets/logo.png',
+          group: 'Group 1',
+        },
+        {
+          title: 'External App #2',
+          url: 'http://example.com/ext/app/2',
+          icon: 'http://example.com/ext/app/2/assets/logo.png',
+          group: 'Group 1',
+        },
+        {
+          title: 'External App #3',
+          url: 'http://example.com/ext/app/3',
+          icon: 'http://example.com/ext/app/3/assets/logo.png',
+          group: 'Group 2',
+        },
+      ],
+    })
     .build();
 }

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/index.tsx
@@ -26,7 +26,7 @@ import { selectUserProfile } from '../../../store/UserProfile/selectors';
 import { AboutMenu } from './AboutMenu';
 import UserMenu from './UserMenu';
 import { ApplicationsMenu } from './ApplicationsMenu';
-import { selectApplications } from '../../../store/ExternalApplications/selectors';
+import { selectApplications } from '../../../store/ClusterInfo/selectors';
 
 type Props = MappedProps & {
   history: History;
@@ -79,7 +79,6 @@ const mapStateToProps = (state: AppState) => ({
   userProfile: selectUserProfile(state),
   branding: selectBranding(state),
   applications: selectApplications(state),
-  extApps: state.externalApplications,
 });
 
 const connector = connect(mapStateToProps);

--- a/packages/dashboard-frontend/src/components/BannerAlert/Custom/index.module.css
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Custom/index.module.css
@@ -1,0 +1,3 @@
+.customBanner {
+  white-space: normal;
+}

--- a/packages/dashboard-frontend/src/components/BannerAlert/Custom/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Custom/index.tsx
@@ -17,6 +17,8 @@ import sanitizeHtml from 'sanitize-html';
 import { AppState } from '../../../store';
 import { selectBannerAlertMessages } from '../../../store/BannerAlert/selectors';
 
+import styles from './index.module.css';
+
 type Props = MappedProps;
 
 class BannerAlertCustomWarning extends React.PureComponent<Props> {
@@ -37,7 +39,7 @@ class BannerAlertCustomWarning extends React.PureComponent<Props> {
     );
 
     const banners = sanitizedMessages.map(message => (
-      <Banner key={message} className="pf-u-text-align-center" variant="warning">
+      <Banner key={message} className={styles.customBanner} variant="warning">
         <div dangerouslySetInnerHTML={{ __html: message }}></div>
       </Banner>
     ));

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/__tests__/index.spec.tsx
@@ -22,17 +22,12 @@ import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilde
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
 import { constructWorkspace } from '../../../services/workspace-adapter';
 import devfileApi from '../../../services/devfileApi';
-import { container } from '../../../inversify.config';
-import { AppAlerts } from '../../../services/alerts/appAlerts';
 
 const mockOnConvert = jest.fn();
 const mockOnSave = jest.fn();
 
 jest.mock('../EditorTab');
 jest.mock('../OverviewTab/StorageType');
-
-const appAlerts = container.get(AppAlerts);
-const spyShowAlert = jest.spyOn(appAlerts, 'showAlert');
 
 let history: History;
 

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -17,7 +17,8 @@ import { KeycloakSetupService } from '../keycloak/setup';
 import { AppState } from '../../store';
 import * as BannerAlertStore from '../../store/BannerAlert';
 import * as BrandingStore from '../../store/Branding';
-import * as ExternalApplicationsStore from '../../store/ExternalApplications';
+import * as ClusterConfigStore from '../../store/ClusterConfig';
+import * as ClusterInfoStore from '../../store/ClusterInfo';
 import * as DevfileRegistriesStore from '../../store/DevfileRegistries';
 import * as InfrastructureNamespacesStore from '../../store/InfrastructureNamespaces';
 import * as PluginsStore from '../../store/Plugins/chePlugins';
@@ -81,7 +82,8 @@ export default class Bootstrap {
       this.watchNamespaces(),
       this.updateDevWorkspaceTemplates(settings),
       this.fetchWorkspaces(),
-      this.fetchApplications(),
+      this.fetchClusterInfo(),
+      this.fetchClusterConfig(),
     ]);
     const errors = results
       .filter(result => result.status === 'rejected')
@@ -91,8 +93,19 @@ export default class Bootstrap {
     }
   }
 
-  private async fetchApplications(): Promise<void> {
-    const { requestClusterInfo } = ExternalApplicationsStore.actionCreators;
+  private async fetchClusterConfig(): Promise<void> {
+    const { requestClusterConfig } = ClusterConfigStore.actionCreators;
+    try {
+      await requestClusterConfig()(this.store.dispatch, this.store.getState, undefined);
+    } catch (e) {
+      console.warn(
+        'Unable to fetch cluster configuration. This is expected behavior unless backend is configured to provide this information.',
+      );
+    }
+  }
+
+  private async fetchClusterInfo(): Promise<void> {
+    const { requestClusterInfo } = ClusterInfoStore.actionCreators;
     try {
       await requestClusterInfo()(this.store.dispatch, this.store.getState, undefined);
     } catch (e) {

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/clusterConfig.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/clusterConfig.ts
@@ -11,14 +11,14 @@
  */
 
 import axios from 'axios';
-import common, { ClusterInfo } from '@eclipse-che/common';
+import common, { ClusterConfig } from '@eclipse-che/common';
 import { prefix } from './const';
 
-export async function fetchClusterInfo(): Promise<ClusterInfo> {
+export async function fetchClusterConfig(): Promise<ClusterConfig> {
   try {
-    const response = await axios.get(`${prefix}/cluster-info`);
+    const response = await axios.get(`${prefix}/cluster-config`);
     return response.data;
   } catch (e) {
-    throw `Failed to fetch cluster information. ${common.helpers.errors.getMessage(e)}`;
+    throw `Failed to fetch cluster configuration. ${common.helpers.errors.getMessage(e)}`;
   }
 }

--- a/packages/dashboard-frontend/src/store/BannerAlert/index.ts
+++ b/packages/dashboard-frontend/src/store/BannerAlert/index.ts
@@ -18,12 +18,12 @@ export interface State {
   messages: string[];
 }
 
-interface AddBannerAction {
+export interface AddBannerAction {
   type: 'ADD_BANNER';
   message: string;
 }
 
-interface RemoveBannerAction {
+export interface RemoveBannerAction {
   type: 'REMOVE_BANNER';
   message: string;
 }

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import mockAxios, { AxiosError } from 'axios';
+import { MockStoreEnhanced } from 'redux-mock-store';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ClusterConfig } from '@eclipse-che/common';
+import { FakeStoreBuilder } from '../../__mocks__/storeBuilder';
+import { AppState } from '../..';
+import * as testStore from '..';
+
+describe('clusterConfig store', () => {
+  const clusterConfig: ClusterConfig = {
+    dashboardWarning: 'Maintenance warning info',
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('actions', () => {
+    let appStore: MockStoreEnhanced<
+      AppState,
+      ThunkDispatch<AppState, undefined, testStore.KnownAction>
+    >;
+
+    beforeEach(() => {
+      appStore = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, testStore.KnownAction>
+      >;
+    });
+
+    it('should create REQUEST_CLUSTER_CONFIG and RECEIVE_CLUSTER_CONFIG when fetching cluster info', async () => {
+      (mockAxios.get as jest.Mock).mockResolvedValueOnce({
+        data: clusterConfig,
+      });
+
+      await appStore.dispatch(testStore.actionCreators.requestClusterConfig());
+
+      const actions = appStore.getActions();
+
+      const expectedActions: testStore.KnownAction[] = [
+        {
+          type: testStore.Type.REQUEST_CLUSTER_CONFIG,
+        },
+        {
+          type: testStore.Type.RECEIVE_CLUSTER_CONFIG,
+          clusterConfig: clusterConfig,
+        },
+      ];
+
+      expect(actions).toEqual(expectedActions);
+    });
+
+    it('should create REQUEST_CLUSTER_CONFIG and RECEIVE_CLUSTER_CONFIG_ERROR when fails to fetch cluster config', async () => {
+      (mockAxios.get as jest.Mock).mockRejectedValueOnce({
+        isAxiosError: true,
+        code: '500',
+        message: 'Something unexpected happened.',
+      } as AxiosError);
+
+      try {
+        await appStore.dispatch(testStore.actionCreators.requestClusterConfig());
+      } catch (e) {
+        // noop
+      }
+
+      const actions = appStore.getActions();
+
+      const expectedActions: testStore.KnownAction[] = [
+        {
+          type: testStore.Type.REQUEST_CLUSTER_CONFIG,
+        },
+        {
+          type: testStore.Type.RECEIVE_CLUSTER_CONFIG_ERROR,
+          error: expect.stringContaining('Something unexpected happened.'),
+        },
+      ];
+
+      expect(actions).toEqual(expectedActions);
+    });
+  });
+
+  describe('reducers', () => {
+    it('should return initial state', () => {
+      const incomingAction: testStore.RequestClusterConfigAction = {
+        type: testStore.Type.REQUEST_CLUSTER_CONFIG,
+      };
+      const initialState = testStore.reducer(undefined, incomingAction);
+
+      const expectedState: testStore.State = {
+        isLoading: false,
+        clusterConfig: {},
+      };
+
+      expect(initialState).toEqual(expectedState);
+    });
+
+    it('should return state if action type is not matched', () => {
+      const initialState: testStore.State = {
+        isLoading: true,
+        clusterConfig: {},
+      };
+      const incomingAction = {
+        type: 'OTHER_ACTION',
+      } as AnyAction;
+      const newState = testStore.reducer(initialState, incomingAction);
+
+      const expectedState: testStore.State = {
+        isLoading: true,
+        clusterConfig: {},
+      };
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle REQUEST_CLUSTER_CONFIG', () => {
+      const initialState: testStore.State = {
+        isLoading: false,
+        clusterConfig: {},
+        error: 'unexpected error',
+      };
+      const incomingAction: testStore.RequestClusterConfigAction = {
+        type: testStore.Type.REQUEST_CLUSTER_CONFIG,
+      };
+
+      const newState = testStore.reducer(initialState, incomingAction);
+
+      const expectedState: testStore.State = {
+        isLoading: true,
+        clusterConfig: {},
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVE_CLUSTER_INFO', () => {
+      const initialState: testStore.State = {
+        isLoading: true,
+        clusterConfig: {},
+      };
+      const incomingAction: testStore.ReceiveClusterConfigAction = {
+        type: testStore.Type.RECEIVE_CLUSTER_CONFIG,
+        clusterConfig,
+      };
+
+      const newState = testStore.reducer(initialState, incomingAction);
+
+      const expectedState: testStore.State = {
+        isLoading: false,
+        clusterConfig: {
+          dashboardWarning: 'Maintenance warning info',
+        },
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVE_CLUSTER_CONFIG_ERROR', () => {
+      const initialState: testStore.State = {
+        isLoading: true,
+        clusterConfig: {},
+      };
+      const incomingAction: testStore.ReceivedClusterConfigErrorAction = {
+        type: testStore.Type.RECEIVE_CLUSTER_CONFIG_ERROR,
+        error: 'unexpected error',
+      };
+
+      const newState = testStore.reducer(initialState, incomingAction);
+
+      const expectedState: testStore.State = {
+        isLoading: false,
+        clusterConfig: {},
+        error: 'unexpected error',
+      };
+
+      expect(newState).toEqual(expectedState);
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
@@ -41,7 +41,7 @@ describe('clusterConfig store', () => {
       >;
     });
 
-    it('should create REQUEST_CLUSTER_CONFIG and RECEIVE_CLUSTER_CONFIG when fetching cluster info', async () => {
+    it('should create REQUEST_CLUSTER_CONFIG and RECEIVE_CLUSTER_CONFIG when fetching cluster config', async () => {
       (mockAxios.get as jest.Mock).mockResolvedValueOnce({
         data: clusterConfig,
       });
@@ -57,6 +57,10 @@ describe('clusterConfig store', () => {
         {
           type: testStore.Type.RECEIVE_CLUSTER_CONFIG,
           clusterConfig: clusterConfig,
+        },
+        {
+          message: 'Maintenance warning info',
+          type: 'ADD_BANNER',
         },
       ];
 

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/selectors.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { MockStoreEnhanced } from 'redux-mock-store';
+import { ThunkDispatch } from 'redux-thunk';
+import { AppState } from '../..';
+import { FakeStoreBuilder } from '../../__mocks__/storeBuilder';
+import * as store from '..';
+import { selectClusterConfigError, selectDashboardWarning } from '../selectors';
+
+const dashboardWarning = 'A warning message';
+describe('ClusterConfig', () => {
+  it('should return an error', () => {
+    const fakeStore = new FakeStoreBuilder()
+      .withClusterConfig({ dashboardWarning }, false, 'Something unexpected')
+      .build() as MockStoreEnhanced<
+      AppState,
+      ThunkDispatch<AppState, undefined, store.KnownAction>
+    >;
+    const state = fakeStore.getState();
+
+    const selectedError = selectClusterConfigError(state);
+    expect(selectedError).toEqual('Something unexpected');
+  });
+
+  it('should return a dashboard warning', () => {
+    const fakeStore = new FakeStoreBuilder()
+      .withClusterConfig({ dashboardWarning }, false, 'Something unexpected')
+      .build() as MockStoreEnhanced<
+      AppState,
+      ThunkDispatch<AppState, undefined, store.KnownAction>
+    >;
+    const state = fakeStore.getState();
+
+    const selectedInfo = selectDashboardWarning(state);
+    expect(selectedInfo).toEqual(dashboardWarning);
+  });
+});

--- a/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
@@ -16,6 +16,7 @@ import { AppThunk } from '..';
 import { createObject } from '../helpers';
 import * as BannerAlertStore from '../BannerAlert';
 import { fetchClusterConfig } from '../../services/dashboard-backend-client/clusterConfig';
+import { AddBannerAction } from '../BannerAlert';
 
 export interface State {
   isLoading: boolean;
@@ -46,7 +47,8 @@ export interface ReceivedClusterConfigErrorAction {
 export type KnownAction =
   | RequestClusterConfigAction
   | ReceiveClusterConfigAction
-  | ReceivedClusterConfigErrorAction;
+  | ReceivedClusterConfigErrorAction
+  | AddBannerAction;
 
 export type ActionCreators = {
   requestClusterConfig: () => AppThunk<KnownAction, Promise<void>>;

--- a/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { createSelector } from 'reselect';
+import { AppState } from '..';
+
+const selectState = (state: AppState) => state.clusterConfig;
+
+export const selectDashboardWarning = createSelector(
+  selectState,
+  state => state.clusterConfig.dashboardWarning || [],
+);
+
+export const selectClusterConfigError = createSelector(selectState, state => state.error);

--- a/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
@@ -14,16 +14,20 @@ import mockAxios, { AxiosError } from 'axios';
 import { MockStoreEnhanced } from 'redux-mock-store';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
+import { ClusterInfo } from '@eclipse-che/common';
 import { FakeStoreBuilder } from '../../__mocks__/storeBuilder';
 import { AppState } from '../..';
 import * as testStore from '..';
-import { ApplicationInfo } from '@eclipse-che/common';
 
-describe('externalApplications store', () => {
-  const clusterInfo: ApplicationInfo = {
-    url: 'web/console/url',
-    title: 'Web Console',
-    icon: 'web/console/icon.png',
+describe('clusterInfo store', () => {
+  const clusterInfo: ClusterInfo = {
+    applications: [
+      {
+        url: 'web/console/url',
+        title: 'Web Console',
+        icon: 'web/console/icon.png',
+      },
+    ],
   };
 
   afterEach(() => {
@@ -43,7 +47,7 @@ describe('externalApplications store', () => {
       >;
     });
 
-    it('should create REQUEST_APP_INFO and RECEIVE_APP_INFO when fetching cluster info', async () => {
+    it('should create REQUEST_CLUSTER_INFO and RECEIVE_CLUSTER_INFO when fetching cluster info', async () => {
       (mockAxios.get as jest.Mock).mockResolvedValueOnce({
         data: clusterInfo,
       });
@@ -54,18 +58,18 @@ describe('externalApplications store', () => {
 
       const expectedActions: testStore.KnownAction[] = [
         {
-          type: testStore.Type.REQUEST_APP_INFO,
+          type: testStore.Type.REQUEST_CLUSTER_INFO,
         },
         {
-          type: testStore.Type.RECEIVE_APP_INFO,
-          appInfo: clusterInfo,
+          type: testStore.Type.RECEIVE_CLUSTER_INFO,
+          clusterInfo: clusterInfo,
         },
       ];
 
       expect(actions).toEqual(expectedActions);
     });
 
-    it('should create REQUEST_APP_INFO and RECEIVE_APP_INFO_ERROR when fails to fetch cluster info', async () => {
+    it('should create REQUEST_CLUSTER_INFO and RECEIVE_CLUSTER_INFO_ERROR when fails to fetch cluster info', async () => {
       (mockAxios.get as jest.Mock).mockRejectedValueOnce({
         isAxiosError: true,
         code: '500',
@@ -82,10 +86,10 @@ describe('externalApplications store', () => {
 
       const expectedActions: testStore.KnownAction[] = [
         {
-          type: testStore.Type.REQUEST_APP_INFO,
+          type: testStore.Type.REQUEST_CLUSTER_INFO,
         },
         {
-          type: testStore.Type.RECEIVE_APP_INFO_ERROR,
+          type: testStore.Type.RECEIVE_CLUSTER_INFO_ERROR,
           error: expect.stringContaining('Something unexpected happened.'),
         },
       ];
@@ -96,14 +100,16 @@ describe('externalApplications store', () => {
 
   describe('reducers', () => {
     it('should return initial state', () => {
-      const incomingAction: testStore.RequestAppInfoAction = {
-        type: testStore.Type.REQUEST_APP_INFO,
+      const incomingAction: testStore.RequestClusterInfoAction = {
+        type: testStore.Type.REQUEST_CLUSTER_INFO,
       };
       const initialState = testStore.reducer(undefined, incomingAction);
 
       const expectedState: testStore.State = {
         isLoading: false,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
       };
 
       expect(initialState).toEqual(expectedState);
@@ -112,7 +118,9 @@ describe('externalApplications store', () => {
     it('should return state if action type is not matched', () => {
       const initialState: testStore.State = {
         isLoading: true,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
       };
       const incomingAction = {
         type: 'OTHER_ACTION',
@@ -121,64 +129,76 @@ describe('externalApplications store', () => {
 
       const expectedState: testStore.State = {
         isLoading: true,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
       };
       expect(newState).toEqual(expectedState);
     });
 
-    it('should handle REQUEST_APP_INFO', () => {
+    it('should handle REQUEST_CLUSTER_INFO', () => {
       const initialState: testStore.State = {
         isLoading: false,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
         error: 'unexpected error',
       };
-      const incomingAction: testStore.RequestAppInfoAction = {
-        type: testStore.Type.REQUEST_APP_INFO,
+      const incomingAction: testStore.RequestClusterInfoAction = {
+        type: testStore.Type.REQUEST_CLUSTER_INFO,
       };
 
       const newState = testStore.reducer(initialState, incomingAction);
 
       const expectedState: testStore.State = {
         isLoading: true,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
       };
 
       expect(newState).toEqual(expectedState);
     });
 
-    it('should handle RECEIVE_APP_INFO', () => {
+    it('should handle RECEIVE_CLUSTER_INFO', () => {
       const initialState: testStore.State = {
         isLoading: true,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
       };
-      const incomingAction: testStore.ReceiveAppInfoAction = {
-        type: testStore.Type.RECEIVE_APP_INFO,
-        appInfo: clusterInfo,
+      const incomingAction: testStore.ReceiveClusterInfoAction = {
+        type: testStore.Type.RECEIVE_CLUSTER_INFO,
+        clusterInfo,
       };
 
       const newState = testStore.reducer(initialState, incomingAction);
 
       const expectedState: testStore.State = {
         isLoading: false,
-        applications: [
-          {
-            url: 'web/console/url',
-            title: 'Web Console',
-            icon: 'web/console/icon.png',
-          },
-        ],
+        clusterInfo: {
+          applications: [
+            {
+              url: 'web/console/url',
+              title: 'Web Console',
+              icon: 'web/console/icon.png',
+            },
+          ],
+        },
       };
 
       expect(newState).toEqual(expectedState);
     });
 
-    it('should handle RECEIVE_APP_INFO_ERROR', () => {
+    it('should handle RECEIVE_CLUSTER_INFO_ERROR', () => {
       const initialState: testStore.State = {
         isLoading: true,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
       };
-      const incomingAction: testStore.ReceivedAppInfoErrorAction = {
-        type: testStore.Type.RECEIVE_APP_INFO_ERROR,
+      const incomingAction: testStore.ReceivedClusterInfoErrorAction = {
+        type: testStore.Type.RECEIVE_CLUSTER_INFO_ERROR,
         error: 'unexpected error',
       };
 
@@ -186,7 +206,9 @@ describe('externalApplications store', () => {
 
       const expectedState: testStore.State = {
         isLoading: false,
-        applications: [],
+        clusterInfo: {
+          applications: [],
+        },
         error: 'unexpected error',
       };
 

--- a/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/selectors.spec.ts
@@ -15,55 +15,37 @@ import { ThunkDispatch } from 'redux-thunk';
 import { AppState } from '../..';
 import { FakeStoreBuilder } from '../../__mocks__/storeBuilder';
 import * as store from '..';
-import { selectApplications, selectApplicationsError } from '../selectors';
+import { selectApplications, selectClusterInfoError } from '../selectors';
 
-describe('External applications', () => {
-  it('should return applications error', () => {
+const applications = [
+  {
+    title: 'App1',
+    url: 'my/app/1',
+    icon: 'my/app/1/logo',
+  },
+  {
+    title: 'App2',
+    url: 'my/app/2',
+    icon: 'my/app/2/logo',
+  },
+];
+describe('ClusterInfo', () => {
+  it('should return an error', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withApplications(
-        [
-          {
-            title: 'App1',
-            url: 'my/app/1',
-            icon: 'my/app/1/logo',
-          },
-          {
-            title: 'App2',
-            url: 'my/app/2',
-            icon: 'my/app/2/logo',
-          },
-        ],
-        false,
-        'Something unexpected',
-      )
+      .withClusterInfo({ applications }, false, 'Something unexpected')
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
     >;
     const state = fakeStore.getState();
 
-    const selectedError = selectApplicationsError(state);
+    const selectedError = selectClusterInfoError(state);
     expect(selectedError).toEqual('Something unexpected');
   });
 
   it('should return all applications', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withApplications(
-        [
-          {
-            title: 'App1',
-            url: 'my/app/1',
-            icon: 'my/app/1/logo',
-          },
-          {
-            title: 'App2',
-            url: 'my/app/2',
-            icon: 'my/app/2/logo',
-          },
-        ],
-        false,
-        'Something unexpected',
-      )
+      .withClusterInfo({ applications }, false, 'Something unexpected')
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
@@ -71,17 +53,6 @@ describe('External applications', () => {
     const state = fakeStore.getState();
 
     const selectedApps = selectApplications(state);
-    expect(selectedApps).toEqual([
-      {
-        title: 'App1',
-        url: 'my/app/1',
-        icon: 'my/app/1/logo',
-      },
-      {
-        title: 'App2',
-        url: 'my/app/2',
-        icon: 'my/app/2/logo',
-      },
-    ]);
+    expect(selectedApps).toEqual(applications);
   });
 });

--- a/packages/dashboard-frontend/src/store/ClusterInfo/index.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/index.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Action, Reducer } from 'redux';
+import common, { ClusterInfo } from '@eclipse-che/common';
+import { AppThunk } from '..';
+import { createObject } from '../helpers';
+import { fetchClusterInfo } from '../../services/dashboard-backend-client/clusterInfo';
+
+export interface State {
+  isLoading: boolean;
+  clusterInfo: ClusterInfo;
+  error?: string;
+}
+
+export enum Type {
+  REQUEST_CLUSTER_INFO = 'REQUEST_CLUSTER_INFO',
+  RECEIVE_CLUSTER_INFO = 'RECEIVE_CLUSTER_INFO',
+  RECEIVE_CLUSTER_INFO_ERROR = 'RECEIVE_CLUSTER_INFO_ERROR',
+}
+
+export interface RequestClusterInfoAction {
+  type: Type.REQUEST_CLUSTER_INFO;
+}
+
+export interface ReceiveClusterInfoAction {
+  type: Type.RECEIVE_CLUSTER_INFO;
+  clusterInfo: ClusterInfo;
+}
+
+export interface ReceivedClusterInfoErrorAction {
+  type: Type.RECEIVE_CLUSTER_INFO_ERROR;
+  error: string;
+}
+
+export type KnownAction =
+  | RequestClusterInfoAction
+  | ReceiveClusterInfoAction
+  | ReceivedClusterInfoErrorAction;
+
+export type ActionCreators = {
+  requestClusterInfo: () => AppThunk<KnownAction, Promise<void>>;
+};
+
+export const actionCreators: ActionCreators = {
+  requestClusterInfo:
+    (): AppThunk<KnownAction, Promise<void>> =>
+    async (dispatch): Promise<void> => {
+      dispatch({
+        type: Type.REQUEST_CLUSTER_INFO,
+      });
+
+      try {
+        const clusterInfo = await fetchClusterInfo();
+        dispatch({
+          type: Type.RECEIVE_CLUSTER_INFO,
+          clusterInfo,
+        });
+      } catch (e) {
+        const errorMessage =
+          'Failed to fetch cluster properties, reason: ' + common.helpers.errors.getMessage(e);
+        dispatch({
+          type: Type.RECEIVE_CLUSTER_INFO_ERROR,
+          error: errorMessage,
+        });
+        throw errorMessage;
+      }
+    },
+};
+
+const unloadedState: State = {
+  isLoading: false,
+  clusterInfo: {
+    applications: [],
+  },
+};
+
+export const reducer: Reducer<State> = (
+  state: State | undefined,
+  incomingAction: Action,
+): State => {
+  if (state === undefined) {
+    return unloadedState;
+  }
+
+  const action = incomingAction as KnownAction;
+  switch (action.type) {
+    case Type.REQUEST_CLUSTER_INFO:
+      return createObject(state, {
+        isLoading: true,
+        error: undefined,
+      });
+    case Type.RECEIVE_CLUSTER_INFO:
+      return createObject(state, {
+        isLoading: false,
+        clusterInfo: action.clusterInfo,
+      });
+    case Type.RECEIVE_CLUSTER_INFO_ERROR:
+      return createObject(state, {
+        isLoading: false,
+        error: action.error,
+      });
+    default:
+      return state;
+  }
+};

--- a/packages/dashboard-frontend/src/store/ClusterInfo/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/selectors.ts
@@ -13,8 +13,11 @@
 import { createSelector } from 'reselect';
 import { AppState } from '..';
 
-const selectState = (state: AppState) => state.externalApplications;
+const selectState = (state: AppState) => state.clusterInfo;
 
-export const selectApplications = createSelector(selectState, state => state.applications);
+export const selectApplications = createSelector(
+  selectState,
+  state => state.clusterInfo.applications || [],
+);
 
-export const selectApplicationsError = createSelector(selectState, state => state.error);
+export const selectClusterInfoError = createSelector(selectState, state => state.error);

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -25,16 +25,22 @@ import { State as UserState } from '../User';
 import { State as UserProfileState } from '../UserProfile';
 import mockThunk from './thunk';
 import devfileApi from '../../services/devfileApi';
-import { ApplicationInfo } from '@eclipse-che/common';
+import { ClusterConfig, ClusterInfo } from '@eclipse-che/common';
 
 export class FakeStoreBuilder {
   private state: AppState = {
     bannerAlert: {
       messages: [],
     },
-    externalApplications: {
+    clusterConfig: {
       isLoading: false,
-      applications: [],
+      clusterConfig: {},
+    },
+    clusterInfo: {
+      isLoading: false,
+      clusterInfo: {
+        applications: [],
+      },
     },
     factoryResolver: {
       isLoading: false,
@@ -146,14 +152,25 @@ export class FakeStoreBuilder {
     return this;
   }
 
-  public withApplications(
-    applications: ApplicationInfo[],
+  public withClusterConfig(
+    clusterConfig: Partial<ClusterConfig>,
     isLoading = false,
     error?: string,
   ): FakeStoreBuilder {
-    this.state.externalApplications.applications = Object.assign([], applications);
-    this.state.externalApplications.isLoading = isLoading;
-    this.state.externalApplications.error = error;
+    this.state.clusterConfig.clusterConfig = Object.assign({}, clusterConfig as ClusterConfig);
+    this.state.clusterConfig.isLoading = isLoading;
+    this.state.clusterConfig.error = error;
+    return this;
+  }
+
+  public withClusterInfo(
+    clusterInfo: Partial<ClusterInfo>,
+    isLoading = false,
+    error?: string,
+  ): FakeStoreBuilder {
+    this.state.clusterInfo.clusterInfo = Object.assign({}, clusterInfo as ClusterInfo);
+    this.state.clusterInfo.isLoading = isLoading;
+    this.state.clusterInfo.error = error;
     return this;
   }
 

--- a/packages/dashboard-frontend/src/store/index.ts
+++ b/packages/dashboard-frontend/src/store/index.ts
@@ -14,7 +14,8 @@ import { Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 import * as BannerAlertStore from './BannerAlert';
 import * as BrandingStore from './Branding';
-import * as ExternalApplications from './ExternalApplications';
+import * as ClusterInfo from './ClusterInfo';
+import * as ClusterConfig from './ClusterConfig';
 import * as DevfileRegistriesStore from './DevfileRegistries';
 import * as FactoryResolverStore from './FactoryResolver';
 import * as InfrastructureNamespacesStore from './InfrastructureNamespaces';
@@ -34,7 +35,8 @@ import * as DwDockerConfigStore from './DockerConfig/dw';
 export interface AppState {
   bannerAlert: BannerAlertStore.State;
   branding: BrandingStore.State;
-  externalApplications: ExternalApplications.State;
+  clusterInfo: ClusterInfo.State;
+  clusterConfig: ClusterConfig.State;
   devfileRegistries: DevfileRegistriesStore.State;
   infrastructureNamespaces: InfrastructureNamespacesStore.State;
   user: UserStore.State;
@@ -58,7 +60,8 @@ export const reducers = {
   devWorkspaces: DevWorkspacesStore.reducer,
   devfileRegistries: DevfileRegistriesStore.reducer,
   branding: BrandingStore.reducer,
-  externalApplications: ExternalApplications.reducer,
+  clusterInfo: ClusterInfo.reducer,
+  clusterConfig: ClusterConfig.reducer,
   user: UserStore.reducer,
   userProfile: UserProfileStore.reducer,
   infrastructureNamespaces: InfrastructureNamespacesStore.reducer,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The Dashboard looks into the CheCluster CR for a warning message:

```yaml
spec:
  dashboard:
    warning: "Eclipse Che hosted by Red Hat is going to ..."
```

and shows it as a permanent banner.


<details>
<summary>Screenshots</summary>

<img width="1788" alt="Screenshot 2022-02-23 at 14 03 02" src="https://user-images.githubusercontent.com/16220722/155322352-915dc977-4c1a-40be-b9da-203212939086.png">


<img width="1128" alt="Screenshot 2022-02-23 at 14 03 24" src="https://user-images.githubusercontent.com/16220722/155322382-1bef9fa0-d820-41b3-b8a4-59fe1544bfaf.png">

</details>

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/20724
