### PR TITLE
chore: change workspaces runningLimit error to warning

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
@@ -25,6 +25,7 @@ import { MIN_STEP_DURATION_MS, TIMEOUT_TO_GET_URL_SEC } from '../../../const';
 import findTargetWorkspace from '../../findTargetWorkspace';
 import { Workspace } from '../../../../../services/workspace-adapter';
 import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../AbstractStep';
+import { RunningWorkspacesExceededError } from '../../../../../store/Workspaces/devWorkspaces';
 
 export type Props = MappedProps &
   LoaderStepProps & {
@@ -148,7 +149,10 @@ class StepOpenWorkspace extends AbstractLoaderStep<Props, State> {
         : {
             key: 'ide-loader-open-ide',
             title: 'Failed to open the workspace',
-            variant: AlertVariant.danger,
+            variant:
+              lastError instanceof RunningWorkspacesExceededError
+                ? AlertVariant.warning
+                : AlertVariant.danger,
             children: common.helpers.errors.getMessage(lastError),
           };
 

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
@@ -28,6 +28,7 @@ import findTargetWorkspace from '../../findTargetWorkspace';
 import workspaceStatusIs from '../workspaceStatusIs';
 import { Workspace } from '../../../../../services/workspace-adapter';
 import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../AbstractStep';
+import { RunningWorkspacesExceededError } from '../../../../../store/Workspaces/devWorkspaces';
 
 export type Props = MappedProps &
   LoaderStepProps & {
@@ -193,7 +194,10 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
         : {
             key: 'ide-loader-start-workspace',
             title: 'Failed to open the workspace',
-            variant: AlertVariant.danger,
+            variant:
+              lastError instanceof RunningWorkspacesExceededError
+                ? AlertVariant.warning
+                : AlertVariant.danger,
             children: common.helpers.errors.getMessage(lastError),
             error: lastError,
           };

--- a/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/Workspace/__tests__/index.spec.tsx
@@ -154,7 +154,7 @@ describe('Workspace loader page', () => {
         key: 'alert-id',
         title:
           'Failed to start the workspace golang-example, reason: You are not allowed to start more workspaces.',
-        variant: AlertVariant.danger,
+        variant: AlertVariant.warning,
         error: new RunningWorkspacesExceededError('You are not allowed to start more workspaces.'),
       };
 
@@ -191,7 +191,7 @@ describe('Workspace loader page', () => {
         key: 'alert-id',
         title:
           'Failed to start the workspace golang-example, reason: You are not allowed to start more workspaces.',
-        variant: AlertVariant.danger,
+        variant: AlertVariant.warning,
         error: new RunningWorkspacesExceededError('You are not allowed to start more workspaces.'),
       };
 
@@ -233,7 +233,7 @@ describe('Workspace loader page', () => {
         key: 'alert-id',
         title:
           'Failed to start the workspace golang-example, reason: You are not allowed to start more workspaces.',
-        variant: AlertVariant.danger,
+        variant: AlertVariant.warning,
         error: new RunningWorkspacesExceededError('You are not allowed to start more workspaces.'),
       };
 
@@ -268,7 +268,7 @@ describe('Workspace loader page', () => {
         key: 'alert-id',
         title:
           'Failed to start the workspace golang-example, reason: You are not allowed to start more workspaces.',
-        variant: AlertVariant.danger,
+        variant: AlertVariant.warning,
         error: new RunningWorkspacesExceededError('You are not allowed to start more workspaces.'),
       };
 


### PR DESCRIPTION
Signed-off-by: dkwon17 <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Changes the `You are not allowed to start more workspaces.` message from an error message to a warning message.

#### Before:
![image](https://user-images.githubusercontent.com/83611742/187781222-7133eb0d-2612-46be-8f93-d90a81413628.png)


#### After:
![image](https://user-images.githubusercontent.com/83611742/187781118-76d48044-d615-4f25-8050-90ec75e0bb72.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21671

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Follow [these steps](https://github.com/eclipse-che/che-dashboard#running-locally-against-remote-che-cluster-nodejs-v16) to run this PR locally. (or, use the docker image built for this PR)
2. By default, Eclipse Che's workspace `runningLimit` is `1`. In the CheCluster spec, the value comes from `spec.components.devWorkspace.runningLimit`. Start a workspace from the dashboard, and immediately start another one. You should see the `You are not allowed to start more workspaces` warning message.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
