### PR TITLE
fix: fixing v1 -> v2 convertion flow. Removing 'ORIGINAL_WORKSPACE_ID_ANNOTATION' since it duplicates 'DEVWORKSPACE_ID_OVERRIDE_ANNOTATION'

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -5,7 +5,7 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `@eclipse-che/common@7.44.1-next` | N/A |
 | `@eclipse-che/dashboard-backend@7.44.1-next` | N/A |
 | `@eclipse-che/dashboard-frontend@7.44.1-next` | N/A |
-| `@eclipse-che/devfile-converter@0.0.1-ca41630` | N/A |
+| `@eclipse-che/devfile-converter@0.0.1-b6a30cc` | N/A |
 | `fastify-swagger@4.11.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify-swagger/4.11.0) |
 | `fsevents@2.3.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fsevents/2.3.2) |
 | `jsdom@16.7.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsdom/16.7.0) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -7,9 +7,9 @@
 | `@eclipse-che/api@7.36.0` | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/che-code-devworkspace-handler@1.64.0-dev-210b722`](git+https://github.com/che-incubator/che-code.git) | EPL-2.0 | clearlydefined |
 | [`@eclipse-che/che-theia-devworkspace-handler@0.0.1-1642670698`](git+https://github.com/eclipse-che/che-theia.git) | EPL-2.0 | clearlydefined |
-| [`@eclipse-che/common@7.43.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
-| [`@eclipse-che/dashboard-backend@7.43.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
-| [`@eclipse-che/dashboard-frontend@7.43.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | N/A |
+| [`@eclipse-che/common@7.44.1-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
+| [`@eclipse-che/dashboard-backend@7.44.1-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | N/A |
+| [`@eclipse-che/dashboard-frontend@7.44.1-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | N/A |
 | [`@eclipse-che/devfile-converter@0.0.1-b6a30cc`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | N/A |
 | [`@eclipse-che/workspace-client@0.0.1-1632305737`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | clearlydefined |
 | [`@fastify/ajv-compiler@1.1.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
@@ -247,7 +247,7 @@
 | [`light-my-request@4.4.4`](https://github.com/fastify/light-my-request.git) | BSD-3-Clause | clearlydefined |
 | [`loader-utils@1.4.0`](https://github.com/webpack/loader-utils.git) | MIT | clearlydefined |
 | [`lodash.isequalwith@4.4.0`](https://github.com/lodash/lodash.git) | MIT | clearlydefined |
-| [`lodash@4.17.21`](https://github.com/lodash/lodash.git) | MIT | clearlydefined |
+| [`lodash@4.17.21`](https://github.com/lodash/lodash.git) | MIT | #2096 |
 | [`loose-envify@1.4.0`](git://github.com/zertosh/loose-envify.git) | MIT | clearlydefined |
 | [`lowercase-keys@2.0.0`](https://github.com/sindresorhus/lowercase-keys.git) | MIT | clearlydefined |
 | [`lru-cache@6.0.0`](git://github.com/isaacs/node-lru-cache.git) | ISC | clearlydefined |

--- a/packages/dashboard-backend/src/typings/models.d.ts
+++ b/packages/dashboard-backend/src/typings/models.d.ts
@@ -35,14 +35,6 @@ declare namespace restParams {
     devworkspaceId: string;
   }
 
-  export interface IStatusUpdate {
-    error?: string;
-    message?: string;
-    status?: string;
-    prevStatus?: string;
-    workspaceId: string;
-  }
-
   export interface ISchemaParams {
     [key: string]: any;
   }

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentItem.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentItem.tsx
@@ -33,7 +33,12 @@ function NavigationRecentItem(props: {
       className={styles.navItem}
       preventDefault={true}
       onClick={() =>
-        handleClick(props.history, props.item.to, props.item.workspaceId, props.item.isDevWorkspace)
+        handleClick(
+          props.history,
+          props.item.to,
+          props.item.workspaceUID,
+          props.item.isDevWorkspace,
+        )
       }
     >
       <span data-testid="recent-workspace-item">
@@ -55,12 +60,12 @@ function NavigationRecentItem(props: {
 function handleClick(
   history: History,
   location: string,
-  workspaceId: string,
+  workspaceUID: string,
   isDevWorkspace: boolean,
 ) {
   if (isDevWorkspace) {
     const link = `#${location}`;
-    window.open(link, workspaceId);
+    window.open(link, workspaceUID);
   } else {
     history.push(location);
   }

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentItemWorkspaceActions.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentItemWorkspaceActions.tsx
@@ -59,7 +59,7 @@ class NavigationItemWorkspaceActions extends React.PureComponent<Props, State> {
       isExpanded: false,
     });
     try {
-      const nextPath = await context.handleAction(selected, this.props.item.workspaceId);
+      const nextPath = await context.handleAction(selected, this.props.item.workspaceUID);
       if (!nextPath) {
         return;
       }

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
@@ -35,7 +35,7 @@ function buildRecentWorkspacesItems(
       to: navigateTo,
       label: workspaceName,
       status: workspace.status,
-      workspaceId: workspace.id,
+      workspaceUID: workspace.uid,
       isDevWorkspace: workspace.isDevWorkspace,
     };
     return (

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentItem.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentItem.spec.tsx
@@ -34,7 +34,7 @@ describe('Navigation Item', () => {
     label: 'workspace',
     to: '/namespace/workspace',
     isDevWorkspace: false,
-    workspaceId: 'test-wrks-id',
+    workspaceUID: 'test-wrks-id',
   };
 
   afterEach(() => {

--- a/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
@@ -42,7 +42,7 @@ export interface NavigationRecentItemObject {
   to: string;
   label: string;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
-  workspaceId: string;
+  workspaceUID: string;
   isDevWorkspace: boolean;
 }
 

--- a/packages/dashboard-frontend/src/components/LogsTab/__tests__/LogsTab.spec.tsx
+++ b/packages/dashboard-frontend/src/components/LogsTab/__tests__/LogsTab.spec.tsx
@@ -102,7 +102,7 @@ describe('The LogsTab component', () => {
 function renderComponent(store: Store, workspaceId: string): ReactTestRenderer {
   return renderer.create(
     <Provider store={store}>
-      <LogsTab workspaceId={workspaceId} isDevWorkspace />
+      <LogsTab workspaceUID={workspaceId} isDevWorkspace />
     </Provider>,
   );
 }

--- a/packages/dashboard-frontend/src/components/LogsTab/index.tsx
+++ b/packages/dashboard-frontend/src/components/LogsTab/index.tsx
@@ -31,7 +31,7 @@ import styles from './index.module.css';
 const maxLogLength = 200;
 
 type Props = {
-  workspaceId: string;
+  workspaceUID: string;
   isDevWorkspace: boolean;
 } & MappedProps;
 
@@ -67,14 +67,14 @@ export class LogsTab extends React.PureComponent<Props, State> {
   }
 
   private updateLogsData() {
-    const { workspaceId, workspacesLogs, allWorkspaces } = this.props;
+    const { workspaceUID, workspacesLogs, allWorkspaces } = this.props;
     if (allWorkspaces && allWorkspaces.length > 0) {
-      const workspace = allWorkspaces.find(workspace => workspace.id === workspaceId);
+      const workspace = allWorkspaces.find(workspace => workspace.uid === workspaceUID);
       if (!workspace) {
         return;
       }
 
-      const logs = workspacesLogs.get(workspaceId);
+      const logs = workspacesLogs.get(workspaceUID);
       const isStopped = workspace.isStopped;
       if (this.state.isStopped !== isStopped || !isEqual(this.state.logs, logs)) {
         this.setState({

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.privateRepo.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/__tests__/FactoryLoader.privateRepo.spec.tsx
@@ -16,8 +16,7 @@ import { render, waitFor } from '@testing-library/react';
 import { ROUTE } from '../../../route.enum';
 import { getMockRouterProps } from '../../../services/__mocks__/router';
 import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
-import FactoryLoaderContainer, { LoadFactorySteps } from '..';
-import { AlertOptions } from '../../../pages/IdeLoader';
+import FactoryLoaderContainer from '..';
 import { constructWorkspace, Devfile } from '../../../services/workspace-adapter';
 import { actionCreators as workspacesActionCreators } from '../../../store/Workspaces';
 import {
@@ -27,6 +26,7 @@ import {
 import SessionStorageService, { SessionStorageKey } from '../../../services/session-storage';
 import { RouterProps } from 'react-router';
 import { Store } from 'redux';
+import { Props } from '../../../pages/FactoryLoader';
 
 const showAlertMock = jest.fn();
 const setWorkspaceQualifiedName = jest.fn();
@@ -34,8 +34,8 @@ const createWorkspaceFromDevfileMock = jest.fn().mockResolvedValue(undefined);
 const requestWorkspaceMock = jest.fn().mockResolvedValue(undefined);
 const startWorkspaceMock = jest.fn().mockResolvedValue(undefined);
 const requestFactoryResolverMock = jest.fn().mockResolvedValue(undefined);
-const setWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
-const clearWorkspaceIdMock = jest.fn().mockResolvedValue(undefined);
+const setWorkspaceUIDMock = jest.fn().mockResolvedValue(undefined);
+const clearWorkspaceUIDMock = jest.fn().mockResolvedValue(undefined);
 
 const createWorkspaceFromResourcesMock = jest.fn().mockReturnValue(undefined);
 jest.mock('../../../store/Workspaces/devWorkspaces/index', () => {
@@ -75,11 +75,11 @@ jest.mock('../../../store/Workspaces');
       });
     },
 );
-(workspacesActionCreators.setWorkspaceId as jest.Mock).mockImplementation(
-  (id: string) => async () => setWorkspaceIdMock(id),
+(workspacesActionCreators.setWorkspaceUID as jest.Mock).mockImplementation(
+  (uid: string) => async () => setWorkspaceUIDMock(uid),
 );
-(workspacesActionCreators.clearWorkspaceId as jest.Mock).mockImplementation(
-  () => async () => clearWorkspaceIdMock(),
+(workspacesActionCreators.clearWorkspaceUID as jest.Mock).mockImplementation(
+  () => async () => clearWorkspaceUIDMock(),
 );
 (workspacesActionCreators.setWorkspaceQualifiedName as jest.Mock).mockImplementation(
   (namespace: string, workspaceName: string) => async () =>
@@ -106,16 +106,7 @@ const actualModule = jest.requireActual('../../../store/FactoryResolver');
 );
 
 jest.mock('../../../pages/FactoryLoader', () => {
-  return function DummyWizard(props: {
-    hasError: boolean;
-    currentStep: LoadFactorySteps;
-    workspaceName: string;
-    workspaceId: string;
-    resolvedDevfileMessage?: string;
-    callbacks?: {
-      showAlert?: (alertOptions: AlertOptions) => void;
-    };
-  }): React.ReactElement {
+  return function DummyWizard(props: Props): React.ReactElement {
     if (props.callbacks) {
       props.callbacks.showAlert = showAlertMock;
     }
@@ -125,7 +116,7 @@ jest.mock('../../../pages/FactoryLoader', () => {
         <div data-testid="factory-loader-has-error">{props.hasError.toString()}</div>
         <div data-testid="factory-loader-current-step">{props.currentStep}</div>
         <div data-testid="factory-loader-workspace-name">{props.workspaceName}</div>
-        <div data-testid="factory-loader-workspace-id">{props.workspaceId}</div>
+        <div data-testid="factory-loader-workspace-uid">{props.workspaceUID}</div>
         <div data-testid="factory-loader-devfile-location-info">{props.resolvedDevfileMessage}</div>
       </div>
     );

--- a/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/FactoryLoader/index.tsx
@@ -24,7 +24,7 @@ import * as DevWorkspacesStore from '../../store/Workspaces/devWorkspaces';
 import FactoryLoader from '../../pages/FactoryLoader';
 import {
   selectAllWorkspaces,
-  selectWorkspaceById,
+  selectWorkspaceByUID,
   selectWorkspaceByQualifiedName,
 } from '../../store/Workspaces/selectors';
 import {
@@ -225,7 +225,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
 
   private clearOldData(): void {
     if (this.props.workspace) {
-      this.props.clearWorkspaceId();
+      this.props.clearWorkspaceUID();
     }
     this.resetOverrideParams();
     this.setState({ hasError: false });
@@ -745,7 +745,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       return;
     }
 
-    this.props.setWorkspaceId(workspace.id);
+    this.props.setWorkspaceUID(workspace.uid);
 
     await this.startWorkspace();
 
@@ -762,14 +762,14 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
       createFromDevfile,
     } = this.state;
     const workspaceName = workspace ? workspace.name : '';
-    const workspaceId = workspace ? workspace.id : '';
+    const workspaceUID = workspace ? workspace.uid : '';
 
     return (
       <FactoryLoader
         currentStep={currentStep}
         hasError={hasError}
         resolvedDevfileMessage={resolvedDevfileMessage}
-        workspaceId={workspaceId}
+        workspaceUID={workspaceUID}
         workspaceName={workspaceName}
         createFromDevfile={createFromDevfile}
         isDevWorkspace={cheDevworkspaceEnabled}
@@ -781,7 +781,7 @@ export class FactoryLoaderContainer extends React.PureComponent<Props, State> {
 
 const mapStateToProps = (state: AppState) => ({
   factoryResolver: state.factoryResolver,
-  workspace: selectWorkspaceById(state),
+  workspace: selectWorkspaceByUID(state),
   allWorkspaces: selectAllWorkspaces(state),
   infrastructureNamespaces: selectInfrastructureNamespaces(state),
   preferredStorageType: selectPreferredStorageType(state),

--- a/packages/dashboard-frontend/src/containers/WorkspaceActions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceActions/__tests__/index.spec.tsx
@@ -46,8 +46,8 @@ describe('Workspace Actions', () => {
   const defaultWorkspaceId = 'workspace-0';
   const nonExistingWorkspaceId = 'non-existing-workspace';
 
-  const mockOnAction = jest.fn((ctx: ActionContextType, action: WorkspaceAction, id: string) =>
-    ctx.handleAction(action, id),
+  const mockOnAction = jest.fn((ctx: ActionContextType, action: WorkspaceAction, uid: string) =>
+    ctx.handleAction(action, uid),
   );
   const mockOnCancel = jest.fn();
 

--- a/packages/dashboard-frontend/src/containers/WorkspaceActions/context.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceActions/context.tsx
@@ -15,7 +15,7 @@ import { Location } from 'history';
 import { WorkspaceAction } from '../../services/helpers/types';
 
 export type ActionContextType = {
-  handleAction: (action: WorkspaceAction, id: string) => Promise<Location | void>;
+  handleAction: (action: WorkspaceAction, uid: string) => Promise<Location | void>;
   showConfirmation: (wantDelete: string[]) => Promise<void>;
   toDelete: string[];
 };

--- a/packages/dashboard-frontend/src/containers/WorkspaceActions/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceActions/index.tsx
@@ -46,8 +46,8 @@ type Props = MappedProps & { history: History } & {
 };
 
 type State = {
-  toDelete: string[];
-  wantDelete: string[];
+  toDelete: string[]; // UIDs
+  wantDelete: string[]; // UIDs
   isOpen: boolean;
   isConfirmed: boolean;
   deferred?: Deferred;
@@ -73,7 +73,7 @@ export class WorkspaceActionsProvider extends React.Component<Props, State> {
   private async handleLocation(location: Location, workspace: Workspace): Promise<Location | void> {
     if (workspace.isDevWorkspace) {
       const link = toHref(this.props.history, location);
-      window.open(link, workspace.id);
+      window.open(link, workspace.uid);
     } else {
       return location;
     }
@@ -87,20 +87,20 @@ export class WorkspaceActionsProvider extends React.Component<Props, State> {
       throw new Error('Only STOPPED workspaces can be deleted.');
     }
 
-    this.deleting.add(workspace.id);
+    this.deleting.add(workspace.uid);
     this.setState({
       toDelete: Array.from(this.deleting),
     });
 
     try {
       await this.props.deleteWorkspace(workspace);
-      this.deleting.delete(workspace.id);
+      this.deleting.delete(workspace.uid);
       this.setState({
         toDelete: Array.from(this.deleting),
       });
       return buildWorkspacesLocation();
     } catch (e) {
-      this.deleting.delete(workspace.id);
+      this.deleting.delete(workspace.uid);
       this.setState({
         toDelete: Array.from(this.deleting),
       });
@@ -111,15 +111,15 @@ export class WorkspaceActionsProvider extends React.Component<Props, State> {
   /**
    * Performs an action on the given workspace
    */
-  private async handleAction(action: WorkspaceAction, id: string): Promise<Location | void> {
-    const workspace = this.props.allWorkspaces.find(workspace => id === workspace.id);
+  private async handleAction(action: WorkspaceAction, uid: string): Promise<Location | void> {
+    const workspace = this.props.allWorkspaces.find(workspace => uid === workspace.uid);
 
     if (!workspace) {
-      console.warn(`Workspace not found, ID: ${id}.`);
+      console.warn(`Workspace not found, UID: ${uid}.`);
       return;
     }
 
-    if (this.deleting.has(id)) {
+    if (this.deleting.has(uid)) {
       console.warn(`Workspace "${workspace.name}" is being deleted.`);
       return;
     }
@@ -283,7 +283,7 @@ export class WorkspaceActionsProvider extends React.Component<Props, State> {
     return (
       <WorkspaceActionsContext.Provider
         value={{
-          handleAction: (action, id) => this.handleAction(action, id),
+          handleAction: (action, uid) => this.handleAction(action, uid),
           showConfirmation: (wantDelete: string[]) => this.showConfirmation(wantDelete),
           toDelete,
         }}

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
@@ -24,10 +24,7 @@ import {
 } from '../../../store/Workspaces';
 import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
 import { CheWorkspaceBuilder } from '../../../store/__mocks__/cheWorkspaceBuilder';
-import {
-  DEVWORKSPACE_ID_OVERRIDE_ANNOTATION,
-  ORIGINAL_WORKSPACE_ID_ANNOTATION,
-} from '../../../services/devfileApi/devWorkspace/metadata';
+import { DEVWORKSPACE_ID_OVERRIDE_ANNOTATION } from '../../../services/devfileApi/devWorkspace/metadata';
 import userEvent from '@testing-library/user-event';
 import devfileApi from '../../../services/devfileApi';
 import { DEVWORKSPACE_METADATA_ANNOTATION } from '../../../services/workspace-client/devworkspace/devWorkspaceClient';
@@ -141,7 +138,7 @@ describe('Workspace Details container', () => {
         const devWorkspace = devWorkspaceBuilder
           .withMetadata({
             annotations: {
-              [ORIGINAL_WORKSPACE_ID_ANNOTATION]: cheWorkspaceId,
+              [DEVWORKSPACE_ID_OVERRIDE_ANNOTATION]: cheWorkspaceId,
             },
           })
           .build();
@@ -166,7 +163,7 @@ describe('Workspace Details container', () => {
         const devWorkspace = devWorkspaceBuilder
           .withMetadata({
             annotations: {
-              [ORIGINAL_WORKSPACE_ID_ANNOTATION]: cheWorkspaceId,
+              [DEVWORKSPACE_ID_OVERRIDE_ANNOTATION]: cheWorkspaceId,
             },
           })
           .build();
@@ -272,7 +269,7 @@ describe('Workspace Details container', () => {
         const devWorkspace = devWorkspaceBuilder
           .withMetadata({
             annotations: {
-              [ORIGINAL_WORKSPACE_ID_ANNOTATION]: cheWorkspaceId,
+              [DEVWORKSPACE_ID_OVERRIDE_ANNOTATION]: cheWorkspaceId,
             },
           })
           .build();
@@ -305,7 +302,6 @@ describe('Workspace Details container', () => {
             metadata: expect.objectContaining({
               attributes: expect.objectContaining({
                 [DEVWORKSPACE_METADATA_ANNOTATION]: {
-                  [ORIGINAL_WORKSPACE_ID_ANNOTATION]: cheWorkspaceId,
                   [DEVWORKSPACE_ID_OVERRIDE_ANNOTATION]: cheWorkspaceId,
                 },
               }),

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
@@ -59,6 +59,7 @@ describe('Workspace Details container', () => {
     const workspaceName = 'wksp';
     const cheWorkspaceId = 'che-wksp-id';
     const devWorkspaceId = 'che-wksp-id';
+    const devWorkspaceUID = 'uid-1234';
     const cheNamespace = 'user-che';
     const devNamespace = 'user-dev';
 
@@ -78,6 +79,7 @@ describe('Workspace Details container', () => {
         .withNamespace(cheNamespace);
       devWorkspaceBuilder = new DevWorkspaceBuilder()
         .withId(devWorkspaceId)
+        .withUID(devWorkspaceUID)
         .withName(workspaceName)
         .withNamespace(devNamespace);
       fakeStoreBuilder = new FakeStoreBuilder()
@@ -247,7 +249,7 @@ describe('Workspace Details container', () => {
       it('should show the Convert button - with attribute', async () => {
         const cheWorkspace = cheWorkspaceBuilder
           .withAttributes({
-            convertedId: devWorkspaceId,
+            convertedId: devWorkspaceUID,
           } as che.WorkspaceAttributes)
           .build();
         const store = new FakeStoreBuilder()
@@ -320,7 +322,7 @@ describe('Workspace Details container', () => {
           expect.objectContaining({
             ref: expect.objectContaining({
               attributes: expect.objectContaining({
-                convertedId: devWorkspaceId,
+                convertedId: devWorkspaceUID,
               }),
             }),
           }),

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
@@ -58,7 +58,7 @@ describe('Workspace Details container', () => {
   describe('devfile v1->v2 conversion', () => {
     const workspaceName = 'wksp';
     const cheWorkspaceId = 'che-wksp-id';
-    const devWorkspaceId = 'dev-wksp-id';
+    const devWorkspaceId = 'che-wksp-id';
     const cheNamespace = 'user-che';
     const devNamespace = 'user-dev';
 

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
@@ -86,19 +86,19 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
       return;
     }
 
-    const oldWorkspaceId =
+    const che7WorkspaceId =
       workspace.ref.metadata.annotations?.[DEVWORKSPACE_ID_OVERRIDE_ANNOTATION];
-    if (!oldWorkspaceId) {
+    if (!che7WorkspaceId) {
       return;
     }
     // check if the old workspace is still available
-    const oldWorkspace = this.props.allWorkspaces.find(
-      workspace => !isDevWorkspace(workspace.ref) && workspace.id === oldWorkspaceId,
+    const che7Workspace = this.props.allWorkspaces.find(
+      workspace => workspace.uid === che7WorkspaceId,
     );
-    if (!oldWorkspace) {
+    if (!che7Workspace) {
       return;
     }
-    return buildDetailsLocation(oldWorkspace, WorkspaceDetailsTab.DEVFILE);
+    return buildDetailsLocation(che7Workspace, WorkspaceDetailsTab.DEVFILE);
   }
 
   private getShowConvertButton(workspace?: Workspace): boolean {
@@ -109,8 +109,8 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
     if (!cheWorkspace.attributes?.convertedId) {
       return true;
     } else {
-      const id = cheWorkspace.attributes.convertedId;
-      return this.props.allWorkspaces.every(workspace => workspace.id !== id);
+      const devWorkspaceUID = cheWorkspace.attributes.convertedId;
+      return this.props.allWorkspaces.every(workspace => workspace.uid !== devWorkspaceUID);
     }
   }
 
@@ -121,7 +121,7 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
   public shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
     return (
       nextProps.isLoading === false &&
-      (this.state.workspace?.id !== nextState.workspace?.id ||
+      (this.state.workspace?.uid !== nextState.workspace?.uid ||
         this.props.location.pathname !== nextProps.location.pathname)
     );
   }
@@ -175,7 +175,7 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
     }
     devfileV2.metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION][
       DEVWORKSPACE_ID_OVERRIDE_ANNOTATION
-    ] = oldWorkspace.id;
+    ] = oldWorkspace.uid;
     const defaultNamespace = this.props.defaultNamespace.name;
     // create a new workspace
     await this.props.createWorkspaceFromDevfile(
@@ -191,7 +191,7 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
       if (isDevWorkspace(workspace.ref)) {
         return (
           workspace.ref.metadata.annotations?.[DEVWORKSPACE_ID_OVERRIDE_ANNOTATION] ===
-          oldWorkspace.id
+          oldWorkspace.uid
         );
       }
       return false;
@@ -204,7 +204,7 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
     // add 'converted' attribute to the old workspace
     // to be able to hide it on the Workspaces page
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    oldWorkspace.ref.attributes!.convertedId = oldWorkspace.id;
+    oldWorkspace.ref.attributes!.convertedId = newWorkspace.uid;
     await this.props.updateWorkspace(oldWorkspace);
 
     // return the new workspace page location

--- a/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
@@ -63,7 +63,7 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
       return Fallback;
     }
 
-    const ids = allWorkspaces.map(workspace => workspace.id);
+    const UIDs = allWorkspaces.map(workspace => workspace.uid);
     const filteredWorkspaces = allWorkspaces.filter(workspace => {
       if (isDevWorkspace(workspace.ref)) {
         return true;
@@ -71,11 +71,11 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
       if (workspace.isDeprecated === false) {
         return true;
       }
-      const convertedId = workspace.ref.attributes?.convertedId;
-      if (convertedId === undefined) {
+      const convertedUID = workspace.ref.attributes?.convertedId;
+      if (convertedUID === undefined) {
         return true;
       }
-      return ids.includes(convertedId) === false;
+      return UIDs.includes(convertedUID) === false;
     });
 
     return (
@@ -86,7 +86,7 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
               branding={branding}
               history={history}
               workspaces={filteredWorkspaces}
-              onAction={(action, id) => context.handleAction(action, id)}
+              onAction={(action, uid) => context.handleAction(action, uid)}
               showConfirmation={wantDelete => context.showConfirmation(wantDelete)}
               toDelete={context.toDelete}
             />

--- a/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
@@ -65,10 +65,10 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
 
     const ids = allWorkspaces.map(workspace => workspace.id);
     const filteredWorkspaces = allWorkspaces.filter(workspace => {
-      if (workspace.isDeprecated === false) {
+      if (isDevWorkspace(workspace.ref)) {
         return true;
       }
-      if (isDevWorkspace(workspace.ref)) {
+      if (workspace.isDeprecated === false) {
         return true;
       }
       const convertedId = workspace.ref.attributes?.convertedId;

--- a/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/IdeLoader.spec.tsx
@@ -20,7 +20,7 @@ import { getMockRouterProps } from '../../services/__mocks__/router';
 import { FakeStoreBuilder } from '../../store/__mocks__/storeBuilder';
 import { WorkspaceStatus } from '../../services/helpers/types';
 import IdeLoaderContainer, { LoadIdeSteps } from '../IdeLoader';
-import { AlertOptions } from '../../pages/IdeLoader';
+import { Props } from '../../pages/IdeLoader';
 import { AppThunk } from '../../store';
 import { ActionCreators } from '../../store/Workspaces';
 import { Workspace } from '../../services/workspace-adapter';
@@ -31,7 +31,7 @@ const hideAlertMock = jest.fn();
 const requestWorkspaceMock = jest.fn().mockResolvedValue(undefined);
 const startWorkspaceMock = jest.fn().mockResolvedValue(undefined);
 const setWorkspaceIdMock = jest.fn();
-const clearWorkspaceIdMock = jest.fn();
+const clearWorkspaceUIDMock = jest.fn();
 
 jest.mock('../../store/Workspaces/index', () => {
   /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -50,11 +50,11 @@ jest.mock('../../store/Workspaces/index', () => {
       requestWorkspaces: (): AppThunk<Action, Promise<void>> => async (): Promise<void> => {
         return Promise.resolve();
       },
-      setWorkspaceId:
+      setWorkspaceUID:
         (id: string): AppThunk<Action, void> =>
         (): void =>
           setWorkspaceIdMock(),
-      clearWorkspaceId: (): AppThunk<Action, void> => (): void => clearWorkspaceIdMock(),
+      clearWorkspaceUID: (): AppThunk<Action, void> => (): void => clearWorkspaceUIDMock(),
       updateWorkspace:
         (workspace: Workspace): AppThunk<Action, Promise<void>> =>
         async (): Promise<void> => {
@@ -66,18 +66,7 @@ jest.mock('../../store/Workspaces/index', () => {
 });
 
 jest.mock('../../pages/IdeLoader', () => {
-  return function DummyWizard(props: {
-    hasError: boolean;
-    status: string | undefined;
-    currentStep: LoadIdeSteps;
-    workspaceName: string;
-    workspaceId: string;
-    ideUrl?: string;
-    callbacks?: {
-      showAlert?: (alertOptions: AlertOptions) => void;
-      hideAlert?: () => void;
-    };
-  }): React.ReactElement {
+  return function DummyWizard(props: Props): React.ReactElement {
     if (props.callbacks) {
       props.callbacks.showAlert = showAlertMock;
       props.callbacks.hideAlert = hideAlertMock;
@@ -88,7 +77,7 @@ jest.mock('../../pages/IdeLoader', () => {
         <div data-testid="ide-loader-has-error">{props.hasError.toString()}</div>
         <div data-testid="ide-loader-current-step">{props.currentStep}</div>
         <div data-testid="ide-loader-workspace-name">{props.workspaceName}</div>
-        <div data-testid="ide-loader-workspace-id">{props.workspaceId}</div>
+        <div data-testid="ide-loader-workspace-uid">{props.workspaceUID}</div>
         <div data-testid="ide-loader-workspace-ide-url">{props.ideUrl}</div>
         <div data-testid="ide-loader-workspace-status">{props.status}</div>
       </div>
@@ -142,7 +131,7 @@ describe('IDE Loader container', () => {
 
   const store = new FakeStoreBuilder()
     .withWorkspaces({
-      workspaceId: 'id-wksp-1',
+      workspaceUID: 'id-wksp-1',
     })
     .withCheWorkspaces({
       workspaces: [workspace_1, workspace_2, workspace_3],
@@ -240,8 +229,8 @@ describe('IDE Loader container', () => {
       expect(startWorkspaceMock).toHaveBeenCalledTimes(1);
     });
 
-    const elementWorkspaceId = screen.getByTestId('ide-loader-workspace-id');
-    expect(elementWorkspaceId.innerHTML).toEqual(workspaceId);
+    const elementWorkspaceUID = screen.getByTestId('ide-loader-workspace-uid');
+    expect(elementWorkspaceUID.innerHTML).toEqual(workspaceId);
 
     const elementWorkspaceName = screen.getByTestId('ide-loader-workspace-name');
     expect(elementWorkspaceName.innerHTML).toEqual(workspaceName);
@@ -278,8 +267,8 @@ describe('IDE Loader container', () => {
     );
     expect(LoadIdeSteps[elementCurrentStep]).toEqual(LoadIdeSteps[LoadIdeSteps.OPEN_IDE]);
 
-    const elementWorkspaceId = screen.getByTestId('ide-loader-workspace-id');
-    expect(elementWorkspaceId.innerHTML).toEqual('');
+    const elementWorkspaceUID = screen.getByTestId('ide-loader-workspace-uid');
+    expect(elementWorkspaceUID.innerHTML).toEqual('');
 
     const elementIdeUrl = screen.getByTestId('ide-loader-workspace-ide-url');
     expect(elementIdeUrl.innerHTML).toEqual(ideUrl);

--- a/packages/dashboard-frontend/src/containers/__tests__/WorkspacesList.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/WorkspacesList.spec.tsx
@@ -36,7 +36,7 @@ jest.mock('../../store/Workspaces/index', () => {
 jest.mock('../../pages/WorkspacesList', () => {
   const FakeWorkspacesList = (props: { workspaces: Workspace[] }): React.ReactElement => {
     const ids = props.workspaces.map(wksp => (
-      <span data-testid="workspace" key={wksp.id}>
+      <span data-testid="workspace" key={wksp.uid}>
         {wksp.name}
       </span>
     ));
@@ -128,14 +128,20 @@ describe('Workspaces List Container', () => {
     describe('in devworkspace mode', () => {
       it('should pass workspaces but not converted che-server based workspaces', () => {
         const deprecated = ['che-wksp-0', 'che-wksp-1', 'che-wksp-2'];
-        WorkspaceAdapter.setDeprecatedIds(deprecated);
+        WorkspaceAdapter.setDeprecatedUIDs(deprecated);
+        const devWorkspaces = [0, 1, 2, 4].map(i =>
+          new DevWorkspaceBuilder()
+            .withId('dev-wksp-' + i)
+            .withName('dev-wksp-' + i)
+            .build(),
+        );
         const cheWorkspaces = [
           new CheWorkspaceBuilder()
             .withId(deprecated[0])
             .withName(deprecated[0])
             .withAttributes({
               created: new Date().toISOString(),
-              convertedId: 'dev-wksp-0',
+              convertedId: WorkspaceAdapter.getUID(devWorkspaces[0]),
               infrastructureNamespace: 'user',
             })
             .build(),
@@ -150,12 +156,6 @@ describe('Workspaces List Container', () => {
             .build(),
           new CheWorkspaceBuilder().withId(deprecated[2]).withName(deprecated[2]).build(),
         ];
-        const devWorkspaces = [0, 1, 2, 4].map(i =>
-          new DevWorkspaceBuilder()
-            .withId('dev-wksp-' + i)
-            .withName('dev-wksp-' + i)
-            .build(),
-        );
         const store = new FakeStoreBuilder()
           .withCheWorkspaces({ workspaces: cheWorkspaces })
           .withDevWorkspaces({ workspaces: devWorkspaces })

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/FactoryLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/__tests__/FactoryLoader.spec.tsx
@@ -26,8 +26,8 @@ jest.mock('react-tooltip', () => {
 });
 
 const workspaceName = 'wksp-test';
-const workspaceId = 'testWorkspaceId';
-const workspace = createFakeCheWorkspace(workspaceId, workspaceName);
+const workspaceUID = 'testWorkspaceId';
+const workspace = createFakeCheWorkspace(workspaceUID, workspaceName);
 const store = new FakeStoreBuilder()
   .withCheWorkspaces({
     workspaces: [workspace],
@@ -38,7 +38,7 @@ describe('The Factory Loader page  component', () => {
   it('should render INITIALIZING step correctly', () => {
     const currentStep = LoadFactorySteps.INITIALIZING;
     const hasError = false;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -46,7 +46,7 @@ describe('The Factory Loader page  component', () => {
   it('should render INITIALIZING step with an error correctly', () => {
     const currentStep = LoadFactorySteps.INITIALIZING;
     const hasError = true;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -59,7 +59,7 @@ describe('The Factory Loader page  component', () => {
       store,
       currentStep,
       workspaceName,
-      workspaceId,
+      workspaceUID,
       hasError,
       resolvedDevfileMessage,
     );
@@ -70,7 +70,7 @@ describe('The Factory Loader page  component', () => {
   it('should render LOOKING_FOR_DEVFILE step without devfile location correctly', () => {
     const currentStep = LoadFactorySteps.LOOKING_FOR_DEVFILE;
     const hasError = false;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -78,7 +78,7 @@ describe('The Factory Loader page  component', () => {
   it('should render LOOKING_FOR_DEVFILE step with an error correctly', () => {
     const currentStep = LoadFactorySteps.LOOKING_FOR_DEVFILE;
     const hasError = true;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -86,7 +86,7 @@ describe('The Factory Loader page  component', () => {
   it('should render APPLYING_DEVFILE step correctly', () => {
     const currentStep = LoadFactorySteps.APPLYING_DEVFILE;
     const hasError = false;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -94,7 +94,7 @@ describe('The Factory Loader page  component', () => {
   it('should render APPLYING_DEVFILE step with an error correctly', () => {
     const currentStep = LoadFactorySteps.APPLYING_DEVFILE;
     const hasError = true;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -102,7 +102,7 @@ describe('The Factory Loader page  component', () => {
   it('should render START_WORKSPACE step correctly', () => {
     const currentStep = LoadFactorySteps.START_WORKSPACE;
     const hasError = false;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -110,7 +110,7 @@ describe('The Factory Loader page  component', () => {
   it('should render START_WORKSPACE step with an error correctly', () => {
     const currentStep = LoadFactorySteps.START_WORKSPACE;
     const hasError = true;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -118,7 +118,7 @@ describe('The Factory Loader page  component', () => {
   it('should render OPEN_IDE step correctly', () => {
     const currentStep = LoadFactorySteps.OPEN_IDE;
     const hasError = false;
-    const component = renderComponent(store, currentStep, workspaceName, workspaceId, hasError);
+    const component = renderComponent(store, currentStep, workspaceName, workspaceUID, hasError);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -128,7 +128,7 @@ function renderComponent(
   store: Store,
   currentStep: LoadFactorySteps,
   workspaceName: string,
-  workspaceId: string,
+  workspaceUID: string,
   hasError: boolean,
   resolvedDevfileMessage?: string,
 ): ReactTestRenderer {
@@ -137,7 +137,7 @@ function renderComponent(
       <FactoryLoaderTabs
         currentStep={currentStep}
         workspaceName={workspaceName}
-        workspaceId={workspaceId}
+        workspaceUID={workspaceUID}
         hasError={hasError}
         resolvedDevfileMessage={resolvedDevfileMessage}
         isDevWorkspace

--- a/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/FactoryLoader/index.tsx
@@ -48,11 +48,11 @@ export type AlertOptions = {
   alertVariant: AlertVariant;
 };
 
-type Props = {
+export type Props = {
   hasError: boolean;
   currentStep: LoadFactorySteps;
   workspaceName: string;
-  workspaceId: string;
+  workspaceUID: string;
   isDevWorkspace: boolean;
   resolvedDevfileMessage?: string;
   createFromDevfile: boolean;
@@ -228,7 +228,7 @@ class FactoryLoader extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { workspaceName, workspaceId, hasError, currentStep, isDevWorkspace } = this.props;
+    const { workspaceName, workspaceUID, hasError, currentStep, isDevWorkspace } = this.props;
     const { isPopupAlertVisible, currentRequestError, currentAlertVariant, alertActionLinks } =
       this.state;
 
@@ -286,7 +286,7 @@ class FactoryLoader extends React.PureComponent<Props, State> {
               title={LoadFactoryTabs[LoadFactoryTabs.Logs]}
               id="factory-loader-page-logs-tab"
             >
-              <WorkspaceLogs workspaceId={workspaceId} isDevWorkspace={isDevWorkspace} />
+              <WorkspaceLogs workspaceUID={workspaceUID} isDevWorkspace={isDevWorkspace} />
             </Tab>
           </Tabs>
         </PageSection>

--- a/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
@@ -149,7 +149,7 @@ function createFakeStore(): Store {
       workspaces: [workspace],
     })
     .withWorkspaces({
-      workspaceId: workspace.id,
+      workspaceUID: workspace.id,
       namespace: namespace,
       workspaceName: workspace.devfile.metadata.name,
     })

--- a/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/IdeLoader.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/IdeLoader.spec.tsx
@@ -228,7 +228,7 @@ function renderComponent(
   store: Store,
   currentStep: LoadIdeSteps,
   workspaceName: string,
-  workspaceId: string,
+  workspaceUID: string,
   hasError: boolean,
   workspaceStatus: WorkspaceStatus | DeprecatedWorkspaceStatus,
   ideUrl?: string,
@@ -238,7 +238,7 @@ function renderComponent(
       <IdeLoaderTabs
         currentStep={currentStep}
         workspaceName={workspaceName}
-        workspaceId={workspaceId}
+        workspaceUID={workspaceUID}
         hasError={hasError}
         status={workspaceStatus}
         ideUrl={ideUrl}

--- a/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/index.tsx
@@ -42,13 +42,13 @@ import './IdeLoader.styl';
 
 export const SECTION_THEME = PageSectionVariants.light;
 
-type Props = {
+export type Props = {
   currentStep: LoadIdeSteps;
   hasError: boolean;
   ideUrl?: string;
   preselectedTabKey?: IdeLoaderTab;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
-  workspaceId: string;
+  workspaceUID: string;
   workspaceName: string;
   isDevWorkspace: boolean;
   callbacks?: {
@@ -59,7 +59,7 @@ type Props = {
 
 type State = {
   ideUrl?: string;
-  workspaceId: string;
+  workspaceUID: string;
   isPopupAlertVisible: boolean;
   activeTabKey: IdeLoaderTab;
   currentRequestError: string;
@@ -94,7 +94,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
       isPopupAlertVisible: false,
       currentRequestError: '',
       isDevWorkspace: this.props.isDevWorkspace,
-      workspaceId: this.props.workspaceId,
+      workspaceUID: this.props.workspaceUID,
       activeTabKey: this.props.preselectedTabKey
         ? this.props.preselectedTabKey
         : IdeLoaderTab.Progress,
@@ -153,14 +153,14 @@ class IdeLoader extends React.PureComponent<Props, State> {
     if (this.props.ideUrl) {
       this.setState({ ideUrl: this.props.ideUrl });
     }
-    if (this.props.workspaceId) {
-      this.setState({ workspaceId: this.props.workspaceId });
+    if (this.props.workspaceUID) {
+      this.setState({ workspaceUID: this.props.workspaceUID });
     }
   }
 
   public async componentDidUpdate(): Promise<void> {
     this.showOnlyContentIfDevWorkspace();
-    const { currentStep, hasError, ideUrl, workspaceId } = this.props;
+    const { currentStep, hasError, ideUrl, workspaceUID } = this.props;
 
     const current = this.wizardRef.current;
     if (current && current.state && current.state.currentStep !== currentStep && !hasError) {
@@ -171,9 +171,9 @@ class IdeLoader extends React.PureComponent<Props, State> {
       this.setState({ currentRequestError: '' });
     }
 
-    if (this.state.workspaceId !== workspaceId) {
+    if (this.state.workspaceUID !== workspaceUID) {
       this.setState({
-        workspaceId,
+        workspaceUID,
         isPopupAlertVisible: false,
       });
     }
@@ -276,7 +276,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { workspaceName, workspaceId, ideUrl, status, currentStep } = this.props;
+    const { workspaceName, workspaceUID, ideUrl, status, currentStep } = this.props;
     const { isPopupAlertVisible, currentAlertVariant, currentRequestError, alertActionLinks } =
       this.state;
 
@@ -347,7 +347,10 @@ class IdeLoader extends React.PureComponent<Props, State> {
               title={IdeLoaderTab[IdeLoaderTab.Logs]}
               id="ide-loader-page-logs-tab"
             >
-              <WorkspaceLogs workspaceId={workspaceId} isDevWorkspace={this.props.isDevWorkspace} />
+              <WorkspaceLogs
+                workspaceUID={workspaceUID}
+                isDevWorkspace={this.props.isDevWorkspace}
+              />
             </Tab>
           </Tabs>
         </PageSection>

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.tsx
@@ -28,7 +28,7 @@ type Props = {
   context: ActionContextType;
   history: History;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
-  workspaceId: string;
+  workspaceUID: string;
   workspaceName: string;
   onAction: (action: WorkspaceAction, context: ActionContextType) => void;
 };
@@ -106,7 +106,7 @@ export default class DropdownActions extends React.PureComponent<Props, State> {
   }
 
   render(): React.ReactElement {
-    const { workspaceId } = this.props;
+    const { workspaceUID } = this.props;
     const { isExpanded } = this.state;
 
     const dropdownItems = this.getDropdownItems();
@@ -116,7 +116,7 @@ export default class DropdownActions extends React.PureComponent<Props, State> {
         className={styles.workspaceActionSelector}
         toggle={
           <DropdownToggle
-            data-testid={`${workspaceId}-action-dropdown`}
+            data-testid={`${workspaceUID}-action-dropdown`}
             onToggle={isExpanded => this.handleToggle(isExpanded)}
             toggleIndicator={CaretDownIcon}
             isPrimary

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
@@ -48,7 +48,7 @@ jest.mock('../../../../../store/Workspaces/index', () => {
 
 const namespace = 'che';
 const workspaceName = 'test-workspace-name';
-const workspaceId = 'test-workspace-id';
+const workspaceUID = 'test-workspace-id';
 
 let cheWorkspace: che.Workspace;
 let store: Store;
@@ -56,7 +56,7 @@ let store: Store;
 describe('Workspace WorkspaceAction widget', () => {
   beforeEach(() => {
     cheWorkspace = new CheWorkspaceBuilder()
-      .withId(workspaceId)
+      .withId(workspaceUID)
       .withName(workspaceName)
       .withNamespace(namespace)
       .withStatus(WorkspaceStatus.STOPPED)
@@ -70,7 +70,7 @@ describe('Workspace WorkspaceAction widget', () => {
       .build();
     store = new FakeStoreBuilder()
       .withWorkspaces({
-        workspaceId,
+        workspaceUID,
         workspaceName,
       })
       .withInfrastructureNamespace([{ name: namespace, attributes: { phase: 'Active' } }], false)
@@ -86,7 +86,7 @@ describe('Workspace WorkspaceAction widget', () => {
 
     renderComponent(component);
 
-    const actionDropdown = screen.getByTestId(`${workspaceId}-action-dropdown`);
+    const actionDropdown = screen.getByTestId(`${workspaceUID}-action-dropdown`);
     actionDropdown.click();
 
     const menuitems = screen.getAllByRole('menuitem');
@@ -112,7 +112,7 @@ describe('Workspace WorkspaceAction widget', () => {
     const actionButton = screen.queryByRole('button', { name: /delete/i });
     expect(actionButton).toBe(null);
 
-    const actionDropdown = screen.queryByTestId(`${workspaceId}-action-dropdown`);
+    const actionDropdown = screen.queryByTestId(`${workspaceUID}-action-dropdown`);
     expect(actionDropdown).toBe(null);
   });
 
@@ -123,7 +123,7 @@ describe('Workspace WorkspaceAction widget', () => {
 
     renderComponent(component);
 
-    const actionDropdown = screen.getByTestId(`${workspaceId}-action-dropdown`);
+    const actionDropdown = screen.getByTestId(`${workspaceUID}-action-dropdown`);
     actionDropdown.click();
 
     expect(history.location.pathname).toBe('/');
@@ -143,7 +143,7 @@ describe('Workspace WorkspaceAction widget', () => {
 
     renderComponent(component);
 
-    const actionDropdown = screen.getByTestId(`${workspaceId}-action-dropdown`);
+    const actionDropdown = screen.getByTestId(`${workspaceUID}-action-dropdown`);
     actionDropdown.click();
 
     expect(history.location.pathname).toBe('/');
@@ -163,7 +163,7 @@ describe('Workspace WorkspaceAction widget', () => {
 
     renderComponent(component);
 
-    const actionDropdown = screen.getByTestId(`${workspaceId}-action-dropdown`);
+    const actionDropdown = screen.getByTestId(`${workspaceUID}-action-dropdown`);
     actionDropdown.click();
 
     expect(history.location.pathname).toBe('/');
@@ -179,7 +179,7 @@ describe('Workspace WorkspaceAction widget', () => {
     const history = createHashHistory();
     renderComponent(createComponent(history));
 
-    const actionDropdown = screen.getByTestId(`${workspaceId}-action-dropdown`);
+    const actionDropdown = screen.getByTestId(`${workspaceUID}-action-dropdown`);
     actionDropdown.click();
 
     expect(history.location.pathname).toBe('/');
@@ -196,7 +196,7 @@ describe('Workspace WorkspaceAction widget', () => {
 
     renderComponent(createComponent(history, WorkspaceStatus.RUNNING));
 
-    const actionDropdown = screen.getByTestId(`${workspaceId}-action-dropdown`);
+    const actionDropdown = screen.getByTestId(`${workspaceUID}-action-dropdown`);
     actionDropdown.click();
 
     expect(history.location.pathname).toBe('/');
@@ -215,7 +215,7 @@ function createComponent(
 ): React.ReactElement {
   return (
     <HeaderActionSelect
-      workspaceId={workspaceId}
+      workspaceUID={workspaceUID}
       workspaceName={workspaceName}
       canDelete={canDelete}
       history={history}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
@@ -32,7 +32,7 @@ import DropdownActions from './Dropdown';
 import ButtonAction from './Button';
 
 type Props = {
-  workspaceId: string;
+  workspaceUID: string;
   workspaceName: string;
   canDelete: boolean;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
@@ -59,7 +59,7 @@ export class HeaderActionSelect extends React.PureComponent<Props> {
           return;
         }
       }
-      const nextPath = await context.handleAction(selectedAction, this.props.workspaceId);
+      const nextPath = await context.handleAction(selectedAction, this.props.workspaceUID);
       if (!nextPath) {
         return;
       }

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/__tests__/index.spec.tsx
@@ -42,7 +42,7 @@ describe('Inline alerts', () => {
 
   it('should render the deprecation warning', () => {
     const deprecatedId = 'wksp-id';
-    WorkspaceAdapter.setDeprecatedIds([deprecatedId]);
+    WorkspaceAdapter.setDeprecatedUIDs([deprecatedId]);
     const workspace = constructWorkspace(
       new CheWorkspaceBuilder().withId(deprecatedId).withName('wksp').withNamespace('user').build(),
     );
@@ -56,7 +56,7 @@ describe('Inline alerts', () => {
 
   it('should render the conversion error', () => {
     const deprecatedId = 'wksp-id';
-    WorkspaceAdapter.setDeprecatedIds([deprecatedId]);
+    WorkspaceAdapter.setDeprecatedUIDs([deprecatedId]);
     const workspace = constructWorkspace(
       new CheWorkspaceBuilder().withId(deprecatedId).withName('wksp').withNamespace('user').build(),
     );

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
@@ -239,7 +239,7 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
             <WorkspaceConversionButton onConvert={() => this.handleConversion(workspace)} />
           )}
           <HeaderActionSelect
-            workspaceId={workspace.id}
+            workspaceUID={workspace.uid}
             workspaceName={workspaceName}
             canDelete={canDelete}
             status={workspace.status}
@@ -273,9 +273,6 @@ export class WorkspaceDetails extends React.PureComponent<Props, State> {
                 onDevWorkspaceWarning={() => this.handleRestartWarning()}
               />
             </Tab>
-            {/* <Tab eventKey={WorkspaceDetailsTabs.Logs} title={WorkspaceDetailsTabs[WorkspaceDetailsTabs.Logs]}>*/}
-            {/*  <LogsTab workspaceId={workspace.id} />*/}
-            {/* </Tab>*/}
           </Tabs>
           <UnsavedChangesModal
             hasUnsavedChanges={() => this.hasUnsavedChanges()}

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
@@ -24,7 +24,7 @@ import { DevWorkspaceStatus, WorkspaceDetailsTab } from '../../services/helpers/
 
 export interface RowData extends IRow {
   props: {
-    workspaceId: string;
+    workspaceUID: string;
   };
 }
 
@@ -38,7 +38,7 @@ export function buildRows(
   const rows: RowData[] = [];
   workspaces
     // skip workspaces that are not match a filter
-    .filter(workspace => filtered.includes(workspace.id))
+    .filter(workspace => filtered.includes(workspace.uid))
     .sort((workspaceA, workspaceB) => {
       if (sortBy.index === 1) {
         const nameA = workspaceA.name || '';
@@ -53,8 +53,8 @@ export function buildRows(
       return 0;
     })
     .forEach(workspace => {
-      const isSelected = selected.includes(workspace.id);
-      const isDeleted = toDelete.includes(workspace.id);
+      const isSelected = selected.includes(workspace.uid);
+      const isDeleted = toDelete.includes(workspace.uid);
 
       const overviewPageLocation = buildDetailsLocation(workspace);
       const devfilePageLocation = buildDetailsLocation(workspace, WorkspaceDetailsTab.DEVFILE);
@@ -169,7 +169,7 @@ export function buildRow(
           isInline
           isSmall
           component={props => (
-            <Link {...props} to={ideLoaderLocation} rel="noreferrer" target={workspace.id} />
+            <Link {...props} to={ideLoaderLocation} rel="noreferrer" target={workspace.uid} />
           )}
         >
           Open
@@ -215,7 +215,7 @@ export function buildRow(
       },
     ],
     props: {
-      workspaceId: workspace.id,
+      workspaceUID: workspace.uid,
     },
     selected: isSelected || isDeleted,
     disableSelection: isDeleted,

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
@@ -168,15 +168,15 @@ describe('Workspaces List Page', () => {
 
         expect(mockOnAction).toHaveBeenCalledWith(
           WorkspaceAction.DELETE_WORKSPACE,
-          workspaces[0].id,
+          workspaces[0].uid,
         );
         expect(mockOnAction).toHaveBeenCalledWith(
           WorkspaceAction.DELETE_WORKSPACE,
-          workspaces[1].id,
+          workspaces[1].uid,
         );
         expect(mockOnAction).toHaveBeenCalledWith(
           WorkspaceAction.DELETE_WORKSPACE,
-          workspaces[2].id,
+          workspaces[2].uid,
         );
       });
 
@@ -274,7 +274,7 @@ describe('Workspaces List Page', () => {
       const checkboxes = screen.getAllByRole('checkbox', { name: /select row/i });
       expect(checkboxes[0]).not.toBeChecked();
 
-      isDeleted = [workspaces[0].id];
+      isDeleted = [workspaces[0].uid];
       rerender(getComponent());
 
       expect(checkboxes[0]).toBeChecked();
@@ -315,7 +315,7 @@ describe('Workspaces List Page', () => {
 
     it('should not open the kebab menu while workspace is being deleted', () => {
       // deleting first workspace
-      isDeleted = [workspaces[0].id];
+      isDeleted = [workspaces[0].uid];
       renderComponent();
 
       const actionButtons = screen.getAllByRole('button', { name: /actions/i });
@@ -336,7 +336,7 @@ describe('Workspaces List Page', () => {
 
       expect(mockOnAction).toHaveBeenCalledWith(
         WorkspaceAction.START_DEBUG_AND_OPEN_LOGS,
-        workspaces[0].id,
+        workspaces[0].uid,
       );
     });
 
@@ -352,7 +352,7 @@ describe('Workspaces List Page', () => {
 
       expect(mockOnAction).toHaveBeenCalledWith(
         WorkspaceAction.START_IN_BACKGROUND,
-        workspaces[0].id,
+        workspaces[0].uid,
       );
     });
 
@@ -380,7 +380,7 @@ describe('Workspaces List Page', () => {
       const stopAction = screen.getByRole('button', { name: /stop workspace/i });
       userEvent.click(stopAction);
 
-      expect(mockOnAction).toHaveBeenCalledWith(WorkspaceAction.STOP_WORKSPACE, workspaces[0].id);
+      expect(mockOnAction).toHaveBeenCalledWith(WorkspaceAction.STOP_WORKSPACE, workspaces[0].uid);
     });
 
     it('should handle "Delete Workspace" action', async () => {
@@ -395,13 +395,16 @@ describe('Workspaces List Page', () => {
 
       await waitFor(() => expect(mockOnAction).toHaveBeenCalled());
 
-      expect(mockOnAction).toHaveBeenCalledWith(WorkspaceAction.DELETE_WORKSPACE, workspaces[0].id);
+      expect(mockOnAction).toHaveBeenCalledWith(
+        WorkspaceAction.DELETE_WORKSPACE,
+        workspaces[0].uid,
+      );
     });
 
     describe('with deprecated workspaces', () => {
       test('actions', () => {
         const deprecatedWorkspaceId = 'deprecated-workspace-id';
-        WorkspaceAdapter.setDeprecatedIds([deprecatedWorkspaceId]);
+        WorkspaceAdapter.setDeprecatedUIDs([deprecatedWorkspaceId]);
         const workspaces: Workspace[] = [
           new CheWorkspaceBuilder()
             .withId(deprecatedWorkspaceId)
@@ -431,7 +434,7 @@ describe('Workspaces List Page', () => {
       test('status icon', () => {
         const deprecatedWorkspaceId = 'deprecated-workspace-id';
         // mark the workspace as deprecated
-        WorkspaceAdapter.setDeprecatedIds([deprecatedWorkspaceId]);
+        WorkspaceAdapter.setDeprecatedUIDs([deprecatedWorkspaceId]);
         const workspaces: Workspace[] = [
           new CheWorkspaceBuilder()
             .withId(deprecatedWorkspaceId)
@@ -451,7 +454,7 @@ describe('Workspaces List Page', () => {
       test('Convert action link should redirect to the workspace page', () => {
         const deprecatedWorkspaceId = 'deprecated-workspace-id';
         // mark the workspace as deprecated
-        WorkspaceAdapter.setDeprecatedIds([deprecatedWorkspaceId]);
+        WorkspaceAdapter.setDeprecatedUIDs([deprecatedWorkspaceId]);
         const workspaces: Workspace[] = [
           new CheWorkspaceBuilder()
             .withId(deprecatedWorkspaceId)

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -38,7 +38,7 @@ import devfileApi from '../devfileApi';
 import { selectDefaultNamespace } from '../../store/InfrastructureNamespaces/selectors';
 import { selectDevWorkspacesResourceVersion } from '../../store/Workspaces/devWorkspaces/selectors';
 import { WorkspaceAdapter } from '../workspace-adapter';
-import { selectDeprecatedWorkspacesIds } from '../../store/Workspaces/selectors';
+import { selectDeprecatedWorkspacesUIDs } from '../../store/Workspaces/selectors';
 import { AppAlerts } from '../alerts/appAlerts';
 import { AlertVariant } from '@patternfly/react-core';
 
@@ -164,8 +164,8 @@ export default class Bootstrap {
   private async fetchWorkspaces(): Promise<void> {
     const { requestWorkspaces } = WorkspacesStore.actionCreators;
     await requestWorkspaces()(this.store.dispatch, this.store.getState, undefined);
-    const deprecatedIds = selectDeprecatedWorkspacesIds(this.store.getState());
-    WorkspaceAdapter.setDeprecatedIds(deprecatedIds);
+    const deprecatedUIDs = selectDeprecatedWorkspacesUIDs(this.store.getState());
+    WorkspaceAdapter.setDeprecatedUIDs(deprecatedUIDs);
   }
 
   private async fetchPlugins(settings: che.WorkspaceSettings): Promise<void> {

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -13,14 +13,11 @@
 import { V1alpha2DevWorkspaceMetadata } from '@devfile/api';
 
 export const DEVWORKSPACE_CHE_EDITOR = 'che.eclipse.org/che-editor';
-// used by UD to get the original Che7 workspace ID
-export const ORIGINAL_WORKSPACE_ID_ANNOTATION = 'che.eclipse.org/original-workspace-id';
 // used by devworkspace-controller to allow to mount the corresponding Che7 workspace folder
 export const DEVWORKSPACE_ID_OVERRIDE_ANNOTATION = 'controller.devfile.io/devworkspace_id_override';
 export const DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION = 'che.eclipse.org/last-updated-timestamp';
 type DevWorkspaceMetadataAnnotation = {
   [DEVWORKSPACE_CHE_EDITOR]?: string;
-  [ORIGINAL_WORKSPACE_ID_ANNOTATION]?: string;
   [DEVWORKSPACE_ID_OVERRIDE_ANNOTATION]?: string;
   [DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION]?: string;
 };

--- a/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
@@ -77,6 +77,13 @@ describe('Workspace adapter', () => {
       expect(workspace.id).toEqual(id);
     });
 
+    it('should return UID', () => {
+      const id = 'workspace1234asdf';
+      const cheWorkspace = new CheWorkspaceBuilder().withId(id).build();
+      const workspace = constructWorkspace(cheWorkspace);
+      expect(workspace.uid).toEqual(id);
+    });
+
     it('should return name', () => {
       const name = 'wksp-1234';
       const cheWorkspace = new CheWorkspaceBuilder().withName(name).build();
@@ -260,6 +267,14 @@ describe('Workspace adapter', () => {
       const devWorkspace = new DevWorkspaceBuilder().withId(id).build();
       const workspace = constructWorkspace(devWorkspace);
       expect(workspace.id).toEqual(id);
+    });
+
+    it('should return UID', () => {
+      const id = '1234asdf';
+      const devWorkspace = new DevWorkspaceBuilder().withId(id).build();
+      const workspace = constructWorkspace(devWorkspace);
+      expect(workspace.uid).not.toEqual(id);
+      expect(workspace.uid).toMatch(/^uid-/);
     });
 
     it('should return name', () => {

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -27,6 +27,7 @@ export interface Workspace {
   readonly ref: che.Workspace | devfileApi.DevWorkspace;
 
   readonly id: string;
+  readonly uid: string;
   name: string;
   readonly namespace: string;
   readonly infrastructureNamespace: string;
@@ -49,7 +50,7 @@ export interface Workspace {
 export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
   implements Workspace
 {
-  private static deprecatedIds: string[] = [];
+  private static deprecatedUIDs: string[] = [];
   private workspace: T;
 
   constructor(workspace: T) {
@@ -61,17 +62,21 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
     }
   }
 
-  static setDeprecatedIds(ids: string[]) {
-    WorkspaceAdapter.deprecatedIds = ids;
+  static setDeprecatedUIDs(UIDs: string[]) {
+    WorkspaceAdapter.deprecatedUIDs = UIDs;
   }
 
   static isDeprecated(workspace: che.Workspace | devfileApi.DevWorkspace): boolean {
     if (isDevWorkspace(workspace)) {
       return false;
     }
-    return WorkspaceAdapter.deprecatedIds.indexOf(WorkspaceAdapter.getId(workspace)) !== -1;
+    return WorkspaceAdapter.deprecatedUIDs.indexOf(WorkspaceAdapter.getId(workspace)) !== -1;
   }
 
+  /**
+   * Returns a workspace ID.
+   * Note that IDs may intersect for Che7 workspaces and DevWorkspaces.
+   */
   static getId(workspace: che.Workspace | devfileApi.DevWorkspace): string {
     if (isCheWorkspace(workspace)) {
       return workspace.id;
@@ -80,6 +85,17 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
         return workspace.status.devworkspaceId;
       }
       return 'workspace' + workspace.metadata.uid.split('-').splice(0, 3).join('');
+    }
+  }
+
+  /**
+   * Returns a unique workspace ID.
+   */
+  static getUID(workspace: che.Workspace | devfileApi.DevWorkspace): string {
+    if (isCheWorkspace(workspace)) {
+      return workspace.id;
+    } else {
+      return workspace.metadata.uid;
     }
   }
 
@@ -106,6 +122,10 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
 
   get id(): string {
     return WorkspaceAdapter.getId(this.workspace);
+  }
+
+  get uid(): string {
+    return WorkspaceAdapter.getUID(this.workspace);
   }
 
   get name(): string {

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -66,6 +66,9 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
   }
 
   static isDeprecated(workspace: che.Workspace | devfileApi.DevWorkspace): boolean {
+    if (isDevWorkspace(workspace)) {
+      return false;
+    }
     return WorkspaceAdapter.deprecatedIds.indexOf(WorkspaceAdapter.getId(workspace)) !== -1;
   }
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -50,7 +50,7 @@ export interface IStatusUpdate {
   status: string;
   message: string;
   prevStatus: string | undefined;
-  workspaceId: string;
+  workspaceUID: string;
 }
 
 export type Subscriber = {
@@ -873,7 +873,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
    */
   private createStatusUpdate(devworkspace: devfileApi.DevWorkspace): IStatusUpdate | undefined {
     const namespace = devworkspace.metadata.namespace;
-    const workspaceId = WorkspaceAdapter.getId(devworkspace);
+    const workspaceUID = WorkspaceAdapter.getUID(devworkspace);
     const status = devworkspace?.status?.phase || DevWorkspaceStatus.STARTING;
     const message = devworkspace?.status?.message || '';
 
@@ -883,15 +883,15 @@ export class DevWorkspaceClient extends WorkspaceClient {
     }
 
     const previousItem = this.previousItems.get(namespace);
-    const prevStatusUpdate = previousItem?.get(workspaceId);
-    const statusUpdate = {
+    const prevStatusUpdate = previousItem?.get(workspaceUID);
+    const statusUpdate: IStatusUpdate = {
       status,
       message,
-      workspaceId,
+      workspaceUID,
       prevStatus: prevStatusUpdate?.status,
     };
 
-    previousItem?.set(workspaceId, statusUpdate);
+    previousItem?.set(workspaceUID, statusUpdate);
 
     if (status === prevStatusUpdate?.status && message === prevStatusUpdate?.message) {
       return undefined;

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -71,7 +71,7 @@ interface UpdateWorkspaceAction extends Action {
 
 interface UpdateWorkspaceStatusAction extends Action {
   type: 'UPDATE_DEVWORKSPACE_STATUS';
-  workspaceId: string;
+  workspaceUID: string;
   status: string;
   message: string;
 }
@@ -83,17 +83,17 @@ interface UpdateWorkspacesLogsAction extends Action {
 
 interface DeleteWorkspaceLogsAction extends Action {
   type: 'DELETE_DEVWORKSPACE_LOGS';
-  workspaceId: string;
+  workspaceUID: string;
 }
 
 interface DeleteWorkspaceAction extends Action {
   type: 'DELETE_DEVWORKSPACE';
-  workspaceId: string;
+  workspaceUID: string;
 }
 
 interface TerminateWorkspaceAction extends Action {
   type: 'TERMINATE_DEVWORKSPACE';
-  workspaceId: string;
+  workspaceUID: string;
   message: string;
 }
 
@@ -151,7 +151,7 @@ export type ActionCreators = {
     editor?: string,
   ) => AppThunk<KnownAction, Promise<void>>;
 
-  deleteWorkspaceLogs: (workspaceId: string) => AppThunk<DeleteWorkspaceLogsAction, void>;
+  deleteWorkspaceLogs: (workspaceUID: string) => AppThunk<DeleteWorkspaceLogsAction, void>;
 };
 export const actionCreators: ActionCreators = {
   updateAddedDevWorkspaces:
@@ -168,10 +168,10 @@ export const actionCreators: ActionCreators = {
   updateDeletedDevWorkspaces:
     (deletedWorkspacesIds: string[]): AppThunk<KnownAction, void> =>
     (dispatch): void => {
-      deletedWorkspacesIds.forEach(workspaceId => {
+      deletedWorkspacesIds.forEach(workspaceUID => {
         dispatch({
           type: 'DELETE_DEVWORKSPACE',
-          workspaceId,
+          workspaceUID,
         });
       });
     },
@@ -302,13 +302,11 @@ export const actionCreators: ActionCreators = {
           type: 'UPDATE_DEVWORKSPACE',
           workspace: updatedWorkspace,
         });
-        const workspaceId = workspace.status?.devworkspaceId;
-        if (workspaceId) {
-          dispatch({
-            type: 'DELETE_DEVWORKSPACE_LOGS',
-            workspaceId,
-          });
-        }
+        const workspaceUID = workspace.metadata.uid;
+        dispatch({
+          type: 'DELETE_DEVWORKSPACE_LOGS',
+          workspaceUID,
+        });
         devWorkspaceClient.checkForDevWorkspaceError(updatedWorkspace);
       } catch (e) {
         const errorMessage =
@@ -344,10 +342,10 @@ export const actionCreators: ActionCreators = {
       ) {
         await onStatusChangeCallback(workspace.status.phase);
       } else {
-        const workspaceId = WorkspaceAdapter.getId(workspace);
-        onStatusChangeCallbacks.set(workspaceId, onStatusChangeCallback);
+        const workspaceUID = WorkspaceAdapter.getUID(workspace);
+        onStatusChangeCallbacks.set(workspaceUID, onStatusChangeCallback);
         toDispose.push({
-          dispose: () => onStatusChangeCallbacks.delete(workspaceId),
+          dispose: () => onStatusChangeCallbacks.delete(workspaceUID),
         });
         if (
           workspace.status?.phase === DevWorkspaceStatus.RUNNING ||
@@ -372,7 +370,7 @@ export const actionCreators: ActionCreators = {
         await devWorkspaceClient.changeWorkspaceStatus(workspace, false);
         dispatch({
           type: 'DELETE_DEVWORKSPACE_LOGS',
-          workspaceId: WorkspaceAdapter.getId(workspace),
+          workspaceUID: WorkspaceAdapter.getId(workspace),
         });
       } catch (e) {
         const errorMessage =
@@ -393,13 +391,13 @@ export const actionCreators: ActionCreators = {
         const namespace = workspace.metadata.namespace;
         const name = workspace.metadata.name;
         await devWorkspaceClient.delete(namespace, name);
-        const workspaceId = WorkspaceAdapter.getId(workspace);
+        const workspaceUID = WorkspaceAdapter.getUID(workspace);
         dispatch({
           type: 'TERMINATE_DEVWORKSPACE',
-          workspaceId,
+          workspaceUID,
           message: workspace.status?.message || 'Cleaning up resources for deletion',
         });
-        dispatch({ type: 'DELETE_DEVWORKSPACE_LOGS', workspaceId });
+        dispatch({ type: 'DELETE_DEVWORKSPACE_LOGS', workspaceUID });
       } catch (e) {
         const resMessage =
           `Failed to delete the workspace ${workspace.metadata.name}, reason: ` +
@@ -588,9 +586,9 @@ export const actionCreators: ActionCreators = {
     },
 
   deleteWorkspaceLogs:
-    (workspaceId: string): AppThunk<DeleteWorkspaceLogsAction, void> =>
+    (workspaceUID: string): AppThunk<DeleteWorkspaceLogsAction, void> =>
     (dispatch): void => {
-      dispatch({ type: 'DELETE_DEVWORKSPACE_LOGS', workspaceId });
+      dispatch({ type: 'DELETE_DEVWORKSPACE_LOGS', workspaceUID });
     },
 };
 
@@ -635,7 +633,7 @@ export const reducer: Reducer<State> = (state: State | undefined, action: KnownA
     case 'UPDATE_DEVWORKSPACE_STATUS':
       return createObject(state, {
         workspaces: state.workspaces.map(workspace => {
-          if (WorkspaceAdapter.getId(workspace) === action.workspaceId) {
+          if (WorkspaceAdapter.getId(workspace) === action.workspaceUID) {
             if (!workspace.status) {
               workspace.status = {} as devfileApi.DevWorkspaceStatus;
             }
@@ -658,7 +656,7 @@ export const reducer: Reducer<State> = (state: State | undefined, action: KnownA
       return createObject(state, {
         isLoading: false,
         workspaces: state.workspaces.map(workspace => {
-          if (WorkspaceAdapter.getId(workspace) === action.workspaceId) {
+          if (WorkspaceAdapter.getId(workspace) === action.workspaceUID) {
             const targetWorkspace = Object.assign({}, workspace);
             if (!targetWorkspace.status) {
               targetWorkspace.status = {} as devfileApi.DevWorkspaceStatus;
@@ -673,7 +671,7 @@ export const reducer: Reducer<State> = (state: State | undefined, action: KnownA
     case 'DELETE_DEVWORKSPACE':
       return createObject(state, {
         workspaces: state.workspaces.filter(
-          workspace => WorkspaceAdapter.getId(workspace) !== action.workspaceId,
+          workspace => WorkspaceAdapter.getUID(workspace) !== action.workspaceUID,
         ),
       });
     case 'UPDATE_DEVWORKSPACE_LOGS':
@@ -682,7 +680,7 @@ export const reducer: Reducer<State> = (state: State | undefined, action: KnownA
       });
     case 'DELETE_DEVWORKSPACE_LOGS':
       return createObject(state, {
-        workspacesLogs: deleteLogs(state.workspacesLogs, action.workspaceId),
+        workspacesLogs: deleteLogs(state.workspacesLogs, action.workspaceUID),
       });
     default:
       return state;
@@ -698,13 +696,13 @@ async function onStatusUpdateReceived(
   if (status !== statusUpdate.prevStatus) {
     dispatch({
       type: 'UPDATE_DEVWORKSPACE_STATUS',
-      workspaceId: statusUpdate.workspaceId,
+      workspaceUID: statusUpdate.workspaceUID,
       message: statusUpdate.message,
       status,
     });
   }
 
-  const callback = onStatusChangeCallbacks.get(statusUpdate.workspaceId);
+  const callback = onStatusChangeCallbacks.get(statusUpdate.workspaceUID);
 
   if (callback && status) {
     callback(status);
@@ -720,7 +718,7 @@ async function onStatusUpdateReceived(
       ) {
         message = `1 error occurred: ${message}`;
       }
-      workspacesLogs.set(statusUpdate.workspaceId, [message]);
+      workspacesLogs.set(statusUpdate.workspaceUID, [message]);
       dispatch({
         type: 'UPDATE_DEVWORKSPACE_LOGS',
         workspacesLogs,
@@ -731,7 +729,7 @@ async function onStatusUpdateReceived(
 
 export async function addKubeConfigInjection(workspace: devfileApi.DevWorkspace): Promise<void> {
   const toDispose = new DisposableCollection();
-  const onStatusChangeCallback = async status => {
+  const onStatusChangeCallback = async (status: string) => {
     if (status === DevWorkspaceStatus.RUNNING) {
       const workspaceId = WorkspaceAdapter.getId(workspace);
       try {
@@ -742,9 +740,9 @@ export async function addKubeConfigInjection(workspace: devfileApi.DevWorkspace)
       toDispose.dispose();
     }
   };
-  const adapterWorkspaceId = WorkspaceAdapter.getId(workspace);
-  onStatusChangeCallbacks.set(adapterWorkspaceId, onStatusChangeCallback);
+  const workspaceUID = WorkspaceAdapter.getUID(workspace);
+  onStatusChangeCallbacks.set(workspaceUID, onStatusChangeCallback);
   toDispose.push({
-    dispose: () => onStatusChangeCallbacks.delete(adapterWorkspaceId),
+    dispose: () => onStatusChangeCallbacks.delete(workspaceUID),
   });
 }

--- a/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
@@ -12,7 +12,7 @@
 
 import { createSelector } from 'reselect';
 import { AppState } from '..';
-import { constructWorkspace, Workspace } from '../../services/workspace-adapter';
+import { constructWorkspace, Workspace, WorkspaceAdapter } from '../../services/workspace-adapter';
 import { selectCheWorkspacesError } from './cheWorkspaces/selectors';
 import { selectDevWorkspacesError } from './devWorkspaces/selectors';
 import { selectDevworkspacesEnabled } from './Settings/selectors';
@@ -32,16 +32,16 @@ export const selectLogs = createSelector(
 );
 
 /**
- * Returns array of IDs of deprecated workspaces
+ * Returns array of UIDs of deprecated workspaces
  */
-export const selectDeprecatedWorkspacesIds = createSelector(
+export const selectDeprecatedWorkspacesUIDs = createSelector(
   selectCheWorkspacesState,
   selectDevworkspacesEnabled,
   (cheWorkspacesState, devworkspacesEnabled) => {
     if (devworkspacesEnabled === false) {
       return [];
     }
-    return cheWorkspacesState.workspaces.map(workspace => workspace.id);
+    return cheWorkspacesState.workspaces.map(workspace => WorkspaceAdapter.getUID(workspace));
   },
 );
 
@@ -67,11 +67,11 @@ export const selectWorkspaceByQualifiedName = createSelector(
   },
 );
 
-export const selectWorkspaceById = createSelector(
+export const selectWorkspaceByUID = createSelector(
   selectState,
   selectAllWorkspaces,
   (state, allWorkspaces) => {
-    return allWorkspaces.find(workspace => workspace.id === state.workspaceId);
+    return allWorkspaces.find(workspace => workspace.uid === state.workspaceUID);
   },
 );
 
@@ -119,10 +119,10 @@ const selectRecentNumber = createSelector(selectState, state => state.recentNumb
 export const selectRecentWorkspaces = createSelector(
   selectRecentNumber,
   selectAllWorkspaces,
-  selectDeprecatedWorkspacesIds,
-  (recentNumber, allWorkspaces, deprecatedWorkspacesIds) =>
+  selectDeprecatedWorkspacesUIDs,
+  (recentNumber, allWorkspaces, deprecatedWorkspacesUIDs) =>
     allWorkspaces
-      .filter(workspace => deprecatedWorkspacesIds.indexOf(workspace.id) === -1)
+      .filter(workspace => deprecatedWorkspacesUIDs.indexOf(workspace.uid) === -1)
       .sort(sortByUpdatedTimeFn)
       .slice(0, recentNumber),
 );

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -50,6 +50,11 @@ export class DevWorkspaceBuilder {
     return this;
   }
 
+  withUID(uid: string): DevWorkspaceBuilder {
+    this.workspace.metadata.uid = uid;
+    return this;
+  }
+
   withName(name: string): DevWorkspaceBuilder {
     this.workspace.metadata.name = name;
     return this;

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -54,7 +54,7 @@ export class FakeStoreBuilder {
       isLoading: false,
       namespace: '',
       workspaceName: '',
-      workspaceId: '',
+      workspaceUID: '',
       recentNumber: 5,
     } as WorkspacesState,
     cheWorkspaces: {
@@ -296,7 +296,7 @@ export class FakeStoreBuilder {
     options: {
       namespace?: string;
       workspaceName?: string;
-      workspaceId?: string;
+      workspaceUID?: string;
       recentNumber?: number;
     },
     isLoading = false,
@@ -307,8 +307,8 @@ export class FakeStoreBuilder {
     if (options.workspaceName) {
       this.state.workspaces.workspaceName = options.workspaceName;
     }
-    if (options.workspaceId) {
-      this.state.workspaces.workspaceId = options.workspaceId;
+    if (options.workspaceUID) {
+      this.state.workspaces.workspaceUID = options.workspaceUID;
     }
     if (options.recentNumber) {
       this.state.workspaces.recentNumber = options.recentNumber;


### PR DESCRIPTION
cherry-picking https://github.com/eclipse-che/che-dashboard/pull/479 to 7.44.x 