### PR TITLE
feat: infer origin remote if not provided in remote url paramter

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getProjectFromUrl.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/getProjectFromUrl.ts
@@ -13,12 +13,12 @@
 import { getProjectName } from '../../../../../../services/helpers/getProjectName';
 import { V220DevfileProjects } from '@devfile/api';
 
-export function getProjectFromUrl(url: string): V220DevfileProjects {
+export function getProjectFromUrl(url: string, remoteName = 'origin'): V220DevfileProjects {
   const sourceUrl = new URL(url);
   const name = getProjectName(url);
   if (sourceUrl.pathname.endsWith('.git')) {
     const origin = `${sourceUrl.origin}${sourceUrl.pathname}`;
-    return { git: { remotes: { origin } }, name };
+    return { git: { remotes: { [remoteName]: origin } }, name };
   } else {
     const sources = sourceUrl.pathname.split('/tree/');
     const origin = `${sourceUrl.origin}${sources[0]}.git`;
@@ -26,12 +26,12 @@ export function getProjectFromUrl(url: string): V220DevfileProjects {
 
     if (revision) {
       return {
-        git: { remotes: { origin }, checkoutFrom: { revision } },
+        git: { remotes: { [remoteName]: origin }, checkoutFrom: { revision } },
         name,
       };
     } else {
       return {
-        git: { remotes: { origin } },
+        git: { remotes: { [remoteName]: origin } },
         name,
       };
     }

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -39,8 +39,8 @@ import { AlertItem } from '../../../../../../services/helpers/types';
 import { selectDefaultDevfile } from '../../../../../../store/DevfileRegistries/selectors';
 import ExpandableWarning from '../../../../../../components/ExpandableWarning';
 import { getProjectFromUrl } from './getProjectFromUrl';
-import { getGitRemotes } from './getGitRemotes';
-import { V220DevfileProjects } from '@devfile/api';
+import { getGitRemotes, GitRemote } from './getGitRemotes';
+import { V220DevfileProjects, V220DevfileProjectsItemsGit } from '@devfile/api';
 import { getProjectName } from '../../../../../../services/helpers/getProjectName';
 
 export class CreateWorkspaceError extends Error {
@@ -321,40 +321,60 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     isDefaultDevfile: boolean,
   ) {
     const parsedRemotes = getGitRemotes(remotes);
-    const gitRemotes = parsedRemotes.reduce((map, remote) => {
-      map[remote.name] = remote.url;
-      return map;
-    }, {});
 
-    const projectName = getProjectName(parsedRemotes[0].url);
-
-    const gitProject = this.getGitProjectForRemotes(devfile.projects);
-    if (gitProject) {
-      // edit existing Git project remote
-      gitProject.remotes = gitRemotes;
-      gitProject.checkoutFrom = { remote: parsedRemotes[0].name };
-    } else {
-      devfile.projects = [
-        {
-          git: {
-            remotes: gitRemotes,
-            checkoutFrom: { remote: parsedRemotes[0].name },
-          },
-          name: projectName,
-        },
-      ];
+    // Determine the remote to set `checkoutFrom.remote` to
+    let checkoutRemote = parsedRemotes.find(remote => remote.name === 'origin');
+    if (!checkoutRemote) {
+      checkoutRemote = parsedRemotes[0];
     }
 
+    // Find the Git project in the devfile to configure remotes for
+    let gitProject = this.getGitProjectForConfiguringRemotes(devfile.projects);
+    if (!gitProject) {
+      if (!devfile.projects) {
+        devfile.projects = [];
+      }
+      devfile.projects[0] = getProjectFromUrl(checkoutRemote.url, checkoutRemote.name);
+      gitProject = devfile.projects[0].git;
+    } else if (Object.keys(gitProject.remotes).includes('origin')) {
+      checkoutRemote = { name: 'origin', url: gitProject.remotes.origin };
+    }
+
+    this.addRemotesToProject(gitProject!, checkoutRemote, parsedRemotes);
+
     if (isDefaultDevfile) {
+      const projectName = getProjectName(checkoutRemote.url);
       devfile.metadata.name = projectName;
       devfile.metadata.generateName = projectName;
     }
   }
 
   /**
+   * Add the remotes specified in `newRemotes` to the `gitProject`.
+   * @param gitProject The Git project to add the new remotes to
+   * @param checkoutRemote The Git remote to set checkoutFrom.remote to
+   * @param newRemotes The array of new Git remotes to add
+   */
+  private addRemotesToProject(
+    gitProject: V220DevfileProjectsItemsGit,
+    checkoutRemote: GitRemote,
+    newRemotes: GitRemote[],
+  ) {
+    const gitRemotes = newRemotes.reduce((map, remote) => {
+      map[remote.name] = remote.url;
+      return map;
+    }, {});
+
+    gitProject.remotes = Object.assign(gitProject.remotes, gitRemotes);
+    gitProject.checkoutFrom = Object.assign(gitProject.checkoutFrom || {}, {
+      remote: checkoutRemote.name,
+    });
+  }
+
+  /**
    * Returns the Git project to replace remotes for
    */
-  private getGitProjectForRemotes(projects: V220DevfileProjects[] | undefined) {
+  private getGitProjectForConfiguringRemotes(projects: V220DevfileProjects[] | undefined) {
     if (!projects) {
       return undefined;
     }


### PR DESCRIPTION
Signed-off-by: dkwon17 <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Implements the functionality described in [here](https://issues.redhat.com/browse/CRW-3482?focusedCommentId=21521544&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21521544)

> If the origin remote is not provided as a parameter we should infer it (as well as the branch) from the URL:
> 
> https://<che-host>#<origin-git-url>?remotes={{upstream,https://github...}}
> The remote to checkout should be the <origin-git-url>.
> 
> Note that the URL could be a raw devfile URL too and in this case we should not use it to add a remote.

    
This is acheived by adding remotes to the projects[0].git.remotes
instead of replacing them.

Additionally if the 'origin' remote exists, projects[0].git.checkoutFrom.remote will be set to 'origin'. If not, first the remote from remotes parameter will be used.

### What issues does this PR fix or reference?
Part of https://issues.redhat.com/browse/CRW-3482

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

To test locally, follow these [steps](https://github.com/eclipse-che/che-dashboard#running-locally-against-remote-che-cluster-nodejs-v16).

Visit `<CHE-HOST>#https://github.com/dkwon17/che-dashboard/tree/7.58.x?remotes={{upstream,https://github.com/eclipse-che/che-dashboard}}`

The resulting DevWorkspace's `spec.template.projects` should have the `origin` remote:
```
    projects:
      - git:
          checkoutFrom:
            revision: 7.58.x
            remote: origin
          remotes:
            origin: 'https://github.com/dkwon17/che-dashboard'
            upstream: 'https://github.com/eclipse-che/che-dashboard'
        name: che-dashboard
```

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
