### PR TITLE
chore: chore: Pass error_code param to factory api instead of throwing an error

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchDevfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchDevfile/index.tsx
@@ -205,9 +205,12 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
    */
   private async resolveDevfile(factoryUrl: string): Promise<boolean> {
     const { factoryParams } = this.state;
+    const params = Object.assign({}, factoryParams.overrides, {
+      error_code: factoryParams.errorCode,
+    });
 
     try {
-      await this.props.requestFactoryResolver(factoryUrl, factoryParams.overrides);
+      await this.props.requestFactoryResolver(factoryUrl, params);
       this.clearNumberOfTries();
       return true;
     } catch (e) {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/__tests__/index.spec.tsx
@@ -142,34 +142,6 @@ describe('Factory Loader, step INITIALIZE', () => {
     expect(mockOnNextStep).not.toHaveBeenCalled();
   });
 
-  test('`access_denied` error code', async () => {
-    const searchParams = new URLSearchParams({
-      [FACTORY_URL_ATTR]: factoryUrl,
-      [ERROR_CODE_ATTR]: 'access_denied',
-    });
-
-    renderComponent(store, loaderSteps, searchParams);
-
-    jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
-
-    const currentStepId = screen.getByTestId('current-step-id');
-    await waitFor(() => expect(currentStepId.textContent).toEqual(stepId));
-
-    const currentStep = screen.getByTestId(stepId);
-    const hasError = within(currentStep).getByTestId('hasError');
-    expect(hasError.textContent).toEqual('true');
-
-    const alertTitle = screen.getByTestId('alert-title');
-    expect(alertTitle.textContent).toEqual('Failed to create the workspace');
-
-    const alertBody = screen.getByTestId('alert-body');
-    expect(alertBody.textContent).toEqual(
-      'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
-    );
-
-    expect(mockOnNextStep).not.toHaveBeenCalled();
-  });
-
   test('`policies.create` valid', async () => {
     const searchParams = new URLSearchParams({
       [FACTORY_URL_ATTR]: factoryUrl,

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
@@ -99,11 +99,6 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
         'Could not resolve devfile from private repository because authentication request is missing a parameter, contains an invalid parameter, includes a parameter more than once, or is otherwise invalid.',
       );
     }
-    if (errorCode === 'access_denied') {
-      throw new Error(
-        'Could not resolve devfile from private repository because the user or authorization server denied the authentication request.',
-      );
-    }
 
     // validate creation policies
     if (this.isCreatePolicy(policiesCreate) === false) {


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Parse authentication status query param and pass it to the che-server's factory API.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21436

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
