### PR TITLE
Remove 'che-pycharm' editor from excludes

### DIFF
--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
@@ -59,13 +59,7 @@ type State = {
   alerts: AlertItem[];
 };
 
-const EXCLUDED_TARGET_EDITOR_NAMES = [
-  'dirigible',
-  'jupyter',
-  'che-pycharm',
-  'eclipseide',
-  'code-server',
-];
+const EXCLUDED_TARGET_EDITOR_NAMES = ['dirigible', 'jupyter', 'eclipseide', 'code-server'];
 
 export class SamplesListGallery extends React.PureComponent<Props, State> {
   private static sortByName(a: TargetEditor, b: TargetEditor): number {


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove 'che-pycharm' editor from excludes.

![Знімок екрана 2022-07-21 о 18 11 56](https://user-images.githubusercontent.com/6310786/180249297-0f799b8c-3392-4ec6-8bbd-ee2f616bacb6.png)

