### PR TITLE
Fix single running workspace restriction for DevWorkspaces

### DIFF
--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.conversion.spec.tsx
@@ -313,7 +313,6 @@ describe('Workspace Details container', () => {
           devNamespace,
           {},
           {},
-          false,
         );
 
         expect(mockUpdateWorkspace).toHaveBeenCalledWith<

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
@@ -178,14 +178,7 @@ class WorkspaceDetailsContainer extends React.Component<Props, State> {
     ] = oldWorkspace.uid;
     const defaultNamespace = this.props.defaultNamespace.name;
     // create a new workspace
-    await this.props.createWorkspaceFromDevfile(
-      devfileV2,
-      undefined,
-      defaultNamespace,
-      {},
-      {},
-      false,
-    );
+    await this.props.createWorkspaceFromDevfile(devfileV2, undefined, defaultNamespace, {}, {});
 
     const newWorkspace = this.props.allWorkspaces.find(workspace => {
       if (isDevWorkspace(workspace.ref)) {

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -282,6 +282,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
       devworkspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR] = editorId;
     }
 
+    devworkspace.spec.started = false;
     const createdWorkspace = await DwApi.createWorkspace(devworkspace);
 
     // create DWT
@@ -345,7 +346,6 @@ export class DevWorkspaceClient extends WorkspaceClient {
     pluginRegistryInternalUrl: string | undefined,
     editorId: string | undefined,
     optionalFilesContent: { [fileName: string]: string },
-    start = true,
   ): Promise<devfileApi.DevWorkspace> {
     if (!devfile.components) {
       devfile.components = [];
@@ -355,7 +355,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     }
 
     const routingClass = 'che';
-    const devworkspace = devfileToDevWorkspace(devfile, routingClass, start);
+    const devworkspace = devfileToDevWorkspace(devfile, routingClass, false);
 
     if (devworkspace.metadata.annotations === undefined) {
       devworkspace.metadata.annotations = {};
@@ -366,6 +366,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     if (editorId) {
       devworkspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR] = editorId;
     }
+    devworkspace.spec.started = false;
 
     const createdWorkspace = await DwApi.createWorkspace(devworkspace);
     const namespace = createdWorkspace.metadata.namespace;
@@ -544,7 +545,6 @@ export class DevWorkspaceClient extends WorkspaceClient {
       }),
     );
 
-    createdWorkspace.spec.started = start;
     const patch = [
       {
         op: 'replace',

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -115,7 +115,6 @@ export type ActionCreators = {
     optionalFilesContent?: {
       [fileName: string]: string;
     },
-    start?: boolean,
   ) => AppThunk<KnownAction, Promise<void>>;
 
   setWorkspaceQualifiedName: (
@@ -291,7 +290,6 @@ export const actionCreators: ActionCreators = {
       optionalFilesContent?: {
         [fileName: string]: string;
       },
-      start = true,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_WORKSPACES' });
@@ -311,7 +309,6 @@ export const actionCreators: ActionCreators = {
               pluginRegistryUrl,
               pluginRegistryInternalUrl,
               attributes,
-              start,
             ),
           );
           dispatch({ type: 'ADD_WORKSPACE' });


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix single running workspace restriction for DevWorkspaces.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21032

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Che with DevWorkspace enabled.
2. Create several workspaces from the samples.
3. You should see the restriction alert "... You are not allowed to start more workspaces.".
<img width="1786" alt="Знімок екрана 2022-04-18 о 16 43 11" src="https://user-images.githubusercontent.com/6310786/163820147-7af227f6-951a-41bf-8c0a-f31869a0b591.png">


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
