### PR TITLE
Fix UI glitches and regressions related to devfiles conversion

### DIFF
--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
@@ -125,10 +125,12 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
     const workspace = this.props.allWorkspaces.find(
       workspace => workspace.namespace === namespace && workspace.name === workspaceName,
     );
-    if (
-      workspace &&
-      (this.props.location.pathname !== prevProps.location.pathname ||
-        !isEqual(workspace, this.state.workspace))
+    if (!workspace) {
+      const workspacesListLocation = buildWorkspacesLocation();
+      this.props.history.push(workspacesListLocation);
+    } else if (
+      this.props.location.pathname !== prevProps.location.pathname ||
+      !isEqual(workspace, this.state.workspace)
     ) {
       this.setState({ workspace });
     }

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
@@ -27,7 +27,6 @@ import { load } from 'js-yaml';
 import stringify from '../../../services/helpers/editor';
 import ImportFromGit from './ImportFromGit';
 import { ResolverState } from '../../../store/FactoryResolver';
-import { Devfile } from '../../../services/workspace-adapter';
 import { DevfileAdapter } from '../../../services/devfile/adapter';
 
 // At runtime, Redux will merge together...

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/index.tsx
@@ -37,9 +37,6 @@ export default class WorkspaceConversionButton extends React.PureComponent<Props
 
     try {
       await this.props.onConvert();
-      this.setState({
-        isDisabled: false,
-      });
     } catch (e) {
       this.setState({
         isDisabled: false,

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -409,7 +409,15 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
   }
 
   public componentDidUpdate(prevProps: Props): void {
-    if (prevProps.workspaces.length !== this.props.workspaces.length) {
+    const prevUIDs = prevProps.workspaces
+      .map(w => w.uid)
+      .sort()
+      .join(',');
+    const UIDs = this.props.workspaces
+      .map(w => w.uid)
+      .sort()
+      .join(',');
+    if (prevUIDs !== UIDs) {
       const selected: string[] = [];
       const filtered: string[] = [];
       this.props.workspaces.forEach(workspace => {

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -37,8 +37,6 @@ import { selectDwEditorsPluginsList } from '../../store/Plugins/devWorkspacePlug
 import devfileApi from '../devfileApi';
 import { selectDefaultNamespace } from '../../store/InfrastructureNamespaces/selectors';
 import { selectDevWorkspacesResourceVersion } from '../../store/Workspaces/devWorkspaces/selectors';
-import { WorkspaceAdapter } from '../workspace-adapter';
-import { selectDeprecatedWorkspacesUIDs } from '../../store/Workspaces/selectors';
 import { AppAlerts } from '../alerts/appAlerts';
 import { AlertVariant } from '@patternfly/react-core';
 
@@ -164,8 +162,6 @@ export default class Bootstrap {
   private async fetchWorkspaces(): Promise<void> {
     const { requestWorkspaces } = WorkspacesStore.actionCreators;
     await requestWorkspaces()(this.store.dispatch, this.store.getState, undefined);
-    const deprecatedUIDs = selectDeprecatedWorkspacesUIDs(this.store.getState());
-    WorkspaceAdapter.setDeprecatedUIDs(deprecatedUIDs);
   }
 
   private async fetchPlugins(settings: che.WorkspaceSettings): Promise<void> {

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/types.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/types.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { DevWorkspaceStatus, isDevWorkspaceStatus } from '../types';
+
+describe('typeguards', () => {
+  describe('isDevWorkspaceStatus', () => {
+    test('with a correct value', () => {
+      const status = DevWorkspaceStatus.RUNNING;
+      expect(status).toEqual('Running');
+      expect(isDevWorkspaceStatus(status)).toBeTruthy();
+    });
+
+    test('with wrong values', () => {
+      const wrongStatus1 = 'RUNNING';
+      expect(isDevWorkspaceStatus(wrongStatus1)).toBeFalsy();
+
+      const wrongStatus2 = true;
+      expect(isDevWorkspaceStatus(wrongStatus2)).toBeFalsy();
+
+      const wrongStatus3 = 1;
+      expect(isDevWorkspaceStatus(wrongStatus3)).toBeFalsy();
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -64,6 +64,10 @@ export enum DevWorkspaceStatus {
   STOPPING = 'Stopping',
 }
 
+export function isDevWorkspaceStatus(status: unknown): status is DevWorkspaceStatus {
+  return DevWorkspaceStatus[status as DevWorkspaceStatus] !== undefined;
+}
+
 export type CreateWorkspaceTab = 'quick-add' | 'custom-workspace';
 
 export enum IdeLoaderTab {

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -65,7 +65,7 @@ export enum DevWorkspaceStatus {
 }
 
 export function isDevWorkspaceStatus(status: unknown): status is DevWorkspaceStatus {
-  return DevWorkspaceStatus[status as DevWorkspaceStatus] !== undefined;
+  return Object.values(DevWorkspaceStatus).includes(status as DevWorkspaceStatus);
 }
 
 export type CreateWorkspaceTab = 'quick-add' | 'custom-workspace';

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -355,7 +355,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     }
 
     const routingClass = 'che';
-    const devworkspace = devfileToDevWorkspace(devfile, routingClass, true);
+    const devworkspace = devfileToDevWorkspace(devfile, routingClass, start);
 
     if (devworkspace.metadata.annotations === undefined) {
       devworkspace.metadata.annotations = {};

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -872,8 +872,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
         this.showAlert({ key, variant: AlertVariant.warning, title });
         return;
       }
-      const workspaceId = maybeWorkspaceId as string;
-      callbacks.updateDeletedDevWorkspaces([workspaceId]);
+      const devworkspaceId = maybeWorkspaceId as string;
+      callbacks.updateDeletedDevWorkspaces([devworkspaceId]);
     });
   }
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -885,10 +885,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
   private createStatusUpdate(devworkspace: devfileApi.DevWorkspace): IStatusUpdate | undefined {
     const namespace = devworkspace.metadata.namespace;
     const workspaceUID = WorkspaceAdapter.getUID(devworkspace);
-    const status =
-      devworkspace.status?.phase && isDevWorkspaceStatus(devworkspace.status.phase)
-        ? devworkspace.status.phase
-        : DevWorkspaceStatus.STARTING;
+    const phase = devworkspace.status?.phase;
+    const status = isDevWorkspaceStatus(phase) ? phase : DevWorkspaceStatus.STARTING;
     const message = devworkspace.status?.message || '';
 
     if (!this.previousItems.has(namespace)) {

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -21,7 +21,7 @@ import {
   devWorkspaceSingularSubresource,
   devWorkspaceVersion,
 } from './converters';
-import { AlertItem, DevWorkspaceStatus } from '../../helpers/types';
+import { AlertItem, DevWorkspaceStatus, isDevWorkspaceStatus } from '../../helpers/types';
 import { KeycloakSetupService } from '../../keycloak/setup';
 import { delay } from '../../helpers/delay';
 import * as DwApi from '../../dashboard-backend-client/devWorkspaceApi';
@@ -52,7 +52,7 @@ import {
 } from '../../devfileApi/devWorkspace/spec';
 
 export interface IStatusUpdate {
-  status: string;
+  status: DevWorkspaceStatus;
   message: string;
   prevStatus: string | undefined;
   workspaceUID: string;
@@ -885,8 +885,11 @@ export class DevWorkspaceClient extends WorkspaceClient {
   private createStatusUpdate(devworkspace: devfileApi.DevWorkspace): IStatusUpdate | undefined {
     const namespace = devworkspace.metadata.namespace;
     const workspaceUID = WorkspaceAdapter.getUID(devworkspace);
-    const status = devworkspace?.status?.phase || DevWorkspaceStatus.STARTING;
-    const message = devworkspace?.status?.message || '';
+    const status =
+      devworkspace.status?.phase && isDevWorkspaceStatus(devworkspace.status.phase)
+        ? devworkspace.status.phase
+        : DevWorkspaceStatus.STARTING;
+    const message = devworkspace.status?.message || '';
 
     if (!this.previousItems.has(namespace)) {
       const defaultItem = new Map<string, IStatusUpdate>();

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -39,7 +39,7 @@ import { injectKubeConfig } from '../../../services/dashboard-backend-client/dev
 import { selectRunningWorkspacesLimit } from '../../ClusterConfig/selectors';
 const devWorkspaceClient = container.get(DevWorkspaceClient);
 
-export const onStatusChangeCallbacks = new Map<string, (status: string) => void>();
+export const onStatusChangeCallbacks = new Map<string, (status: DevWorkspaceStatus) => void>();
 
 export interface State {
   isLoading: boolean;
@@ -327,7 +327,7 @@ export const actionCreators: ActionCreators = {
     async (dispatch): Promise<void> => {
       const defer: IDeferred<void> = getDefer();
       const toDispose = new DisposableCollection();
-      const onStatusChangeCallback = async status => {
+      const onStatusChangeCallback = async (status: DevWorkspaceStatus) => {
         if (status === DevWorkspaceStatus.STOPPED || status === DevWorkspaceStatus.FAILED) {
           toDispose.dispose();
           try {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -89,7 +89,7 @@ interface DeleteWorkspaceLogsAction extends Action {
 
 interface DeleteWorkspaceAction extends Action {
   type: 'DELETE_DEVWORKSPACE';
-  workspaceUID: string;
+  workspaceId: string;
 }
 
 interface TerminateWorkspaceAction extends Action {
@@ -169,10 +169,10 @@ export const actionCreators: ActionCreators = {
   updateDeletedDevWorkspaces:
     (deletedWorkspacesIds: string[]): AppThunk<KnownAction, void> =>
     (dispatch): void => {
-      deletedWorkspacesIds.forEach(workspaceUID => {
+      deletedWorkspacesIds.forEach(workspaceId => {
         dispatch({
           type: 'DELETE_DEVWORKSPACE',
-          workspaceUID,
+          workspaceId,
         });
       });
     },
@@ -673,7 +673,7 @@ export const reducer: Reducer<State> = (state: State | undefined, action: KnownA
     case 'DELETE_DEVWORKSPACE':
       return createObject(state, {
         workspaces: state.workspaces.filter(
-          workspace => WorkspaceAdapter.getUID(workspace) !== action.workspaceUID,
+          workspace => WorkspaceAdapter.getId(workspace) !== action.workspaceId,
         ),
       });
     case 'UPDATE_DEVWORKSPACE_LOGS':

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -647,6 +647,7 @@ export const reducer: Reducer<State> = (state: State | undefined, action: KnownA
       });
     case 'ADD_DEVWORKSPACE':
       return createObject(state, {
+        isLoading: false,
         workspaces: state.workspaces
           .filter(
             workspace =>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes:

- bug: duplicate items appeared in the recent workspaces section after conversion
- regression: deleting devworkspaces stuck in the Terminating phase
- regression: converted workspace was started automatically
- bug: browser console error: updating React state on an unmounted component
- regression: dashboard didn't open the new workspace after conversion is done
- regression: dashboard didn't update the workspaces list after deleting a converted workspace
- bug: che7 workspace didn't have the correct status icon 


### What issues does this PR fix or reference?

https://github.com/eclipse-che/che-dashboard/pull/479#issuecomment-1076193524
fixes https://github.com/eclipse/che/issues/21316
fixes https://github.com/eclipse/che/issues/21208