### PR TITLE
Provide links to [stop/go to] running workspace when trying to start a workspace when workspace limit reached

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/AbstractStep.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/AbstractStep.tsx
@@ -24,7 +24,11 @@ export type LoaderStepProps = {
   onRestart: () => void;
 };
 export type LoaderStepState = {
-  lastError?: string;
+  lastError?: LoaderStepError;
+};
+export type LoaderStepError = {
+  message: string;
+  error: unknown;
 };
 export abstract class AbstractLoaderStep<
   P extends LoaderStepProps,
@@ -61,7 +65,10 @@ export abstract class AbstractLoaderStep<
     const currentStep = loaderSteps.get(currentStepIndex).value;
 
     currentStep.hasError = true;
-    const lastError = common.helpers.errors.getMessage(e);
+    const lastError = {
+      message: common.helpers.errors.getMessage(e),
+      error: e,
+    };
     this.setState({
       lastError,
     });

--- a/packages/dashboard-frontend/src/containers/Loader/AbstractStep.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/AbstractStep.tsx
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import common from '@eclipse-che/common';
 import React from 'react';
 import { Cancellation, pseudoCancellable } from 'real-cancellable-promise';
 import { List, LoaderStep } from '../../components/Loader/Step';
@@ -24,12 +23,9 @@ export type LoaderStepProps = {
   onRestart: () => void;
 };
 export type LoaderStepState = {
-  lastError?: LoaderStepError;
+  lastError?: unknown;
 };
-export type LoaderStepError = {
-  message: string;
-  error: unknown;
-};
+
 export abstract class AbstractLoaderStep<
   P extends LoaderStepProps,
   S extends LoaderStepState,
@@ -65,12 +61,8 @@ export abstract class AbstractLoaderStep<
     const currentStep = loaderSteps.get(currentStepIndex).value;
 
     currentStep.hasError = true;
-    const lastError = {
-      message: common.helpers.errors.getMessage(e),
-      error: e,
-    };
     this.setState({
-      lastError,
+      lastError: e,
     });
   }
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyDevfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyDevfile/index.tsx
@@ -84,7 +84,7 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
 
@@ -142,7 +142,9 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldCreate === false) {
-      throw new Error(this.state.lastError || 'The workspace creation unexpectedly failed.');
+      throw new Error(
+        this.state.lastError?.message || 'The workspace creation unexpectedly failed.',
+      );
     }
 
     const devfile = factoryResolverConverted?.devfileV2;
@@ -211,7 +213,7 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-' + getRandomString(4),
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyDevfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyDevfile/index.tsx
@@ -13,7 +13,9 @@
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { isEqual } from 'lodash';
 import { AlertVariant } from '@patternfly/react-core';
+import { helpers } from '@eclipse-che/common';
 import { AppState } from '../../../../../store';
 import * as WorkspacesStore from '../../../../../store/Workspaces';
 import { DisposableCollection } from '../../../../../services/helpers/disposable';
@@ -84,7 +86,7 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
 
@@ -142,9 +144,10 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldCreate === false) {
-      throw new Error(
-        this.state.lastError?.message || 'The workspace creation unexpectedly failed.',
-      );
+      if (this.state.lastError instanceof Error) {
+        throw this.state.lastError;
+      }
+      throw new Error('The workspace creation unexpectedly failed.');
     }
 
     const devfile = factoryResolverConverted?.devfileV2;
@@ -213,7 +216,7 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-' + getRandomString(4),
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
+            children: helpers.errors.getMessage(lastError),
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyResources/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyResources/index.tsx
@@ -13,7 +13,9 @@
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { isEqual } from 'lodash';
 import { AlertVariant } from '@patternfly/react-core';
+import { helpers } from '@eclipse-che/common';
 import { AppState } from '../../../../../store';
 import * as FactoryResolverStore from '../../../../../store/FactoryResolver';
 import * as WorkspacesStore from '../../../../../store/Workspaces';
@@ -91,7 +93,7 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
 
@@ -149,9 +151,10 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldCreate === false) {
-      throw new Error(
-        this.state.lastError?.message || 'The workspace creation unexpectedly failed.',
-      );
+      if (this.state.lastError instanceof Error) {
+        throw this.state.lastError;
+      }
+      throw new Error('The workspace creation unexpectedly failed.');
     }
 
     const resources = devWorkspaceResources[sourceUrl]?.resources;
@@ -212,7 +215,7 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-' + getRandomString(4),
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
+            children: helpers.errors.getMessage(lastError),
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyResources/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/ApplyResources/index.tsx
@@ -91,7 +91,7 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
 
