### PR TITLE
Add preload script HTML

### DIFF
--- a/packages/dashboard-frontend/src/preload/index.html
+++ b/packages/dashboard-frontend/src/preload/index.html
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2015-2018 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body></body>
+</html>

--- a/packages/dashboard-frontend/webpack.config.common.js
+++ b/packages/dashboard-frontend/webpack.config.common.js
@@ -151,7 +151,7 @@ const config = {
       filename: 'index.html',
     }),
     new HtmlWebpackPlugin({
-      template: path.resolve(__dirname, './static/loader.html'),
+      template: path.resolve(__dirname, 'src/preload/index.html'),
       chunks : ['accept-factory-link'],
       filename: '../index.html',
       publicPath: '/dashboard/',


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum, you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add preload script HTML.

### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-2967

### Is it tested? How?
<!-- 
Please provide instructions here on which scenario you fix/implement
and in which way you tested it, provide as much as you think the reviewer
needs to do the same.
-->

1) Open Google Chrome in incognito mode

2) Go to ```<CHE-Server>``` and you will be redirected to ```<CHE-Server>/dashboard/```  without loading any images or styles.