### PR TITLE
Put plugins into devWorkspace.spec.contributions

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/__tests__/prepareResources.spec.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/__tests__/prepareResources.spec.ts
@@ -39,18 +39,18 @@ describe('FactoryLoaderContainer/prepareResources', () => {
           uid: '',
         },
         spec: {
+          contributions: [
+            {
+              name: devWorkspaceTemplateName,
+              kubernetes: {
+                name: devWorkspaceTemplateName,
+                namespace: 'user-che',
+              },
+            },
+          ],
           started: false,
           template: {
-            components: [
-              {
-                name: devWorkspaceTemplateName,
-                plugin: {
-                  kubernetes: {
-                    name: devWorkspaceTemplateName,
-                  },
-                },
-              },
-            ],
+            components: [],
           },
         },
       },
@@ -94,14 +94,13 @@ describe('FactoryLoaderContainer/prepareResources', () => {
       // DevWorkspace
       expect(result[0].metadata.generateName).toBeUndefined();
       expect(result[0].metadata.name).toEqual(generateName + suffix);
-      expect(result[0].spec.template.components).toEqual(
+      expect(result[0].spec.contributions).toEqual(
         expect.arrayContaining([
           {
             name: devWorkspaceTemplateName + suffix,
-            plugin: {
-              kubernetes: {
-                name: devWorkspaceTemplateName + suffix,
-              },
+            kubernetes: {
+              name: devWorkspaceTemplateName + suffix,
+              namespace: 'user-che',
             },
           },
         ]),
@@ -122,14 +121,13 @@ describe('FactoryLoaderContainer/prepareResources', () => {
       // DevWorkspace
       expect(result[0].metadata.generateName).toBeUndefined();
       expect(result[0].metadata.name).toEqual(generateName + suffix);
-      expect(result[0].spec.template.components).toEqual(
+      expect(result[0].spec.contributions).toEqual(
         expect.arrayContaining([
           {
             name: devWorkspaceTemplateName + suffix,
-            plugin: {
-              kubernetes: {
-                name: devWorkspaceTemplateName + suffix,
-              },
+            kubernetes: {
+              name: devWorkspaceTemplateName + suffix,
+              namespace: 'user-che',
             },
           },
         ]),
@@ -145,14 +143,13 @@ describe('FactoryLoaderContainer/prepareResources', () => {
       // DevWorkspace
       expect(result[0].metadata.generateName).toBeUndefined();
       expect(result[0].metadata.name).toEqual(devWorkspaceName);
-      expect(result[0].spec.template.components).toEqual(
+      expect(result[0].spec.contributions).toEqual(
         expect.arrayContaining([
           {
             name: devWorkspaceTemplateName,
-            plugin: {
-              kubernetes: {
-                name: devWorkspaceTemplateName,
-              },
+            kubernetes: {
+              name: devWorkspaceTemplateName,
+              namespace: 'user-che',
             },
           },
         ]),
@@ -168,14 +165,13 @@ describe('FactoryLoaderContainer/prepareResources', () => {
       // DevWorkspace
       expect(result[0].metadata.generateName).toBeUndefined();
       expect(result[0].metadata.name).toEqual(devWorkspaceName + suffix);
-      expect(result[0].spec.template.components).toEqual(
+      expect(result[0].spec.contributions).toEqual(
         expect.arrayContaining([
           {
             name: devWorkspaceTemplateName + suffix,
-            plugin: {
-              kubernetes: {
-                name: devWorkspaceTemplateName + suffix,
-              },
+            kubernetes: {
+              name: devWorkspaceTemplateName + suffix,
+              namespace: 'user-che',
             },
           },
         ]),

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/prepareResources.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/prepareResources.ts
@@ -69,13 +69,13 @@ function addSuffix(devWorkspace: DevWorkspace, devWorkspaceTemplate: DevWorkspac
   }
 
   // update editor plugin name
-  const editorPlugin = devWorkspace.spec.template.components?.find(
+  const editorPlugin = devWorkspace.spec.contributions?.find(
     component => component.name === editorPluginName,
   );
   if (editorPlugin) {
     editorPlugin.name = editorPluginName + suffix;
-    if (editorPlugin.plugin?.kubernetes) {
-      editorPlugin.plugin.kubernetes.name = editorPluginName + suffix;
+    if (editorPlugin?.kubernetes) {
+      editorPlugin.kubernetes.name = editorPluginName + suffix;
     }
   }
 

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/index.ts
@@ -15,6 +15,15 @@ import { DevWorkspaceMetadata } from './metadata';
 import { DevWorkspaceSpec } from './spec';
 
 export type DevWorkspaceKind = 'DevWorkspace';
+export type DevWorkspacePlugin = {
+  name: string;
+  attributes?: { [key: string]: string | boolean };
+  uri?: string;
+  kubernetes?: {
+    name: string;
+    namespace: string;
+  };
+};
 export const devWorkspaceKind: DevWorkspaceKind = 'DevWorkspace';
 
 type DevWorkspaceLikeRequired = Pick<V1alpha2DevWorkspace, 'apiVersion' | 'kind'>;
@@ -29,5 +38,5 @@ type DevWorkspaceRequired = Pick<DevWorkspaceLike, 'apiVersion' | 'kind' | 'meta
 export type DevWorkspace = DevWorkspaceLike &
   Required<DevWorkspaceRequired> & {
     metadata: DevWorkspaceMetadata;
-    spec: DevWorkspaceSpec;
+    spec: DevWorkspaceSpec & { contributions?: DevWorkspacePlugin[] };
   };

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -351,9 +351,7 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
     if (isCheWorkspace(this.workspace)) {
       this.workspace.devfile = devfile as che.WorkspaceDevfile;
     } else {
-      const plugins = (this.workspace.spec.template.components || []).filter(component => {
-        return component.plugin !== undefined;
-      });
+      const plugins = this.workspace.spec.contributions || [];
       const converted = devfileToDevWorkspace(
         devfile as devfileApi.Devfile,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -361,10 +359,10 @@ export class WorkspaceAdapter<T extends che.Workspace | devfileApi.DevWorkspace>
         this.workspace.spec.started,
       );
       if (isDevWorkspace(converted)) {
-        if (converted.spec.template.components === undefined) {
-          converted.spec.template.components = [];
+        if (converted.spec.contributions === undefined) {
+          converted.spec.contributions = [];
         }
-        converted.spec.template.components.push(...plugins);
+        converted.spec.contributions.push(...plugins);
         (this.workspace as devfileApi.DevWorkspace) = converted;
       } else {
         console.error(

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
@@ -128,19 +128,19 @@ export class DevWorkspaceDefaultPluginsHandler {
     pluginName: string,
     pluginUri: string,
   ): boolean {
-    if (!workspace.spec.template.components) {
-      workspace.spec.template.components = [];
+    if (!workspace.spec.contributions) {
+      workspace.spec.contributions = [];
     }
 
-    if (workspace.spec.template.components.find(component => component.name === pluginName)) {
+    if (workspace.spec.contributions.find(component => component.name === pluginName)) {
       // plugin already exists
       return false;
     }
 
-    workspace.spec.template.components.push({
+    workspace.spec.contributions.push({
       name: pluginName,
       attributes: { [DEFAULT_PLUGIN_ATTRIBUTE]: true },
-      plugin: { uri: pluginUri },
+      uri: pluginUri,
     });
     return true;
   }

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
@@ -46,12 +46,10 @@ describe('DevWorkspace client, start', () => {
 
     await client.onStart(testWorkspace, defaults, editor);
 
-    expect(testWorkspace.spec.template.components?.length).toBe(1);
-    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(defaultPluginUri);
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(defaultPluginUri);
     expect(
-      (testWorkspace.spec.template.components![0].attributes as any)[
-        'che.eclipse.org/default-plugin'
-      ],
+      (testWorkspace.spec.contributions![0].attributes as any)['che.eclipse.org/default-plugin'],
     ).toBe(true);
     expect(patchWorkspace).toHaveBeenCalled();
   });

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -950,22 +950,20 @@ export class DevWorkspaceClient extends WorkspaceClient {
    * @param namespace A namespace
    */
   private addPlugin(workspace: devfileApi.DevWorkspace, pluginName: string, namespace: string) {
-    if (!workspace.spec.template.components) {
-      workspace.spec.template.components = [];
+    if (!workspace.spec.contributions) {
+      workspace.spec.contributions = [];
     }
-    const components = workspace.spec.template.components.filter(
-      component => component.name !== pluginName,
+    const contributions = workspace.spec.contributions.filter(
+      contribution => contribution.name !== pluginName,
     );
-    components.push({
+    contributions.push({
       name: pluginName,
-      plugin: {
-        kubernetes: {
-          name: pluginName,
-          namespace,
-        },
+      kubernetes: {
+        name: pluginName,
+        namespace,
       },
     });
-    workspace.spec.template.components = components;
+    workspace.spec.contributions = contributions;
   }
 
   async subscribeToNamespace(subscriber: Subscriber): Promise<void> {

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/updateDevWorkspacePlugins.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/updateDevWorkspacePlugins.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import updateDevWorkspacePlugins from '../updateDevWorkspacePlugins';
+import devfileApi from '../../../services/devfileApi';
+
+describe('Update DevWorkspace Plugins', () => {
+  it('Should move devWorkspace plugins from components to contributions', () => {
+    const devWorkspace = {
+      apiVersion: 'workspace.devfile.io/v1alpha2',
+      kind: 'DevWorkspace',
+      metadata: {
+        name: 'apache-camel-k',
+      },
+      spec: {
+        template: {
+          components: [
+            {
+              name: 'tools',
+              container: {
+                image: 'quay.io/devfile/universal-developer-image:ubi8',
+              },
+            },
+            {
+              name: 'theia-ide-apache-camel-k',
+              plugin: {
+                kubernetes: {
+                  name: 'theia-ide-apache-camel-k',
+                },
+              },
+            },
+          ],
+        },
+      },
+    } as devfileApi.DevWorkspace;
+
+    updateDevWorkspacePlugins(devWorkspace);
+
+    expect(devWorkspace).toEqual({
+      apiVersion: 'workspace.devfile.io/v1alpha2',
+      kind: 'DevWorkspace',
+      metadata: {
+        name: 'apache-camel-k',
+      },
+      spec: {
+        contributions: [
+          {
+            name: 'theia-ide-apache-camel-k',
+            kubernetes: {
+              name: 'theia-ide-apache-camel-k',
+            },
+          },
+        ],
+        template: {
+          components: [
+            {
+              name: 'tools',
+              container: {
+                image: 'quay.io/devfile/universal-developer-image:ubi8',
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('Should leave devWorkspace without changes if it doesn`t have plugins in components', () => {
+    const devWorkspace = {
+      apiVersion: 'workspace.devfile.io/v1alpha2',
+      kind: 'DevWorkspace',
+      metadata: {
+        name: 'apache-camel-k',
+      },
+      spec: {
+        contributions: [
+          {
+            name: 'theia-ide-apache-camel-k',
+            kubernetes: {
+              name: 'theia-ide-apache-camel-k',
+            },
+          },
+        ],
+        template: {
+          components: [
+            {
+              name: 'tools',
+              container: {
+                image: 'quay.io/devfile/universal-developer-image:ubi8',
+              },
+            },
+          ],
+        },
+      },
+    } as devfileApi.DevWorkspace;
+
+    updateDevWorkspacePlugins(devWorkspace);
+
+    expect(devWorkspace).toEqual({
+      apiVersion: 'workspace.devfile.io/v1alpha2',
+      kind: 'DevWorkspace',
+      metadata: {
+        name: 'apache-camel-k',
+      },
+      spec: {
+        contributions: [
+          {
+            name: 'theia-ide-apache-camel-k',
+            kubernetes: {
+              name: 'theia-ide-apache-camel-k',
+            },
+          },
+        ],
+        template: {
+          components: [
+            {
+              name: 'tools',
+              container: {
+                image: 'quay.io/devfile/universal-developer-image:ubi8',
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
@@ -22,6 +22,7 @@ import { isDevworkspacesEnabled } from '../../services/helpers/devworkspace';
 import fetchAndUpdateDevfileSchema from './fetchAndUpdateDevfileSchema';
 import devfileApi from '../../services/devfileApi';
 import { fetchResources, loadResourcesContent } from '../../services/registry/resources';
+import updateDevWorkspacePlugins from './updateDevWorkspacePlugins';
 
 const WorkspaceClient = container.get(CheWorkspaceClient);
 export const DEFAULT_REGISTRY = '/dashboard/devfile-registry/';
@@ -240,6 +241,7 @@ export const actionCreators: ActionCreators = {
         if (!devWorkspace) {
           throw new Error('Failed to find a devworkspace in prebuilt resources.');
         }
+        updateDevWorkspacePlugins(devWorkspace);
         const devWorkspaceTemplate = resources.find(
           resource => resource.kind === 'DevWorkspaceTemplate',
         ) as devfileApi.DevWorkspaceTemplate;

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/updateDevWorkspacePlugins.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/updateDevWorkspacePlugins.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { DevWorkspacePlugin } from '../../services/devfileApi/devWorkspace';
+import devfileApi from '../../services/devfileApi';
+
+export default function updateDevWorkspacePlugins(devWorkspace: devfileApi.DevWorkspace): void {
+  if (!devWorkspace.spec.contributions) {
+    devWorkspace.spec.contributions = [];
+  }
+  const contributions = devWorkspace.spec.contributions;
+  const components: V1alpha2DevWorkspaceSpecTemplateComponents[] = [];
+  const allComponents = devWorkspace.spec.template.components || [];
+  allComponents.forEach(component => {
+    if (component.plugin) {
+      const contribution = Object.assign({}, component.plugin, component);
+      delete contribution.plugin;
+      contributions.push(contribution as DevWorkspacePlugin);
+    } else {
+      components.push(component);
+    }
+  });
+  if (contributions[0]) {
+    devWorkspace.spec.template.components = components;
+  }
+}


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR implemented a new rule for putting plugins into DevWorkspace ```.spec.contributions```.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21737

![Знімок екрана 2022-11-21 о 16 57 41](https://user-images.githubusercontent.com/6310786/203087253-95974a3a-a418-4e84-bb78-8bab37bc7170.png)


You can test it with [https://eclipse-che.apps.cluster-z2zcs.z2zcs.sandbox1571.opentlc.com](https://eclipse-che.apps.cluster-zxs5p.zxs5p.sandbox2586.opentlc.com/dashboard/)
