### PR TITLE
fix: run licenses check only on main branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,7 @@ jobs:
 
   dash-licenses:
     runs-on: ubuntu-20.04
+    if: ${{ github.base_ref == 'main' }}
     steps:
       -
         name: "Checkout Che Dashboard source code"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR prevents running the licenses check PR job against any branch except the `main`.
