### PR TITLE
fix: preload page

### DIFF
--- a/.deps/EXCLUDED/dev.md
+++ b/.deps/EXCLUDED/dev.md
@@ -5,6 +5,7 @@ This file contains a manual contribution to .deps/dev.md and it's needed because
 | `@testing-library/dom@7.31.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@testing-library/dom/7.31.2) |
 | `css-select@4.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/css-select/4.2.1) |
 | `default-gateway@6.0.3` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/default-gateway/6.0.3) |
+| `eslint@7.32.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/eslint/7.32.0) |
 | `exec-sh@0.3.6` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/exec-sh/0.3.6) |
 | `fs-monkey@1.0.3` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fs-monkey/1.0.3) |
 | `fsevents@2.3.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fsevents/2.3.2) |
@@ -17,6 +18,7 @@ This file contains a manual contribution to .deps/dev.md and it's needed because
 | `node-notifier@8.0.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/node-notifier/8.0.2) |
 | `postcss-syntax@0.36.2` | [CQ22418](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22418) |
 | `prettier@2.5.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/prettier/2.5.1) |
+| `readdirp@3.6.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/readdirp/3.6.0) |
 | `resolve-url@0.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/resolve-url/0.2.1) |
 | `sockjs@0.3.24` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/sockjs/0.3.24) |
 | `source-map-url@0.4.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/source-map-url/0.4.1) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -346,7 +346,7 @@
 | [`cliui@6.0.0`](http://github.com/yargs/cliui.git) | ISC | clearlydefined |
 | [`clone-deep@4.0.1`](https://github.com/jonschlinkert/clone-deep.git) | MIT | clearlydefined |
 | [`clone-regexp@2.2.0`](https://github.com/sindresorhus/clone-regexp.git) | MIT | clearlydefined |
-| [`clone@1.0.4`](git://github.com/pvorb/node-clone.git) | MIT |  |
+| [`clone@1.0.4`](git://github.com/pvorb/node-clone.git) | MIT | #2729 |
 | [`cmd-shim@4.1.0`](https://github.com/npm/cmd-shim.git) | ISC | clearlydefined |
 | [`co@4.6.0`](https://github.com/tj/co.git) | MIT | clearlydefined |
 | [`code-point-at@1.1.0`](https://github.com/sindresorhus/code-point-at.git) | MIT | clearlydefined |
@@ -452,7 +452,7 @@
 | [`eslint-scope@5.1.1`](https://github.com/eslint/eslint-scope.git) | BSD-2-Clause | clearlydefined |
 | [`eslint-utils@2.1.0`](git+https://github.com/mysticatea/eslint-utils.git) | MIT | #2498 |
 | [`eslint-visitor-keys@2.1.0`](https://github.com/eslint/eslint-visitor-keys.git) | Apache-2.0 | #2433 |
-| [`eslint@7.32.0`](https://github.com/eslint/eslint.git) | MIT |  |
+| [`eslint@7.32.0`](https://github.com/eslint/eslint.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/eslint/7.32.0) |
 | [`espree@7.3.1`](https://github.com/eslint/espree.git) | BSD-2-Clause | #903 |
 | [`esquery@1.4.0`](https://github.com/estools/esquery.git) | BSD-3-Clause | #1100 |
 | [`esrecurse@4.3.0`](https://github.com/estools/esrecurse.git) | BSD-2-Clause | clearlydefined |
@@ -844,7 +844,7 @@
 | [`read-pkg@3.0.0`](https://github.com/sindresorhus/read-pkg.git) | MIT | clearlydefined |
 | [`read@1.0.7`](git://github.com/isaacs/read.git) | ISC | clearlydefined |
 | [`readdir-scoped-modules@1.1.0`](https://github.com/npm/readdir-scoped-modules) | ISC | clearlydefined |
-| [`readdirp@3.6.0`](git://github.com/paulmillr/readdirp.git) | MIT |  |
+| [`readdirp@3.6.0`](git://github.com/paulmillr/readdirp.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/readdirp/3.6.0) |
 | [`rechoir@0.7.1`](https://github.com/gulpjs/rechoir.git) | MIT | clearlydefined |
 | [`redent@3.0.0`](https://github.com/sindresorhus/redent.git) | MIT | clearlydefined |
 | [`redux-mock-store@1.5.4`](git+https://github.com/arnaudbenard/redux-mock-store.git) | MIT | clearlydefined |

--- a/.deps/problems.md
+++ b/.deps/problems.md
@@ -2,7 +2,4 @@
 
 ## UNRESOLVED Development dependencies
 
-1. `clone@1.0.4`
-2. `eslint@7.32.0`
-3. `readdirp@3.6.0`
-4. `urix@0.1.0`
+1. `urix@0.1.0`

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start:prepare": "${PWD}/run/prepare-local-run.sh",
     "start:cleanup": "${PWD}/run/revert-local-run.sh",
     "license:check": "docker run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses@sha256:2f82a3b85a5858eaaeb9d9038cbfeef186824eb0671c8539bb56cdbb42c66737 --check",
-    "license:generate": "docker run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses@sha256:2f82a3b85a5858eaaeb9d9038cbfeef186824eb0671c8539bb56cdbb42c66737",
+    "license:generate": "docker run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses:next",
     "test": "lerna run test --stream -- --no-cache $@",
     "pretest": "yarn run prebuild",
     "test:coverage": "yarn run test -- --runInBand --coverage",

--- a/packages/dashboard-frontend/webpack.config.common.js
+++ b/packages/dashboard-frontend/webpack.config.common.js
@@ -39,9 +39,8 @@ const config = {
     clean: true,
   },
   optimization: {
-    chunkIds: 'named',
+    chunkIds: 'deterministic',
     splitChunks: {
-      name: 'vendor',
       chunks: 'initial',
       cacheGroups: {
         default: false,
@@ -61,7 +60,7 @@ const config = {
         common: {
           name: 'common',
           minChunks: 2,
-          chunks: 'all',
+          chunks: 'async',
           priority: 10,
           reuseExistingChunk: true,
           enforce: true


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Updates the webpack build not to inject the chunk named 'common' into the preload page. 

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/21490

