### PR TITLE
fix: allow devfiles without `metadata.name`

### DIFF
--- a/packages/dashboard-backend/src/api/devworkspaceApi.ts
+++ b/packages/dashboard-backend/src/api/devworkspaceApi.ts
@@ -40,7 +40,7 @@ export function registerDevworkspaceApi(server: FastifyInstance) {
       devworkspace.metadata.namespace = namespace;
       const token = getToken(request);
       const { devworkspaceApi } = await getDevWorkspaceClient(token);
-      return devworkspaceApi.create(devworkspace);
+      return devworkspaceApi.create(devworkspace, namespace);
     },
   );
 

--- a/packages/dashboard-backend/src/devworkspace-client/__tests__/integration.spec.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/__tests__/integration.spec.ts
@@ -55,7 +55,7 @@ describe('DevWorkspace API integration testing against cluster', () => {
         expect(namespaceExists).toBe(true);
 
         // check that creation works
-        const newDevWorkspace = await dwClient.devworkspaceApi.create(devWorkspace);
+        const newDevWorkspace = await dwClient.devworkspaceApi.create(devWorkspace, namespace);
         expect(newDevWorkspace.metadata?.name).toBe(name);
         expect(newDevWorkspace.metadata?.namespace).toBe(namespace);
 

--- a/packages/dashboard-backend/src/devworkspace-client/services/api/workspace-api.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/services/api/workspace-api.ts
@@ -66,16 +66,21 @@ export class DevWorkspaceApi implements IDevWorkspaceApi {
     }
   }
 
-  async create(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace> {
+  async create(
+    devworkspace: V1alpha2DevWorkspace,
+    namespace: string,
+  ): Promise<V1alpha2DevWorkspace> {
     try {
-      if (!devworkspace.metadata?.name || !devworkspace.metadata?.namespace) {
-        throw 'DevWorkspace.metadata with name and namespace are required';
+      if (!devworkspace.metadata?.name && !devworkspace.metadata?.generateName) {
+        throw new Error(
+          'Either DevWorkspace `metadata.name` or `metadata.generateName` is required.',
+        );
       }
 
       const resp = await this.customObjectAPI.createNamespacedCustomObject(
         devworkspaceGroup,
         devworkspaceLatestVersion,
-        devworkspace.metadata.namespace,
+        namespace,
         devworkspacePlural,
         devworkspace,
       );

--- a/packages/dashboard-backend/src/devworkspace-client/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspace-client/types/index.ts
@@ -55,7 +55,7 @@ export interface IDevWorkspaceApi {
   /**
    * Create a devworkspace based on the specified configuration.
    */
-  create(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace>;
+  create(devworkspace: V1alpha2DevWorkspace, namespace: string): Promise<V1alpha2DevWorkspace>;
 
   /**
    * Updates the DevWorkspace with the given configuration

--- a/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
@@ -16,18 +16,12 @@ export function isDevfileV2Like(devfile: unknown): devfile is devfileApi.Devfile
   return (devfile as devfileApi.DevfileLike).schemaVersion !== undefined;
 }
 
+const schemaVersionRe =
+  /^([2-9])\.([0-9]+)\.([0-9]+)(-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
 export function isDevfileV2(devfile: unknown): devfile is devfileApi.Devfile {
   return (
     (devfile as devfileApi.Devfile).schemaVersion !== undefined &&
-    isDevfileV2Metadata((devfile as devfileApi.Devfile).metadata)
-  );
-}
-
-export function isDevfileV2Metadata(metadata: unknown): metadata is devfileApi.DevfileMetadata {
-  return (
-    metadata !== undefined &&
-    ((metadata as devfileApi.DevfileMetadata).name !== undefined ||
-      (metadata as devfileApi.DevfileMetadata).generateName !== undefined)
+    schemaVersionRe.test((devfile as devfileApi.Devfile).schemaVersion)
   );
 }
 

--- a/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
@@ -83,6 +83,9 @@ export default function normalizeDevfileV2(
   } else if (location) {
     devfileSource = safeDump({ url: { location } });
   }
+  if (!devfile.metadata) {
+    devfile.metadata = {} as devfileApi.DevfileMetadata;
+  }
   const metadata = devfile.metadata;
   if (!metadata.attributes) {
     metadata.attributes = {};
@@ -92,6 +95,9 @@ export default function normalizeDevfileV2(
   }
   metadata.attributes[DEVWORKSPACE_METADATA_ANNOTATION][DEVWORKSPACE_DEVFILE_SOURCE] =
     devfileSource;
+  if (!metadata.name && !metadata.generateName) {
+    metadata.generateName = getProjectName(scmInfo?.clone_url || location);
+  }
   devfile = Object.assign({}, devfile, { metadata });
 
   return devfile;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR allows the dashboard to create workspaces from devfiles without the `metadata` section.


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/21429



### Is it tested? How?

Open link https://eclipse-che.apps.cluster-wb6n9.wb6n9.sandbox506.opentlc.com/#https://github.com/l0rd/tilt-example-java/tree/cc88c7f683e5ab50d36722e7b8366d871f6a73d4

