### PR TITLE
Backport: Remove "browser you are using is not supported" warning

### DIFF
--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__tests__/index.spec.tsx
@@ -13,13 +13,19 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import BannerAlertNotSupportedBrowser from '..';
-import { isSafari } from '../../../../services/helpers/detectBrowser';
+
+const mockIsSupportedBrowser = jest.fn();
+jest.mock('../isSupportedBrowser', () => ({
+  isSupportedBrowser: () => mockIsSupportedBrowser(),
+}));
 
 const unsupportedBrowserMessage = 'The browser you are using is not supported.';
 
 describe('BannerAlertNotSupportedBrowser component', () => {
   it('should not show error message', () => {
+    mockIsSupportedBrowser.mockReturnValue(true);
     render(<BannerAlertNotSupportedBrowser />);
+
     expect(
       screen.queryByText(unsupportedBrowserMessage, {
         exact: false,
@@ -27,9 +33,8 @@ describe('BannerAlertNotSupportedBrowser component', () => {
     ).toBeFalsy();
   });
 
-  it('should show error message when error found after mounting', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (isSafari as any) = true;
+  it('should show error message', () => {
+    mockIsSupportedBrowser.mockReturnValue(false);
     render(<BannerAlertNotSupportedBrowser />);
 
     expect(

--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/index.tsx
@@ -12,12 +12,12 @@
 
 import { Banner } from '@patternfly/react-core';
 import React from 'react';
-import { isSafari } from '../../../services/helpers/detectBrowser';
+import { isSupportedBrowser } from './isSupportedBrowser';
 
 type Props = unknown;
 
 type State = {
-  isNotSupported: boolean;
+  isSupportedBrowser: boolean;
 };
 
 export default class BannerAlertNotSupportedBrowser extends React.PureComponent<Props, State> {
@@ -25,12 +25,12 @@ export default class BannerAlertNotSupportedBrowser extends React.PureComponent<
     super(props);
 
     this.state = {
-      isNotSupported: isSafari,
+      isSupportedBrowser: isSupportedBrowser(),
     };
   }
 
   render() {
-    if (this.state.isNotSupported === false) {
+    if (this.state.isSupportedBrowser === true) {
       return null;
     }
 

--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/isSupportedBrowser.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/isSupportedBrowser.tsx
@@ -10,4 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-export const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+// Tests browser for features it has to support
+export function isSupportedBrowser(): boolean {
+  return true;
+}

--- a/packages/dashboard-frontend/src/components/BannerAlert/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/index.tsx
@@ -14,7 +14,6 @@ import React from 'react';
 import BannerAlertBranding from './Branding';
 import BannerAlertWebSocket from './WebSocket';
 import BannerAlertCustomWarning from './Custom';
-import BannerAlertNotSupportedBrowser from './NotSupportedBrowser';
 
 type Props = unknown;
 
@@ -27,7 +26,6 @@ export class BannerAlert extends React.PureComponent<Props, State> {
     super(props);
     this.state = {
       bannerAlerts: [
-        <BannerAlertNotSupportedBrowser key="BannerAlertNotSupportedBrowser"></BannerAlertNotSupportedBrowser>,
         <BannerAlertWebSocket key="BannerAlertWebSocket"></BannerAlertWebSocket>,
         <BannerAlertBranding key="BannerAlertBranding"></BannerAlertBranding>,
         <BannerAlertCustomWarning key="BannerAlertCustomWarning"></BannerAlertCustomWarning>,


### PR DESCRIPTION


cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/701
