### PR TITLE
Fix dev-server webpack configuration

### DIFF
--- a/packages/dashboard-frontend/webpack.config.dev-server.js
+++ b/packages/dashboard-frontend/webpack.config.dev-server.js
@@ -25,7 +25,7 @@ module.exports = () => {
         logging: 'info',
       },
       devMiddleware: {
-        publicPath: '/',
+        publicPath: '/dashboard/',
         writeToDisk: false,
       },
       host: 'localhost',
@@ -47,7 +47,25 @@ module.exports = () => {
           changeOrigin: true,
           headers,
         },
+        '/dashboard/devfile-registry': {
+          target: headers.origin,
+          secure: false,
+          changeOrigin: true,
+          headers,
+        },
         '/dashboard/api': {
+          target: headers.origin,
+          secure: false,
+          changeOrigin: true,
+          headers,
+        },
+        '/auth': {
+          target: headers.origin,
+          secure: false,
+          changeOrigin: true,
+          headers,
+        },
+        '/oauth': {
           target: headers.origin,
           secure: false,
           changeOrigin: true,


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix dev-server webpack configuration.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21939

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Running locally against remote Che Cluster
```yarn```
```yarn start:prepare```
```yarn start```
2. Login http://localhost:8080/dashboard/
3. Run Dev Server
```yarn frontend:start```
4. Open http://localhost:3000/dashboard/ 

