### PR TITLE
[build] feat: add env to set endpoints for non standard oidc auth in …

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -8,6 +8,30 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+set -a
+
+if [ ! -z "$CHE_INFRA_KUBERNETES_PORT" ]
+then
+    KUBERNETES_PORT=$CHE_INFRA_KUBERNETES_PORT
+fi
+
+if [ ! -z "$CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR" ]
+then
+    KUBERNETES_PORT_443_TCP_ADDR=$CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR
+fi
+
+if [ ! -z "$CHE_INFRA_KUBERNETES_PORT_443_TCP" ]
+then
+    KUBERNETES_PORT_443_TCP=$CHE_INFRA_KUBERNETES_PORT_443_TCP
+fi
+
+if [ ! -z "$CHE_INFRA_KUBERNETES_SERVICE_HOST" ]
+then
+    KUBERNETES_SERVICE_HOST=$CHE_INFRA_KUBERNETES_SERVICE_HOST
+fi
+
+set +a
+
 set -e
 echo 'Starting Dashboard backend server...'
 start_server="node /backend/server/backend.js --publicFolder /public"


### PR DESCRIPTION
…kubernetes

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Add env vars ( KUBERNETES_PORT, KUBERNETES_PORT_443_TCP_ADDR, KUBERNETES_PORT_443_TCP, KUBERNETES_SERVICE_HOST ) to the dashboard so that one can set the endpoints for custom oidc auth in a kubernetes deployment. This also goes with the changes to che-operator that set these env vars in the deployment. This allows custom oidc endpoints for deployments in gke and other cloud providers that do not have dex setup.

goes with: https://github.com/eclipse-che/che-operator/pull/1465

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/21260



### Is it tested? How?

The environment variables are added to the dashboard deployment if they are present in the operator manifest. Then is the env vars are set in the dashboard deployment the entrypoint.sh will check and see if they are present and is so set them. If not default values will stay with those env vars. Currently no tests for this. 


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

Add env var to dashboard to change KUBERNETES_PORT, KUBERNETES_PORT_443_TCP_ADDR, KUBERNETES_PORT_443_TCP, KUBERNETES_SERVICE_HOST based on env vars from che-operator. 


#### Docs PR https://github.com/eclipse-che/che-docs/pull/2413
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
