### PR TITLE
Get running workspaces limit from the cluster

### DIFF
--- a/packages/common/src/dto/cluster-config.ts
+++ b/packages/common/src/dto/cluster-config.ts
@@ -12,4 +12,5 @@
 
 export interface ClusterConfig {
   dashboardWarning?: string;
+  runningWorkspacesLimit: number;
 }

--- a/packages/dashboard-backend/src/api/clusterConfig.ts
+++ b/packages/dashboard-backend/src/api/clusterConfig.ts
@@ -28,8 +28,9 @@ async function buildClusterConfig(): Promise<ClusterConfig> {
   const token = getServiceAccountToken();
   const { serverConfigApi } = await getDevWorkspaceClient(token);
 
-  const dashboardWarning = await serverConfigApi.getDashboardWarning();
-  const runningWorkspacesLimit = await serverConfigApi.getRunningWorkspacesLimit();
+  const cheCustomResource = await serverConfigApi.getCheCustomResource();
+  const dashboardWarning = await serverConfigApi.getDashboardWarning(cheCustomResource);
+  const runningWorkspacesLimit = await serverConfigApi.getRunningWorkspacesLimit(cheCustomResource);
 
   return { dashboardWarning, runningWorkspacesLimit };
 }

--- a/packages/dashboard-backend/src/api/clusterConfig.ts
+++ b/packages/dashboard-backend/src/api/clusterConfig.ts
@@ -28,7 +28,8 @@ async function buildClusterConfig(): Promise<ClusterConfig> {
   const token = getServiceAccountToken();
   const { serverConfigApi } = await getDevWorkspaceClient(token);
 
-  return {
-    dashboardWarning: await serverConfigApi.getDashboardWarning(),
-  };
+  const dashboardWarning = await serverConfigApi.getDashboardWarning();
+  const runningWorkspacesLimit = await serverConfigApi.getRunningWorkspacesLimit();
+
+  return { dashboardWarning, runningWorkspacesLimit };
 }

--- a/packages/dashboard-backend/src/devworkspace-client/services/api/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/api/serverConfigApi.ts
@@ -95,4 +95,18 @@ export class ServerConfigApi implements IServerConfigApi {
       );
     }
   }
+
+  async getRunningWorkspacesLimit(): Promise<number> {
+    try {
+      const cheCustomResource = await this.getCheCustomResource();
+
+      return cheCustomResource.spec.server.runningWorkspacesLimit || 1;
+    } catch (e) {
+      throw createError(
+        e,
+        CUSTOM_RESOURCE_DEFINITIONS_API_ERROR_LABEL,
+        'Unable to fetch listClusterCustomObject',
+      );
+    }
+  }
 }

--- a/packages/dashboard-backend/src/devworkspace-client/services/api/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/api/serverConfigApi.ts
@@ -31,7 +31,15 @@ export class ServerConfigApi implements IServerConfigApi {
     this.customObjectAPI = kc.makeApiClient(k8s.CustomObjectsApi);
   }
 
