### PR TITLE
fix: Improve IdeLoader banner to better reflect state of DevWorkspace

### DIFF
--- a/packages/dashboard-frontend/src/containers/IdeLoader.tsx
+++ b/packages/dashboard-frontend/src/containers/IdeLoader.tsx
@@ -229,7 +229,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
       },
     });
 
-    const { isLoading, requestWorkspaces, allWorkspaces } = this.props;
+    const { isLoading, requestWorkspaces, updateWorkspace, allWorkspaces } = this.props;
     let workspace = allWorkspaces.find(
       workspace =>
         workspace.namespace === this.state.namespace && workspace.name === this.state.workspaceName,
@@ -245,6 +245,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
     if (workspace && workspace.ideUrl && workspace.isRunning) {
       return await this.updateIdeUrl(workspace.ideUrl);
     } else if (workspace && workspace.hasError) {
+      await updateWorkspace(workspace);
       this.showErrorAlert(workspace);
     }
     await this.applyIdeLoadingStep();

--- a/packages/dashboard-frontend/src/containers/IdeLoader.tsx
+++ b/packages/dashboard-frontend/src/containers/IdeLoader.tsx
@@ -202,6 +202,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
 
   private async restartWorkspace(workspace: Workspace): Promise<void> {
     this.setState({ isWaitingForRestart: true });
+    this.ideLoaderCallbacks?.hideAlert?.();
     try {
       await this.props.restartWorkspace(workspace);
       this.setState({ isWaitingForRestart: false });

--- a/packages/dashboard-frontend/src/containers/IdeLoader.tsx
+++ b/packages/dashboard-frontend/src/containers/IdeLoader.tsx
@@ -482,7 +482,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
     if (this.state.currentStep === LoadIdeSteps.INITIALIZING) {
       this.setState({ currentStep: LoadIdeSteps.START_WORKSPACE });
       await this.props.requestWorkspace(workspace);
-      if (this.props.workspace?.isStopped) {
+      if (workspace?.isStopped) {
         try {
           await this.props.startWorkspace(workspace);
         } catch (e) {

--- a/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
@@ -55,6 +55,11 @@ jest.mock('../../store/Workspaces/index', () => {
         (): void =>
           setWorkspaceIdMock(),
       clearWorkspaceId: (): AppThunk<Action, void> => (): void => clearWorkspaceIdMock(),
+      updateWorkspace:
+        (workspace: Workspace): AppThunk<Action, Promise<void>> =>
+        async (): Promise<void> => {
+          return Promise.resolve();
+        },
     } as ActionCreators,
   };
   /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -185,13 +190,16 @@ describe('IDE Loader container', () => {
     expect(LoadIdeSteps[elementCurrentStep]).toEqual(LoadIdeSteps[LoadIdeSteps.INITIALIZING]);
   });
 
-  it('error links are passed to alert when workspace start error is found', () => {
+  it('error links are passed to alert when workspace start error is found', async () => {
     const namespace = 'admin3';
     const workspaceName = 'name-wksp-3';
 
     renderComponent(namespace, workspaceName);
 
-    expect(requestWorkspaceMock).toBeCalled();
+    await waitFor(() => {
+      expect(requestWorkspaceMock).toBeCalled();
+    });
+    // TODO: This does not work as expected as startWorkspaceMock is called asynchronously
     expect(startWorkspaceMock).not.toBeCalled();
 
     expect(showAlertMock).toBeCalled();

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
@@ -34,7 +34,7 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
     window.Date = dateConstructor;
   });
 
@@ -50,6 +50,8 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
     const spyPatchWorkspace = jest
       .spyOn(DwApi, 'patchWorkspace')
       .mockResolvedValueOnce(testWorkspace);
+
+    jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
 
     await client.changeWorkspaceStatus(testWorkspace, true);
 
@@ -84,6 +86,8 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
       .spyOn(DwApi, 'patchWorkspace')
       .mockResolvedValueOnce(testWorkspace);
 
+    jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
+
     await client.changeWorkspaceStatus(testWorkspace, true);
 
     expect(spyPatchWorkspace).toBeCalledWith(
@@ -111,6 +115,8 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
     const spyPatchWorkspace = jest
       .spyOn(DwApi, 'patchWorkspace')
       .mockResolvedValueOnce(testWorkspace);
+
+    jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
 
     await client.changeWorkspaceStatus(testWorkspace, false);
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -769,7 +769,13 @@ export class DevWorkspaceClient extends WorkspaceClient {
     if (!skipErrorCheck) {
       this.checkForDevWorkspaceError(changedWorkspace);
     }
-    return changedWorkspace;
+    // Need to request DevWorkspace again to get updated Status -- we've patched spec.started
+    // but status still may contain an earlier error until DevWorkspace Operator updates it.
+    const clusterWorkspace = await DwApi.getWorkspaceByName(
+      changedWorkspace.metadata.namespace,
+      changedWorkspace.metadata.name,
+    );
+    return clusterWorkspace;
   }
 
   /**


### PR DESCRIPTION
**This PR is a copy of https://github.com/eclipse-che/che-dashboard/pull/469 but based in the main repo (not a fork) in order to allow github actions to run correctly.**

### What does this PR do?
* Clear error message in IdeLoader when "restart" button is clicked
* Request the DevWorkspace on load to ensure logs include the last failure reason for failed DevWorkspaces

### What issues does this PR fix or reference?
Closes https://github.com/eclipse/che/issues/21134

### Is it tested? How?
1. Create a workspace (devfile v2) and update it so that it fails to start (e.g. change image tag to non-existent one)
2. Start workspace, wait for it to fail (due to ImagePullBackoff)
3. Load failed workspace from sidebar
    * Verify that error message references ImagePullBackoff and is not "Unknown error."
4. Click "Restart" button in error banner
    * Verify that banner is cleared as DevWorkspace attempts to start
    * Verify that error banner returns when DevWorkspace fails again
5. Update Devfile to use valid image again
6. Open workspace from sidebar, verify banner still reports correct last failure reason, disappears on clicking "Restart", and workspace starts correctly.

#### Release Notes
N/A

#### Docs PR
N/A