### PR TITLE
backport: set up Git remotes from factory url (#691)

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/getGitRemotes.spec.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/getGitRemotes.spec.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { getGitRemotes, GitRemote, sanitizeValue } from '../getGitRemotes';
+
+describe('getGitRemotes functions', () => {
+  describe('getGitRemotes()', () => {
+    it('should return remotes when one remote is provided', () => {
+      const input = '{https://github.com/test1/che-dashboard}';
+      const expected: GitRemote[] = [
+        { name: 'origin', url: 'https://github.com/test1/che-dashboard' },
+      ];
+      expect(getGitRemotes(input)).toMatchObject(expected);
+    });
+    it('should return remotes when two remotes are provided', () => {
+      const input =
+        '{https://github.com/test1/che-dashboard, https://github.com/test2/che-dashboard}';
+      const expected: GitRemote[] = [
+        { name: 'origin', url: 'https://github.com/test1/che-dashboard' },
+        { name: 'upstream', url: 'https://github.com/test2/che-dashboard' },
+      ];
+      expect(getGitRemotes(input)).toMatchObject(expected);
+    });
+
+    it('should return remotes when three remotes are provided', () => {
+      const input =
+        '{https://github.com/test1/che-dashboard, https://github.com/test2/che-dashboard, https://github.com/test3/che-dashboard}';
+      const expected: GitRemote[] = [
+        { name: 'origin', url: 'https://github.com/test1/che-dashboard' },
+        { name: 'upstream', url: 'https://github.com/test2/che-dashboard' },
+        { name: 'fork1', url: 'https://github.com/test3/che-dashboard' },
+      ];
+      expect(getGitRemotes(input)).toMatchObject(expected);
+    });
+
+    it('should return remotes when two remotes with names are provided', () => {
+      const input =
+        '{{test1,https://github.com/test1/che-dashboard},{test2,https://github.com/test2/che-dashboard}}';
+      const expected: GitRemote[] = [
+        { name: 'test1', url: 'https://github.com/test1/che-dashboard' },
+        { name: 'test2', url: 'https://github.com/test2/che-dashboard' },
+      ];
+      expect(getGitRemotes(input)).toMatchObject(expected);
+    });
+
+    it('should return remotes when one remote with name is provided', () => {
+      const input = '{{test1,https://github.com/test1/che-dashboard}}';
+      const expected: GitRemote[] = [
+        { name: 'test1', url: 'https://github.com/test1/che-dashboard' },
+      ];
+      expect(getGitRemotes(input)).toMatchObject(expected);
+    });
+
+    it('should return remotes when multiple remotes with names are provided', () => {
+      const input =
+        '{{test1,https://github.com/test1/che-dashboard},{test2,https://github.com/test2/che-dashboard},{test3,https://github.com/test3/che-dashboard},{test4,https://github.com/test4/che-dashboard}}';
+      const expected: GitRemote[] = [
+        { name: 'test1', url: 'https://github.com/test1/che-dashboard' },
+        { name: 'test2', url: 'https://github.com/test2/che-dashboard' },
+        { name: 'test3', url: 'https://github.com/test3/che-dashboard' },
+        { name: 'test4', url: 'https://github.com/test4/che-dashboard' },
+      ];
+      expect(getGitRemotes(input)).toMatchObject(expected);
+    });
+
+    it('should throw error when cannot parse remotes input', () => {
+      const input =
+        '{{https://github.com/test1/che-dashboard,https://github.com/test2/che-dashboard}';
+      expect(() => {
+        getGitRemotes(input);
+      }).toThrow();
+    });
+  });
+
+  describe('sanitizeValue()', () => {
+    it('should remove all whitespaces', () => {
+      const input =
+        '[ https://github.com/test1/che-dashboard, https://github.com/test2/che-dashboard   ] ';
+      const expected =
+        '["https://github.com/test1/che-dashboard","https://github.com/test2/che-dashboard"]';
+      expect(sanitizeValue(input)).toBe(expected);
+    });
+    it('should convert left braces', () => {
+      const input =
+        '{{test,https://github.com/test1/che-dashboard],{test2,https://github.com/test2/che-dashboard]]';
+      const expected =
+        '[["test","https://github.com/test1/che-dashboard"],["test2","https://github.com/test2/che-dashboard"]]';
+      expect(sanitizeValue(input)).toBe(expected);
+    });
+    it('should convert right braces', () => {
+      const input =
+        '[[test,https://github.com/test1/che-dashboard},[test2,https://github.com/test2/che-dashboard}}';
+      const expected =
+        '[["test","https://github.com/test1/che-dashboard"],["test2","https://github.com/test2/che-dashboard"]]';
+      expect(sanitizeValue(input)).toBe(expected);
+    });
+    it('should add quotations beside left square brackets', () => {
+      const input =
+        '[[test","https://github.com/test1/che-dashboard"],[test2","https://github.com/test2/che-dashboard"]]';
+      const expected =
+        '[["test","https://github.com/test1/che-dashboard"],["test2","https://github.com/test2/che-dashboard"]]';
+      expect(sanitizeValue(input)).toBe(expected);
+    });
+    it('should add quotations beside right square brackets', () => {
+      const input =
+        '[["test","https://github.com/test1/che-dashboard],["test2","https://github.com/test2/che-dashboard]]';
+      const expected =
+        '[["test","https://github.com/test1/che-dashboard"],["test2","https://github.com/test2/che-dashboard"]]';
+      expect(sanitizeValue(input)).toBe(expected);
+    });
+    it('should add quotations when in between two strings', () => {
+      const input =
+        '[["test,https://github.com/test1/che-dashboard"],["test2,https://github.com/test2/che-dashboard"]]';
+      const expected =
+        '[["test","https://github.com/test1/che-dashboard"],["test2","https://github.com/test2/che-dashboard"]]';
+      expect(sanitizeValue(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getGitRemotes.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getGitRemotes.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import common from '@eclipse-che/common';
+
+export interface GitRemote {
+  name: string;
+  url: string;
+}
+
+/**
+ * Returns parsed Git remotes given a string in one of the following
+ * formats:
+ *
+ * 1. Explicit name and URL
+ * {{origin,https://git...},{upstream,https://git...},...}
+ *
+ * 2. URLs only, name is implicit: first is origin, second is upstream, subsequent are fork1, fork2
+ * {https://git...,https://git...,...}
+ *
+ * @param remotes input string to parse
+ * @returns parsed array of Git remotes
+ */
+export function getGitRemotes(remotes: string): GitRemote[] {
+  if (remotes.length === 0) {
+    return [];
+  }
+  const remotesArray = parseRemotes(remotes);
+  if (Array.isArray(remotesArray[0])) {
+    return parseNameAndUrls(remotesArray, remotes);
+  }
+  return parseUrls(remotesArray, remotes);
+}
+
+function parseRemotes(remotes: string): string[] {
+  try {
+    return JSON.parse(sanitizeValue(remotes));
+  } catch (e) {
+    throw `Unable to parse remotes attribute. ${common.helpers.errors.getMessage(e)}`;
+  }
+}
+
+/**
+ * Replaces braces ({}) with square brackets ([]) and adds
+ * quotation marks (") around strings
+ * @param str
+ * @returns string representing an array
+ */
+export function sanitizeValue(str: string): string {
+  return (
+    str
+      .replace(/\s/g, '')
+      .replace(/{/g, '[')
+      .replace(/}/g, ']')
+      /* eslint-disable no-useless-escape */
+      // replace '[<string>' with '["<char>'
+      .replace(/(\[([^\["]))/g, '["$2')
+      // replace '<string>]' with '<char>"]'
+      .replace(/(([^\]"])\])/g, '$2"]')
+      // replace '<string>,<string>' with '<char>","<char>'
+      .replace(/(([^\]"]),([^\["]))/g, '$2","$3')
+    /* eslint-enable no-useless-escape */
+  );
+}
+
+function parseNameAndUrls(remotesArray, remotesString): GitRemote[] {
+  const remotes: GitRemote[] = [];
+  remotesArray.forEach(value => {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw `Malformed remotes provided: ${remotesString}`;
+    }
+    remotes.push({ name: value[0], url: value[1] });
+  });
+  return remotes;
+}
+
+function parseUrls(remotesArray, remotesString): GitRemote[] {
+  const remotes: GitRemote[] = [];
+
+  remotesArray.forEach((value, i) => {
+    if (typeof value !== 'string') {
+      throw `Malformed remotes provided: ${remotesString}`;
+    }
+
+    let name;
+    if (i === 0) {
+      name = 'origin';
+    } else if (i === 1) {
+      name = 'upstream';
+    } else {
+      name = `fork${i - 1}`;
+    }
+    remotes.push({ name, url: value });
+  });
+  return remotes;
+}

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -32,6 +32,7 @@ import {
   MIN_STEP_DURATION_MS,
   OVERRIDE_ATTR_PREFIX,
   TIMEOUT_TO_RESOLVE_SEC,
+  REMOTES_ATTR,
 } from '../../../../../const';
 import { StateMock } from '@react-mock/state';
 import buildFactoryParams from '../../../../buildFactoryParams';
@@ -130,6 +131,21 @@ describe('Factory Loader container, step CREATE_WORKSPACE__FETCH_DEVFILE', () =>
     userEvent.click(restartButton);
 
     expect(mockOnRestart).toHaveBeenCalled();
+  });
+
+  test('no project url, remotes exist', async () => {
+    const store = new FakeStoreBuilder().build();
+
+    const remotesAttr =
+      '{{test-1,http://git-test-1.git},{test-2,http://git-test-2.git},{test-3,http://git-test-3.git}}';
+    searchParams.append(REMOTES_ATTR, remotesAttr);
+    searchParams.delete(FACTORY_URL_ATTR);
+
+    renderComponent(store, loaderSteps, searchParams);
+
+    jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
+
+    await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
   });
 
   describe('step title', () => {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -117,11 +117,20 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
   private init() {
     const { factoryResolver } = this.props;
     const { factoryParams, useDefaultDevfile } = this.state;
-    const { sourceUrl } = factoryParams;
+    const { sourceUrl, remotes } = factoryParams;
     if (sourceUrl && (useDefaultDevfile || sourceUrl === factoryResolver?.location)) {
       // prevent a resource being fetched one more time
       this.setState({
         shouldResolve: false,
+      });
+    }
+
+    // make it possible to start a workspace without a sourceUrl as long as
+    // remotes are specified
+    if (!sourceUrl && remotes) {
+      this.setState({
+        shouldResolve: false,
+        useDefaultDevfile: true,
       });
     }
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Initialize/index.tsx
@@ -82,12 +82,12 @@ class StepInitialize extends AbstractLoaderStep<Props, State> {
   protected async runStep(): Promise<boolean> {
     await delay(MIN_STEP_DURATION_MS);
 
-    const { useDevworkspaceResources, sourceUrl, errorCode, policiesCreate } =
+    const { useDevworkspaceResources, sourceUrl, errorCode, policiesCreate, remotes } =
       this.state.factoryParams;
 
     if (useDevworkspaceResources === true && sourceUrl === '') {
       throw new Error('Devworkspace resources URL is missing.');
-    } else if (useDevworkspaceResources === false && sourceUrl === '') {
+    } else if (useDevworkspaceResources === false && sourceUrl === '' && !remotes) {
       const factoryPath = generatePath(ROUTE.FACTORY_LOADER_URL, {
         url: 'your-repository-url',
       });

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/buildFactoryParams.ts
@@ -19,6 +19,7 @@ import {
   OVERRIDE_ATTR_PREFIX,
   POLICIES_CREATE_ATTR,
   STORAGE_TYPE_ATTR,
+  REMOTES_ATTR,
 } from '../const';
 import { ErrorCode, FactoryParams, PoliciesCreate } from './types';
 
@@ -32,6 +33,7 @@ export default function (searchParams: URLSearchParams): FactoryParams {
     policiesCreate: getPoliciesCreate(searchParams),
     sourceUrl: getSourceUrl(searchParams),
     storageType: getStorageType(searchParams),
+    remotes: getRemotes(searchParams),
     useDevworkspaceResources: getDevworkspaceResourcesUrl(searchParams) !== undefined,
   };
 }
@@ -72,6 +74,10 @@ function getEditorId(searchParams: URLSearchParams): string | undefined {
 
 function getErrorCode(searchParams: URLSearchParams): ErrorCode | undefined {
   return (searchParams.get(ERROR_CODE_ATTR) as ErrorCode) || undefined;
+}
+
+function getRemotes(searchParams: URLSearchParams): string | undefined {
+  return searchParams.get(REMOTES_ATTR) || undefined;
 }
 
 function buildFactoryId(searchParams: URLSearchParams): string {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/types.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/types.tsx
@@ -20,6 +20,7 @@ export type FactoryParams = {
   errorCode: ErrorCode | undefined;
   storageType: che.WorkspaceStorageType | undefined;
   cheEditor: string | undefined;
+  remotes: string | undefined;
 };
 
 export type PoliciesCreate = 'perclick' | 'peruser';

--- a/packages/dashboard-frontend/src/containers/Loader/const.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/const.tsx
@@ -16,6 +16,7 @@ export const ERROR_CODE_ATTR = 'error_code';
 export const FACTORY_URL_ATTR = 'url';
 export const POLICIES_CREATE_ATTR = 'policies.create';
 export const STORAGE_TYPE_ATTR = 'storageType';
+export const REMOTES_ATTR = 'remotes';
 export const PROPAGATE_FACTORY_ATTRS = [
   'workspaceDeploymentAnnotations',
   'workspaceDeploymentLabels',
@@ -24,6 +25,7 @@ export const PROPAGATE_FACTORY_ATTRS = [
   FACTORY_URL_ATTR,
   POLICIES_CREATE_ATTR,
   STORAGE_TYPE_ATTR,
+  REMOTES_ATTR,
 ];
 export const OVERRIDE_ATTR_PREFIX = 'override.';
 

--- a/packages/dashboard-frontend/src/preload/index.ts
+++ b/packages/dashboard-frontend/src/preload/index.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { PROPAGATE_FACTORY_ATTRS } from '../containers/Loader/const';
+import { PROPAGATE_FACTORY_ATTRS, REMOTES_ATTR } from '../containers/Loader/const';
 import SessionStorageService, { SessionStorageKey } from '../services/session-storage';
 
 (function acceptNewFactoryLink(): void {
@@ -28,6 +28,13 @@ import SessionStorageService, { SessionStorageKey } from '../services/session-st
     }
     window.location.href =
       window.location.origin + '/dashboard' + buildFactoryLoaderPath(factoryUrl);
+  } else if (
+    window.location.search.startsWith(`?${REMOTES_ATTR}=`) ||
+    window.location.search.includes(`&${REMOTES_ATTR}=`)
+  ) {
+    // allow starting workspaces when no project url, but remotes are provided
+    window.location.href =
+      window.origin + '/dashboard' + buildFactoryLoaderPath(window.location.href, false);
   } else {
     window.location.href = window.location.origin + '/dashboard/';
   }
@@ -39,7 +46,7 @@ export function storePathIfNeeded(path: string) {
   }
 }
 
-export function buildFactoryLoaderPath(url: string): string {
+export function buildFactoryLoaderPath(url: string, appendUrl = true): string {
   const fullUrl = new window.URL(url);
 
   const initParams = PROPAGATE_FACTORY_ATTRS.map(paramName => {
@@ -57,7 +64,10 @@ export function buildFactoryLoaderPath(url: string): string {
   }
 
   const searchParams = new URLSearchParams(initParams);
-  searchParams.append('url', fullUrl.toString());
+
+  if (appendUrl) {
+    searchParams.append('url', fullUrl.toString());
+  }
 
   return '/f?' + searchParams.toString();
 }

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -532,7 +532,6 @@ export class DevWorkspaceClient extends WorkspaceClient {
       },
     ];
     return DwApi.patchWorkspace(namespace, name, patch);
-    await delay();
   }
 
   /**

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -223,9 +223,13 @@ export class FakeStoreBuilder {
   ): FakeStoreBuilder {
     if (options.resolver) {
       this.state.factoryResolver.resolver = Object.assign({}, options.resolver as ResolverState);
+    } else {
+      delete this.state.factoryResolver.resolver;
     }
     if (options.converted) {
       this.state.factoryResolver.converted = Object.assign({}, options.converted as ConvertedState);
+    } else {
+      delete this.state.factoryResolver.converted;
     }
     this.state.factoryResolver.isLoading = isLoading;
     return this;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Backports https://github.com/eclipse-che/che-dashboard/pull/691 to Che 7.58


### What issues does this PR fix or reference?
Part of https://issues.redhat.com/browse/CRW-3482 and https://github.com/eclipse/che/issues/21315

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Please refer to the original PR: https://github.com/eclipse-che/che-dashboard/pull/691

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
