### PR TITLE
Fix a devworkspace start action

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.debugMode.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.debugMode.spec.ts
@@ -56,10 +56,10 @@ describe('DevWorkspaceClient debug mode', () => {
       const mockPatch = mockAxios.patch as jest.Mock;
       mockPatch.mockResolvedValue({ data: undefined });
 
-      let resultData = await devWorkspaceClient.updateDebugMode(devWorkspaceNoDebug, false);
+      let resultData = await devWorkspaceClient.manageDebugMode(devWorkspaceNoDebug, false);
       expect(resultData).toEqual(devWorkspaceNoDebug);
 
-      resultData = await devWorkspaceClient.updateDebugMode(devWorkspaceWithDebug, true);
+      resultData = await devWorkspaceClient.manageDebugMode(devWorkspaceWithDebug, true);
       expect(resultData).toEqual(devWorkspaceWithDebug);
 
       expect(mockPatch.mock.calls.length).toEqual(0);
@@ -71,7 +71,7 @@ describe('DevWorkspaceClient debug mode', () => {
 
       expect(devWorkspaceClient.getDebugMode(devWorkspaceNoDebug)).toEqual(false);
 
-      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.updateDebugMode(
+      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.manageDebugMode(
         devWorkspaceNoDebug,
         true,
       );
@@ -104,7 +104,7 @@ describe('DevWorkspaceClient debug mode', () => {
 
       expect(devWorkspaceClient.getDebugMode(devWorkspaceNoDebug)).toEqual(false);
 
-      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.updateDebugMode(
+      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.manageDebugMode(
         devWorkspaceNoDebug,
         true,
       );
@@ -127,7 +127,7 @@ describe('DevWorkspaceClient debug mode', () => {
 
       expect(devWorkspaceClient.getDebugMode(devWorkspaceWithDebug)).toEqual(true);
 
-      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.updateDebugMode(
+      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.manageDebugMode(
         devWorkspaceWithDebug,
         false,
       );

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -751,7 +751,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     return workspace.metadata.annotations?.[DEVWORKSPACE_DEBUG_START_ANNOTATION] === 'true';
   }
 
-  async updateConfigData(
+  async managePvcStrategy(
     workspace: devfileApi.DevWorkspace,
     config: api.IServerConfig,
   ): Promise<devfileApi.DevWorkspace> {
@@ -831,7 +831,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
     return updatedDwvWorkspace;
   }
 
-  async updateDebugMode(
+  async manageDebugMode(
     workspace: devfileApi.DevWorkspace,
     debugMode: boolean,
   ): Promise<devfileApi.DevWorkspace> {
@@ -858,13 +858,14 @@ export class DevWorkspaceClient extends WorkspaceClient {
   /**
    * Injects or removes the container build attribute depending on the CR `disableContainerBuildCapabilities` field value.
    */
-  async updateContainerBuildAttribute(
+  async manageContainerBuildAttribute(
     workspace: devfileApi.DevWorkspace,
     config: api.IServerConfig,
   ): Promise<devfileApi.DevWorkspace> {
     const patch: api.IPatch[] = [];
     if (config.containerBuild.disableContainerBuildCapabilities) {
       if (workspace.spec.template.attributes?.[DEVWORKSPACE_CONTAINER_BUILD_ATTR]) {
+        // remove the attribute
         const path = `/spec/template/attributes/${this.escape(DEVWORKSPACE_CONTAINER_BUILD_ATTR)}`;
         patch.push({ op: 'remove', path });
       }
@@ -875,11 +876,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
         'Skip injecting the container build attribute: "openShiftSecurityContextConstraint" is undefined',
       );
     } else {
+      // add the attribute
       if (!workspace.spec.template.attributes) {
-        workspace.spec.template.attributes = {
-          [DEVWORKSPACE_CONTAINER_BUILD_ATTR]:
-            config.containerBuild.containerBuildConfiguration.openShiftSecurityContextConstraint,
-        };
         const path = '/spec/template/attributes';
         const value = {
           [DEVWORKSPACE_CONTAINER_BUILD_ATTR]:

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -330,12 +330,12 @@ export const actionCreators: ActionCreators = {
 
         await dispatch(DwServerConfigStore.actionCreators.requestServerConfig());
         const config = getState().dwServerConfig.config;
-        workspace = await devWorkspaceClient.updateConfigData(workspace, config);
+        workspace = await devWorkspaceClient.managePvcStrategy(workspace, config);
 
         // inject or remove the container build attribute
-        workspace = await devWorkspaceClient.updateContainerBuildAttribute(workspace, config);
+        workspace = await devWorkspaceClient.manageContainerBuildAttribute(workspace, config);
 
-        workspace = await devWorkspaceClient.updateDebugMode(workspace, debugWorkspace);
+        workspace = await devWorkspaceClient.manageDebugMode(workspace, debugWorkspace);
 
         const workspaceUID = workspace.metadata.uid;
         dispatch({

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import common, { api } from '@eclipse-che/common';
+import common from '@eclipse-che/common';
 import { cloneDeep } from 'lodash';
 import { Action, Reducer } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -23,7 +23,6 @@ import {
   DEVWORKSPACE_CHE_EDITOR,
   DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION,
 } from '../../../services/devfileApi/devWorkspace/metadata';
-import { DEVWORKSPACE_CONTAINER_BUILD_ATTR } from '../../../services/devfileApi/devWorkspace/spec/template';
 import { getDefer, IDeferred } from '../../../services/helpers/deferred';
 import { delay } from '../../../services/helpers/delay';
 import { DisposableCollection } from '../../../services/helpers/disposable';
@@ -294,7 +293,7 @@ export const actionCreators: ActionCreators = {
       debugWorkspace = false,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
-      const workspace = getState().devWorkspaces.workspaces.find(
+      let workspace = getState().devWorkspaces.workspaces.find(
         w => w.metadata.uid === _workspace.metadata.uid,
       );
       if (workspace === undefined) {
@@ -308,15 +307,6 @@ export const actionCreators: ActionCreators = {
       dispatch({ type: 'REQUEST_DEVWORKSPACE' });
       try {
         checkRunningWorkspacesLimit(getState());
-        await dispatch(DwServerConfigStore.actionCreators.requestServerConfig());
-        const config = getState().dwServerConfig.config;
-        await devWorkspaceClient.updateConfigData(workspace, config);
-        await devWorkspaceClient.updateDebugMode(workspace, debugWorkspace);
-        const workspaceUID = workspace.metadata.uid;
-        dispatch({
-          type: 'DELETE_DEVWORKSPACE_LOGS',
-          workspaceUID,
-        });
 
         if (workspace.metadata.annotations?.[DEVWORKSPACE_NEXT_START_ANNOTATION]) {
           const storedDevWorkspace = JSON.parse(
@@ -334,23 +324,38 @@ export const actionCreators: ActionCreators = {
 
           delete workspace.metadata.annotations[DEVWORKSPACE_NEXT_START_ANNOTATION];
           workspace.spec.template = storedDevWorkspace.spec.template;
+          workspace.spec.started = false;
+          workspace = await devWorkspaceClient.update(workspace);
         }
 
+        await dispatch(DwServerConfigStore.actionCreators.requestServerConfig());
+        const config = getState().dwServerConfig.config;
+        workspace = await devWorkspaceClient.updateConfigData(workspace, config);
+
         // inject or remove the container build attribute
-        manageContainerBuildAttribute(workspace, config);
+        workspace = await devWorkspaceClient.updateContainerBuildAttribute(workspace, config);
 
-        // update and start the workspace
-        workspace.spec.started = true;
-        const updatedWorkspace = await devWorkspaceClient.update(workspace);
+        workspace = await devWorkspaceClient.updateDebugMode(workspace, debugWorkspace);
 
-        const editor = updatedWorkspace.metadata.annotations
-          ? updatedWorkspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR]
+        const workspaceUID = workspace.metadata.uid;
+        dispatch({
+          type: 'DELETE_DEVWORKSPACE_LOGS',
+          workspaceUID,
+        });
+
+        const startingWorkspace = await devWorkspaceClient.changeWorkspaceStatus(
+          workspace,
+          true,
+          true,
+        );
+        const editor = startingWorkspace.metadata.annotations
+          ? startingWorkspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR]
           : undefined;
         const defaultPlugins = getState().dwPlugins.defaultPlugins;
-        await devWorkspaceClient.onStart(updatedWorkspace, defaultPlugins, editor);
+        await devWorkspaceClient.onStart(startingWorkspace, defaultPlugins, editor);
         dispatch({
           type: 'UPDATE_DEVWORKSPACE',
-          workspace: updatedWorkspace,
+          workspace: startingWorkspace,
         });
 
         // sometimes workspace don't have enough time to change its status.
@@ -370,7 +375,7 @@ export const actionCreators: ActionCreators = {
         await Promise.race([defer.promise, delay(startingTimeout)]);
         toDispose.dispose();
 
-        devWorkspaceClient.checkForDevWorkspaceError(updatedWorkspace);
+        devWorkspaceClient.checkForDevWorkspaceError(startingWorkspace);
       } catch (e) {
         const errorMessage =
           `Failed to start the workspace ${workspace.metadata.name}, reason: ` +
@@ -814,40 +819,5 @@ async function onStatusUpdateReceived(
     } catch (e) {
       console.error(e);
     }
-  }
-}
-
-/**
- * Injects or removes the container build attribute depending on the CR `disableContainerBuildCapabilities` field value.
- */
-export function manageContainerBuildAttribute(
-  workspace: devfileApi.DevWorkspace,
-  config: api.IServerConfig,
-) {
-  const { disableContainerBuildCapabilities, containerBuildConfiguration } = config.containerBuild;
-
-  if (
-    disableContainerBuildCapabilities === true &&
-    workspace.spec.template.attributes !== undefined
-  ) {
-    // remove the attribute
-    delete workspace.spec.template.attributes?.[DEVWORKSPACE_CONTAINER_BUILD_ATTR];
-    if (Object.keys(workspace.spec.template.attributes).length === 0) {
-      delete workspace.spec.template.attributes;
-    }
-    return;
-  }
-
-  // add the attribute
-  if (containerBuildConfiguration?.openShiftSecurityContextConstraint === undefined) {
-    console.warn(
-      'Skip injecting the container build attribute: "openShiftSecurityContextConstraint" is undefined',
-    );
-  } else {
-    if (workspace.spec.template.attributes === undefined) {
-      workspace.spec.template.attributes = {};
-    }
-    workspace.spec.template.attributes[DEVWORKSPACE_CONTAINER_BUILD_ATTR] =
-      containerBuildConfiguration.openShiftSecurityContextConstraint;
   }
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes a PVC bug by adding attributes ```storage-type``` and ```scc``` in the right way.

The result should be something like this:
```
...
attributes:
  controller.devfile.io/devworkspace-config:
    name: devworkspace-config
    namespace: eclipse-che
  controller.devfile.io/scc: container-build
  controller.devfile.io/storage-type: per-user
...
```

![Знімок екрана 2022-11-17 о 14 45 25](https://user-images.githubusercontent.com/6310786/202450371-f127c4d5-8c03-449a-be61-a4497799eeb4.png)

You can test it with https://eclipse-che.apps.cluster-z2zcs.z2zcs.sandbox1571.opentlc.com
