### PR TITLE
Handle gracefully when an invalid devfile is found in a git repository

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -7,11 +7,11 @@
 | `@eclipse-che/api@7.44.0` | EPL-2.0 | ecd.che |
 | [`@eclipse-che/che-code-devworkspace-handler@1.64.0-dev-210b722`](git+https://github.com/che-incubator/che-code.git) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/che-theia-devworkspace-handler@0.0.1-1642670698`](git+https://github.com/eclipse-che/che-theia.git) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/common@7.54.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-backend@7.54.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-frontend@7.54.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/common@7.56.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-backend@7.56.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-frontend@7.56.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/devfile-converter@0.0.1-d624e3e`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/workspace-client@0.0.1-1632305737`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/workspace-client@0.0.1-1663851810`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | ecd.che |
 | [`@fastify/ajv-compiler@1.1.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
 | [`@fastify/cors@7.0.0`](git+https://github.com/fastify/fastify-cors.git) | MIT | clearlydefined |
 | [`@fastify/error@3.0.0`](git+https://github.com/fastify/fastify-error.git) | MIT | clearlydefined |
@@ -324,7 +324,7 @@
 | [`pino-std-serializers@3.2.0`](git+ssh://git@github.com/pinojs/pino-std-serializers.git) | MIT | clearlydefined |
 | [`pino@6.14.0`](git+https://github.com/pinojs/pino.git) | MIT | clearlydefined |
 | [`popper.js@1.16.1`](git+https://github.com/FezVrasta/popper.js.git) | MIT | [CQ22353](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22353) |
-| [`postcss@8.4.14`](https://github.com/postcss/postcss.git) | MIT | clearlydefined |
+| [`postcss@8.4.14`](https://github.com/postcss/postcss.git) | MIT | #3545 |
 | [`prettier@2.0.5`](https://github.com/prettier/prettier.git) | MIT | #1523 |
 | [`private@0.1.8`](git://github.com/benjamn/private.git) | MIT | clearlydefined |
 | [`process-warning@1.0.0`](git+https://github.com/fastify/processs-warning.git) | MIT | clearlydefined |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -59,7 +59,7 @@
     "process": "^0.11.10",
     "qs": "^6.9.4",
     "react": "^16.14.0",
-    "react-copy-to-clipboard": "^5.0.2",
+    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^6.1.0",
     "react-pluralize": "^1.6.3",

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expandable warning items should correctly render the component 1`] = `
+<div
+  className="pf-c-content"
+>
+  <small
+    className=""
+    data-pf-content={true}
+  >
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi non sollicitudin lorem, a suscipit massa. Cras egestas ante vel est pulvinar, a elementum orci faucibus. Etiam in risus et augue sollicitudin facilisis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Vivamus ligula arcu, imperdiet hendrerit nulla varius, molestie volutpat nunc.
+  </small>
+  <small
+    className=""
+    data-pf-content={true}
+  >
+    <div
+      className="pf-c-code-block error"
+    >
+      <div
+        className="pf-c-code-block__header"
+      >
+        <div
+          className="pf-c-code-block__actions"
+        >
+          <div
+            className="pf-c-code-block__actions-item"
+          >
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-small"
+              data-ouia-component-id="OUIA-Generated-Button-link-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+                />
+              </svg>
+               
+              Copy to clipboard
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pf-c-code-block__content"
+      >
+        <pre
+          className="pf-c-code-block__pre"
+        >
+          <code
+            className="pf-c-code-block__code"
+          >
+            <small
+              className="hideOverflow"
+              data-pf-content={true}
+              data-testid="expandable-warning-error-message"
+              id="expandable-warning-error-message"
+            >
+              Ut venenatis, purus ut ultrices luctus, nisi leo rutrum tortor, id sagittis nisl augue ac risus. In hac habitasse platea dictumst. Curabitur vitae dui eu elit egestas consectetur ac sed lacus. Nam nisl arcu, mollis eget tempor consequat, egestas nec lacus. Sed elementum, nibh id suscipit accumsan, metus mauris ultrices nisi, ut gravida sapien ipsum at elit. Maecenas in ultrices ex, id efficitur ante. Nulla facilisi.
+            </small>
+          </code>
+        </pre>
+      </div>
+    </div>
+  </small>
+  <small
+    className=""
+    data-pf-content={true}
+  >
+    Sed iaculis dictum nibh nec varius. Pellentesque ac diam vestibulum nisl condimentum feugiat. Sed et est in dolor posuere pharetra. Aliquam sodales lorem eu velit efficitur vestibulum. Praesent ornare ut tellus nec cursus. Proin at hendrerit metus, sed placerat justo. Cras id hendrerit ante, et consequat orci. Ut ante ipsum, eleifend sit amet iaculis quis, scelerisque eget mi. Pellentesque aliquam porttitor neque ut consectetur. Vivamus euismod elit velit, eget suscipit sem euismod vitae. Quisque sagittis, felis ut rhoncus vestibulum, arcu dui tincidunt quam, sit amet congue ligula dolor id sapien.
+  </small>
+</div>
+`;

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/index.spec.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import ExpandableWarningItems, { ERROR_MESSAGE_ID } from '../';
+import { render, RenderResult, screen } from '@testing-library/react';
+
+describe('Expandable warning items', () => {
+  it('should correctly render the component', () => {
+    const component = getComponent(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi non sollicitudin lorem, a suscipit massa. Cras egestas ante vel est pulvinar, a elementum orci faucibus. Etiam in risus et augue sollicitudin facilisis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Vivamus ligula arcu, imperdiet hendrerit nulla varius, molestie volutpat nunc.',
+      'Ut venenatis, purus ut ultrices luctus, nisi leo rutrum tortor, id sagittis nisl augue ac risus. In hac habitasse platea dictumst. Curabitur vitae dui eu elit egestas consectetur ac sed lacus. Nam nisl arcu, mollis eget tempor consequat, egestas nec lacus. Sed elementum, nibh id suscipit accumsan, metus mauris ultrices nisi, ut gravida sapien ipsum at elit. Maecenas in ultrices ex, id efficitur ante. Nulla facilisi.',
+      'Sed iaculis dictum nibh nec varius. Pellentesque ac diam vestibulum nisl condimentum feugiat. Sed et est in dolor posuere pharetra. Aliquam sodales lorem eu velit efficitur vestibulum. Praesent ornare ut tellus nec cursus. Proin at hendrerit metus, sed placerat justo. Cras id hendrerit ante, et consequat orci. Ut ante ipsum, eleifend sit amet iaculis quis, scelerisque eget mi. Pellentesque aliquam porttitor neque ut consectetur. Vivamus euismod elit velit, eget suscipit sem euismod vitae. Quisque sagittis, felis ut rhoncus vestibulum, arcu dui tincidunt quam, sit amet congue ligula dolor id sapien.',
+    );
+    const json = renderer.create(component).toJSON();
+
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should show a short error message and an expand button', () => {
+    const component = getComponent(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi non sollicitudin lorem, a suscipit massa. Cras egestas ante vel est pulvinar, a elementum orci faucibus. Etiam in risus et augue sollicitudin facilisis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Vivamus ligula arcu, imperdiet hendrerit nulla varius, molestie volutpat nunc.',
+      'Ut venenatis, purus ut ultrices luctus, nisi leo rutrum tortor, id sagittis nisl augue ac risus. In hac habitasse platea dictumst. Curabitur vitae dui eu elit egestas consectetur ac sed lacus. Nam nisl arcu, mollis eget tempor consequat, egestas nec lacus. Sed elementum, nibh id suscipit accumsan, metus mauris ultrices nisi, ut gravida sapien ipsum at elit. Maecenas in ultrices ex, id efficitur ante. Nulla facilisi.',
+      'Sed iaculis dictum nibh nec varius. Pellentesque ac diam vestibulum nisl condimentum feugiat. Sed et est in dolor posuere pharetra. Aliquam sodales lorem eu velit efficitur vestibulum. Praesent ornare ut tellus nec cursus. Proin at hendrerit metus, sed placerat justo. Cras id hendrerit ante, et consequat orci. Ut ante ipsum, eleifend sit amet iaculis quis, scelerisque eget mi. Pellentesque aliquam porttitor neque ut consectetur. Vivamus euismod elit velit, eget suscipit sem euismod vitae. Quisque sagittis, felis ut rhoncus vestibulum, arcu dui tincidunt quam, sit amet congue ligula dolor id sapien.',
+    );
+
+    renderComponent(component);
+
+    expect(screen.queryByTestId(ERROR_MESSAGE_ID)).toBeTruthy;
+    expect(screen.getByTestId(ERROR_MESSAGE_ID).className).toEqual('hideOverflow');
+    expect(screen.queryByText('Show More')).toBeTruthy;
+  });
+});
+
+function getComponent(
+  textBefore: string,
+  errorMessage: string,
+  textAfter: string,
+): React.ReactElement {
+  return (
+    <ExpandableWarningItems
+      textBefore={textBefore}
+      errorMessage={errorMessage}
+      textAfter={textAfter}
+    />
+  );
+}
+
+function renderComponent(component: React.ReactElement): RenderResult {
+  return render(component);
+}

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/index.module.css
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/index.module.css
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+.error {
+  border-top: 2px solid;
+  border-color: var(--pf-global--palette--red-100);
+  background-color: var(--pf-global--palette--red-50);
+}
+
+.error small,
+.error button {
+  font-size: small;
+}
+
+.hideOverflow {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
@@ -38,7 +38,7 @@ type State = {
   isExpanded: boolean;
 };
 
-class ExpandableWarningItems extends React.Component<Props, State> {
+class ExpandableWarning extends React.Component<Props, State> {
   private readonly checkOverflow: () => void;
   private copiedTimer: number | undefined;
 
@@ -152,4 +152,4 @@ class ExpandableWarningItems extends React.Component<Props, State> {
   }
 }
 
-export default ExpandableWarningItems;
+export default ExpandableWarning;

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import {
+  Button,
+  CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
+  ExpandableSectionToggle,
+  TextContent,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import { CopyIcon } from '@patternfly/react-icons/dist/js/icons';
+import styles from './index.module.css';
+
+export const ERROR_MESSAGE_ID = 'expandable-warning-error-message';
+
+type Props = {
+  textBefore: string;
+  errorMessage: string;
+  textAfter: string;
+};
+type State = {
+  copied: boolean;
+  hasExpand: boolean;
+  isExpanded: boolean;
+};
+
+class ExpandableWarningItems extends React.Component<Props, State> {
+  private readonly checkOverflow: () => void;
+  private copiedTimer: number | undefined;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      copied: false,
+      hasExpand: false,
+      isExpanded: false,
+    };
+
+    this.checkOverflow = () => {
+      if (this.state.isExpanded) {
+        this.setState({
+          isExpanded: false,
+        });
+        return;
+      }
+      const errorMessageElement = document.getElementById(ERROR_MESSAGE_ID);
+      if (errorMessageElement !== null) {
+        const { offsetWidth, scrollWidth } = errorMessageElement;
+        const showExpandToggle = scrollWidth > offsetWidth;
+        this.setState({
+          hasExpand: showExpandToggle,
+        });
+      }
+    };
+  }
+
+  public componentDidMount(): void {
+    window.addEventListener('resize', this.checkOverflow, false);
+    this.checkOverflow();
+  }
+
+  public componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>) {
+    if (
+      prevProps.errorMessage !== this.props.errorMessage ||
+      (prevState.isExpanded && !this.state.isExpanded)
+    ) {
+      this.checkOverflow();
+    }
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('resize', this.checkOverflow);
+  }
+
+  private onToggle(isExpanded: boolean) {
+    this.setState({ isExpanded });
+  }
+
+  private onCopyToClipboard() {
+    this.setState({ copied: true });
+    if (this.copiedTimer) {
+      clearTimeout(this.copiedTimer);
+    }
+    this.copiedTimer = window.setTimeout(() => {
+      this.setState({ copied: false });
+    }, 3000);
+  }
+
+  render(): React.ReactElement {
+    const { errorMessage, textBefore, textAfter } = this.props;
+    const { hasExpand, isExpanded, copied } = this.state;
+    const copyIconTitle = copied ? 'Copied' : 'Copy to clipboard';
+    const actions = (
+      <CodeBlockAction>
+        <CopyToClipboard text={errorMessage} onCopy={() => this.onCopyToClipboard()}>
+          <Button variant="link" isSmall={true}>
+            <CopyIcon />
+            &nbsp;{copyIconTitle}
+          </Button>
+        </CopyToClipboard>
+      </CodeBlockAction>
+    );
+
+    const expandableSectionTitle = isExpanded ? 'Show Less' : 'Show More';
+    const messageClassName = isExpanded ? undefined : styles.hideOverflow;
+    return (
+      <>
+        <TextContent>
+          <Text component={TextVariants.small}>{textBefore}</Text>
+          <Text component={TextVariants.small}>
+            <CodeBlock actions={actions} className={styles.error}>
+              <CodeBlockCode>
+                <Text
+                  id={ERROR_MESSAGE_ID}
+                  data-testid={ERROR_MESSAGE_ID}
+                  className={messageClassName}
+                  component={TextVariants.small}
+                >
+                  {errorMessage}
+                </Text>
+              </CodeBlockCode>
+              {hasExpand && (
+                <ExpandableSectionToggle
+                  isExpanded={isExpanded}
+                  onToggle={isExpanded => this.onToggle(isExpanded)}
+                  direction="up"
+                >
+                  {expandableSectionTitle}
+                </ExpandableSectionToggle>
+              )}
+            </CodeBlock>
+          </Text>
+          <Text component={TextVariants.small}>{textAfter}</Text>
+        </TextContent>
+      </>
+    );
+  }
+}
+
+export default ExpandableWarningItems;

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { isEqual } from 'lodash';
 import { AlertVariant } from '@patternfly/react-core';
-import { helpers } from '@eclipse-che/common';
+import common, { helpers } from '@eclipse-che/common';
 import { AppState } from '../../../../../../store';
 import * as WorkspacesStore from '../../../../../../store/Workspaces';
 import { DisposableCollection } from '../../../../../../services/helpers/disposable';
@@ -36,6 +36,16 @@ import { FactoryParams } from '../../../types';
 import buildFactoryParams from '../../../buildFactoryParams';
 import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../../AbstractStep';
 import { AlertItem } from '../../../../../../services/helpers/types';
+import { selectDefaultDevfile } from '../../../../../../store/DevfileRegistries/selectors';
+import { getProjectName } from '../../../../../../services/helpers/getProjectName';
+import ExpandableWarningItems from '../../../../../../components/ExpandableWarning';
+
+export class CreateWorkspaceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CreateWorkspaceError';
+  }
+}
 
 export type Props = MappedProps &
   LoaderStepProps & {
@@ -126,12 +136,45 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     this.props.onRestart();
   }
 
