### PR TITLE
chore: Check OAuth token when workspace starts

### DIFF
--- a/packages/dashboard-backend/src/index.ts
+++ b/packages/dashboard-backend/src/index.ts
@@ -37,6 +37,7 @@ import {
 import { registerFactory } from './factory';
 import { namespaceApi } from './api/namespaceApi';
 import { registerYamlResolverApi } from './api/yamlResolverApi';
+import { registerWorkspace } from './workspace';
 
 const CHE_HOST = process.env.CHE_HOST as string;
 
@@ -86,6 +87,8 @@ registerCors(isLocalRun, server);
 registerStaticServer(publicFolder, server);
 
 registerFactory(server);
+
+registerWorkspace(server);
 
 registerDevworkspaceWebsocketWatcher(server);
 

--- a/packages/dashboard-backend/src/workspace.ts
+++ b/packages/dashboard-backend/src/workspace.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+export function registerWorkspace(server: FastifyInstance): void {
+  // redirect to the Dashboard factory flow
+  function redirectWorkspaceFlow(path: string) {
+    server.get(path, async (request: FastifyRequest, reply: FastifyReply) => {
+      const searchParams = new URLSearchParams(decodeURIComponent(request.url.replace(path, '')));
+      const params = searchParams.get('params');
+      if (params) {
+        const parse: { namespace: string; workspace: string } = JSON.parse(params);
+        return reply.redirect(`/dashboard/#/ide/${parse.namespace}/${parse.workspace}`);
+      }
+    });
+  }
+  redirectWorkspaceFlow('/w');
+  redirectWorkspaceFlow('/dashboard/w');
+}

--- a/packages/dashboard-backend/src/workspace.ts
+++ b/packages/dashboard-backend/src/workspace.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -36,7 +36,7 @@
     "@eclipse-che/che-code-devworkspace-handler": "1.64.0-dev-210b722",
     "@eclipse-che/che-theia-devworkspace-handler": "0.0.1-1642670698",
     "@eclipse-che/devfile-converter": "0.0.1-d624e3e",
-    "@eclipse-che/workspace-client": "0.0.1-1632305737",
+    "@eclipse-che/workspace-client": "0.0.1-1663851810",
     "@patternfly/react-core": "4.120.0",
     "@patternfly/react-icons": "^4.3.5",
     "@patternfly/react-table": "^4.5.7",

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -186,6 +186,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     });
 
     try {
+      SessionStorageService.update(SessionStorageKey.AUTHENTICATION_STATUS, 'started');
       await this.props.requestFactoryResolver(factoryUrl, params);
       this.clearNumberOfTries();
       return true;

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -21,7 +21,6 @@ import { DisposableCollection } from '../../../../../../services/helpers/disposa
 import { selectAllWorkspaces } from '../../../../../../store/Workspaces/selectors';
 import { delay } from '../../../../../../services/helpers/delay';
 import { FactoryLoaderPage } from '../../../../../../pages/Loader/Factory';
-import { isOAuthResponse } from '../../../../../../store/FactoryResolver';
 import { getEnvironment, isDevEnvironment } from '../../../../../../services/helpers/environment';
 import SessionStorageService, {
   SessionStorageKey,
@@ -36,6 +35,7 @@ import { MIN_STEP_DURATION_MS, TIMEOUT_TO_RESOLVE_SEC } from '../../../../const'
 import buildFactoryParams from '../../../buildFactoryParams';
 import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../../AbstractStep';
 import { AlertItem } from '../../../../../../services/helpers/types';
+import OAuthService, { isOAuthResponse } from '../../../../../../services/oauth';
 
 const RELOADS_LIMIT = 2;
 type ReloadsInfo = {
@@ -186,7 +186,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     });
 
     try {
-      SessionStorageService.update(SessionStorageKey.AUTHENTICATION_STATUS, 'started');
+      OAuthService.setOauthStartedState();
       await this.props.requestFactoryResolver(factoryUrl, params);
       this.clearNumberOfTries();
       return true;
@@ -196,31 +196,19 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
         this.increaseNumberOfTries(factoryUrl);
 
         // open authentication page
-        this.openAuthPage(e.attributes.oauth_authentication_url, factoryUrl);
+        const env = getEnvironment();
+        // build redirect URL
+        let redirectHost = window.location.protocol + '//' + window.location.host;
+        if (isDevEnvironment(env)) {
+          redirectHost = env.server;
+        }
+        const redirectUrl = new URL('/f', redirectHost);
+        redirectUrl.searchParams.set('url', factoryUrl);
+        OAuthService.openOAuthPage(e.attributes.oauth_authentication_url, redirectUrl.toString());
         return false;
       }
 
       throw e;
-    }
-  }
-
-  private openAuthPage(oauthUrl: string, factoryUrl: string): void {
-    try {
-      const env = getEnvironment();
-      // build redirect URL
-      let redirectHost = window.location.protocol + '//' + window.location.host;
-      if (isDevEnvironment(env)) {
-        redirectHost = env.server;
-      }
-      const redirectUrl = new URL('/f', redirectHost);
-      redirectUrl.searchParams.set('url', factoryUrl);
-
-      const oauthUrlTmp = new window.URL(oauthUrl);
-      const fullOauthUrl =
-        oauthUrlTmp.toString() + '&redirect_after_login=' + redirectUrl.toString();
-      window.location.href = fullOauthUrl;
-    } catch (e) {
-      throw new Error(`Failed to open authentication page. ${helpers.errors.getMessage(e)}`);
     }
   }
 