@@ -149,7 +149,9 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldCreate === false) {
-      throw new Error(this.state.lastError || 'The workspace creation unexpectedly failed.');
+      throw new Error(
+        this.state.lastError?.message || 'The workspace creation unexpectedly failed.',
+      );
     }
 
     const resources = devWorkspaceResources[sourceUrl]?.resources;
@@ -210,7 +212,7 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-' + getRandomString(4),
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/CreateWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/CreateWorkspace/index.tsx
@@ -71,7 +71,7 @@ export default class StepCreateWorkspace extends AbstractLoaderStep<Props, State
             key: 'factory-loader-' + getRandomString(4),
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/CreateWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/CreateWorkspace/index.tsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import { AlertVariant } from '@patternfly/react-core';
+import { helpers } from '@eclipse-che/common';
 import { DisposableCollection } from '../../../../../services/helpers/disposable';
 import { delay } from '../../../../../services/helpers/delay';
 import { FactoryLoaderPage } from '../../../../../pages/Loader/Factory';
@@ -71,7 +72,7 @@ export default class StepCreateWorkspace extends AbstractLoaderStep<Props, State
             key: 'factory-loader-' + getRandomString(4),
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
+            children: helpers.errors.getMessage(lastError),
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchDevfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchDevfile/index.tsx
@@ -96,7 +96,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
 
@@ -170,7 +170,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldResolve === false) {
-      throw new Error(this.state.lastError || 'Failed to resolve the devfile.');
+      throw new Error(this.state.lastError?.message || 'Failed to resolve the devfile.');
     }
 
     // start resolving the devfile
@@ -314,7 +314,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-fetch-devfile',
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchDevfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchDevfile/index.tsx
@@ -12,7 +12,8 @@
 
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import common from '@eclipse-che/common';
+import { isEqual } from 'lodash';
+import { helpers } from '@eclipse-che/common';
 import { AlertVariant } from '@patternfly/react-core';
 import { AppState } from '../../../../../store';
 import * as FactoryResolverStore from '../../../../../store/FactoryResolver';
@@ -96,7 +97,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
 
@@ -170,7 +171,10 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldResolve === false) {
-      throw new Error(this.state.lastError?.message || 'Failed to resolve the devfile.');
+      if (this.state.lastError instanceof Error) {
+        throw this.state.lastError;
+      }
+      throw new Error('Failed to resolve the devfile.');
     }
 
     // start resolving the devfile
@@ -243,7 +247,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
         oauthUrlTmp.toString() + '&redirect_after_login=' + redirectUrl.toString();
       window.location.href = fullOauthUrl;
     } catch (e) {
-      throw new Error(`Failed to open authentication page. ${common.helpers.errors.getMessage(e)}`);
+      throw new Error(`Failed to open authentication page. ${helpers.errors.getMessage(e)}`);
     }
   }
 
@@ -314,7 +318,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-fetch-devfile',
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
+            children: helpers.errors.getMessage(lastError),
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchResources/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchResources/index.tsx
@@ -12,7 +12,9 @@
 
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { isEqual } from 'lodash';
 import { AlertVariant } from '@patternfly/react-core';
+import { helpers } from '@eclipse-che/common';
 import { AppState } from '../../../../../store';
 import * as DevfileRegistriesStore from '../../../../../store/DevfileRegistries';
 import { DisposableCollection } from '../../../../../services/helpers/disposable';
@@ -84,7 +86,7 @@ class StepFetchResources extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
 
@@ -146,7 +148,10 @@ class StepFetchResources extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldResolve === false) {
-      throw new Error(lastError?.message || 'Failed to fetch pre-built resources');
+      if (lastError instanceof Error) {
+        throw lastError;
+      }
+      throw new Error('Failed to fetch pre-built resources');
     }
 
     await this.props.requestResources(sourceUrl);
@@ -186,7 +191,7 @@ class StepFetchResources extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-fetch-resources',
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
+            children: helpers.errors.getMessage(lastError),
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchResources/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchResources/index.tsx
@@ -84,7 +84,7 @@ class StepFetchResources extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
 
@@ -146,7 +146,7 @@ class StepFetchResources extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldResolve === false) {
-      throw new Error(lastError || 'Failed to fetch pre-built resources');
+      throw new Error(lastError?.message || 'Failed to fetch pre-built resources');
     }
 
     await this.props.requestResources(sourceUrl);
@@ -186,7 +186,7 @@ class StepFetchResources extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-fetch-resources',
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
@@ -60,7 +60,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
 
