### PR TITLE
Fix unauthorized errors flow

### DIFF
--- a/packages/dashboard-frontend/index.html
+++ b/packages/dashboard-frontend/index.html
@@ -18,15 +18,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Dashboard</title>
-  <link rel="shortcut icon" href="./assets/branding/favicon.ico">
-  <link rel="stylesheet" type="text/css" href="./assets/branding/branding.css">
-  <link rel="manifest" href="./assets/branding/manifest.json"/>
+  <link rel="shortcut icon" href="/dashboard/assets/branding/favicon.ico">
+  <link rel="stylesheet" type="text/css" href="/dashboard/assets/branding/branding.css">
+  <link rel="manifest" href="/dashboard/assets/branding/manifest.json"/>
 </head>
 <body>
 <div class="ui-container" style="height: 100%;">
   <div class="main-page-loader">
     <div class="ide-page-loader-content">
-      <img src="./assets/branding/loader.svg"/>
+      <img src="/dashboard/assets/branding/loader.svg"/>
     </div>
   </div>
 </div>

--- a/packages/dashboard-frontend/src/Layout/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/index.tsx
@@ -32,6 +32,7 @@ import { ROUTE } from '../route.enum';
 import { selectUser } from '../store/User/selectors';
 import { selectBranding } from '../store/Branding/selectors';
 import { ToggleBarsContext } from '../contexts/ToggleBars';
+import { signOut } from '../services/helpers/login';
 
 const THEME_KEY = 'theme';
 const IS_MANAGED_SIDEBAR = false;
@@ -63,11 +64,6 @@ export class Layout extends React.PureComponent<Props, State> {
       isSidebarVisible: true,
       theme,
     };
-  }
-
-  private logout(): void {
-    // assume that Che deployed with `nativeUserMode` enabled
-    window.location.href = '/oauth/sign_out';
   }
 
   private toggleNav(): void {
@@ -183,7 +179,7 @@ export class Layout extends React.PureComponent<Props, State> {
               isVisible={isHeaderVisible}
               logoUrl={logoUrl}
               user={user}
-              logout={() => this.logout()}
+              logout={() => signOut()}
               toggleNav={() => this.toggleNav()}
               changeTheme={theme => this.changeTheme(theme)}
             />

--- a/packages/dashboard-frontend/src/services/helpers/login.ts
+++ b/packages/dashboard-frontend/src/services/helpers/login.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export function signIn(): void {
+  window.location.pathname = '/oauth/sign_in';
+}
+
+export function signOut(): void {
+  window.location.pathname = '/oauth/sign_out';
+}

--- a/packages/dashboard-frontend/src/services/workspace-client/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/index.ts
@@ -56,7 +56,7 @@ export abstract class WorkspaceClient {
         }
       }
       return response;
-      });
+    });
   }
 
   private checkPathPrefix(response: AxiosResponse, prefix: string): boolean {

--- a/packages/dashboard-frontend/src/services/workspace-client/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/index.ts
@@ -48,15 +48,23 @@ export abstract class WorkspaceClient {
     );
 
     // dashboard-backend axios interceptor
-    axios.interceptors.response.use(async response => {
-      const isApi = this.checkPathPrefix(response, '/dashboard/api/');
-      if (isApi) {
-        if (isUnauthorized(response) || isForbidden(response)) {
+    axios.interceptors.response.use(
+      async response => {
+        const isApi = this.checkPathPrefix(response, '/dashboard/api/');
+        if (isApi) {
+          if (isUnauthorized(response) || isForbidden(response)) {
+            signIn();
+          }
+        }
+        return response;
+      },
+      async error => {
+        if (isUnauthorized(error) || isForbidden(error)) {
           signIn();
         }
-      }
-      return response;
-    });
+        return Promise.reject(error);
+      },
+    );
   }
 
   private checkPathPrefix(response: AxiosResponse, prefix: string): boolean {

--- a/packages/dashboard-frontend/src/store/Branding/index.ts
+++ b/packages/dashboard-frontend/src/store/Branding/index.ts
@@ -19,7 +19,7 @@ import common from '@eclipse-che/common';
 import { BRANDING_DEFAULT, BrandingData } from '../../services/bootstrap/branding.constant';
 import { createObject } from '../helpers';
 import { isForbidden, isInternalServerError } from '../../services/workspace-client/helpers';
-import { signOut } from '../../services/helpers/login';
+import { signIn } from '../../services/helpers/login';
 
 const ASSET_PREFIX = './assets/branding/';
 
@@ -151,7 +151,7 @@ async function getApiInfo(): Promise<{
   } catch (e) {
     const errorMessage = common.helpers.errors.getMessage(e);
     if (isInternalServerError(e) || isForbidden(e)) {
-      signOut();
+      signIn();
     }
     throw errorMessage;
   }

--- a/packages/dashboard-frontend/src/store/Branding/index.ts
+++ b/packages/dashboard-frontend/src/store/Branding/index.ts
@@ -18,8 +18,8 @@ import axios from 'axios';
 import common from '@eclipse-che/common';
 import { BRANDING_DEFAULT, BrandingData } from '../../services/bootstrap/branding.constant';
 import { createObject } from '../helpers';
-import { deauthorizeCallback } from '../../services/workspace-client';
 import { isForbidden, isInternalServerError } from '../../services/workspace-client/helpers';
+import { signOut } from '../../services/helpers/login';
 
 const ASSET_PREFIX = './assets/branding/';
 
@@ -151,9 +151,7 @@ async function getApiInfo(): Promise<{
   } catch (e) {
     const errorMessage = common.helpers.errors.getMessage(e);
     if (isInternalServerError(e) || isForbidden(e)) {
-      await deauthorizeCallback().catch(() => {
-        // noop
-      });
+      signOut();
     }
     throw errorMessage;
   }


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix unauthorized errors flow.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3060

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Install CHE on OpenShift.
2. Set cluster accessTokenInactivityTimeout = 5 minutes:
```oc patch OAuth/cluster -p '{ "spec": { "tokenConfig": { "accessTokenInactivityTimeout": "5m" }}}' --type merge```
3. Open CHE Dashboard page in Google Chrome.
4. Leave it along about 20 minutes.
5. Refresh CHE Dashboard page.
6. CHE Dashboard should be redirected to the login page.

You can tested it with https://eclipse-che.apps.cluster-7vz9l.7vz9l.sandbox688.opentlc.com/dashboard/