### PR TITLE
chore: Don't request workspace if user namespace is not created

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/__tests__/index.spec.tsx
@@ -213,7 +213,7 @@ describe('Factory Loader, step INITIALIZE', () => {
 
     const alertBody = screen.getByTestId('alert-body');
     expect(alertBody.textContent).toEqual(
-      'Failed to accept the factory URL. The infrastructure namespace is required to be created. Please create a regular workspace to workaround the issue and open factory URL again.',
+      'Failed to start a workspace. The infrastructure namespace is required to be created. Please, contact the cluster administrator.',
     );
 
     expect(mockOnNextStep).not.toHaveBeenCalled();

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/__tests__/index.spec.tsx
@@ -213,7 +213,7 @@ describe('Factory Loader, step INITIALIZE', () => {
 
     const alertBody = screen.getByTestId('alert-body');
     expect(alertBody.textContent).toEqual(
-      'Failed to start a workspace. The infrastructure namespace is required to be created. Please, contact the cluster administrator.',
+      'Failed to create a workspace. The infrastructure namespace is required to be created. Please, contact the cluster administrator.',
     );
 
     expect(mockOnNextStep).not.toHaveBeenCalled();

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
@@ -113,7 +113,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
     const namespaces = this.props.infrastructureNamespaces;
     if (namespaces.length === 0 || (namespaces.length === 1 && !namespaces[0].attributes.phase)) {
       throw new Error(
-        'Failed to accept the factory URL. The infrastructure namespace is required to be created. Please create a regular workspace to workaround the issue and open factory URL again.',
+        'Failed to start a workspace. The infrastructure namespace is required to be created. Please, contact the cluster administrator.',
       );
     }
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
@@ -113,7 +113,7 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
     const namespaces = this.props.infrastructureNamespaces;
     if (namespaces.length === 0 || (namespaces.length === 1 && !namespaces[0].attributes.phase)) {
       throw new Error(
-        'Failed to start a workspace. The infrastructure namespace is required to be created. Please, contact the cluster administrator.',
+        'Failed to create a workspace. The infrastructure namespace is required to be created. Please, contact the cluster administrator.',
       );
     }
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -217,9 +217,12 @@ export const actionCreators: ActionCreators = {
       try {
         const defaultKubernetesNamespace = selectDefaultNamespace(getState());
         const defaultNamespace = defaultKubernetesNamespace.name;
-        const { workspaces, resourceVersion } = await devWorkspaceClient.getAllWorkspaces(
+        const { workspaces, resourceVersion } = defaultNamespace ? await devWorkspaceClient.getAllWorkspaces(
           defaultNamespace,
-        );
+        ) : {
+          workspaces: [],
+          resourceVersion: '',
+        };
 
         dispatch({
           type: 'RECEIVE_DEVWORKSPACE',

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -217,12 +217,12 @@ export const actionCreators: ActionCreators = {
       try {
         const defaultKubernetesNamespace = selectDefaultNamespace(getState());
         const defaultNamespace = defaultKubernetesNamespace.name;
-        const { workspaces, resourceVersion } = defaultNamespace ? await devWorkspaceClient.getAllWorkspaces(
-          defaultNamespace,
-        ) : {
-          workspaces: [],
-          resourceVersion: '',
-        };
+        const { workspaces, resourceVersion } = defaultNamespace
+          ? await devWorkspaceClient.getAllWorkspaces(defaultNamespace)
+          : {
+              workspaces: [],
+              resourceVersion: '',
+            };
 
         dispatch({
           type: 'RECEIVE_DEVWORKSPACE',


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Don't request workspace if user namespace is not created
* Update error message if user tries to start a workspace when namespace is not created

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21582

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
N/A

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A

![screenshot-192 168 39 83 nip io-2022 09 02-17_18_31](https://user-images.githubusercontent.com/1640675/188169518-6acb6276-bca9-4767-bfb3-596f30699827.png)