@@ -136,7 +136,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-initialize',
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
@@ -13,7 +13,9 @@
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { generatePath } from 'react-router-dom';
+import { isEqual } from 'lodash';
 import { AlertVariant } from '@patternfly/react-core';
+import { helpers } from '@eclipse-che/common';
 import { AppState } from '../../../../../store';
 import { selectInfrastructureNamespaces } from '../../../../../store/InfrastructureNamespaces/selectors';
 import { DisposableCollection } from '../../../../../services/helpers/disposable';
@@ -60,7 +62,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
     }
 
     // current step failed
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
 
@@ -136,7 +138,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
             key: 'factory-loader-initialize',
             title: 'Failed to create the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
+            children: helpers.errors.getMessage(lastError),
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/Initialize/index.tsx
@@ -16,7 +16,7 @@ import { AlertVariant } from '@patternfly/react-core';
 import { AppState } from '../../../../../store';
 import { selectAllWorkspaces } from '../../../../../store/Workspaces/selectors';
 import * as WorkspaceStore from '../../../../../store/Workspaces';
-import { WorkspaceLoaderPage } from '../../../../../pages/Loader/Workspace';
+import WorkspaceLoaderPage from '../../../../../pages/Loader/Workspace';
 import { Workspace } from '../../../../../services/workspace-adapter';
 import { DevWorkspaceStatus } from '../../../../../services/helpers/types';
 import { DisposableCollection } from '../../../../../services/helpers/disposable';
@@ -69,7 +69,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
       return true;
     }
     // set the error for the current step
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
     return false;
@@ -161,9 +161,9 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
             key: 'ide-loader-initialize',
             title: 'Failed to open the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
+            error: lastError.error,
           };
-
     return (
       <WorkspaceLoaderPage
         alertItem={alertItem}

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/Initialize/index.tsx
@@ -12,7 +12,9 @@
 
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { isEqual } from 'lodash';
 import { AlertVariant } from '@patternfly/react-core';
+import { helpers } from '@eclipse-che/common';
 import { AppState } from '../../../../../store';
 import { selectAllWorkspaces } from '../../../../../store/Workspaces/selectors';
 import * as WorkspaceStore from '../../../../../store/Workspaces';
@@ -69,7 +71,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
       return true;
     }
     // set the error for the current step
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
     return false;
@@ -161,8 +163,8 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
             key: 'ide-loader-initialize',
             title: 'Failed to open the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
-            error: lastError.error,
+            children: helpers.errors.getMessage(lastError),
+            error: lastError,
           };
     return (
       <WorkspaceLoaderPage

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
@@ -16,7 +16,7 @@ import { AlertVariant } from '@patternfly/react-core';
 import { AppState } from '../../../../../store';
 import { selectAllWorkspaces } from '../../../../../store/Workspaces/selectors';
 import * as WorkspaceStore from '../../../../../store/Workspaces';
-import { WorkspaceLoaderPage } from '../../../../../pages/Loader/Workspace';
+import WorkspaceLoaderPage from '../../../../../pages/Loader/Workspace';
 import { DisposableCollection } from '../../../../../services/helpers/disposable';
 import { delay } from '../../../../../services/helpers/delay';
 import { MIN_STEP_DURATION_MS, TIMEOUT_TO_GET_URL_SEC } from '../../../const';
@@ -69,7 +69,7 @@ class StepOpenWorkspace extends AbstractLoaderStep<Props, State> {
       return true;
     }
     // set the error for the current step
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
     return false;
@@ -147,7 +147,7 @@ class StepOpenWorkspace extends AbstractLoaderStep<Props, State> {
             key: 'ide-loader-open-ide',
             title: 'Failed to open the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
@@ -12,7 +12,9 @@
 
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { isEqual } from 'lodash';
 import { AlertVariant } from '@patternfly/react-core';
+import common from '@eclipse-che/common';
 import { AppState } from '../../../../../store';
 import { selectAllWorkspaces } from '../../../../../store/Workspaces/selectors';
 import * as WorkspaceStore from '../../../../../store/Workspaces';
@@ -69,7 +71,7 @@ class StepOpenWorkspace extends AbstractLoaderStep<Props, State> {
       return true;
     }
     // set the error for the current step
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
     return false;
@@ -147,7 +149,7 @@ class StepOpenWorkspace extends AbstractLoaderStep<Props, State> {
             key: 'ide-loader-open-ide',
             title: 'Failed to open the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
+            children: common.helpers.errors.getMessage(lastError),
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
@@ -17,7 +17,7 @@ import common from '@eclipse-che/common';
 import { AppState } from '../../../../../store';
 import { selectAllWorkspaces, selectLogs } from '../../../../../store/Workspaces/selectors';
 import * as WorkspaceStore from '../../../../../store/Workspaces';
-import { WorkspaceLoaderPage } from '../../../../../pages/Loader/Workspace';
+import WorkspaceLoaderPage from '../../../../../pages/Loader/Workspace';
 import { DevWorkspaceStatus } from '../../../../../services/helpers/types';
 import { DisposableCollection } from '../../../../../services/helpers/disposable';
 import { delay } from '../../../../../services/helpers/delay';
@@ -77,7 +77,7 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
       return true;
     }
     // set the error for the current step
-    if (this.state.lastError !== nextState.lastError) {
+    if (this.state.lastError?.message !== nextState.lastError?.message) {
       return true;
     }
     return false;
@@ -171,7 +171,14 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
         // do not switch to the next step
         return false;
       } catch (e) {
-        throw new Error(common.helpers.errors.getMessage(e));
+        const message = common.helpers.errors.getMessage(e);
+
+        if (common.helpers.errors.isError(e)) {
+          // throw original error
+          e.message = message;
+          throw e;
+        }
+        throw new Error(message);
       }
     }
 
@@ -198,7 +205,8 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
             key: 'ide-loader-start-workspace',
             title: 'Failed to open the workspace',
             variant: AlertVariant.danger,
-            children: lastError,
+            children: lastError.message,
+            error: lastError.error,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { AlertVariant } from '@patternfly/react-core';
 import common from '@eclipse-che/common';
+import { isEqual } from 'lodash';
 import { AppState } from '../../../../../store';
 import { selectAllWorkspaces, selectLogs } from '../../../../../store/Workspaces/selectors';
 import * as WorkspaceStore from '../../../../../store/Workspaces';
@@ -77,7 +78,7 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
       return true;
     }
     // set the error for the current step
