### PR TITLE
fix: set buildx version to 0.9.1

### DIFF
--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -41,6 +41,8 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
       -
         name: "Docker quay.io Login"
         uses: docker/login-action@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,6 +94,8 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.platform }}"
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
       -
         name: "Cache Docker layers"
         uses: actions/cache@v3


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Set buildx version to 0.9.1 to fix `Next container image` and `PR` workflows.
