### PR TITLE
Fix blank screen on dashboard startup failure

### DIFF
--- a/packages/common/src/helpers/__tests__/errors.spec.ts
+++ b/packages/common/src/helpers/__tests__/errors.spec.ts
@@ -286,5 +286,25 @@ describe('Errors helper', () => {
       };
       expect(getMessage(error)).toEqual(expectedMessage);
     });
+
+    it('should return response message if `error.response.data` is present', () => {
+      const expectedMessage =
+        'Creating the namespace "user-che" is not allowed, yet it was not found.';
+      const error = {
+        name: 'Error',
+        config: {},
+        request: {},
+        response: {
+          data: expectedMessage,
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: {},
+          config: {},
+          request: {},
+        },
+        message: '"500" returned by "/kubernetes/namespace/provision".',
+      };
+      expect(getMessage(error)).toEqual(expectedMessage);
+    });
   });
 });

--- a/packages/common/src/helpers/errors.ts
+++ b/packages/common/src/helpers/errors.ts
@@ -46,7 +46,9 @@ export function getMessage(error: unknown): string {
 
   if (includesAxiosResponse(error)) {
     const response = error.response;
-    if (response.data.message) {
+    if (typeof response.data === 'string') {
+      return response.data;
+    } else if (response.data.message) {
       return response.data.message;
     } else if (response.config.url) {
       return `"${response.status} ${response.statusText}" returned by "${response.config.url}".`;

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -39,6 +39,8 @@ import { selectDefaultNamespace } from '../../store/InfrastructureNamespaces/sel
 import { selectDevWorkspacesResourceVersion } from '../../store/Workspaces/devWorkspaces/selectors';
 import { WorkspaceAdapter } from '../workspace-adapter';
 import { selectDeprecatedWorkspacesIds } from '../../store/Workspaces/selectors';
+import { AppAlerts } from '../alerts/appAlerts';
+import { AlertVariant } from '@patternfly/react-core';
 
 /**
  * This class executes a few initial instructions
@@ -56,6 +58,9 @@ export default class Bootstrap {
 
   @lazyInject(DevWorkspaceClient)
   private readonly devWorkspaceClient: DevWorkspaceClient;
+
+  @lazyInject(AppAlerts)
+  private readonly appAlerts: AppAlerts;
 
   private store: Store<AppState>;
 
@@ -226,7 +231,15 @@ export default class Bootstrap {
 
   private async fetchInfrastructureNamespaces(): Promise<void> {
     const { requestNamespaces } = InfrastructureNamespacesStore.actionCreators;
-    await requestNamespaces()(this.store.dispatch, this.store.getState, undefined);
+    try {
+      await requestNamespaces()(this.store.dispatch, this.store.getState, undefined);
+    } catch (e) {
+      this.appAlerts.showAlert({
+        key: 'bootstrap-request-namespaces',
+        title: common.helpers.errors.getMessage(e),
+        variant: AlertVariant.danger,
+      });
+    }
   }
 
   private async fetchWorkspaceSettings(): Promise<che.WorkspaceSettings> {

--- a/packages/dashboard-frontend/src/store/InfrastructureNamespaces/index.ts
+++ b/packages/dashboard-frontend/src/store/InfrastructureNamespaces/index.ts
@@ -51,8 +51,9 @@ export const actionCreators: ActionCreators = {
     async (dispatch): Promise<Array<che.KubernetesNamespace>> => {
       dispatch({ type: 'REQUEST_NAMESPACES' });
 
+      await WorkspaceClient.restApiClient.provisionKubernetesNamespace();
+
       try {
-        await WorkspaceClient.restApiClient.provisionKubernetesNamespace();
         const namespaces = await WorkspaceClient.restApiClient.getKubernetesNamespace<
           Array<che.KubernetesNamespace>
         >();

--- a/packages/dashboard-frontend/src/store/InfrastructureNamespaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/InfrastructureNamespaces/selectors.ts
@@ -19,7 +19,8 @@ export const selectDefaultNamespace = createSelector(
   selectState,
   state =>
     state.namespaces.find(namespace => namespace.attributes.default === 'true') ||
-    state.namespaces[0],
+    state.namespaces[0] ||
+    ({} as che.KubernetesNamespace),
 );
 
 export const selectInfrastructureNamespaces = createSelector(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes the regression with with "blank" screen that happens when `CHE_INFRA_KUBERNETES_NAMESPACE_CREATION__ALLOWED` is set to `false` and a user doesn't have a pre-created namespace. With this PR, the dashboard opens successfully and shows the error alert with the message: `Creating the namespace '<username>' is not allowed, yet it was not found.` 

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-2788

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

Deploy Che with option `CHE_INFRA_KUBERNETES_NAMESPACE_CREATION__ALLOWED: 'false'` and use this dashboard image: **quay.io/eclipse/che-dashboard:pr-483**.