-    if (this.state.lastError?.message !== nextState.lastError?.message) {
+    if (!isEqual(this.state.lastError, nextState.lastError)) {
       return true;
     }
     return false;
@@ -171,14 +172,10 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
         // do not switch to the next step
         return false;
       } catch (e) {
-        const message = common.helpers.errors.getMessage(e);
-
         if (common.helpers.errors.isError(e)) {
-          // throw original error
-          e.message = message;
           throw e;
         }
-        throw new Error(message);
+        throw new Error(common.helpers.errors.getMessage(e));
       }
     }
 
@@ -205,8 +202,8 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
             key: 'ide-loader-start-workspace',
             title: 'Failed to open the workspace',
             variant: AlertVariant.danger,
-            children: lastError.message,
-            error: lastError.error,
+            children: common.helpers.errors.getMessage(lastError),
+            error: lastError,
           };
 
     return (

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
@@ -166,17 +166,9 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
       this.state.shouldStart &&
       workspaceStatusIs(workspace, DevWorkspaceStatus.STOPPED, DevWorkspaceStatus.FAILED)
     ) {
-      try {
-        await this.props.startWorkspace(workspace);
-
-        // do not switch to the next step
-        return false;
-      } catch (e) {
-        if (common.helpers.errors.isError(e)) {
-          throw e;
-        }
-        throw new Error(common.helpers.errors.getMessage(e));
-      }
+      await this.props.startWorkspace(workspace);
+      // do not switch to the next step
+      return false;
     }
 
     // switch to the next step

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/__mocks__/index.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 import { Props, State } from '..';
 
