### PR TITLE
Chore: Update GitHub actions to use node 16 and Ubuntu to latest #686

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,7 +20,7 @@ on:
 jobs:
 
   coverage-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       -
         name: "Checkout Che Dashboard source code"
@@ -40,7 +40,7 @@ jobs:
         run: yarn test:coverage
       -
         name: "Build Codecov report"
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3
         with:
           files: ./packages/dashboard-frontend/coverage/lcov.info,./packages/dashboard-backend/coverage/lcov.info,./packages/common/coverage/lcov.info
           flags: unittests

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,18 +20,18 @@ on:
 jobs:
 
   coverage-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       -
         name: "Checkout Che Dashboard source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       -
         name: "Use Node.js"
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       -
         name: "Install dependencies"
         run: yarn
@@ -40,7 +40,7 @@ jobs:
         run: yarn test:coverage
       -
         name: "Build Codecov report"
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3.1.1
         with:
           files: ./packages/dashboard-frontend/coverage/lcov.info,./packages/dashboard-backend/coverage/lcov.info,./packages/common/coverage/lcov.info
           flags: unittests

--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -22,7 +22,7 @@ env:
 jobs:
 
   build-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +75,7 @@ jobs:
   create-manifest:
     if: always()
     needs: build-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       -
         name: "Docker quay.io Login"

--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -22,7 +22,7 @@ env:
 jobs:
 
   build-images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -34,30 +34,30 @@ jobs:
     steps:
       -
         name: "Checkout Che Dashboard source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: "Docker quay.io Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       -
         name: "Docker docker.io Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       -
         name: "Build and push ${{ matrix.arch }}"
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE_FULL }}
           cache-to: type=registry,ref=${{ env.CACHE_IMAGE_FULL }},mode=max
@@ -75,11 +75,11 @@ jobs:
   create-manifest:
     if: always()
     needs: build-images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       -
         name: "Docker quay.io Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ env:
 jobs:
 
   dash-licenses:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.base_ref == 'main' }}
     steps:
       -
@@ -41,7 +41,7 @@ jobs:
         run: yarn license:check
 
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [14.x, 16.x]
@@ -69,7 +69,7 @@ jobs:
 
   docker-build:
     needs: build-and-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.default == false }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,15 +22,15 @@ env:
 jobs:
 
   dash-licenses:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.base_ref == 'main' }}
     steps:
       -
         name: "Checkout Che Dashboard source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: "Use Node 16"
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       -
@@ -41,17 +41,17 @@ jobs:
         run: yarn license:check
 
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [14.x, 16.x]
     steps:
       -
         name: "Checkout Che Dashboard source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: "Use Node.js ${{ matrix.node-version }}"
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       -
@@ -69,7 +69,7 @@ jobs:
 
   docker-build:
     needs: build-and-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.default == false }}
     strategy:
       fail-fast: false
@@ -84,19 +84,19 @@ jobs:
     steps:
       -
         name: "Checkout Che Dashboard source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.DIR_DASHBOARD }}
           ref: ${{ github.event.pull_request.head.sha }}
       -
         name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: "Set up Docker Buildx ${{ matrix.platform }}"
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: "Cache Docker layers"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -104,14 +104,14 @@ jobs:
             ${{ runner.os }}-buildx-
       -
         name: "Docker quay.io Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       -
         name: "Build and push ${{ matrix.platform }}"
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -122,7 +122,7 @@ jobs:
           tags: ${{ env.ORGANIZATION }}/che-dashboard:${{ env.IMAGE_VERSION }}
       -
         name: "Comment with image name"
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         if: ${{ matrix.default == true }}
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
 
   build-images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -30,23 +30,23 @@ jobs:
     steps:
       -
         name: "Checkout Che Dashboard source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: "Docker quay.io Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       -
         name: "Build and push ${{ matrix.arch }}"
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./build/dockerfiles/Dockerfile
@@ -61,11 +61,11 @@ jobs:
 
   create-manifest:
     needs: build-images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       -
         name: "Docker quay.io Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -99,14 +99,14 @@ jobs:
 
   tag-release:
     needs: create-manifest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       -
         name: "Checkout Che Dashboard source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: "Setup Node"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "14"
       -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
 
   build-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +61,7 @@ jobs:
 
   create-manifest:
     needs: build-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       -
         name: "Docker quay.io Login"
@@ -99,7 +99,7 @@ jobs:
 
   tag-release:
     needs: create-manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       -
         name: "Checkout Che Dashboard source code"

--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-link:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Web IDE Pull Request Check
         id: try-in-web-ide

--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-link:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Web IDE Pull Request Check
         id: try-in-web-ide


### PR DESCRIPTION
Signed-off-by: sdawley <sdawley@redhat.com>

Replaces https://github.com/eclipse-che/che-dashboard/pull/686 against origin so PR checks can pass.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Update GitHub actions to use node 16 and Ubuntu to latest

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21763

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
