### PR TITLE
Pin buildx to v0.9.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
       -
         name: "Docker quay.io Login"
         uses: docker/login-action@v2


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Attempt to fix release by pinning buildx to 0.9.1 since it seems to have broken when the image updated to 0.10.0

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
