### PR TITLE
fix: getting the default project from the factory URL

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/getProjectFromUrl.spec.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/getProjectFromUrl.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { getProjectFromUrl } from '../getProjectFromUrl';
+
+describe('FactoryLoaderContainer/getProjectFromUrl', () => {
+  test('Get a project from the URL which does not include "*/tree/*" and "*.git"', () => {
+    const url = 'https://github.com/test/rest-repo';
+
+    const project = getProjectFromUrl(url);
+
+    expect(project).toEqual({
+      git: {
+        remotes: {
+          origin: 'https://github.com/test/rest-repo.git',
+        },
+      },
+      name: 'rest-repo',
+    });
+  });
+
+  test('Get a project from the URL which ends with ".git"', () => {
+    const url = 'https://github.com/test/rest-repo.git';
+
+    const project = getProjectFromUrl(url);
+
+    expect(project).toEqual({
+      git: {
+        remotes: {
+          origin: 'https://github.com/test/rest-repo.git',
+        },
+      },
+      name: 'rest-repo',
+    });
+  });
+
+  test('Get a project from the URL which includs "*/tree/*"', () => {
+    const url = 'https://github.com/test/rest-repo/tree/a4f1949c33ddab5f66c19c27a844af1c46aa0820';
+
+    const project = getProjectFromUrl(url);
+
+    expect(project).toEqual({
+      git: {
+        checkoutFrom: {
+          revision: 'a4f1949c33ddab5f66c19c27a844af1c46aa0820',
+        },
+        remotes: {
+          origin: 'https://github.com/test/rest-repo.git',
+        },
+      },
+      name: 'a4f1949c33ddab5f66c19c27a844af1c46aa0820',
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getProjectFromUrl.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getProjectFromUrl.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { getProjectName } from '../../../../../../services/helpers/getProjectName';
+
+export type Project = {
+  git: {
+    remotes: {
+      origin: string;
+    };
+    checkoutFrom?: { revision: string };
+  };
+  name: string;
+};
+
+export function getProjectFromUrl(url: string): Project {
+  const sourceUrl = new URL(url);
+  const name = getProjectName(url);
+  if (sourceUrl.pathname.endsWith('.git')) {
+    const origin = `${sourceUrl.origin}${sourceUrl.pathname}`;
+    return { git: { remotes: { origin } }, name };
+  } else {
+    const sources = sourceUrl.pathname.split('/tree/');
+    const origin = `${sourceUrl.origin}${sources[0]}.git`;
+    const revision = sources[1];
+
+    if (revision) {
+      return {
+        git: { remotes: { origin }, checkoutFrom: { revision } },
+        name,
+      };
+    } else {
+      return {
+        git: { remotes: { origin } },
+        name,
+      };
+    }
+  }
+}

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getProjectFromUrl.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getProjectFromUrl.ts
@@ -11,18 +11,9 @@
  */
 
 import { getProjectName } from '../../../../../../services/helpers/getProjectName';
+import { V220DevfileProjects } from '@devfile/api';
 
-export type Project = {
-  git: {
-    remotes: {
-      origin: string;
-    };
-    checkoutFrom?: { revision: string };
-  };
-  name: string;
-};
-
-export function getProjectFromUrl(url: string): Project {
+export function getProjectFromUrl(url: string): V220DevfileProjects {
   const sourceUrl = new URL(url);
   const name = getProjectName(url);
   if (sourceUrl.pathname.endsWith('.git')) {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -37,7 +37,6 @@ import buildFactoryParams from '../../../buildFactoryParams';
 import { AbstractLoaderStep, LoaderStepProps, LoaderStepState } from '../../../../AbstractStep';
 import { AlertItem } from '../../../../../../services/helpers/types';
 import { selectDefaultDevfile } from '../../../../../../store/DevfileRegistries/selectors';
-import { getProjectName } from '../../../../../../services/helpers/getProjectName';
 import ExpandableWarning from '../../../../../../components/ExpandableWarning';
 import { getProjectFromUrl } from './getProjectFromUrl';
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -39,6 +39,7 @@ import { AlertItem } from '../../../../../../services/helpers/types';
 import { selectDefaultDevfile } from '../../../../../../store/DevfileRegistries/selectors';
 import { getProjectName } from '../../../../../../services/helpers/getProjectName';
 import ExpandableWarning from '../../../../../../components/ExpandableWarning';
+import { getProjectFromUrl } from './getProjectFromUrl';
 
 export class CreateWorkspaceError extends Error {
   constructor(message: string) {
@@ -147,15 +148,11 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
       }
       if (devfile.projects.length === 0) {
         // adds a default project from the source URL
-        const sourceUrl = new URL(factoryParams.sourceUrl);
-        const name = getProjectName(factoryParams.sourceUrl);
-        const origin = sourceUrl.pathname.endsWith('.git')
-          ? `${sourceUrl.origin}${sourceUrl.pathname}`
-          : `${sourceUrl.origin}${sourceUrl.pathname}.git`;
-        devfile.projects[0] = { git: { remotes: { origin } }, name };
+        const project = getProjectFromUrl(factoryParams.sourceUrl);
+        devfile.projects[0] = project;
         // change default name
-        devfile.metadata.name = name;
-        devfile.metadata.generateName = name;
+        devfile.metadata.name = project.name;
+        devfile.metadata.generateName = project.name;
       }
     }
     // test the devfile name to decide if we need to append a suffix to is


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
fix getting the default project from the factory URL.

### Is it tested? How?
1. Deploy Che (dashboard image: quay.io/eclipse/che-dashboard:pr-643).
2. Try to accept the factory:
```$CHE_HOST#/#https://github.com/l0rd/che-operator/tree/a4f1949c33ddab5f66c19c27a844af1c46aa0820```.  
3. A warning message about starting anyway will be shown. Apply the flow with the default devfile.
4. We should have the next project section in Devfile:
```
  - git:
      checkoutFrom:
        revision: a4f1949c33ddab5f66c19c27a844af1c46aa0820
      remotes:
        origin: 'https://github.com/l0rd/che-operator.git'
    name: a4f1949c33ddab5f66c19c27a844af1c46aa0820
```
![Знімок екрана 2022-11-04 о 17 00 26](https://user-images.githubusercontent.com/6310786/200008484-a006e45f-4a8f-4ad2-a348-b10921b0c479.png)
