### PR TITLE
Fix a devworkspace start action (#675)

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.debugMode.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.debugMode.spec.ts
@@ -56,10 +56,10 @@ describe('DevWorkspaceClient debug mode', () => {
       const mockPatch = mockAxios.patch as jest.Mock;
       mockPatch.mockResolvedValue({ data: undefined });
 
-      let resultData = await devWorkspaceClient.updateDebugMode(devWorkspaceNoDebug, false);
+      let resultData = await devWorkspaceClient.manageDebugMode(devWorkspaceNoDebug, false);
       expect(resultData).toEqual(devWorkspaceNoDebug);
 
-      resultData = await devWorkspaceClient.updateDebugMode(devWorkspaceWithDebug, true);
+      resultData = await devWorkspaceClient.manageDebugMode(devWorkspaceWithDebug, true);
       expect(resultData).toEqual(devWorkspaceWithDebug);
 
       expect(mockPatch.mock.calls.length).toEqual(0);
@@ -71,7 +71,7 @@ describe('DevWorkspaceClient debug mode', () => {
 
       expect(devWorkspaceClient.getDebugMode(devWorkspaceNoDebug)).toEqual(false);
 
-      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.updateDebugMode(
+      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.manageDebugMode(
         devWorkspaceNoDebug,
         true,
       );
@@ -104,7 +104,7 @@ describe('DevWorkspaceClient debug mode', () => {
 
       expect(devWorkspaceClient.getDebugMode(devWorkspaceNoDebug)).toEqual(false);
 
-      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.updateDebugMode(
+      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.manageDebugMode(
         devWorkspaceNoDebug,
         true,
       );
@@ -127,7 +127,7 @@ describe('DevWorkspaceClient debug mode', () => {
 
       expect(devWorkspaceClient.getDebugMode(devWorkspaceWithDebug)).toEqual(true);
 
-      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.updateDebugMode(
+      const resultData: devfileApi.DevWorkspace = await devWorkspaceClient.manageDebugMode(
         devWorkspaceWithDebug,
         false,
       );


### PR DESCRIPTION
* fix: a patches queue for the devworkspace start action

Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/675 into https://github.com/eclipse-che/che-dashboard/tree/7.56.x

