### PR TITLE
Sanitize workspace name

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/prepareDevfile.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/prepareDevfile.ts
@@ -15,6 +15,7 @@ import { cloneDeep } from 'lodash';
 import devfileApi from '../../../../../../services/devfileApi';
 import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '../../../../../../services/devfileApi/devWorkspace/spec/template';
 import { generateWorkspaceName } from '../../../../../../services/helpers/generateName';
+import sanitizeName from '../../../../../../services/helpers/sanitizeName';
 import {
   DEVWORKSPACE_DEVFILE_SOURCE,
   DEVWORKSPACE_METADATA_ANNOTATION,
@@ -57,6 +58,8 @@ export function prepareDevfile(
   } else if (appendSuffix) {
     devfile.metadata.name = generateWorkspaceName(devfile.metadata.name);
   }
+  // sanitize the workspace name
+  devfile.metadata.name = sanitizeName(devfile.metadata.name);
 
   // propagate storage type
   if (storageType === 'ephemeral') {

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
@@ -26,9 +26,9 @@ describe('sanitizeName', () => {
   });
 
   test('with non-alphanumeric character in the middle', () => {
-    const name = 'test%project';
+    const name = 'test%-#project';
     const sanitizedName = sanitizeName(name);
-    expect(sanitizedName).toEqual('test-project');
+    expect(sanitizedName).toEqual('test---project');
   });
 
   test('with non-alphanumeric first character', () => {

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
@@ -31,14 +31,14 @@ describe('sanitizeName', () => {
     expect(sanitizedName).toEqual('test---project');
   });
 
-  test('with non-alphanumeric first character', () => {
-    const name = '-test-project';
+  test('with non-alphanumeric first characters', () => {
+    const name = '-@&test-project';
     const sanitizedName = sanitizeName(name);
     expect(sanitizedName).toEqual('test-project');
   });
 
-  test('with non-alphanumeric last character', () => {
-    const name = 'test-project-';
+  test('with non-alphanumeric last characters', () => {
+    const name = 'test-project-@&';
     const sanitizedName = sanitizeName(name);
     expect(sanitizedName).toEqual('test-project');
   });

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import sanitizeName from '../sanitizeName';
+
+describe('sanitizeName', () => {
+  test('correct name', () => {
+    const name = 'test-project';
+    const sanitizedName = sanitizeName(name);
+    expect(sanitizedName).toEqual('test-project');
+  });
+
+  test('with uppercase character', () => {
+    const name = 'testProject';
+    const sanitizedName = sanitizeName(name);
+    expect(sanitizedName).toEqual('testproject');
+  });
+
+  test('with non-alphanumeric character in the middle', () => {
+    const name = 'test%project';
+    const sanitizedName = sanitizeName(name);
+    expect(sanitizedName).toEqual('test-project');
+  });
+
+  test('with non-alphanumeric first character', () => {
+    const name = '-test-project';
+    const sanitizedName = sanitizeName(name);
+    expect(sanitizedName).toEqual('test-project');
+  });
+
+  test('with non-alphanumeric last character', () => {
+    const name = 'test-project-';
+    const sanitizedName = sanitizeName(name);
+    expect(sanitizedName).toEqual('test-project');
+  });
+});

--- a/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
@@ -18,8 +18,8 @@ export default function sanitizeName(name: string): string {
 
   const sanitized = name
     .toLowerCase()
-    .replace(/^[^a-z0-9]/, '')
-    .replace(/[^a-z0-9]$/, '')
+    .replace(/^[^a-z0-9]+/, '')
+    .replace(/[^a-z0-9]+$/, '')
     .replace(/[^-.a-z0-9]/g, '-');
   return sanitized;
 }

--- a/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
@@ -20,6 +20,6 @@ export default function sanitizeName(name: string): string {
     .toLowerCase()
     .replace(/^[^a-z0-9]/, '')
     .replace(/[^a-z0-9]$/, '')
-    .replaceAll(/[^-.a-z0-9]/g, '-');
+    .replace(/[^-.a-z0-9]/g, '-');
   return sanitized;
 }

--- a/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export default function sanitizeName(name: string): string {
+  const re = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+  if (re.test(name)) {
+    return name;
+  }
+
+  const sanitized = name
+    .toLowerCase()
+    .replace(/^[^a-z0-9]/, '')
+    .replace(/[^a-z0-9]$/, '')
+    .replaceAll(/[^-.a-z0-9]/g, '-');
+  return sanitized;
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The User Dashboard sanitizes the devworkspace name before creating the devworkspace.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/21750

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

- unit test added
- successfully created DW from https://github.com/kamlendu1982/tower_engin
