### PR TITLE
Do not throw oauth provider not found error on workspace start

### DIFF
--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -159,12 +159,6 @@ export const actionCreators: ActionCreators = {
       dispatch({ type: 'REQUEST_WORKSPACES' });
       try {
         await OAuthService.refreshTokenIfNeeded(workspace);
-
-        const debugWorkspace = params && params['debug-workspace-start'];
-        await dispatch(
-          DevWorkspacesStore.actionCreators.startWorkspace(workspace.ref, debugWorkspace),
-        );
-        dispatch({ type: 'UPDATE_WORKSPACE' });
       } catch (e) {
         if (common.helpers.errors.includesAxiosResponse(e)) {
           const response = e.response;
@@ -185,9 +179,12 @@ export const actionCreators: ActionCreators = {
             return;
           }
         }
-        dispatch({ type: 'RECEIVE_ERROR' });
-        throw e;
       }
+      const debugWorkspace = params && params['debug-workspace-start'];
+      await dispatch(
+        DevWorkspacesStore.actionCreators.startWorkspace(workspace.ref, debugWorkspace),
+      );
+      dispatch({ type: 'UPDATE_WORKSPACE' });
     },
 
   restartWorkspace:


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Catch only the unauthorised exception when fetching oauth token on workspace start. Do not throw any other errors.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21896

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy che without any oAuth providers.
2. Start a factory from a public GitHub repo.
3. Stop the workspace.
4. Restart the che pod in the openshift console
5.  Start the workspace.
See: no error appears.


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
