### PR TITLE
chore: Respect spec.devEnvironments.maxNumberOfRunningWorkspacesPerUs…

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -113,8 +113,8 @@ export class ServerConfigApiService implements IServerConfigApi {
 
   getRunningWorkspacesLimit(cheCustomResource: CustomResourceDefinition): number {
     return (
-      cheCustomResource.spec.components?.devWorkspace?.runningLimit ||
       cheCustomResource.spec.devEnvironments?.maxNumberOfRunningWorkspacesPerUser ||
+      cheCustomResource.spec.components?.devWorkspace?.runningLimit ||
       1
     );
   }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -111,10 +111,12 @@ export class ServerConfigApiService implements IServerConfigApi {
     return cheCustomResource.spec.components?.dashboard?.headerMessage?.text;
   }
 
+  // getRunningWorkspacesLimit return the maximum number of running workspaces.
+  // See https://github.com/eclipse-che/che-operator/pull/1585 for details.
   getRunningWorkspacesLimit(cheCustomResource: CustomResourceDefinition): number {
     return (
       cheCustomResource.spec.devEnvironments?.maxNumberOfRunningWorkspacesPerUser ||
-      cheCustomResource.spec.components?.devWorkspace?.rt ||
+      cheCustomResource.spec.components?.devWorkspace?.runningLimit ||
       1
     );
   }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -114,7 +114,7 @@ export class ServerConfigApiService implements IServerConfigApi {
   getRunningWorkspacesLimit(cheCustomResource: CustomResourceDefinition): number {
     return (
       cheCustomResource.spec.devEnvironments?.maxNumberOfRunningWorkspacesPerUser ||
-      cheCustomResource.spec.components?.devWorkspace?.runningLimit ||
+      cheCustomResource.spec.components?.devWorkspace?.rt ||
       1
     );
   }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -112,7 +112,11 @@ export class ServerConfigApiService implements IServerConfigApi {
   }
 
   getRunningWorkspacesLimit(cheCustomResource: CustomResourceDefinition): number {
-    return cheCustomResource.spec.components?.devWorkspace?.runningLimit || 1;
+    return (
+      cheCustomResource.spec.components?.devWorkspace?.runningLimit ||
+      cheCustomResource.spec.devEnvironments?.maxNumberOfRunningWorkspacesPerUser ||
+      1
+    );
   }
 
   getWorkspaceInactivityTimeout(cheCustomResource: CustomResourceDefinition): number {

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -122,6 +122,7 @@ export type CustomResourceDefinitionSpecDevEnvironments = {
   storage?: {
     pvcStrategy?: string;
   };
+  maxNumberOfRunningWorkspacesPerUser: number;
 };
 
 export type CustomResourceDefinitionSpecComponents = {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/selectors.ts
@@ -40,5 +40,5 @@ export const selectRunningDevWorkspacesLimitExceeded = createSelector(
   selectRunningDevWorkspaces,
   selectRunningWorkspacesLimit,
   (runningDevWorkspaces, runningWorkspacesLimit) =>
-    runningDevWorkspaces.length >= runningWorkspacesLimit,
+    runningWorkspacesLimit !== -1 && runningDevWorkspaces.length >= runningWorkspacesLimit,
 );


### PR DESCRIPTION
…er as running limit for workspaces

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Respect `spec.devEnvironments.maxNumberOfRunningWorkspacesPerUser` as running limit for workspaces
* Allow unlimited number of running workspaces

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21860

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
N/A

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A