### PR TITLE
chore: remove --idle-timeout in DWT mock

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
@@ -79,8 +79,6 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
               '/go/bin/che-machine-exec',
               '--url',
               '127.0.0.1:3333',
-              '--idle-timeout',
-              '15m',
             ],
             cpuLimit: '500m',
             cpuRequest: '30m',


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Since the `--idle-timeout` flag for che-machine-exec in the Theia definition is to be removed (see https://github.com/eclipse/che/issues/21390), this PR updates the DWT mock to be consistent with the removal


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Running `npm test` should still pass all tests:
```
$ npm test

...

lerna success - @eclipse-che/common
lerna success - @eclipse-che/dashboard-backend
lerna success - @eclipse-che/dashboard-frontend
```

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
