### PR TITLE
Fix the bootstrap queue

### DIFF
--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -88,9 +88,8 @@ export default class Bootstrap {
       this.fetchDwPlugins(),
       this.fetchDefaultDwPlugins(),
       this.fetchRegistriesMetadata().then(() => this.fetchEmptyWorkspace()),
-      this.watchNamespaces(),
       this.updateDevWorkspaceTemplates(),
-      this.fetchWorkspaces().then(() => this.checkWorkspaceStopped()),
+      this.fetchWorkspaces().then(() => this.watchNamespaces()),
       this.fetchClusterInfo(),
       this.fetchClusterConfig(),
     ]);
@@ -167,6 +166,7 @@ export default class Bootstrap {
   private async fetchWorkspaces(): Promise<void> {
     const { requestWorkspaces } = WorkspacesStore.actionCreators;
     await requestWorkspaces()(this.store.dispatch, this.store.getState, undefined);
+    this.checkWorkspaceStopped();
   }
 
   private async fetchPlugins(): Promise<void> {
@@ -307,7 +307,7 @@ export default class Bootstrap {
     );
   }
 
-  private checkWorkspaceStopped() {
+  private checkWorkspaceStopped(): void {
     let stoppedWorkspace: Workspace | undefined = undefined;
 
     try {

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -89,7 +89,10 @@ export default class Bootstrap {
       this.fetchDefaultDwPlugins(),
       this.fetchRegistriesMetadata().then(() => this.fetchEmptyWorkspace()),
       this.updateDevWorkspaceTemplates(),
-      this.fetchWorkspaces().then(() => this.watchNamespaces()),
+      this.fetchWorkspaces().then(() => {
+        this.checkWorkspaceStopped();
+        return this.watchNamespaces();
+      }),
       this.fetchClusterInfo(),
       this.fetchClusterConfig(),
     ]);
@@ -166,7 +169,6 @@ export default class Bootstrap {
   private async fetchWorkspaces(): Promise<void> {
     const { requestWorkspaces } = WorkspacesStore.actionCreators;
     await requestWorkspaces()(this.store.dispatch, this.store.getState, undefined);
-    this.checkWorkspaceStopped();
   }
 
   private async fetchPlugins(): Promise<void> {

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -135,14 +135,10 @@ export const actionCreators: ActionCreators = {
     async (dispatch, getState): Promise<void> => {
       dispatch({ type: 'REQUEST_WORKSPACES' });
       try {
-        const state = getState();
-        const cheDevworkspaceEnabled = isDevworkspacesEnabled(state.workspacesSettings.settings);
-
-        const promises: Promise<unknown>[] = [];
-        if (cheDevworkspaceEnabled) {
-          promises.push(dispatch(DevWorkspacesStore.actionCreators.requestWorkspaces()));
-        }
-        promises.push(dispatch(CheWorkspacesStore.actionCreators.requestWorkspaces()));
+        const promises: Promise<unknown>[] = [
+          dispatch(DevWorkspacesStore.actionCreators.requestWorkspaces()),
+          dispatch(CheWorkspacesStore.actionCreators.requestWorkspaces()),
+        ];
 
         await Promise.allSettled(promises);
 

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -132,7 +132,7 @@ export type ActionCreators = {
 export const actionCreators: ActionCreators = {
   requestWorkspaces:
     (): AppThunk<KnownAction, Promise<void>> =>
-    async (dispatch, getState): Promise<void> => {
+    async (dispatch): Promise<void> => {
       dispatch({ type: 'REQUEST_WORKSPACES' });
       try {
         const promises: Promise<unknown>[] = [


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix the bootstrap queue to guarantee to have resourceVersion before subscribing to the onChange event.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21809

![Знімок екрана 2022-11-22 о 18 42 33](https://user-images.githubusercontent.com/6310786/203373023-a3597b2d-0c44-44e0-827a-e9694b5ac2ee.png)