-  private async getCheCustomResource(): Promise<{ [key: string]: any }> {
+  async getCheCustomResource(): Promise<{ [key: string]: any }> {
+    if (!NAME || !NAMESPACE) {
+      throw createError(
+        undefined,
+        CUSTOM_RESOURCE_DEFINITIONS_API_ERROR_LABEL,
+        'Mandatory environment variables are not defined: $CHECLUSTER_CR_NAMESPACE, $CHECLUSTER_CR_NAME',
+      );
+    }
+
     const resp = await this.customObjectAPI.listClusterCustomObject(GROUP, VERSION, PLURAL);
 
     const cheCustomResource = (resp.body as any).items.find(
@@ -49,29 +57,12 @@ export class ServerConfigApi implements IServerConfigApi {
     return cheCustomResource;
   }
 
-  async getDefaultPlugins(): Promise<api.IWorkspacesDefaultPlugins[]> {
-    if (!NAME || !NAMESPACE) {
-      throw createError(
-        undefined,
-        CUSTOM_RESOURCE_DEFINITIONS_API_ERROR_LABEL,
-        'Mandatory environment variables are not defined: $CHECLUSTER_CR_NAMESPACE, $CHECLUSTER_CR_NAME',
-      );
-    }
-
+  async getDefaultPlugins(cheCustomResource?: {
+    [key: string]: any;
+  }): Promise<api.IWorkspacesDefaultPlugins[]> {
     try {
-      const resp = await this.customObjectAPI.listClusterCustomObject(GROUP, VERSION, PLURAL);
-
-      const cheCustomResource = (resp.body as any).items.find(
-        (item: k8s.V1CustomResourceDefinition) =>
-          item.metadata?.name === NAME && item.metadata?.namespace === NAMESPACE,
-      );
-
       if (!cheCustomResource) {
-        throw createError(
-          undefined,
-          CUSTOM_RESOURCE_DEFINITIONS_API_ERROR_LABEL,
-          'Unable to find CheCustomResource',
-        );
+        cheCustomResource = await this.getCheCustomResource();
       }
       return cheCustomResource.spec.server.workspacesDefaultPlugins || [];
     } catch (e) {
@@ -83,9 +74,11 @@ export class ServerConfigApi implements IServerConfigApi {
     }
   }
 
-  async getDashboardWarning(): Promise<string> {
+  async getDashboardWarning(cheCustomResource?: { [key: string]: any }): Promise<string> {
     try {
-      const cheCustomResource = await this.getCheCustomResource();
+      if (!cheCustomResource) {
+        cheCustomResource = await this.getCheCustomResource();
+      }
       return cheCustomResource.spec.dashboard?.warning;
     } catch (e) {
       throw createError(
@@ -96,11 +89,12 @@ export class ServerConfigApi implements IServerConfigApi {
     }
   }
 
-  async getRunningWorkspacesLimit(): Promise<number> {
+  async getRunningWorkspacesLimit(cheCustomResource?: { [key: string]: any }): Promise<number> {
     try {
-      const cheCustomResource = await this.getCheCustomResource();
-
-      return cheCustomResource.spec.server.runningWorkspacesLimit || 1;
+      if (!cheCustomResource) {
+        cheCustomResource = await this.getCheCustomResource();
+      }
+      return cheCustomResource.spec.devWorkspace.runningLimit || 1;
     } catch (e) {
       throw createError(
         e,

--- a/packages/dashboard-backend/src/devworkspace-client/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/types/index.ts
@@ -95,6 +95,11 @@ export interface IServerConfigApi {
    * Returns a maintenance warning
    */
   getDashboardWarning(): Promise<string>;
+
+  /**
+   * Returns limit of running workspaces per user
+   */
+  getRunningWorkspacesLimit(): Promise<number>;
 }
 
 export interface IKubeConfigApi {

--- a/packages/dashboard-backend/src/devworkspace-client/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/types/index.ts
@@ -87,19 +87,25 @@ export interface IDevWorkspaceTemplateApi {
 
 export interface IServerConfigApi {
   /**
+   * Returns custom resource
+   */
+  getCheCustomResource(): Promise<{ [key: string]: any }>;
+  /**
    * Returns default plugins
    */
-  getDefaultPlugins(): Promise<api.IWorkspacesDefaultPlugins[]>;
+  getDefaultPlugins(cheCustomResource?: {
+    [key: string]: any;
+  }): Promise<api.IWorkspacesDefaultPlugins[]>;
 
   /**
    * Returns a maintenance warning
    */
-  getDashboardWarning(): Promise<string>;
+  getDashboardWarning(cheCustomResource?: { [key: string]: any }): Promise<string>;
 
   /**
    * Returns limit of running workspaces per user
    */
-  getRunningWorkspacesLimit(): Promise<number>;
+  getRunningWorkspacesLimit(cheCustomResource?: { [key: string]: any }): Promise<number>;
 }
 
 export interface IKubeConfigApi {

--- a/packages/dashboard-backend/src/swagger.ts
+++ b/packages/dashboard-backend/src/swagger.ts
@@ -27,15 +27,6 @@ export function registerSwagger(server: FastifyInstance): void {
         version: '0.1.0',
       },
       'x-express-openapi-validation-strict': false,
-      components: {
-        securitySchemes: {
-          Authorization: {
-            type: 'apiKey',
-            name: 'Authorization',
-            in: 'header',
-          },
-        },
-      },
     },
     uiConfig: {
       tryItOutEnabled: true,

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
@@ -33,7 +33,7 @@ export class DevWorkspaceDefaultPluginsHandler {
   ): Promise<void> {
     const componentsUpdated = this.handleUriPlugins(workspace, defaultPlugins[editorId]);
     if (componentsUpdated) {
-      this.patchWorkspaceComponents(workspace);
+      await this.patchWorkspaceComponents(workspace);
     }
   }
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
@@ -15,17 +15,19 @@ import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBui
 import { DevWorkspaceClient } from '../devWorkspaceClient';
 import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
 import * as ServerConfigApi from '../../../dashboard-backend-client/serverConfigApi';
+import mockAxios from 'axios';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 describe('DevWorkspace client, start', () => {
   let client: DevWorkspaceClient;
 
   beforeEach(() => {
-    client = container.get(DevWorkspaceClient);
-  });
+    jest.clearAllMocks();
 
-  afterEach(() => {
-    jest.resetAllMocks();
+    const mockPatch = mockAxios.patch as jest.Mock;
+    mockPatch.mockResolvedValue({ data: undefined });
+
+    client = container.get(DevWorkspaceClient);
   });
 
   it('should add default plugin uri', async () => {
@@ -42,8 +44,10 @@ describe('DevWorkspace client, start', () => {
 
     const defaults = { 'eclipse/theia/next': [defaultPluginUri] };
     const editor = 'eclipse/theia/next';
+
     await client.onStart(testWorkspace, defaults, editor);
-    expect(testWorkspace.spec.template.components!.length).toBe(1);
+
+    expect(testWorkspace.spec.template.components?.length).toBe(1);
     expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(defaultPluginUri);
     expect(
       (testWorkspace.spec.template.components![0].attributes as any)[
@@ -67,6 +71,7 @@ describe('DevWorkspace client, start', () => {
 
     const defaults = { 'eclipse/theia/next': [defaultPluginUri] };
     const editor = undefined;
+
     await client.onStart(testWorkspace, defaults, editor);
 
     // expect that no plug-in has been added
@@ -90,6 +95,7 @@ describe('DevWorkspace client, start', () => {
 
     // different editor
     const editor = 'eclipse/theia/latest';
+
     await client.onStart(testWorkspace, defaults, editor);
 
     // expect that no plug-in has been added
@@ -119,8 +125,10 @@ describe('DevWorkspace client, start', () => {
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
     const defaults = { 'eclipse/theia/next': [] };
     const editor = 'eclipse/theia/next';
+
     await client.onStart(testWorkspace, defaults, editor);
-    expect(testWorkspace.spec.template.components!.length).toBe(0);
+
+    expect(testWorkspace.spec.template.components?.length).toBe(0);
     expect(patchWorkspace).toHaveBeenCalled();
   });
 
@@ -146,8 +154,10 @@ describe('DevWorkspace client, start', () => {
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
     const defaults = {};
     const editor = 'eclipse/theia/next';
+
     await client.onStart(testWorkspace, defaults, editor);
-    expect(testWorkspace.spec.template.components!.length).toBe(0);
+
+    expect(testWorkspace.spec.template.components?.length).toBe(0);
     expect(patchWorkspace).toHaveBeenCalled();
   });
 
@@ -173,8 +183,10 @@ describe('DevWorkspace client, start', () => {
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
     const defaults = { 'eclipse/theia/next': [] };
     const editor = 'eclipse/theia/next';
+
     await client.onStart(testWorkspace, defaults, editor);
-    expect(testWorkspace.spec.template.components!.length).toBe(1);
+
+    expect(testWorkspace.spec.template.components?.length).toBe(1);
     expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
     expect(testWorkspace.spec.template.components![0].attributes).toBeUndefined();
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
@@ -203,8 +215,10 @@ describe('DevWorkspace client, start', () => {
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
     const defaults = { 'eclipse/theia/next': [] };
     const editor = 'eclipse/theia/next';
+
     await client.onStart(testWorkspace, defaults, editor);
-    expect(testWorkspace.spec.template.components!.length).toBe(1);
+
+    expect(testWorkspace.spec.template.components?.length).toBe(1);
     expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
@@ -222,7 +236,9 @@ describe('DevWorkspace client, start', () => {
     const getDefaultPlugins = jest.spyOn(ServerConfigApi, 'getDefaultPlugins');
     const defaults = {};
     const editor = 'eclipse/theia/next';
+
     await client.onStart(testWorkspace, defaults, editor);
+
     expect(getDefaultPlugins).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
@@ -22,6 +22,7 @@ import * as testStore from '..';
 describe('clusterConfig store', () => {
   const clusterConfig: ClusterConfig = {
     dashboardWarning: 'Maintenance warning info',
+    runningWorkspacesLimit: 1,
   };
 
   afterEach(() => {
@@ -105,7 +106,7 @@ describe('clusterConfig store', () => {
 
       const expectedState: testStore.State = {
         isLoading: false,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
       };
 
       expect(initialState).toEqual(expectedState);
@@ -114,7 +115,7 @@ describe('clusterConfig store', () => {
     it('should return state if action type is not matched', () => {
       const initialState: testStore.State = {
         isLoading: true,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
       };
       const incomingAction = {
         type: 'OTHER_ACTION',
@@ -123,7 +124,7 @@ describe('clusterConfig store', () => {
 
       const expectedState: testStore.State = {
         isLoading: true,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
       };
       expect(newState).toEqual(expectedState);
     });
@@ -131,7 +132,7 @@ describe('clusterConfig store', () => {
     it('should handle REQUEST_CLUSTER_CONFIG', () => {
       const initialState: testStore.State = {
         isLoading: false,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
         error: 'unexpected error',
       };
       const incomingAction: testStore.RequestClusterConfigAction = {
@@ -142,7 +143,7 @@ describe('clusterConfig store', () => {
 
       const expectedState: testStore.State = {
         isLoading: true,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
       };
 
       expect(newState).toEqual(expectedState);
@@ -151,7 +152,7 @@ describe('clusterConfig store', () => {
     it('should handle RECEIVE_CLUSTER_INFO', () => {
       const initialState: testStore.State = {
         isLoading: true,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
       };
       const incomingAction: testStore.ReceiveClusterConfigAction = {
         type: testStore.Type.RECEIVE_CLUSTER_CONFIG,
@@ -164,6 +165,7 @@ describe('clusterConfig store', () => {
         isLoading: false,
         clusterConfig: {
           dashboardWarning: 'Maintenance warning info',
+          runningWorkspacesLimit: 1,
         },
       };
 
@@ -173,7 +175,7 @@ describe('clusterConfig store', () => {
     it('should handle RECEIVE_CLUSTER_CONFIG_ERROR', () => {
       const initialState: testStore.State = {
         isLoading: true,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
       };
       const incomingAction: testStore.ReceivedClusterConfigErrorAction = {
         type: testStore.Type.RECEIVE_CLUSTER_CONFIG_ERROR,
@@ -184,7 +186,7 @@ describe('clusterConfig store', () => {
 
       const expectedState: testStore.State = {
         isLoading: false,
-        clusterConfig: {},
+        clusterConfig: { runningWorkspacesLimit: 1 },
         error: 'unexpected error',
       };
 

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/selectors.spec.ts
@@ -15,13 +15,16 @@ import { ThunkDispatch } from 'redux-thunk';
 import { AppState } from '../..';
 import { FakeStoreBuilder } from '../../__mocks__/storeBuilder';
 import * as store from '..';
-import { selectClusterConfigError, selectDashboardWarning } from '../selectors';
+import {
+  selectClusterConfigError,
+  selectDashboardWarning,
+  selectRunningWorkspacesLimit,
+} from '../selectors';
 
-const dashboardWarning = 'A warning message';
 describe('ClusterConfig', () => {
   it('should return an error', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withClusterConfig({ dashboardWarning }, false, 'Something unexpected')
+      .withClusterConfig(undefined, false, 'Something unexpected')
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
@@ -34,7 +37,7 @@ describe('ClusterConfig', () => {
 
   it('should return a dashboard warning', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withClusterConfig({ dashboardWarning }, false, 'Something unexpected')
+      .withClusterConfig({ dashboardWarning: 'A warning message' }, false, 'Something unexpected')
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
@@ -42,6 +45,32 @@ describe('ClusterConfig', () => {
     const state = fakeStore.getState();
 
     const selectedInfo = selectDashboardWarning(state);
-    expect(selectedInfo).toEqual(dashboardWarning);
+    expect(selectedInfo).toEqual('A warning message');
+  });
+
+  it('should return the default value for running workspaces limit', () => {
+    const fakeStore = new FakeStoreBuilder()
+      .withClusterConfig(undefined, false, 'Something unexpected')
+      .build() as MockStoreEnhanced<
+      AppState,
+      ThunkDispatch<AppState, undefined, store.KnownAction>
+    >;
+    const state = fakeStore.getState();
+
+    const runningLimit = selectRunningWorkspacesLimit(state);
+    expect(runningLimit).toEqual(1);
+  });
+
+  it('should return a running workspaces limit', () => {
+    const fakeStore = new FakeStoreBuilder()
+      .withClusterConfig({ runningWorkspacesLimit: 2 }, false, 'Something unexpected')
+      .build() as MockStoreEnhanced<
+      AppState,
+      ThunkDispatch<AppState, undefined, store.KnownAction>
+    >;
+    const state = fakeStore.getState();
+
+    const runningLimit = selectRunningWorkspacesLimit(state);
+    expect(runningLimit).toEqual(2);
   });
 });

--- a/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
@@ -86,7 +86,9 @@ export const actionCreators: ActionCreators = {
 
 const unloadedState: State = {
   isLoading: false,
-  clusterConfig: {},
+  clusterConfig: {
+    runningWorkspacesLimit: 1,
+  },
 };
 
 export const reducer: Reducer<State> = (

--- a/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
@@ -20,4 +20,9 @@ export const selectDashboardWarning = createSelector(
   state => state.clusterConfig.dashboardWarning || [],
 );
 
+export const selectRunningWorkspacesLimit = createSelector(
+  selectState,
+  state => state.clusterConfig.runningWorkspacesLimit,
+);
+
 export const selectClusterConfigError = createSelector(selectState, state => state.error);

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -36,6 +36,7 @@ import {
 import * as DwPluginsStore from '../../Plugins/devWorkspacePlugins';
 import { selectDefaultNamespace } from '../../InfrastructureNamespaces/selectors';
 import { injectKubeConfig } from '../../../services/dashboard-backend-client/devWorkspaceApi';
+import { selectRunningWorkspacesLimit } from '../../ClusterConfig/selectors';
 const devWorkspaceClient = container.get(DevWorkspaceClient);
 
 export const onStatusChangeCallbacks = new Map<string, (status: string) => void>();
@@ -266,7 +267,8 @@ export const actionCreators: ActionCreators = {
           workspace.metadata.namespace,
         );
         const runningWorkspaces = workspaces.filter(workspace => workspace.spec.started === true);
-        if (runningWorkspaces.length > 0) {
+        const runningLimit = selectRunningWorkspacesLimit(getState());
+        if (runningWorkspaces.length >= runningLimit) {
           throw new Error('You are not allowed to start more workspaces.');
         }
         await devWorkspaceClient.updateDebugMode(workspace, debugWorkspace);

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -34,7 +34,9 @@ export class FakeStoreBuilder {
     },
     clusterConfig: {
       isLoading: false,
-      clusterConfig: {},
+      clusterConfig: {
+        runningWorkspacesLimit: 1,
+      },
     },
     clusterInfo: {
       isLoading: false,
@@ -153,11 +155,13 @@ export class FakeStoreBuilder {
   }
 
   public withClusterConfig(
-    clusterConfig: Partial<ClusterConfig>,
+    clusterConfig: Partial<ClusterConfig> | undefined,
     isLoading = false,
     error?: string,
   ): FakeStoreBuilder {
-    this.state.clusterConfig.clusterConfig = Object.assign({}, clusterConfig as ClusterConfig);
+    if (clusterConfig) {
+      this.state.clusterConfig.clusterConfig = Object.assign({}, clusterConfig as ClusterConfig);
+    }
     this.state.clusterConfig.isLoading = isLoading;
     this.state.clusterConfig.error = error;
     return this;


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Get running workspaces limit from the cluster.

### What issues does this PR fix or reference?
fix https://github.com/eclipse/che/issues/21032