+  private updateCurrentDevfile(devfile: devfileApi.Devfile): void {
+    const { factoryResolver, allWorkspaces, defaultDevfile } = this.props;
+    const { factoryParams } = this.state;
+    const { factoryId, policiesCreate, storageType } = factoryParams;
+    // when using the default devfile instead of a user devfile
+    if (factoryResolver === undefined && isEqual(devfile, defaultDevfile)) {
+      if (devfile.projects === undefined) {
+        devfile.projects = [];
+      }
+      if (devfile.projects.length === 0) {
+        // adds a default project from the source URL
+        const sourceUrl = new URL(factoryParams.sourceUrl);
+        const name = getProjectName(factoryParams.sourceUrl);
+        const origin = sourceUrl.pathname.endsWith('.git')
+          ? `${sourceUrl.origin}${sourceUrl.pathname}`
+          : `${sourceUrl.origin}${sourceUrl.pathname}.git`;
+        devfile.projects[0] = { git: { remotes: { origin } }, name };
+        // change default name
+        devfile.metadata.name = name;
+        devfile.metadata.generateName = name;
+      }
+    }
+    // test the devfile name to decide if we need to append a suffix to is
+    const nameConflict = allWorkspaces.some(w => devfile.metadata.name === w.name);
+    const appendSuffix = policiesCreate === 'perclick' || nameConflict;
+
+    const updatedDevfile = prepareDevfile(devfile, factoryId, storageType, appendSuffix);
+
+    this.setState({
+      devfile: updatedDevfile,
+      newWorkspaceName: updatedDevfile.metadata.name,
+    });
+  }
+
   protected async runStep(): Promise<boolean> {
     await delay(MIN_STEP_DURATION_MS);
 
-    const { factoryResolverConverted } = this.props;
-    const { shouldCreate, factoryParams, devfile } = this.state;
-    const { factoryId, policiesCreate, storageType } = factoryParams;
+    const { factoryResolverConverted, factoryResolver, defaultDevfile } = this.props;
+    const { shouldCreate, devfile } = this.state;
 
     const workspace = this.findTargetWorkspace(this.props, this.state);
     if (workspace !== undefined) {
@@ -150,25 +193,28 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     if (devfile === undefined) {
+      if (factoryResolver === undefined) {
+        const _devfile = defaultDevfile;
+        if (_devfile === undefined) {
+          throw new Error('Failed to resolve the default devfile.');
+        }
+        this.updateCurrentDevfile(_devfile);
+        return false;
+      }
       const _devfile = factoryResolverConverted?.devfileV2;
       if (_devfile === undefined) {
         throw new Error('Failed to resolve the devfile.');
       }
-
-      // test the devfile name to decide if we need to append a suffix to is
-      const nameConflict = this.props.allWorkspaces.some(w => _devfile.metadata.name === w.name);
-      const appendSuffix = policiesCreate === 'perclick' || nameConflict;
-
-      const updatedDevfile = prepareDevfile(_devfile, factoryId, storageType, appendSuffix);
-
-      this.setState({
-        devfile: updatedDevfile,
-        newWorkspaceName: updatedDevfile.metadata.name,
-      });
+      this.updateCurrentDevfile(_devfile);
       return false;
     }
 
-    await this.createWorkspaceFromDevfile(devfile);
+    try {
+      await this.createWorkspaceFromDevfile(devfile);
+    } catch (e) {
+      const errorMessage = common.helpers.errors.getMessage(e);
+      throw new CreateWorkspaceError(errorMessage);
+    }
 
     // wait for the workspace creation to complete
     try {
@@ -206,7 +252,45 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     );
   }
 
+  private handleCreateWorkspaceError(): void {
+    const { defaultDevfile } = this.props;
+    const { devfile } = this.state;
+    const _devfile = defaultDevfile;
+    if (_devfile && devfile) {
+      _devfile.projects = devfile.projects;
+      _devfile.metadata.name = devfile.metadata.name;
+      _devfile.metadata.generateName = devfile.metadata.generateName;
+      this.updateCurrentDevfile(_devfile);
+    }
+    this.clearStepError();
+  }
+
   private getAlertItem(error: unknown): AlertItem | undefined {
+    if (error instanceof CreateWorkspaceError) {
+      return {
+        key: 'factory-loader-create-workspace-error',
+        title: 'Warning',
+        variant: AlertVariant.warning,
+        children: (
+          <ExpandableWarningItems
+            textBefore="The new Workspace couldn't be created from the Devfile in the git repository:"
+            errorMessage={helpers.errors.getMessage(error)}
+            textAfter="If you continue it will be ignored and a regular workspace will be created.
+            You will have a chance to fix the Devfile from the IDE once it is started."
+          />
+        ),
+        actionCallbacks: [
+          {
+            title: 'Continue with the default devfile',
+            callback: () => this.handleCreateWorkspaceError(),
+          },
+          {
+            title: 'Reload',
+            callback: () => this.clearStepError(),
+          },
+        ],
+      };
+    }
     if (!error) {
       return;
     }
@@ -249,6 +333,7 @@ const mapStateToProps = (state: AppState) => ({
   defaultNamespace: selectDefaultNamespace(state),
   factoryResolver: selectFactoryResolver(state),
   factoryResolverConverted: selectFactoryResolverConverted(state),
+  defaultDevfile: selectDefaultDevfile(state),
 });
 
 const connector = connect(

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -38,7 +38,7 @@ import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../.
 import { AlertItem } from '../../../../../../services/helpers/types';
 import { selectDefaultDevfile } from '../../../../../../store/DevfileRegistries/selectors';
 import { getProjectName } from '../../../../../../services/helpers/getProjectName';
-import ExpandableWarningItems from '../../../../../../components/ExpandableWarning';
+import ExpandableWarning from '../../../../../../components/ExpandableWarning';
 
 export class CreateWorkspaceError extends Error {
   constructor(message: string) {
@@ -272,7 +272,7 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
         title: 'Warning',
         variant: AlertVariant.warning,
         children: (
-          <ExpandableWarningItems
+          <ExpandableWarning
             textBefore="The new Workspace couldn't be created from the Devfile in the git repository:"
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="If you continue it will be ignored and a regular workspace will be created.

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/CheckExistingWorkspaces/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/CheckExistingWorkspaces/index.tsx
@@ -147,13 +147,17 @@ class StepCheckExistingWorkspaces extends AbstractLoaderStep<Props, State> {
     let newWorkspaceName: string;
     if (prevLoaderStep.id === LoadingStep.CREATE_WORKSPACE__FETCH_DEVFILE) {
       if (
-        factoryResolver?.location !== factoryParams.sourceUrl ||
-        factoryResolverConverted?.devfileV2 === undefined
+        factoryResolver?.location === factoryParams.sourceUrl &&
+        factoryResolverConverted?.devfileV2 !== undefined
       ) {
+        const devfile = factoryResolverConverted.devfileV2;
+        newWorkspaceName = devfile.metadata.name;
+      } else {
+        if (factoryResolver === undefined) {
+          return true;
+        }
         throw new Error('Failed to resolve the devfile.');
       }
-      const devfile = factoryResolverConverted.devfileV2;
-      newWorkspaceName = devfile.metadata.name;
     } else {
       const resources = devWorkspaceResources[factoryParams.sourceUrl]?.resources;
       if (resources === undefined) {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -36,7 +36,7 @@ import buildFactoryParams from '../../../buildFactoryParams';
 import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../../AbstractStep';
 import { AlertItem } from '../../../../../../services/helpers/types';
 import OAuthService, { isOAuthResponse } from '../../../../../../services/oauth';
-import ExpandableWarningItems from '../../../../../../components/ExpandableWarning';
+import ExpandableWarning from '../../../../../../components/ExpandableWarning';
 
 export class ApplyingDevfileError extends Error {
   constructor(message) {
@@ -299,7 +299,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
         title: 'Warning',
         variant: AlertVariant.warning,
         children: (
-          <ExpandableWarningItems
+          <ExpandableWarning
             textBefore="The Devfile in the git repository is invalid:"
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="If you continue it will be ignored and a regular workspace will be created.

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { isEqual } from 'lodash';
-import { helpers } from '@eclipse-che/common';
+import common, { helpers } from '@eclipse-che/common';
 import { AlertVariant } from '@patternfly/react-core';
 import { AppState } from '../../../../../../store';
 import * as FactoryResolverStore from '../../../../../../store/FactoryResolver';
@@ -36,6 +36,14 @@ import buildFactoryParams from '../../../buildFactoryParams';
 import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../../AbstractStep';
 import { AlertItem } from '../../../../../../services/helpers/types';
 import OAuthService, { isOAuthResponse } from '../../../../../../services/oauth';
+import ExpandableWarningItems from '../../../../../../components/ExpandableWarning';
+
+export class ApplyingDevfileError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ApplyingDevfileError';
+  }
+}
 
 const RELOADS_LIMIT = 2;
 type ReloadsInfo = {
@@ -49,6 +57,7 @@ export type Props = MappedProps &
 export type State = LoaderStepState & {
   factoryParams: FactoryParams;
   shouldResolve: boolean;
+  useDefaultDevfile: boolean;
 };
 
 class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
@@ -60,6 +69,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     this.state = {
       factoryParams: buildFactoryParams(props.searchParams),
       shouldResolve: true,
+      useDefaultDevfile: false,
     };
   }
 
@@ -106,9 +116,9 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
 
   private init() {
     const { factoryResolver } = this.props;
-    const { factoryParams } = this.state;
+    const { factoryParams, useDefaultDevfile } = this.state;
     const { sourceUrl } = factoryParams;
-    if (sourceUrl && sourceUrl === factoryResolver?.location) {
+    if (sourceUrl && (useDefaultDevfile || sourceUrl === factoryResolver?.location)) {
       // prevent a resource being fetched one more time
       this.setState({
         shouldResolve: false,
@@ -129,7 +139,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
   protected async runStep(): Promise<boolean> {
     await delay(MIN_STEP_DURATION_MS);
 
-    const { factoryParams, shouldResolve } = this.state;
+    const { factoryParams, shouldResolve, useDefaultDevfile } = this.state;
     const { currentStepIndex, factoryResolver, factoryResolverConverted, loaderSteps } = this.props;
     const { sourceUrl } = factoryParams;
 
@@ -151,15 +161,30 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     }
 
     if (shouldResolve === false) {
+      if (useDefaultDevfile) {
+        // go to the next step
+        return true;
+      }
+
       if (this.state.lastError instanceof Error) {
         throw this.state.lastError;
       }
       throw new Error('Failed to resolve the devfile.');
     }
 
-    // start resolving the devfile
-    const resolveDone = await this.resolveDevfile(sourceUrl);
-    if (resolveDone === false) {
+    let resolveDone = false;
+    try {
+      // start resolving the devfile
+      resolveDone = await this.resolveDevfile(sourceUrl);
+    } catch (e) {
+      const errorMessage = common.helpers.errors.getMessage(e);
+      // check if it is a scheme validation error
+      if (errorMessage.includes('schema validation failed')) {
+        throw new ApplyingDevfileError(errorMessage);
+      }
+      throw e;
+    }
+    if (!resolveDone) {
       return false;
     }
 
@@ -174,6 +199,13 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
         `Devfile hasn't been resolved in the last ${TIMEOUT_TO_RESOLVE_SEC} seconds.`,
       );
     }
+  }
+
+  private handleDevfileError(): void {
+    this.setState({
+      useDefaultDevfile: true,
+    });
+    this.clearStepError();
   }
 
   /**
@@ -261,6 +293,31 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
   }
 
   private getAlertItem(error: unknown): AlertItem | undefined {
+    if (error instanceof ApplyingDevfileError) {
+      return {
+        key: 'factory-loader-devfile-error',
+        title: 'Warning',
+        variant: AlertVariant.warning,
+        children: (
+          <ExpandableWarningItems
+            textBefore="The Devfile in the git repository is invalid:"
+            errorMessage={helpers.errors.getMessage(error)}
+            textAfter="If you continue it will be ignored and a regular workspace will be created.
+            You will have a chance to fix the Devfile from the IDE once it is started."
+          />
+        ),
+        actionCallbacks: [
+          {
+            title: 'Continue with the default devfile',
+            callback: () => this.handleDevfileError(),
+          },
+          {
+            title: 'Reload',
+            callback: () => this.clearStepError(),
+          },
+        ],
+      };
+    }
     if (!error) {
       return;
     }

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
@@ -31,7 +31,10 @@ import { AppState } from '../../../store';
 import * as DevfileRegistriesStore from '../../../store/DevfileRegistries';
 import { SampleCard } from './SampleCard';
 import { AlertItem } from '../../../services/helpers/types';
-import { selectMetadataFiltered } from '../../../store/DevfileRegistries/selectors';
+import {
+  EMPTY_WORKSPACE_TAG,
+  selectMetadataFiltered,
+} from '../../../store/DevfileRegistries/selectors';
 import { selectWorkspacesSettings } from '../../../store/Workspaces/Settings/selectors';
 import * as FactoryResolverStore from '../../../store/FactoryResolver';
 import { isDevworkspacesEnabled } from '../../../services/helpers/devworkspace';
@@ -60,7 +63,6 @@ type State = {
 };
 
 export const VISIBLE_TAGS = ['Community', 'Tech-Preview'];
-export const EMPTY_WORKSPACE_TAG = 'Empty';
 
 const EXCLUDED_TARGET_EDITOR_NAMES = ['dirigible', 'jupyter', 'eclipseide', 'code-server'];
 

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -42,6 +42,7 @@ import { buildDetailsLocation, buildIdeLoaderLocation } from '../helpers/locatio
 import { Workspace } from '../workspace-adapter';
 import { WorkspaceRunningError, WorkspaceStoppedDetector } from './workspaceStoppedDetector';
 import { selectOpenVSXUrl } from '../../store/ServerConfig/selectors';
+import { selectEmptyWorkspaceUrl } from '../../store/DevfileRegistries/selectors';
 
 /**
  * This class executes a few initial instructions
@@ -88,7 +89,7 @@ export default class Bootstrap {
       this.fetchPlugins().then(() => this.fetchDevfileSchema()),
       this.fetchDwPlugins(),
       this.fetchDefaultDwPlugins(),
-      this.fetchRegistriesMetadata(),
+      this.fetchRegistriesMetadata().then(() => this.fetchEmptyWorkspace()),
       this.watchNamespaces(),
       this.updateDevWorkspaceTemplates(),
       this.fetchWorkspaces().then(() => this.checkWorkspaceStopped()),
@@ -285,6 +286,15 @@ export default class Bootstrap {
       this.store.getState,
       undefined,
     );
+  }
+
+  private async fetchEmptyWorkspace(): Promise<void> {
+    const { requestDevfile } = DevfileRegistriesStore.actionCreators;
+    const state = this.store.getState();
+    const emptyWorkspaceUrl = selectEmptyWorkspaceUrl(state);
+    if (emptyWorkspaceUrl) {
+      await requestDevfile(emptyWorkspaceUrl)(this.store.dispatch, this.store.getState, undefined);
+    }
   }
 
   private async fetchDevfileSchema(): Promise<void> {

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
@@ -25,7 +25,11 @@ export async function createWorkspace(
     );
     return response.data;
   } catch (e) {
-    throw `Failed to create a new workspace. ${helpers.errors.getMessage(e)}`;
+    const errorMessage = helpers.errors.getMessage(e);
+    if (errorMessage.startsWith('Unable to create devworkspace')) {
+      throw errorMessage;
+    }
+    throw `Failed to create a new workspace. ${errorMessage}`;
   }
 }
 

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -167,7 +167,7 @@ describe('FactoryResolver store', () => {
         },
         {
           type: 'RECEIVE_FACTORY_RESOLVER_ERROR',
-          error: expect.stringContaining('Failed to request factory resolver'),
+          error: expect.stringContaining('Unexpected error'),
         },
       ];
 
@@ -181,7 +181,7 @@ describe('FactoryResolver store', () => {
       const location = 'http://factory-link';
       await expect(
         store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
-      ).rejects.toMatch('Failed to request factory resolver');
+      ).rejects.toMatch('Unexpected error');
       expect(actions).toEqual(expectedActions);
 
       isAxiosErrorMock.mockRestore();

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -38,7 +38,7 @@ export type OAuthResponse = {
     oauth_authentication_url: string;
   };
   errorCode: number;
-  message: string;
+  message: string | undefined;
 };
 
 export interface ResolverState extends FactoryResolver {
@@ -72,7 +72,7 @@ interface ReceiveFactoryResolverAction {
 
 interface ReceiveFactoryResolverErrorAction {
   type: 'RECEIVE_FACTORY_RESOLVER_ERROR';
-  error: string;
+  error: string | undefined;
 }
 
 export type KnownAction =
@@ -212,8 +212,7 @@ export const actionCreators: ActionCreators = {
             throw response.data;
           }
         }
-        const errorMessage =
-          'Failed to request factory resolver: ' + common.helpers.errors.getMessage(e);
+        const errorMessage = common.helpers.errors.getMessage(e);
         dispatch({
           type: 'RECEIVE_FACTORY_RESOLVER_ERROR',
           error: errorMessage,

--- a/packages/dashboard-frontend/src/store/Workspaces/cheWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/cheWorkspaces/index.ts
@@ -420,9 +420,7 @@ export const actionCreators: ActionCreators = {
           workspace,
         });
       } catch (e) {
-        const errorMessage =
-          'Failed to create a new workspace from the devfile, reason: ' +
-          common.helpers.errors.getMessage(e);
+        const errorMessage = common.helpers.errors.getMessage(e);
         dispatch({
           type: 'CHE_RECEIVE_ERROR',
           error: errorMessage,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -635,9 +635,7 @@ export const actionCreators: ActionCreators = {
           workspace,
         });
       } catch (e) {
-        const errorMessage =
-          'Failed to create a new workspace from the devfile, reason: ' +
-          common.helpers.errors.getMessage(e);
+        const errorMessage = common.helpers.errors.getMessage(e);
         dispatch({
           type: 'RECEIVE_DEVWORKSPACE_ERROR',
           error: errorMessage,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10170,9 +10170,9 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-copy-to-clipboard@^5.0.2:
+react-copy-to-clipboard@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz#09aae5ec4c62750ccb2e6421a58725eabc41255c"
   integrity sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==
   dependencies:
     copy-to-clipboard "^3.3.1"


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add a warning message for the user and prompt him if the workspace should start anyway (ignoring the existing devfile).

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/20738

### Is it tested? How?
1. Deploy Che (dashboard image: quay.io/eclipse/che-dashboard:pr-643).
2. Try to accept the factory with the wrong URL, like 
```$CHE_HOST#https://github.com/AObuchow/che-dashboardrrrr```.
An error message should be shown:
![Знімок екрана 2022-10-06 о 17 08 30](https://user-images.githubusercontent.com/6310786/194335126-37624238-c047-4014-bc5d-6a5f70a14991.png)
3. Try to accept the factory from the repo with an invalid devfile scheme, like 
```$CHE_HOST#https://github.com/olexii4/che-dashboard```.
A warning message about starting anyway should be shown:
![Знімок екрана 2022-10-14 о 17 54 00](https://user-images.githubusercontent.com/6310786/195883222-5b9f60c4-2aa1-41a9-9333-7b468dafb733.png)
4. Try to accept the factory from the repo with a valid devfile wich includes unsuported attributes for target platform, like 
```$CHE_HOST#https://github.com/AObuchow/che-dashboard```.
A warning message about starting anyway should be shown:
![Знімок екрана 2022-10-14 о 17 53 41](https://user-images.githubusercontent.com/6310786/195883291-44b52a33-c534-4f1e-9a12-7b69d80daa31.png)