-export class WorkspaceLoaderPage extends React.PureComponent<Props, State> {
+export default class WorkspaceLoaderPage extends React.PureComponent<Props, State> {
   render(): React.ReactNode {
     const { alertItem, currentStepId, steps, onRestart } = this.props;
     const wizardSteps = steps.map(step => (

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AlertVariant } from '@patternfly/react-core';
-import { WorkspaceLoaderPage } from '..';
+import WorkspaceLoaderPage from '..';
 import { LoadingStep, List, LoaderStep } from '../../../../components/Loader/Step';
 import {
   getWorkspaceLoadingSteps,
@@ -22,6 +22,9 @@ import {
 } from '../../../../components/Loader/Step/buildSteps';
 import { AlertItem, LoaderTab } from '../../../../services/helpers/types';
 import getComponentRenderer from '../../../../services/__mocks__/getComponentRenderer';
+import { Provider } from 'react-redux';
+import { Store } from 'redux';
+import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
 
 jest.mock('react-tooltip', () => {
   return function DummyTooltip(): React.ReactElement {
@@ -98,19 +101,28 @@ describe('Workspace loader page', () => {
   });
 });
 
-function getComponent(props: {
-  steps: LoaderStep[];
-  initialTab?: keyof typeof LoaderTab;
-  alertItem?: AlertItem;
-}): React.ReactElement {
+function getComponent(
+  props: {
+    steps: LoaderStep[];
+    initialTab?: keyof typeof LoaderTab;
+    alertItem?: AlertItem;
+  },
+  store?: Store,
+): React.ReactElement {
+  if (!store) {
+    store = new FakeStoreBuilder().build();
+  }
+
   return (
-    <WorkspaceLoaderPage
-      alertItem={props.alertItem}
-      currentStepId={currentStepId}
-      onRestart={mockOnWorkspaceRestart}
-      steps={props.steps}
-      tabParam={'Progress'}
-      workspace={undefined}
-    />
+    <Provider store={store}>
+      <WorkspaceLoaderPage
+        alertItem={props.alertItem}
+        currentStepId={currentStepId}
+        onRestart={mockOnWorkspaceRestart}
+        steps={props.steps}
+        tabParam={'Progress'}
+        workspace={undefined}
+      />
+    </Provider>
   );
 }

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
@@ -11,7 +11,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AlertVariant } from '@patternfly/react-core';
 import WorkspaceLoaderPage from '..';
@@ -25,6 +25,10 @@ import getComponentRenderer from '../../../../services/__mocks__/getComponentRen
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
 import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
+import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
+import { Workspace, WorkspaceAdapter } from '../../../../services/workspace-adapter';
+import { RunningWorkspacesExceededError } from '../../../../store/Workspaces/devWorkspaces';
+import { DevWorkspace } from '../../../../services/devfileApi/devWorkspace';
 
 jest.mock('react-tooltip', () => {
   return function DummyTooltip(): React.ReactElement {
@@ -99,6 +103,160 @@ describe('Workspace loader page', () => {
 
     expect(activeTab?.textContent).toEqual(LoaderTab.Logs.toString());
   });
+
+  describe('workspaces runningLimit has been reached', () => {
+    let startedWorkspace1: DevWorkspace;
+    let startedWorkspace2: DevWorkspace;
+    let stoppedWorkspace: DevWorkspace;
+    let currentWorkspace: DevWorkspace;
+
+    beforeEach(() => {
+      const namespace = 'user-che';
+
+      startedWorkspace1 = new DevWorkspaceBuilder()
+        .withName('bash')
+        .withNamespace(namespace)
+        .withMetadata({ uid: 'uid-bash' })
+        .build();
+      startedWorkspace1.spec.started = true;
+
+      startedWorkspace2 = new DevWorkspaceBuilder()
+        .withName('python-hello-world')
+        .withNamespace(namespace)
+        .withMetadata({ uid: 'uid-python-hello-world' })
+        .build();
+      startedWorkspace2.spec.started = true;
+
+      stoppedWorkspace = new DevWorkspaceBuilder()
+        .withName('nodejs-web-app')
+        .withNamespace(namespace)
+        .withMetadata({ uid: 'uid-nodejs-web-app' })
+        .build();
+
+      currentWorkspace = new DevWorkspaceBuilder()
+        .withName('golang-example')
+        .withNamespace(namespace)
+        .withMetadata({ uid: 'uid-golang-example' })
+        .build();
+    });
+
+    it('should show options if workspace running limit has been reached, and there is only one running workspace', () => {
+      const alertItem: AlertItem = {
+        key: 'alert-id',
+        title:
+          'Failed to start the workspace golang-example, reason: You are not allowed to start more workspaces.',
+        variant: AlertVariant.danger,
+        error: new RunningWorkspacesExceededError('You are not allowed to start more workspaces.'),
+      };
+
+      const store = new FakeStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [startedWorkspace1, stoppedWorkspace, currentWorkspace],
+        })
+        .build();
+
+      renderComponent(
+        { steps: steps.values, alertItem, workspace: new WorkspaceAdapter(currentWorkspace) },
+        store,
+      );
+
+      const alert = screen.getByTestId('action-links');
+      const buttons = within(alert).getAllByRole('button');
+      expect(buttons.length).toEqual(2);
+      expect(buttons[0].textContent).toEqual('Switch to running workspace (bash)');
+      expect(buttons[1].textContent).toEqual(
+        'Close running workspace (bash) and restart golang-example',
+      );
+    });
+
+    it('should switch to running workspace when there is only one running workspace and button clicked', async () => {
+      createWindowMock({
+        href: 'https://che-host/dashboard/#/ide/user-che/golang-example',
+        origin: 'https://che-host',
+      });
+      window.open = jest.fn();
+      window.location.href = 'asdfsadf';
+
+      const alertItem: AlertItem = {
+        key: 'alert-id',
+        title:
+          'Failed to start the workspace golang-example, reason: You are not allowed to start more workspaces.',
+        variant: AlertVariant.danger,
+        error: new RunningWorkspacesExceededError('You are not allowed to start more workspaces.'),
+      };
+
+      const store = new FakeStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [startedWorkspace1, stoppedWorkspace, currentWorkspace],
+        })
+        .build();
+
+      renderComponent(
+        { steps: steps.values, alertItem, workspace: new WorkspaceAdapter(currentWorkspace) },
+        store,
+      );
+
+      const alert = screen.getByTestId('action-links');
+      const buttons = within(alert).getAllByRole('button');
+      expect(buttons.length).toEqual(2);
+      expect(buttons[0].textContent).toEqual('Switch to running workspace (bash)');
+
+      userEvent.click(buttons[0]);
+      await waitFor(() =>
+        expect(window.open).toHaveBeenCalledWith(
+          'https://che-host/dashboard/#/ide/user-che/bash',
+          'uid-bash',
+        ),
+      );
+    });
+
+    it('should show options if workspace running limit has been reached, and there more than one running workspaces', async () => {
+      createWindowMock({ origin: 'https://che-host' });
+
+      const alertItem: AlertItem = {
+        key: 'alert-id',
+        title:
+          'Failed to start the workspace golang-example, reason: You are not allowed to start more workspaces.',
+        variant: AlertVariant.danger,
+        error: new RunningWorkspacesExceededError('You are not allowed to start more workspaces.'),
+      };
+
+      const store = new FakeStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [startedWorkspace1, startedWorkspace2, stoppedWorkspace, currentWorkspace],
+        })
+        .build();
+
+      const spyWindowLocation = jest.spyOn(window.location, 'href', 'set');
+
+      renderComponent(
+        { steps: steps.values, alertItem, workspace: new WorkspaceAdapter(currentWorkspace) },
+        store,
+      );
+
+      const button = screen.getByRole('button', { name: 'Return to dashboard' });
+      userEvent.click(button);
+      await waitFor(() =>
+        expect(spyWindowLocation).toHaveBeenCalledWith('https://che-host/dashboard/'),
+      );
+    });
+  });
+
+  function createWindowMock(location: { href?: string; origin?: string }) {
+    delete (window as any).location;
+    (window.location as any) = {
+      origin: location.origin,
+    };
+    Object.defineProperty(window.location, 'href', {
+      set: () => {
+        // no-op
+      },
+      get: () => {
+        return location.href;
+      },
+      configurable: true,
+    });
+  }
 });
 
 function getComponent(
@@ -106,6 +264,7 @@ function getComponent(
     steps: LoaderStep[];
     initialTab?: keyof typeof LoaderTab;
     alertItem?: AlertItem;
+    workspace?: Workspace;
   },
   store?: Store,
 ): React.ReactElement {
@@ -121,7 +280,7 @@ function getComponent(
         onRestart={mockOnWorkspaceRestart}
         steps={props.steps}
         tabParam={'Progress'}
-        workspace={undefined}
+        workspace={props.workspace}
       />
     </Provider>
   );

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
@@ -172,9 +172,11 @@ describe('Workspace loader page', () => {
       const alert = screen.getByTestId('action-links');
       const buttons = within(alert).getAllByRole('button');
       expect(buttons.length).toEqual(2);
-      expect(buttons[0].textContent).toEqual('Switch to running workspace (bash)');
-      expect(buttons[1].textContent).toEqual(
+      expect(buttons[0].textContent).toEqual(
         'Close running workspace (bash) and restart golang-example',
+      );
+      expect(buttons[1].textContent).toEqual(
+        'Switch to running workspace (bash) to save any changes',
       );
     });
 
@@ -207,9 +209,11 @@ describe('Workspace loader page', () => {
       const alert = screen.getByTestId('action-links');
       const buttons = within(alert).getAllByRole('button');
       expect(buttons.length).toEqual(2);
-      expect(buttons[0].textContent).toEqual('Switch to running workspace (bash)');
+      expect(buttons[1].textContent).toEqual(
+        'Switch to running workspace (bash) to save any changes',
+      );
 
-      userEvent.click(buttons[0]);
+      userEvent.click(buttons[1]);
       await waitFor(() =>
         expect(window.open).toHaveBeenCalledWith(
           'https://che-host/dashboard/#/ide/user-che/bash',
@@ -247,11 +251,11 @@ describe('Workspace loader page', () => {
       const alert = screen.getByTestId('action-links');
       const buttons = within(alert).getAllByRole('button');
       expect(buttons.length).toEqual(2);
-      expect(buttons[1].textContent).toEqual(
+      expect(buttons[0].textContent).toEqual(
         'Close running workspace (bash) and restart golang-example',
       );
 
-      userEvent.click(buttons[1]);
+      userEvent.click(buttons[0]);
 
       await waitFor(() => expect(mockStopWorkspace).toHaveBeenCalled());
       await waitFor(() => expect(mockOnWorkspaceRestart).toHaveBeenCalled());

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/index.tsx
@@ -152,9 +152,6 @@ const mapStateToProps = (state: AppState) => ({
   allWorkspaces: selectAllDevWorkspaces(state),
 });
 
-const connector = connect(mapStateToProps, WorkspaceStore.actionCreators, null, {
-  // forwardRef is mandatory for using `@react-mock/state` in unit tests
-  forwardRef: true,
-});
+const connector = connect(mapStateToProps, WorkspaceStore.actionCreators);
 type MappedProps = ConnectedProps<typeof connector>;
 export default connector(WorkspaceLoaderPage);

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/index.tsx
@@ -106,6 +106,7 @@ class WorkspaceLoaderPage extends React.PureComponent<Props, State> {
                   this.handleRestart(false);
                 })
                 .catch(err => {
+                  console.log('CATCH!!!:', common.helpers.errors.getMessage(err));
                   this.appAlerts.showAlert({
                     key: 'workspace-loader-page-' + getRandomString(4),
                     title: common.helpers.errors.getMessage(err),

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/index.tsx
@@ -90,14 +90,6 @@ class WorkspaceLoaderPage extends React.PureComponent<Props, State> {
         const runningWorkspace = new WorkspaceAdapter(runningWorkspaces[0]);
         return [
           {
-            title: `Switch to running workspace (${runningWorkspace.name})`,
-            callback: () => {
-              const ideLoader = buildIdeLoaderLocation(runningWorkspace);
-              const url = window.location.href.split('#')[0];
-              window.open(`${url}#${ideLoader.pathname}`, runningWorkspace.uid);
-            },
-          },
-          {
             title: `Close running workspace (${runningWorkspace.name}) and restart ${this.props.workspace?.name}`,
             callback: () => {
               this.props
@@ -106,13 +98,20 @@ class WorkspaceLoaderPage extends React.PureComponent<Props, State> {
                   this.handleRestart(false);
                 })
                 .catch(err => {
-                  console.log('CATCH!!!:', common.helpers.errors.getMessage(err));
                   this.appAlerts.showAlert({
                     key: 'workspace-loader-page-' + getRandomString(4),
                     title: common.helpers.errors.getMessage(err),
                     variant: AlertVariant.danger,
                   });
                 });
+            },
+          },
+          {
+            title: `Switch to running workspace (${runningWorkspace.name}) to save any changes`,
+            callback: () => {
+              const ideLoader = buildIdeLoaderLocation(runningWorkspace);
+              const url = window.location.href.split('#')[0];
+              window.open(`${url}#${ideLoader.pathname}`, runningWorkspace.uid);
             },
           },
         ];

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -19,6 +19,7 @@ export interface AlertItem {
   title: string;
   variant: AlertVariant;
   children?: React.ReactNode;
+  error?: unknown;
 }
 
 export interface FactoryResolver {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -54,6 +54,13 @@ export interface State {
   workspacesLogs: WorkspacesLogs;
 }
 
+export class RunningWorkspacesExceededError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'RunningWorkspacesExceededError';
+  }
+}
+
 interface RequestDevWorkspacesAction extends Action {
   type: 'REQUEST_DEVWORKSPACE';
 }
@@ -281,8 +288,7 @@ export const actionCreators: ActionCreators = {
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_DEVWORKSPACE' });
-      // await delay(500);
-      // throw new Error('asdfjkl;');
+
       try {
         const { workspaces } = await devWorkspaceClient.getAllWorkspaces(
           workspace.metadata.namespace,
@@ -290,7 +296,7 @@ export const actionCreators: ActionCreators = {
         const runningWorkspaces = workspaces.filter(w => w.spec.started === true);
         const runningLimit = selectRunningWorkspacesLimit(getState());
         if (runningWorkspaces.length >= runningLimit) {
-          throw new Error('You are not allowed to start more workspaces.');
+          throw new RunningWorkspacesExceededError('You are not allowed to start more workspaces.');
         }
         await devWorkspaceClient.updateDebugMode(workspace, debugWorkspace);
         let updatedWorkspace: devfileApi.DevWorkspace;
@@ -358,6 +364,12 @@ export const actionCreators: ActionCreators = {
           type: 'RECEIVE_DEVWORKSPACE_ERROR',
           error: errorMessage,
         });
+
+        if (common.helpers.errors.isError(e)) {
+          // throw original error
+          e.message = errorMessage;
+          throw e;
+        }
         throw errorMessage;
       }
     },

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -288,7 +288,6 @@ export const actionCreators: ActionCreators = {
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_DEVWORKSPACE' });
-
       try {
         const { workspaces } = await devWorkspaceClient.getAllWorkspaces(
           workspace.metadata.namespace,
@@ -366,8 +365,6 @@ export const actionCreators: ActionCreators = {
         });
 
         if (common.helpers.errors.isError(e)) {
-          // throw original error
-          e.message = errorMessage;
           throw e;
         }
         throw errorMessage;

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -418,6 +418,7 @@ export const actionCreators: ActionCreators = {
     (workspace: devfileApi.DevWorkspace): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch): Promise<void> => {
       try {
+        throw '<error message here>';
         await devWorkspaceClient.changeWorkspaceStatus(workspace, false);
         dispatch({
           type: 'DELETE_DEVWORKSPACE_LOGS',

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -418,7 +418,6 @@ export const actionCreators: ActionCreators = {
     (workspace: devfileApi.DevWorkspace): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch): Promise<void> => {
       try {
-        throw '<error message here>';
         await devWorkspaceClient.changeWorkspaceStatus(workspace, false);
         dispatch({
           type: 'DELETE_DEVWORKSPACE_LOGS',

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -367,7 +367,7 @@ export const actionCreators: ActionCreators = {
         if (common.helpers.errors.isError(e)) {
           throw e;
         }
-        throw errorMessage;
+        throw new Error(errorMessage);
       }
     },
 


### PR DESCRIPTION
Signed-off-by: dkwon17 <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When starting a workspace when there is already a workspace running, since the running workspace limit is `1` by default, there are now new links to:
* go to the running workspace
* stop the running workspace and restart the current workspace



<img width="721" alt="image" src="https://user-images.githubusercontent.com/83611742/184721655-82c5a0e9-5fd4-455f-9276-1cdbf0ac9204.png">

When clicking "Close running workspace (bash) and restart golang-example", if there is an error when trying to stop the workspace, and alert with an error message will be displayed on the top right:

<img width="973" alt="image" src="https://user-images.githubusercontent.com/83611742/185501648-59b7d380-2e00-4e26-8c5f-d0475d71a228.png">


When there is more than one running workspace, there is a 'Return to Dashboard' link instead:

<img width="1406" alt="image" src="https://user-images.githubusercontent.com/83611742/184724944-2601eb96-1d92-4ded-8ecf-01b067862fb5.png">


<details>
<summary>Demo video</summary>

https://user-images.githubusercontent.com/83611742/184721559-4265d656-b07e-4140-99e8-20a69d6e8e0a.mov

</details>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21359

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Check out this PR and run locally: See [readme](https://github.com/eclipse-che/che-dashboard#running-locally-against-remote-che-cluster-nodejs-v16) (or, test with this docker image: `quay.io/eclipse/che-dashboard:pr-607`)
2. Start any workspace
3. Start another workspace and verify that you see the following:
<img width="721" alt="image" src="https://user-images.githubusercontent.com/83611742/184721655-82c5a0e9-5fd4-455f-9276-1cdbf0ac9204.png">

4. Verify that both links work
6. Start a second workspace (ie. set a DevWorkspace's `spec.started` to `true`)
7. Start another workspace from the dashboard and verify that the dashboard prevents you from starting a workspace, and that you see the "Return to dashboard" link 
8. Verify that the "Return to dashboard" link works


To test the alert that appears on the top right of the dashboard when there is an error when stopping a workspace, I've created a dashboard image: `quay.io/dkwon17/che-dashboard:multiworkspace-improvement-error` that implements the following change:
```diff
diff --git a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
index 5cfea278..ad2d8b3b 100644
--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -417,6 +417,7 @@ export const actionCreators: ActionCreators = {
     (workspace: devfileApi.DevWorkspace): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch): Promise<void> => {
       try {
+        throw '<error message here>';
         await devWorkspaceClient.changeWorkspaceStatus(workspace, false);
         dispatch({
           type: 'DELETE_DEVWORKSPACE_LOGS',
```
1. Run the dashboard with the following image: `quay.io/dkwon17/che-dashboard:multiworkspace-improvement-error`
2. Start any workspace
3. Start another workspace and verify that the dashboard prevents you from starting the workspace and that you see the `Close running workspace and restart [current workspace]` link.
4. Click on the link, verify that an error alert appears on the top right. 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