--- a/packages/dashboard-frontend/src/services/oauth/index.ts
+++ b/packages/dashboard-frontend/src/services/oauth/index.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { helpers } from '@eclipse-che/common';
+import { OAuthResponse } from '../../store/FactoryResolver';
+import SessionStorageService, { SessionStorageKey } from '../session-storage';
+import { container } from '../../inversify.config';
+import { CheWorkspaceClient } from '../workspace-client/cheworkspace/cheWorkspaceClient';
+import { Workspace } from '../workspace-adapter';
+
+const WorkspaceClient = container.get(CheWorkspaceClient);
+
+export default class OAuthService {
+  static openOAuthPage(authenticationUrl: string, redirectUrl: string): void {
+    try {
+      const oauthUrlTmp = new window.URL(authenticationUrl);
+      window.location.href =
+        oauthUrlTmp.toString() + '&redirect_after_login=' + redirectUrl.toString();
+    } catch (e) {
+      throw new Error(`Failed to open authentication page. ${helpers.errors.getMessage(e)}`);
+    }
+  }
+
+  static async refreshTokenIfNeeded(workspace: Workspace): Promise<void> {
+    if (
+      SessionStorageService.get(SessionStorageKey.AUTHENTICATION_STATUS) !== 'started' &&
+      workspace.devfile.projects
+    ) {
+      SessionStorageService.update(SessionStorageKey.AUTHENTICATION_STATUS, 'started');
+      const project = workspace.devfile.projects.find(p => (p.name = workspace.projects[0]));
+      if (project && project.git) {
+        await WorkspaceClient.restApiClient.refreshFactoryOauthToken(project.git.remotes.origin);
+      }
+    }
+  }
+
+  static setOauthStartedState(): void {
+    SessionStorageService.update(SessionStorageKey.AUTHENTICATION_STATUS, 'started');
+  }
+}
+
+export function isOAuthResponse(responseData: any): responseData is OAuthResponse {
+  if (
+    responseData?.attributes?.oauth_provider &&
+    responseData?.attributes?.oauth_authentication_url
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/packages/dashboard-frontend/src/services/session-storage/index.ts
+++ b/packages/dashboard-frontend/src/services/session-storage/index.ts
@@ -13,6 +13,7 @@
 export enum SessionStorageKey {
   PRIVATE_FACTORY_RELOADS = 'private-factory-reloads-number',
   ORIGINAL_LOCATION_PATH = 'original-location-path',
+  AUTHENTICATION_STATUS = 'authentication-status',
 }
 
 export default class SessionStorageService {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -27,6 +27,7 @@ import normalizeDevfileV1 from './normalizeDevfileV1';
 import { selectDefaultNamespace } from '../InfrastructureNamespaces/selectors';
 import { getYamlResolver } from '../../services/dashboard-backend-client/yamlResolverApi';
 import { DEFAULT_REGISTRY } from '../DevfileRegistries';
+import { isOAuthResponse } from '../../services/oauth';
 
 const WorkspaceClient = container.get(CheWorkspaceClient);
 
@@ -40,15 +41,6 @@ export type OAuthResponse = {
   message: string;
 };
 
-export function isOAuthResponse(responseData: any): responseData is OAuthResponse {
-  if (
-    responseData?.attributes?.oauth_provider &&
-    responseData?.attributes?.oauth_authentication_url
-  ) {
-    return true;
-  }
-  return false;
-}
 export interface ResolverState extends FactoryResolver {
   optionalFilesContent?: {
     [fileName: string]: string;

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -18,11 +18,8 @@ import { isCheWorkspace, Workspace } from '../../services/workspace-adapter';
 import * as CheWorkspacesStore from './cheWorkspaces';
 import * as DevWorkspacesStore from './devWorkspaces';
 import { isDevworkspacesEnabled } from '../../services/helpers/devworkspace';
-import { container } from '../../inversify.config';
-import { CheWorkspaceClient } from '../../services/workspace-client/cheworkspace/cheWorkspaceClient';
-import common, { helpers } from '@eclipse-che/common';
-import { isOAuthResponse } from '../FactoryResolver';
-import SessionStorageService, { SessionStorageKey } from '../../services/session-storage';
+import common from '@eclipse-che/common';
+import OAuthService, { isOAuthResponse } from '../../services/oauth';
 
 // This state defines the type of data maintained in the Redux store.
 export interface State {
@@ -132,8 +129,6 @@ export type ActionCreators = {
   deleteWorkspaceLogs: (workspace: Workspace) => AppThunk<DeleteWorkspaceLogsAction>;
 };
 
-const WorkspaceClient = container.get(CheWorkspaceClient);
-
 export const actionCreators: ActionCreators = {
   requestWorkspaces:
     (): AppThunk<KnownAction, Promise<void>> =>
@@ -183,38 +178,11 @@ export const actionCreators: ActionCreators = {
   startWorkspace:
     (workspace: Workspace, params?: ResourceQueryParams): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
-      const openOauthPage = (oauthUrl: string, namespace: string, workspaceName: string) => {
-        try {
-          // build redirect URL
-          const redirectHost = window.location.protocol + '//' + window.location.host;
-          const redirectUrl = new URL('dashboard/w', redirectHost);
-          redirectUrl.searchParams.set(
-            'params',
-            `{"namespace":"${namespace}","workspace":"${workspaceName}"}`,
-          );
-          const oauthUrlTmp = new window.URL(oauthUrl);
-          window.location.href =
-            oauthUrlTmp.toString() + '&redirect_after_login=' + redirectUrl.toString();
-        } catch (e) {
-          throw new Error(`Failed to open authentication page. ${helpers.errors.getMessage(e)}`);
-        }
-      };
       dispatch({ type: 'REQUEST_WORKSPACES' });
       try {
         const state = getState();
         const cheDevworkspaceEnabled = isDevworkspacesEnabled(state.workspacesSettings.settings);
-        if (
-          SessionStorageService.get(SessionStorageKey.AUTHENTICATION_STATUS) !== 'started' &&
-          workspace.devfile.projects
-        ) {
-          SessionStorageService.update(SessionStorageKey.AUTHENTICATION_STATUS, 'started');
-          const project = workspace.devfile.projects.find(p => (p.name = workspace.projects[0]));
-          if (project && project.git) {
-            await WorkspaceClient.restApiClient.refreshFactoryOauthToken(
-              project.git.remotes.origin,
-            );
-          }
-        }
+        await OAuthService.refreshTokenIfNeeded(workspace);
 
         if (cheDevworkspaceEnabled && isDevWorkspace(workspace.ref)) {
           const debugWorkspace = params && params['debug-workspace-start'];
@@ -234,11 +202,18 @@ export const actionCreators: ActionCreators = {
         if (common.helpers.errors.includesAxiosResponse(e)) {
           const response = e.response;
           if (response.status === 401 && isOAuthResponse(response.data)) {
-            // open authentication page
-            openOauthPage(
+            // build redirect URL
+            const redirectUrl = new URL(
+              'dashboard/w',
+              window.location.protocol + '//' + window.location.host,
+            );
+            redirectUrl.searchParams.set(
+              'params',
+              `{"namespace":"${workspace.namespace}","workspace":"${workspace.name}"}`,
+            );
+            OAuthService.openOAuthPage(
               response.data.attributes.oauth_authentication_url,
-              workspace.namespace,
-              workspace.name,
+              redirectUrl.toString(),
             );
             return;
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,10 +381,10 @@
     jsonc-parser "^3.0.0"
     reflect-metadata "^0.1.13"
 
-"@eclipse-che/workspace-client@0.0.1-1632305737":
-  version "0.0.1-1632305737"
-  resolved "https://registry.npmjs.org/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1632305737.tgz"
-  integrity sha512-wIzrfAJI4unTFMeaqWBKyhLZkwrV3o5BeFHLXIw4/dhKwJwuZQ46PQB6orDejxrAErktq6pX8L1UXlJkMdLG+A==
+"@eclipse-che/workspace-client@0.0.1-1663851810":
+  version "0.0.1-1663851810"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1663851810.tgz#575c6e9c359a536ec3b1f359d7142bcd6b59d735"
+  integrity sha512-oV+zTmsrMcV+SvnZBuHWbrwYimqUqWil2BHGjQYpK1TroEMHiOgfs0Xjh7FxdrgcYUc05Rnb7yvwe4QSjw7iTQ==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "^0.21.1"


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Set a flag to the browsers `SessionStorageService` when an OAuth authorisation is requested.
* When a factory is created and stoped and started again, check if the flag is set.
* If the flag is set, send a request to `che-server` to check the OAuth token
* If `che-server` returns an error, open an authentication page to authenticate.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21640

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
