### PR TITLE
fix: fixing link to devfile v2 migration docs

### DIFF
--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/InlineAlerts/index.tsx
@@ -25,7 +25,7 @@ import devfileApi from '../../../services/devfileApi';
 import { DevWorkspaceStatus } from '../../../services/helpers/types';
 import { Workspace } from '../../../services/workspace-adapter';
 
-const migratingDocs = 'https://devfile.io/docs/devfile/2.2.0/user-guide/migrating-to-devfile-v2/';
+const migratingDocs = 'https://devfile.io/docs/2.2.0-alpha/migrating-to-devfile-v2';
 
 type Props = {
   workspace: Workspace;


### PR DESCRIPTION
### What does this PR do?
Backport https://github.com/eclipse-che/che-dashboard/pull/611 to 7.52.x

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
