### PR TITLE
Add e2e puppeteer test to CHE-Dashboard project

### DIFF
--- a/.ci/oci-dashboard-puppeteer.sh
+++ b/.ci/oci-dashboard-puppeteer.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (c) 2019-2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Catch the finish of the job and write logs in artifacts.
+
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# uncomment to print each command before executing it
+set -x
+
+export CI_CHE_DASHBOARD_IMAGE="quay.io/eclipse/che-dashboard:next"
+export CHE_REPO_BRANCH="main"
+export CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
+export DEVWORKSPACE_HAPPY_PATH="https://raw.githubusercontent.com/eclipse/che/${CHE_REPO_BRANCH}/tests/devworkspace-happy-path"
+export ECLIPSE_CHE_URL="${ECLIPSE_CHE_URL:-localhost}"
+export KUBE_ADMIN_PASSWORD="${ECLIPSE_CHE_URL:-admin}"
+
+source <(curl -s ${DEVWORKSPACE_HAPPY_PATH}/common.sh)
+
+#trap 'collectLogs $?' EXIT SIGINT
+
+setupCheDashboard() {
+  # Deploy Eclipse Che with a custom dashboard image
+  cat >/tmp/che-cr-patch.yaml <<EOF
+spec:
+  components:
+    dashboard:
+      deployment:
+        containers:
+          - image: ${CI_CHE_DASHBOARD_IMAGE}
+EOF
+  chectl server:deploy \
+    --platform openshift \
+    --che-operator-cr-patch-yaml /tmp/che-cr-patch.yaml \
+    --batch \
+    --telemetry=off
+}
+
+setUpTestPod() {
+  echo '------------------------------------------'
+  oc delete project puppeteer --ignore-not-found
+  oc new-project puppeteer --description="puppeteer" --display-name="puppeteer" || true
+  KUBE_ADMIN_PASSWORD="$(cat $KUBEADMIN_PASSWORD_FILE)"
+
+  echo '---------------------env.CHE_NAMESPACE---------------------'
+  echo $CHE_NAMESPACE
+
+  ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
+
+  echo '---------------------env.ECLIPSE_CHE_URL---------------------'
+  echo $ECLIPSE_CHE_URL
+
+  echo '--------------- ENV-LIST -------------------'
+  env
+  echo '--------------- ENV-LIST-end -------------------'
+
+  yq -iy '(.spec.containers[].env[]? | select(.name=="BASE_URL")).value = env.ECLIPSE_CHE_URL' .ci/resources/dashboard-pod.yaml
+  yq -iy '(.spec.containers[].env[]? | select(.value=="crw4ever!")).value = env.KUBE_ADMIN_PASSWORD' .ci/resources/dashboard-pod.yaml
+
+  echo '---------------pupetter-test-pod---------------:'
+  cat .ci/resources/dashboard-pod.yaml
+  echo '---------------end-of-pupetter-test-pod---------------'
+  oc apply -f .ci/resources/dashboard-pod.yaml
+}
+
+setupCheDashboard
+setUpTestPod

--- a/.ci/resources/dashboard-pod.yaml
+++ b/.ci/resources/dashboard-pod.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: puppeteer
+  namespace: puppeteer
+spec:
+  volumes:
+    - name: test-run-results
+    - name: dshm
+      emptyDir:
+        medium: Memory
+  containers:
+    # container containing the tests
+    - name: puppeteer
+      image: quay.io/mmusiien/puppeteer-chrome-dashboard:v1
+      imagePullPolicy: Always
+      command: ["/bin/sh"]
+      args: ["-c", "yarn test"]
+      env:
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: '0'
+        - name: BASE_URL
+          value: "https://eclipse-che.apps.ocp411-mmusiie.crw-qe.com"
+        - name: IDP_ITEM
+          value: ""
+        - name: USERNAME
+          value: "admin"
+        - name: USER_PASSWORD
+          value: "crw4ever!"
+        - name: PLATFORM
+          value: "OpenShift"
+      volumeMounts:
+        - name: test-run-results
+          mountPath: /tmp/e2e/report/
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "2"
+        limits:
+          memory: "4Gi"
+          cpu: "2"
+    # Download results
+    - name: download-reports
+      image: quay.io/instrumentisto/rsync-ssh
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - name: test-run-results
+          mountPath: /tmp/e2e/report/
+      command: ["sh"]
+      args:
+        [
+          "-c",
+          "while true; if [[ -f /tmp/done ]]; then exit 0; fi; do sleep 1; done",
+        ]
+  restartPolicy: Never


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* This PR added script and resources for running the e2e tests based on jest+puppeteer stacks on an Openshift CI. It uses RedHat PROW CI.
* This works in the next way: after setting up an OpenShift cluster, install eclipse-che  (latest version) build the dashboard image, and patch the dashboard container section for consuming the image.  The next step is to apply the script in the **oci-dashboard-puppeteer.sh** file. It adds the test pod in the cluster which includes an image with a puppeteer codebase and a headless chrome browser.
* The test-pod performs the next scenario: go to the dashboard, create the empty workspace from the samples, and waiting for starting the workspace. After this go to the dashboard again and try to create a workspace from the same sample. Waiting for the massage with the proposal go to the existing workspace and check success entering.
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20108

### Is it tested? How?

It was checked during the creation new job on OpenShift CI: https://github.com/openshift/release/pull/33622



#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
