### PR TITLE
fix: polyfill crypto package

### DIFF
--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -43,6 +43,7 @@
     "axios": "^0.21.1",
     "buffer": "^6.0.3",
     "connected-react-router": "^6.7.0",
+    "crypto-browserify": "^3.12.0",
     "date-fns": "^2.16.1",
     "detect-browser": "^5.2.0",
     "gravatar-url": "^3.1.0",
@@ -74,6 +75,7 @@
     "reflect-metadata": "^0.1.13",
     "reselect": "^4.0.0",
     "sanitize-html": "2.3.2",
+    "stream-browserify": "^3.0.0",
     "umd-compat-loader": "2.1.2",
     "vscode-languageserver-protocol": "~3.16.0",
     "yaml-language-server": "^0.13.0"

--- a/packages/dashboard-frontend/webpack.config.common.js
+++ b/packages/dashboard-frontend/webpack.config.common.js
@@ -137,13 +137,14 @@ const config = {
       "fs": false,
       "net": false,
       "module": false,
-      "crypto": false,
       "path": false,
       "os": false,
+      "crypto": require.resolve("crypto-browserify"),
+      "stream": require.resolve("stream-browserify"),
     },
   },
   resolveLoader: {},
-  node: false,
+  node: { global: true },
   plugins: [
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Since webpack v5 doesn't automatically polyfill node packages (see this [doc](https://gist.github.com/ef4/d2cf5672a93cf241fd47c020b9b3066a#webpack-5-node-polyfills-upgrade-cheatsheet)), this PR introduces polyfill for the Crypto package.

### What issues does this PR fix or reference?
This PR prevents this error message from happening on devworkspace startup:
![image](https://user-images.githubusercontent.com/83611742/171963483-bc2786b6-d5fd-490e-948f-70751db7f592.png)

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Check out this PR and follow [these steps](https://github.com/eclipse-che/che-dashboard#running-locally-against-remote-che-cluster) to run the dashboard locally against a cluster with Che + Devworkspace engine enabled.

Create a new devworkspace from the dashboard. The devworkspace should start successfully without the error message in the screenshot above.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
