### PR TITLE
feat: do not allow starting a DevWorkspace if there is already one running

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devfile-parent.yaml
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devfile-parent.yaml
@@ -8,5 +8,5 @@ metadata:
       any.custom.settings: 'true'
 parent:
   id: nodejs
-  registryUrl: "https://registry.devfile.io"
+  registryUrl: 'https://registry.devfile.io'
 components: []

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devworkspace-parent.yaml
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devworkspace-parent.yaml
@@ -13,5 +13,5 @@ spec:
   template:
     parent:
       id: nodejs
-      registryUrl: "https://registry.devfile.io"
+      registryUrl: 'https://registry.devfile.io'
     components: []

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -262,6 +262,13 @@ export const actionCreators: ActionCreators = {
     async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_DEVWORKSPACE' });
       try {
+        const defaultKubernetesNamespace = selectDefaultNamespace(getState());
+        const defaultNamespace = defaultKubernetesNamespace.name;
+        const { workspaces } = await devWorkspaceClient.getAllWorkspaces(defaultNamespace);
+        const runningWorkspaces = workspaces.filter(workspace => workspace.spec.started === true);
+        if (runningWorkspaces.length > 0) {
+          throw new Error('You are not allowed to start more workspaces.');
+        }
         await devWorkspaceClient.updateDebugMode(workspace, debugWorkspace);
         let updatedWorkspace: devfileApi.DevWorkspace;
         await addKubeConfigInjection(workspace);


### PR DESCRIPTION
### What does this PR do?
Do not allow starting a DevWorkspace if there is already one running

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21032

Based on the internal discussion, for the time being, it was decided not to add extra property similar to `CHE_LIMITS_USER_WORKSPACES_RUN_COUNT` since we only support the common PVC strategy, so by definition only a single running workspace is allowed for RWO volumes.

### Is it tested? How?
![do not  allow more workspaces](https://user-images.githubusercontent.com/1461122/157464062-c4c55d13-c30f-42bd-8e07-bc50179c51f5.gif)

![verbose](https://user-images.githubusercontent.com/1461122/157464122-c92dc451-b896-4371-90b6-ccbc59e2a286.gif)

#### Release Notes

#### Docs PR
N/A