### PR TITLE
fix: handle zip locations when migrating from v1 to v2

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -10,7 +10,7 @@
 | [`@eclipse-che/common@7.47.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/dashboard-backend@7.47.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/dashboard-frontend@7.47.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/devfile-converter@0.0.1-e37ee54`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/devfile-converter@0.0.1-3d5ba2a`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/workspace-client@0.0.1-1632305737`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | ecd.che |
 | [`@fastify/ajv-compiler@1.1.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
 | [`@hapi/address@2.1.4`](git://github.com/hapijs/address) | BSD-3-Clause | clearlydefined |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@eclipse-che/che-code-devworkspace-handler": "1.64.0-dev-210b722",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1642670698",
-    "@eclipse-che/devfile-converter": "0.0.1-e37ee54",
+    "@eclipse-che/devfile-converter": "0.0.1-3d5ba2a",
     "@eclipse-che/workspace-client": "0.0.1-1632305737",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,10 +369,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/devfile-converter@0.0.1-e37ee54":
-  version "0.0.1-e37ee54"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-e37ee54.tgz#68072645d8093ea332525dac1f5cb386f733ffaf"
-  integrity sha512-YQ4Z6ZhvvBEre7c4ABOEPJ/SCxuuO/6gNOgRNlm3bMV8Ii/9hciWn3FvSEbIOOnNL1ljQsXC1QZQMMWTxx6kLw==
+"@eclipse-che/devfile-converter@0.0.1-3d5ba2a":
+  version "0.0.1-3d5ba2a"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/devfile-converter/-/devfile-converter-0.0.1-3d5ba2a.tgz#a9bd583373c68c292def4eda3800430d0d9308ac"
+  integrity sha512-xseASa+37GsArFhPoYGGChsvLldKAcuzGS+7KU1rTPdd/EIQ0DmbKoLMt7zFaVkBvxea3cFVkJh1hg4Mbk8fdg==
   dependencies:
     "@devfile/api" "2.2.0-alpha-1637255314"
     "@eclipse-che/api" "^7.39.2"


### PR DESCRIPTION
### What does this PR do?
update zip location to match local network

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3011

### Is it tested? How?
[unit test in devfile-converter library](https://github.com/che-incubator/devfile-converter/commit/158532917deec3183193142791f8413a021aefe2)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
