### PR TITLE
Fix workspace details page status update

### DIFF
--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
@@ -30,18 +30,19 @@ import { DEVWORKSPACE_ID_OVERRIDE_ANNOTATION } from '../../services/devfileApi/d
 import { convertDevfileV1toDevfileV2 } from '../../services/devfile/converters';
 import { DEVWORKSPACE_METADATA_ANNOTATION } from '../../services/workspace-client/devworkspace/devWorkspaceClient';
 import { selectDefaultNamespace } from '../../store/InfrastructureNamespaces/selectors';
+import { isEqual } from 'lodash';
 
 type Props = MappedProps & { history: History } & RouteComponentProps<{
     namespace: string;
     workspaceName: string;
-  }>; // incoming parameters
+  }>;
 
 type State = {
   workspace?: Workspace;
 };
 
 class WorkspaceDetailsContainer extends React.Component<Props, State> {
-  private workspacesLink: string;
+  private readonly workspacesLink: string;
 
   constructor(props: Props) {
     super(props);
@@ -118,22 +119,19 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
     this.init();
   }
 
-  public shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
-    return (
-      nextProps.isLoading === false &&
-      (this.state.workspace?.uid !== nextState.workspace?.uid ||
-        this.props.location.pathname !== nextProps.location.pathname)
-    );
-  }
-
-  public componentDidUpdate(): void {
+  public componentDidUpdate(prevProps: Props): void {
     const namespace = this.props.match.params.namespace;
     const workspaceName = this.props.match.params.workspaceName;
-
     const workspace = this.props.allWorkspaces.find(
       workspace => workspace.namespace === namespace && workspace.name === workspaceName,
     );
-    this.setState({ workspace });
+    if (
+      workspace &&
+      (this.props.location.pathname !== prevProps.location.pathname ||
+        !isEqual(workspace, this.state.workspace))
+    ) {
+      this.setState({ workspace });
+    }
   }
 
   render() {

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.tsx
@@ -52,6 +52,8 @@ export default class DropdownActions extends React.PureComponent<Props, State> {
 
   private getDropdownItems(): React.ReactNode[] {
     const { context, status } = this.props;
+    const isWorkspaceStopped =
+      status === WorkspaceStatus.STOPPED || status === DevWorkspaceStatus.STOPPED;
 
     return [
       <DropdownItem
@@ -63,7 +65,7 @@ export default class DropdownActions extends React.PureComponent<Props, State> {
       </DropdownItem>,
       <DropdownItem
         key={`action-${WorkspaceAction.START_DEBUG_AND_OPEN_LOGS}`}
-        isDisabled={status === DevWorkspaceStatus.TERMINATING || status !== WorkspaceStatus.STOPPED}
+        isDisabled={status === DevWorkspaceStatus.TERMINATING || !isWorkspaceStopped}
         onClick={async () =>
           this.props.onAction(WorkspaceAction.START_DEBUG_AND_OPEN_LOGS, context)
         }
@@ -72,21 +74,21 @@ export default class DropdownActions extends React.PureComponent<Props, State> {
       </DropdownItem>,
       <DropdownItem
         key={`action-${WorkspaceAction.START_IN_BACKGROUND}`}
-        isDisabled={status === DevWorkspaceStatus.TERMINATING || status !== WorkspaceStatus.STOPPED}
+        isDisabled={status === DevWorkspaceStatus.TERMINATING || !isWorkspaceStopped}
         onClick={async () => this.props.onAction(WorkspaceAction.START_IN_BACKGROUND, context)}
       >
         <div>{WorkspaceAction.START_IN_BACKGROUND}</div>
       </DropdownItem>,
       <DropdownItem
         key={`action-${WorkspaceAction.RESTART_WORKSPACE}`}
-        isDisabled={status === DevWorkspaceStatus.TERMINATING || status === WorkspaceStatus.STOPPED}
+        isDisabled={status === DevWorkspaceStatus.TERMINATING || isWorkspaceStopped}
         onClick={async () => this.props.onAction(WorkspaceAction.RESTART_WORKSPACE, context)}
       >
         <div>{WorkspaceAction.RESTART_WORKSPACE}</div>
       </DropdownItem>,
       <DropdownItem
         key={`action-${WorkspaceAction.STOP_WORKSPACE}`}
-        isDisabled={status === DevWorkspaceStatus.TERMINATING || status === WorkspaceStatus.STOPPED}
+        isDisabled={status === DevWorkspaceStatus.TERMINATING || isWorkspaceStopped}
         onClick={async () => this.props.onAction(WorkspaceAction.STOP_WORKSPACE, context)}
       >
         <div>{WorkspaceAction.STOP_WORKSPACE}</div>

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -395,7 +395,7 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
   }
 
   private handleAddWorkspace(): void {
-    const location = buildGettingStartedLocation('custom-workspace');
+    const location = buildGettingStartedLocation('quick-add');
     this.props.history.push(location);
   }
 


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix workspace details page status update.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21314

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Open the workspace overview page.
2. Start (or stop) the workspace using the Recent workspaces section in the navigation bar.
3. Pay attention to the workspace status in the main page section.
4. Workspace status should get updated on the workspace overview page as well.

