### PR TITLE
feat: do not allow starting a DevWorkspace if there is already one running

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devfile-parent.yaml
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devfile-parent.yaml
@@ -8,5 +8,5 @@ metadata:
       any.custom.settings: 'true'
 parent:
   id: nodejs
-  registryUrl: "https://registry.devfile.io"
+  registryUrl: 'https://registry.devfile.io'
 components: []

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devworkspace-parent.yaml
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/fixtures/test-devworkspace-parent.yaml
@@ -13,5 +13,5 @@ spec:
   template:
     parent:
       id: nodejs
-      registryUrl: "https://registry.devfile.io"
+      registryUrl: 'https://registry.devfile.io'
     components: []

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -262,6 +262,13 @@ export const actionCreators: ActionCreators = {
     async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_DEVWORKSPACE' });
       try {
+        const { workspaces } = await devWorkspaceClient.getAllWorkspaces(
+          workspace.metadata.namespace,
+        );
+        const runningWorkspaces = workspaces.filter(workspace => workspace.spec.started === true);
+        if (runningWorkspaces.length > 0) {
+          throw new Error('You are not allowed to start more workspaces.');
+        }
         await devWorkspaceClient.updateDebugMode(workspace, debugWorkspace);
         let updatedWorkspace: devfileApi.DevWorkspace;
         await addKubeConfigInjection(workspace);


### PR DESCRIPTION
cherry-picking - https://github.com/eclipse-che/che-dashboard/pull/472