### PR TITLE
feat: drop 'session' and 'code' attributes during startup

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/index.tsx
@@ -24,6 +24,7 @@ import {
 import FactoryLoader from './Factory';
 import buildFactoryParams from './Factory/buildFactoryParams';
 import WorkspaceLoader from './Workspace';
+import { sanitizeLocation } from '../../services/helpers/location';
 
 type LoaderMode = 'factory' | 'workspace';
 
@@ -51,7 +52,9 @@ class LoaderContainer extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const searchParams = new URLSearchParams(this.props.history.location.search);
+    const { location: dirtyLocation } = this.props.history;
+    const { search } = sanitizeLocation(dirtyLocation);
+    const searchParams = new URLSearchParams(search);
     const tabParam = searchParams.get('tab') || undefined;
 
     const { mode } = this.getMode(props);

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/location.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/location.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { sanitizeLocation } from '../location';
+import { Location } from 'history';
+
+describe('location/sanitizeLocation', () => {
+  it("should return the same values if location variables don't have OAuth params included", () => {
+    const search = '?url=https%3A%2F%2Fgithub.com%2Ftest-samples&storageType=persistent';
+    const pathname = '/f';
+
+    const newLocation = sanitizeLocation({ search, pathname } as Location);
+
+    expect(newLocation.search).toEqual(search);
+    expect(newLocation.pathname).toEqual(pathname);
+  });
+
+  it('should return sanitized value of location.search', () => {
+    const search =
+      '?url=https%3A%2F%2Fgithub.com%2Ftest-samples&state=9284564475&session_state=45645654567&code=9844646765&storageType=persistent';
+    const pathname = '/f';
+
+    const newLocation = sanitizeLocation({ search, pathname } as Location);
+
+    expect(newLocation.search).not.toEqual(search);
+    expect(newLocation.search).toEqual(
+      '?url=https%3A%2F%2Fgithub.com%2Ftest-samples&storageType=persistent',
+    );
+    expect(newLocation.pathname).toEqual(pathname);
+  });
+
+  it('should return sanitized value of location.pathname', () => {
+    const search = '?url=https%3A%2F%2Fgithub.com%2Ftest-samples';
+    const pathname = '/f&code=1239844646765';
+
+    const newLocation = sanitizeLocation({ search, pathname } as Location);
+
+    expect(newLocation.search).toEqual(search);
+    expect(newLocation.pathname).not.toEqual(pathname);
+    expect(newLocation.pathname).toEqual('/f');
+  });
+});

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -93,3 +93,26 @@ function _buildLocationObject(pathAndQuery: string): Location {
 export function toHref(history: History, location: Location): string {
   return history.createHref(location);
 }
+
+const oauthParams = ['state', 'session_state', 'code'];
+/**
+ * Removes oauth params.
+ */
+export function sanitizeLocation(location: Location, removeParams: string[] = []): Location {
+  const toRemove = [...oauthParams, ...removeParams];
+  // clear search params
+  if (location.search) {
+    const searchParams = new window.URLSearchParams(location.search);
+    toRemove.forEach(val => searchParams.delete(val));
+    location.search = '?' + searchParams.toString();
+  }
+
+  // clear pathname
+  toRemove.forEach(param => {
+    const re = new RegExp('&' + param + '=[^&]+', 'i');
+    const newPathname = location.pathname.replace(re, '');
+    location.pathname = newPathname;
+  });
+
+  return location;
+}


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR is a cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/623 to the 7.52.x branch

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21655