### PR TITLE
Fix expected response for adding kubeconfig

### DIFF
--- a/packages/dashboard-backend/src/api/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/api/kubeConfigApi.ts
@@ -22,7 +22,16 @@ const tags = ['Kube Config'];
 export function registerKubeConfigApi(server: FastifyInstance) {
   server.post(
     `${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig`,
-    getSchema({ tags, params: namespacedKubeConfigSchema }),
+    getSchema({
+      tags,
+      params: namespacedKubeConfigSchema,
+      response: {
+        204: {
+          description: 'The cube config file is successfully injected',
+          type: 'null',
+        },
+      },
+    }),
     async function (request: FastifyRequest, reply: FastifyReply) {
       const token = getToken(request);
       const { kubeConfigApi } = await getDevWorkspaceClient(token);


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix expected response for adding kubeconfig.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21480

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse CHE on k8s platform using  ```chectl```
2. Create a new workspace from one of the samples. 
3.  `config` file should be in `~/.kube/` 
```
$ ls ~/.kube/
```
4. Open swagger ```/dashboard/api/swagger``` and try to use 'Kube Config'
5. Response code should be 204

<img width="1632" alt="Знімок екрана 2022-07-05 о 12 43 56" src="https://user-images.githubusercontent.com/6310786/177303846-6754eb94-69f4-4a34-b3e0-68233ed5a29b.png">
<img width="1292" alt="Знімок екрана 2022-07-05 о 15 12 21" src="https://user-images.githubusercontent.com/6310786/177324685-020dcf39-3531-4a5f-b014-76ddfd2debe0.png">

