### PR TITLE
Add scroll down automatically for logs

### DIFF
--- a/packages/dashboard-frontend/src/components/LogsTab/__tests__/__snapshots__/LogsTab.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/LogsTab/__tests__/__snapshots__/LogsTab.spec.tsx.snap
@@ -130,7 +130,10 @@ exports[`The LogsTab component should render workspace-logs widget with logs ins
         4
          lines
       </div>
-      <pre>
+      <pre
+        id="output-logs"
+        tabIndex={0}
+      >
         <p
           className=""
         >
@@ -242,7 +245,10 @@ exports[`The LogsTab component should render workspace-logs widget without logs 
         0
          lines
       </div>
-      <pre />
+      <pre
+        id="output-logs"
+        tabIndex={0}
+      />
     </div>
   </div>
 </section>

--- a/packages/dashboard-frontend/src/components/LogsTab/index.tsx
+++ b/packages/dashboard-frontend/src/components/LogsTab/index.tsx
@@ -101,7 +101,7 @@ export class LogsTab extends React.PureComponent<Props, State> {
   }
 
   private getLines(): JSX.Element[] {
-    let logs = this.state.logs ? [...this.state.logs] : [];
+    let logs = this.state.logs || [];
     if (logs.length > MAX_LOG_LENGTH) {
       logs = logs.slice(logs.length - MAX_LOG_LENGTH);
     }

--- a/packages/dashboard-frontend/src/components/LogsTab/index.tsx
+++ b/packages/dashboard-frontend/src/components/LogsTab/index.tsx
@@ -28,7 +28,8 @@ import { isEqual } from 'lodash';
 
 import styles from './index.module.css';
 
-const maxLogLength = 200;
+const MAX_LOG_LENGTH = 500;
+const OUTPUT_LOG_ID = 'output-logs';
 
 type Props = {
   workspaceUID: string;
@@ -59,11 +60,25 @@ export class LogsTab extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
+    window.addEventListener('resize', this.updateScrollTop, false);
     this.updateLogsData();
+    this.updateScrollTop();
   }
 
   public componentDidUpdate(): void {
     this.updateLogsData();
+    this.updateScrollTop();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateScrollTop);
+  }
+
+  updateScrollTop() {
+    const objLog = document.getElementById(OUTPUT_LOG_ID);
+    if (objLog && document.activeElement?.id !== OUTPUT_LOG_ID) {
+      objLog.scrollTop = objLog.scrollHeight;
+    }
   }
 
   private updateLogsData() {
@@ -86,9 +101,9 @@ export class LogsTab extends React.PureComponent<Props, State> {
   }
 
   private getLines(): JSX.Element[] {
-    const logs = this.state.logs || [];
-    if (logs.length > maxLogLength) {
-      logs.splice(0, logs.length - maxLogLength);
+    let logs = this.state.logs ? [...this.state.logs] : [];
+    if (logs.length > MAX_LOG_LENGTH) {
+      logs = logs.slice(logs.length - MAX_LOG_LENGTH);
     }
 
     const createLine = (text: string, key: number, isError = false): React.ReactElement => {
@@ -114,7 +129,9 @@ export class LogsTab extends React.PureComponent<Props, State> {
     return (
       <div className={styles.consoleOutput}>
         <div>{lines.length} lines</div>
-        <pre>{lines}</pre>
+        <pre id={OUTPUT_LOG_ID} tabIndex={0}>
+          {lines}
+        </pre>
       </div>
     );
   }

--- a/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/__snapshots__/IdeLoader.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/__snapshots__/IdeLoader.spec.tsx.snap
@@ -861,7 +861,10 @@ Array [
               0
                lines
             </div>
-            <pre />
+            <pre
+              id="output-logs"
+              tabIndex={0}
+            />
           </div>
         </div>
       </section>
@@ -1352,7 +1355,10 @@ Array [
               0
                lines
             </div>
-            <pre />
+            <pre
+              id="output-logs"
+              tabIndex={0}
+            />
           </div>
         </div>
       </section>
@@ -2282,7 +2288,10 @@ Array [
               0
                lines
             </div>
-            <pre />
+            <pre
+              id="output-logs"
+              tabIndex={0}
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add scroll down automatically for logs.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/19255
