### PR TITLE
Add scroll down automatically for logs

### DIFF
--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -434,7 +434,7 @@
 | [`dedent@0.7.0`](git://github.com/dmnd/dedent.git) | MIT | clearlydefined |
 | [`deep-equal@1.1.1`](http://github.com/substack/node-deep-equal.git) | MIT | clearlydefined |
 | [`deep-extend@0.6.0`](git://github.com/unclechu/node-deep-extend.git) | MIT | clearlydefined |
-| [`deep-is@0.1.4`](http://github.com/thlorenz/deep-is.git) | MIT | clearlydefined |
+| [`deep-is@0.1.4`](http://github.com/thlorenz/deep-is.git) | MIT | #2130 |
 | [`default-gateway@4.2.0`](https://github.com/silverwind/default-gateway.git) | BSD-2-Clause | #146 |
 | [`defaults@1.0.3`](git://github.com/tmpvar/defaults.git) | MIT | clearlydefined |
 | [`define-properties@1.1.3`](git://github.com/ljharb/define-properties.git) | MIT | clearlydefined |
@@ -702,7 +702,7 @@
 | [`json-parse-better-errors@1.0.2`](https://github.com/zkat/json-parse-better-errors) | MIT | clearlydefined |
 | [`json-parse-even-better-errors@2.3.1`](https://github.com/npm/json-parse-even-better-errors) | MIT | clearlydefined |
 | [`json-stable-stringify-without-jsonify@1.0.1`](git://github.com/samn/json-stable-stringify.git) | MIT | clearlydefined |
-| [`json5@2.2.0`](git+https://github.com/json5/json5.git) | MIT | clearlydefined |
+| [`json5@2.2.0`](git+https://github.com/json5/json5.git) | MIT | #2126 |
 | [`jsonparse@1.3.1`](http://github.com/creationix/jsonparse.git) | MIT | clearlydefined |
 | [`jsx-ast-utils@3.2.0`](https://github.com/evcohen/jsx-ast-utils) | MIT | clearlydefined |
 | [`keycloak-js@10.0.2`](https://github.com/keycloak/keycloak) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/keycloak-js/10.0.2) |

--- a/packages/dashboard-frontend/src/components/LogsTab/__tests__/__snapshots__/LogsTab.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/LogsTab/__tests__/__snapshots__/LogsTab.spec.tsx.snap
@@ -130,7 +130,10 @@ exports[`The LogsTab component should render workspace-logs widget with logs ins
         4
          lines
       </div>
-      <pre>
+      <pre
+        id="output-logs"
+        tabIndex={0}
+      >
         <p
           className=""
         >
@@ -242,7 +245,10 @@ exports[`The LogsTab component should render workspace-logs widget without logs 
         0
          lines
       </div>
-      <pre />
+      <pre
+        id="output-logs"
+        tabIndex={0}
+      />
     </div>
   </div>
 </section>

--- a/packages/dashboard-frontend/src/components/LogsTab/index.tsx
+++ b/packages/dashboard-frontend/src/components/LogsTab/index.tsx
@@ -28,7 +28,8 @@ import { isEqual } from 'lodash';
 
 import styles from './index.module.css';
 
-const maxLogLength = 200;
+const MAX_LOG_LENGTH = 500;
+const OUTPUT_LOG_ID = 'output-logs';
 
 type Props = {
   workspaceUID: string;
@@ -59,11 +60,25 @@ export class LogsTab extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
+    window.addEventListener('resize', this.updateScrollTop, false);
     this.updateLogsData();
+    this.updateScrollTop();
   }
 
   public componentDidUpdate(): void {
     this.updateLogsData();
+    this.updateScrollTop();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateScrollTop);
+  }
+
+  updateScrollTop() {
+    const objLog = document.getElementById(OUTPUT_LOG_ID);
+    if (objLog && document.activeElement?.id !== OUTPUT_LOG_ID) {
+      objLog.scrollTop = objLog.scrollHeight;
+    }
   }
 
   private updateLogsData() {
@@ -86,9 +101,9 @@ export class LogsTab extends React.PureComponent<Props, State> {
   }
 
   private getLines(): JSX.Element[] {
-    const logs = this.state.logs || [];
-    if (logs.length > maxLogLength) {
-      logs.splice(0, logs.length - maxLogLength);
+    let logs = this.state.logs || [];
+    if (logs.length > MAX_LOG_LENGTH) {
+      logs = logs.slice(logs.length - MAX_LOG_LENGTH);
     }
 
     const createLine = (text: string, key: number, isError = false): React.ReactElement => {
@@ -114,7 +129,9 @@ export class LogsTab extends React.PureComponent<Props, State> {
     return (
       <div className={styles.consoleOutput}>
         <div>{lines.length} lines</div>
-        <pre>{lines}</pre>
+        <pre id={OUTPUT_LOG_ID} tabIndex={0}>
+          {lines}
+        </pre>
       </div>
     );
   }

--- a/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/__snapshots__/IdeLoader.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/IdeLoader/__tests__/__snapshots__/IdeLoader.spec.tsx.snap
@@ -861,7 +861,10 @@ Array [
               0
                lines
             </div>
-            <pre />
+            <pre
+              id="output-logs"
+              tabIndex={0}
+            />
           </div>
         </div>
       </section>
@@ -1352,7 +1355,10 @@ Array [
               0
                lines
             </div>
-            <pre />
+            <pre
+              id="output-logs"
+              tabIndex={0}
+            />
           </div>
         </div>
       </section>
@@ -2282,7 +2288,10 @@ Array [
               0
                lines
             </div>
-            <pre />
+            <pre
+              id="output-logs"
+              tabIndex={0}
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
* fix: add scroll down automatically for logs

Signed-off-by: Oleksii Orel <oorel@redhat.com>

* fixup! fix: add scroll down automatically for logs

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->


### What does this PR do?
Cherry-pick for [Add scroll down automatically for logs](https://github.com/eclipse-che/che-dashboard/pull/493)

