### PR TITLE
Show warning when unsupported Devfile features used

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -79,10 +79,10 @@ export interface IDevWorkspaceList {
   items: V1alpha2DevWorkspace[];
 }
 
-export interface IDevworkspaceResources {
+export interface IDevWorkspaceResources {
   devfileContent: string | undefined;
   editorPath: string | undefined;
   pluginRegistryUrl: string | undefined;
-  editorEntry: string | undefined;
+  editorId: string | undefined;
   editorContent: string | undefined;
 }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceApi.spec.ts
@@ -22,6 +22,7 @@ import { api } from '@eclipse-che/common';
 import { IPatch } from '@eclipse-che/common/src/dto/api';
 import * as mockClient from '@kubernetes/client-node';
 import { CustomObjectsApi } from '@kubernetes/client-node';
+import { IncomingMessage } from 'http';
 import { DevWorkspaceApiService } from '../devWorkspaceApi';
 
 const namespace = 'user-che';
@@ -32,7 +33,10 @@ describe('DevWorkspace API Service', () => {
 
   const stubCustomObjectsApi = {
     createNamespacedCustomObject: () => {
-      return Promise.resolve({ body: getDevWorkspace() });
+      return Promise.resolve({
+        body: getDevWorkspace(),
+        response: { headers: {} } as IncomingMessage,
+      });
     },
     deleteNamespacedCustomObject: () => {
       return Promise.resolve({ body: {} });
@@ -123,7 +127,8 @@ describe('DevWorkspace API Service', () => {
     } as V1alpha2DevWorkspace;
 
     const res = await devWorkspaceService.create(devWorkspace, namespace);
-    expect(res).toEqual(getDevWorkspace());
+    expect(res.devWorkspace).toStrictEqual(getDevWorkspace());
+    expect(res.headers).toStrictEqual({});
     expect(spyCreateNamespacedCustomObject).toHaveBeenCalledWith(
       devworkspaceGroup,
       devworkspaceLatestVersion,

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceApi.spec.ts
@@ -48,7 +48,10 @@ describe('DevWorkspace API Service', () => {
       return Promise.resolve({ body: buildListNamespacesCustomObject() });
     },
     patchNamespacedCustomObject: () => {
-      return Promise.resolve({ body: getDevWorkspace() });
+      return Promise.resolve({
+        body: getDevWorkspace(),
+        response: { headers: {} } as IncomingMessage,
+      });
     },
     replaceNamespacedCustomObject: () => {
       return Promise.resolve({ body: getDevWorkspace() });
@@ -74,10 +77,6 @@ describe('DevWorkspace API Service', () => {
   const spyPatchNamespacedCustomObject = jest.spyOn(
     stubCustomObjectsApi,
     'patchNamespacedCustomObject',
-  );
-  const spyReplaceNamespacedCustomObject = jest.spyOn(
-    stubCustomObjectsApi,
-    'replaceNamespacedCustomObject',
   );
 
   beforeEach(() => {
@@ -148,7 +147,8 @@ describe('DevWorkspace API Service', () => {
     ];
 
     const res = await devWorkspaceService.patch(namespace, name, patches);
-    expect(res).toEqual(getDevWorkspace());
+    expect(res.devWorkspace).toStrictEqual(getDevWorkspace());
+    expect(res.headers).toStrictEqual({});
     expect(spyPatchNamespacedCustomObject).toHaveBeenCalledWith(
       devworkspaceGroup,
       devworkspaceLatestVersion,
@@ -160,28 +160,6 @@ describe('DevWorkspace API Service', () => {
       undefined,
       undefined,
       expect.anything(),
-    );
-  });
-
-  test('updating', async () => {
-    const devWorkspace = {
-      apiVersion: 'workspace.devfile.io/v1alpha2',
-      kind: 'DevWorkspace',
-      metadata: {
-        name: 'wksp-name',
-        namespace,
-      },
-    } as V1alpha2DevWorkspace;
-
-    const res = await devWorkspaceService.update(devWorkspace);
-    expect(res).toEqual(getDevWorkspace());
-    expect(spyReplaceNamespacedCustomObject).toHaveBeenCalledWith(
-      devworkspaceGroup,
-      devworkspaceLatestVersion,
-      namespace,
-      devworkspacePlural,
-      devWorkspace.metadata?.name,
-      devWorkspace,
     );
   });
 

--- a/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspaceApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspaceApi.ts
@@ -71,6 +71,17 @@ export class DevWorkspaceApiService implements IDevWorkspaceApi {
     }
   }
 
+  private propagateHeaders(resp: { response: http.IncomingMessage; body: unknown }) {
+    const propagateHeaders = ['warning'];
+    const headers = Object.entries(resp.response.headers).reduce((acc, [key, value]) => {
+      if (propagateHeaders.includes(key)) {
+        acc[key] = value;
+      }
+      return acc;
+    }, {} as Partial<IncomingHttpHeaders>);
+    return headers;
+  }
+
   async create(
     devworkspace: V1alpha2DevWorkspace,
     namespace: string,
@@ -90,52 +101,10 @@ export class DevWorkspaceApiService implements IDevWorkspaceApi {
         devworkspace,
       );
       const devWorkspace = resp.body as V1alpha2DevWorkspace;
-
-      const propagateHeaders = ['warning'];
-      const headers = Object.entries(resp.response.headers).reduce((acc, [key, value]) => {
-        if (propagateHeaders.includes(key)) {
-          acc[key] = value;
-        }
-        return acc;
-      }, {} as Partial<IncomingHttpHeaders>);
-
+      const headers = this.propagateHeaders(resp);
       return { devWorkspace, headers };
     } catch (e) {
       throw createError(e, DEV_WORKSPACE_API_ERROR_LABEL, 'Unable to create devworkspace');
-    }
-  }
-
-  async update(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace> {
-    try {
-      if (!devworkspace.metadata?.name || !devworkspace.metadata?.namespace) {
-        throw new Error('DevWorkspace.metadata with name and namespace are required');
-      }
-
-      // you have to delete some elements from the devworkspace in order to update
-      if (devworkspace.metadata?.uid) {
-        devworkspace.metadata.uid = undefined;
-      }
-      if (devworkspace.metadata?.creationTimestamp) {
-        delete devworkspace.metadata.creationTimestamp;
-      }
-      if (devworkspace.metadata?.deletionTimestamp) {
-        delete devworkspace.metadata.deletionTimestamp;
-      }
-
-      const name = devworkspace.metadata.name;
-      const namespace = devworkspace.metadata.namespace;
-
-      const resp = await this.customObjectAPI.replaceNamespacedCustomObject(
-        devworkspaceGroup,
-        devworkspaceLatestVersion,
-        namespace,
-        devworkspacePlural,
-        name,
-        devworkspace,
-      );
-      return resp.body as V1alpha2DevWorkspace;
-    } catch (e) {
-      throw createError(e, DEV_WORKSPACE_API_ERROR_LABEL, 'Unable to update devworkspace');
     }
   }
 
@@ -164,11 +133,7 @@ export class DevWorkspaceApiService implements IDevWorkspaceApi {
     namespace: string,
     name: string,
     patches: api.IPatch[],
-  ): Promise<V1alpha2DevWorkspace> {
-    return this.createPatch(namespace, name, patches);
-  }
-
-  private async createPatch(namespace: string, name: string, patches: api.IPatch[]) {
+  ): Promise<{ devWorkspace: V1alpha2DevWorkspace; headers: Partial<IncomingHttpHeaders> }> {
     try {
       const options = {
         headers: {
@@ -187,7 +152,9 @@ export class DevWorkspaceApiService implements IDevWorkspaceApi {
         undefined,
         options,
       );
-      return resp.body as V1alpha2DevWorkspace;
+      const devWorkspace = resp.body as V1alpha2DevWorkspace;
+      const headers = this.propagateHeaders(resp);
+      return { devWorkspace, headers };
     } catch (e) {
       throw createError(e, DEV_WORKSPACE_API_ERROR_LABEL, 'Unable to patch devworkspace');
     }

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -50,22 +50,17 @@ export interface IDevWorkspaceApi extends IWatcherService {
   getByName(namespace: string, name: string): Promise<V1alpha2DevWorkspace>;
 
   /**
-   * Get list of devworkspaces in the given namespace
+   * Get list of DevWorkspaces in the given namespace
    */
   listInNamespace(namespace: string): Promise<api.IDevWorkspaceList>;
 
   /**
-   * Create a devworkspace based on the specified configuration.
+   * Create a DevWorkspace based on the specified configuration.
    */
   create(
-    devworkspace: V1alpha2DevWorkspace,
+    devWorkspace: V1alpha2DevWorkspace,
     namespace: string,
   ): Promise<{ devWorkspace: V1alpha2DevWorkspace; headers: Partial<IncomingHttpHeaders> }>;
-
-  /**
-   * Updates the DevWorkspace with the given configuration
-   */
-  update(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace>;
 
   /**
    * Delete the DevWorkspace with given name in the specified namespace
@@ -75,7 +70,11 @@ export interface IDevWorkspaceApi extends IWatcherService {
   /**
    * Patches the DevWorkspace with given name in the specified namespace
    */
-  patch(namespace: string, name: string, patches: api.IPatch[]): Promise<V1alpha2DevWorkspace>;
+  patch(
+    namespace: string,
+    name: string,
+    patches: api.IPatch[],
+  ): Promise<{ devWorkspace: V1alpha2DevWorkspace; headers: Partial<IncomingHttpHeaders> }>;
 }
 
 export interface IEventApi extends IWatcherService {

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -18,6 +18,7 @@ import {
 import { api } from '@eclipse-che/common';
 import * as k8s from '@kubernetes/client-node';
 import { MessageListener } from '../../services/types/Observer';
+import { IncomingHttpHeaders } from 'http';
 
 /**
  * Holds the methods for working with dockerconfig for devworkspace
@@ -56,7 +57,10 @@ export interface IDevWorkspaceApi extends IWatcherService {
   /**
    * Create a devworkspace based on the specified configuration.
    */
-  create(devworkspace: V1alpha2DevWorkspace, namespace: string): Promise<V1alpha2DevWorkspace>;
+  create(
+    devworkspace: V1alpha2DevWorkspace,
+    namespace: string,
+  ): Promise<{ devWorkspace: V1alpha2DevWorkspace; headers: Partial<IncomingHttpHeaders> }>;
 
   /**
    * Updates the DevWorkspace with the given configuration

--- a/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
@@ -29,14 +29,14 @@ export function registerDevworkspaceResourcesRoute(server: FastifyInstance) {
     `${baseApiPath}/devworkspace-resources`,
     getSchema({ tags, body: devWorkspaceResourcesSchema }),
     async function (request: FastifyRequest) {
-      const { devfileContent, editorPath, pluginRegistryUrl, editorEntry, editorContent } =
-        request.body as api.IDevworkspaceResources;
+      const { devfileContent, editorPath, pluginRegistryUrl, editorId, editorContent } =
+        request.body as api.IDevWorkspaceResources;
       const context = await generator.generateDevfileContext(
         {
           devfileContent,
           editorPath,
           pluginRegistryUrl,
-          editorEntry,
+          editorEntry: editorId,
           editorContent,
           projects: [],
         },

--- a/packages/dashboard-backend/src/routes/api/devworkspaces.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaces.ts
@@ -74,12 +74,19 @@ export function registerDevworkspacesRoutes(server: FastifyInstance) {
   server.patch(
     `${baseApiPath}/namespace/:namespace/devworkspaces/:workspaceName`,
     getSchema({ tags, params: namespacedWorkspaceSchema, body: devworkspacePatchSchema }),
-    async function (request: FastifyRequest) {
+    async function (request: FastifyRequest, reply: FastifyReply) {
       const { namespace, workspaceName } = request.params as restParams.INamespacedWorkspaceParams;
       const patch = request.body as api.IPatch[];
       const token = getToken(request);
       const { devworkspaceApi } = getDevWorkspaceClient(token);
-      return devworkspaceApi.patch(namespace, workspaceName, patch);
+      const { headers, devWorkspace } = await devworkspaceApi.patch(
+        namespace,
+        workspaceName,
+        patch,
+      );
+
+      reply.headers(headers);
+      reply.send(devWorkspace);
     },
   );
 

--- a/packages/dashboard-backend/src/routes/api/devworkspaces.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaces.ts
@@ -41,7 +41,7 @@ export function registerDevworkspacesRoutes(server: FastifyInstance) {
   server.post(
     `${baseApiPath}/namespace/:namespace/devworkspaces`,
     getSchema({ tags, params: namespacedSchema, body: devworkspaceSchema }),
-    async function (request: FastifyRequest) {
+    async function (request: FastifyRequest, reply: FastifyReply) {
       const { devworkspace } = request.body as restParams.IDevWorkspaceSpecParams;
       const { namespace } = request.params as restParams.INamespacedParams;
       if (!devworkspace.metadata) {
@@ -53,7 +53,10 @@ export function registerDevworkspacesRoutes(server: FastifyInstance) {
       devworkspace.metadata.namespace = namespace;
       const token = getToken(request);
       const { devworkspaceApi } = getDevWorkspaceClient(token);
-      return devworkspaceApi.create(devworkspace, namespace);
+      const { headers, devWorkspace } = await devworkspaceApi.create(devworkspace, namespace);
+
+      reply.headers(headers);
+      reply.send(devWorkspace);
     },
   );
 

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -18,6 +18,7 @@ import {
   V221DevfileComponents,
 } from '@devfile/api';
 import { api } from '@eclipse-che/common';
+import { IncomingHttpHeaders } from 'http';
 import {
   DevWorkspaceClient,
   IDevWorkspaceApi,
@@ -56,6 +57,7 @@ export const stubDevWorkspace: V1alpha2DevWorkspace = {
   apiVersion: 'workspace.devfile.io/v1alpha2',
   kind: 'DevWorkspace',
 };
+export const stubHeaders: IncomingHttpHeaders = {};
 
 export const stubDevWorkspaceTemplatesList = [
   {
@@ -95,7 +97,8 @@ export function getDevWorkspaceClient(_args: Parameters<typeof helper>): ReturnT
       getWorkspaceStartTimeout: _cheCustomResource => stubWorkspaceStartupTimeout,
     } as IServerConfigApi,
     devworkspaceApi: {
-      create: (_devworkspace, _namespace) => Promise.resolve(stubDevWorkspace),
+      create: (_devworkspace, _namespace) =>
+        Promise.resolve({ devWorkspace: stubDevWorkspace, headers: stubHeaders }),
       delete: (_namespace, _name) => Promise.resolve(undefined),
       getByName: (_namespace, _name) => Promise.resolve(stubDevWorkspace),
       listInNamespace: _namespace => Promise.resolve(stubDevWorkspacesList),

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -102,7 +102,8 @@ export function getDevWorkspaceClient(_args: Parameters<typeof helper>): ReturnT
       delete: (_namespace, _name) => Promise.resolve(undefined),
       getByName: (_namespace, _name) => Promise.resolve(stubDevWorkspace),
       listInNamespace: _namespace => Promise.resolve(stubDevWorkspacesList),
-      patch: (_namespace, _name, _patches) => Promise.resolve(stubDevWorkspace),
+      patch: (_namespace, _name, _patches) =>
+        Promise.resolve({ devWorkspace: stubDevWorkspace, headers: stubHeaders }),
     } as IDevWorkspaceApi,
     dockerConfigApi: {
       read: _namespace => Promise.resolve(stubDockerConfig),

--- a/packages/dashboard-frontend/src/components/Loader/Progress/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Loader/Progress/__tests__/__snapshots__/index.spec.tsx.snap
@@ -30,9 +30,9 @@ exports[`Loader Progress Step INITIALIZATION snapshot 1`] = `
         <svg
           aria-hidden={true}
           aria-labelledby={null}
-          className="rotate stepIcon"
+          className="inProgressIcon rotate stepIcon"
           data-testid="step-in-progress-icon"
-          fill="#0e6fe0"
+          fill="currentColor"
           height="1em"
           role="img"
           style={
@@ -135,9 +135,9 @@ exports[`Loader Progress Step INITIALIZATION snapshot 1`] = `
               <svg
                 aria-hidden={true}
                 aria-labelledby={null}
-                className="rotate stepIcon"
+                className="inProgressIcon rotate stepIcon"
                 data-testid="step-in-progress-icon"
-                fill="#0e6fe0"
+                fill="currentColor"
                 height="1em"
                 role="img"
                 style={

--- a/packages/dashboard-frontend/src/components/Loader/Progress/index.tsx
+++ b/packages/dashboard-frontend/src/components/Loader/Progress/index.tsx
@@ -30,14 +30,6 @@ export class LoaderProgress extends React.PureComponent<Props> {
     this.wizardRef = React.createRef();
   }
 
-  public componentDidUpdate(): void {
-    const { currentStepId } = this.props;
-    const wizardCurrent = this.wizardRef.current;
-    if (wizardCurrent?.state?.currentStep !== currentStepId) {
-      wizardCurrent.state.currentStep = currentStepId;
-    }
-  }
-
   render(): React.ReactNode {
     const { currentStepId, steps } = this.props;
 

--- a/packages/dashboard-frontend/src/components/Loader/Step/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Loader/Step/__tests__/__snapshots__/index.spec.tsx.snap
@@ -5,9 +5,9 @@ Array [
   <svg
     aria-hidden={true}
     aria-labelledby={null}
-    className="stepIcon"
+    className="errorIcon stepIcon"
     data-testid="step-failed-icon"
-    fill="red"
+    fill="currentColor"
     height="1em"
     role="img"
     style={
@@ -36,9 +36,9 @@ Array [
   <svg
     aria-hidden={true}
     aria-labelledby={null}
-    className="rotate stepIcon"
+    className="inProgressIcon rotate stepIcon"
     data-testid="step-in-progress-icon"
-    fill="#0e6fe0"
+    fill="currentColor"
     height="1em"
     role="img"
     style={
@@ -79,9 +79,9 @@ Array [
   <svg
     aria-hidden={true}
     aria-labelledby={null}
-    className="stepIcon"
+    className="successIcon stepIcon"
     data-testid="step-done-icon"
-    fill="green"
+    fill="currentColor"
     height="1em"
     role="img"
     style={

--- a/packages/dashboard-frontend/src/components/Loader/Step/index.module.css
+++ b/packages/dashboard-frontend/src/components/Loader/Step/index.module.css
@@ -31,3 +31,19 @@
   top: 3px;
   left: -56px;
 }
+
+.errorIcon {
+  fill: var(--pf-global--danger-color--100);
+}
+
+.warningIcon {
+  fill: var(--pf-global--warning-color--100);
+}
+
+.inProgressIcon {
+  fill: #0e6fe0;
+}
+
+.successIcon {
+  fill: var(--pf-global--success-color--100);
+}

--- a/packages/dashboard-frontend/src/components/Loader/Step/index.tsx
+++ b/packages/dashboard-frontend/src/components/Loader/Step/index.tsx
@@ -12,7 +12,12 @@
 
 import React from 'react';
 import { WizardStep } from '@patternfly/react-core';
-import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  InProgressIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
 
 import workspaceStatusLabelStyles from '../../WorkspaceStatusLabel/index.module.css';
 import styles from './index.module.css';
@@ -59,7 +64,8 @@ export class LoaderStep {
   private _id: number;
   private _title: string;
   private _parentId: number | undefined;
-  public hasError: boolean;
+  public hasError = false;
+  public hasWarning = false;
 
   static toWizardSteps(
     currentStepId: number,
@@ -97,30 +103,38 @@ export class LoaderStep {
   }
 
   private buildIcon(currentStepId: number): React.ReactNode {
-    if (currentStepId < this.id) {
-      return '';
-    }
-
-    if (currentStepId > this.id) {
-      return (
-        <CheckCircleIcon data-testid="step-done-icon" className={styles.stepIcon} color="green" />
-      );
-    }
-
     if (this.hasError) {
       return (
         <ExclamationCircleIcon
           data-testid="step-failed-icon"
-          className={styles.stepIcon}
-          color="red"
+          className={`${styles.errorIcon} ${styles.stepIcon}`}
+        />
+      );
+    }
+
+    if (this.hasWarning) {
+      return (
+        <ExclamationTriangleIcon
+          data-testid="step-warning-icon"
+          className={`${styles.warningIcon} ${styles.stepIcon}`}
+        />
+      );
+    }
+
+    if (currentStepId < this.id) {
+      return '';
+    } else if (currentStepId > this.id) {
+      return (
+        <CheckCircleIcon
+          data-testid="step-done-icon"
+          className={`${styles.successIcon} ${styles.stepIcon}`}
         />
       );
     } else {
       return (
         <InProgressIcon
           data-testid="step-in-progress-icon"
-          className={`${workspaceStatusLabelStyles.rotate} ${styles.stepIcon}`}
-          color="#0e6fe0"
+          className={`${styles.inProgressIcon} ${workspaceStatusLabelStyles.rotate} ${styles.stepIcon}`}
         />
       );
     }

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
@@ -59,9 +59,9 @@ export class WorkspaceEvents extends React.PureComponent<Props> {
     return events
       .filter(event => event.message)
       .sort(compareEventTime)
-      .map(event => {
+      .map((event, index) => {
         return (
-          <StackItem key={event.message}>
+          <StackItem key={`${event.message}${event.metadata.uid}` || index}>
             <div className={styles.fadeIn}>
               <WorkspaceEventsItem event={event}></WorkspaceEventsItem>
             </div>

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/index.tsx
@@ -28,6 +28,7 @@ import { selectAllWorkspaces } from '../../store/Workspaces/selectors';
 import WorkspaceLogsTools from './Tools';
 
 import styles from './index.module.css';
+import { DevWorkspaceStatus } from '../../services/helpers/types';
 
 const MAX_LOG_LENGTH = 500;
 const LOGS_CONTAINER_ID = 'output-logs';
@@ -40,6 +41,7 @@ export type Props = {
 export type State = {
   isExpanded: boolean;
   isStarting: boolean;
+  isFailed: boolean;
   logs: string[];
 };
 
@@ -50,6 +52,7 @@ export class WorkspaceLogs extends React.PureComponent<Props, State> {
     this.state = {
       isExpanded: false,
       isStarting: false,
+      isFailed: false,
       logs: [],
     };
   }
@@ -103,6 +106,11 @@ export class WorkspaceLogs extends React.PureComponent<Props, State> {
         logs,
       });
     }
+
+    const isFailed = workspace.status === DevWorkspaceStatus.FAILED;
+    this.setState({
+      isFailed,
+    });
   }
 
   private getLines(): JSX.Element[] {
@@ -143,10 +151,10 @@ export class WorkspaceLogs extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { isExpanded, isStarting, logs } = this.state;
+    const { isExpanded, isStarting, isFailed, logs } = this.state;
     const shouldToggleNavbar = true;
 
-    if (isStarting === false) {
+    if (isStarting === false && isFailed == false) {
       return (
         <EmptyState>
           <EmptyStateIcon icon={FileIcon} />

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/index.spec.tsx
@@ -657,6 +657,40 @@ describe('Factory Loader container, step CREATE_WORKSPACE__APPLYING_DEVFILE', ()
 
     expect(hasError.textContent).toEqual('false');
   });
+
+  test('handle warning when creating a workspace', async () => {
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withUID('workspace-uid')
+      .withName(devfileName)
+      .withNamespace('user-che')
+      .build();
+    const warningMessage = 'This is a warning';
+
+    const store = getStoreBuilder()
+      .withFactoryResolver({
+        resolver: {},
+        converted: {
+          devfileV2: devfile,
+        },
+      })
+      .withDevWorkspaces({
+        workspaces: [devWorkspace],
+        warnings: { 'workspace-uid': warningMessage },
+      })
+      .build();
+
+    renderComponent(store, loaderSteps, searchParams, currentStepIndex);
+
+    jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
+
+    await waitFor(() => expect(screen.getByText(`Warning: ${warningMessage}`)).toBeTruthy());
+
+    await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
+
+    const currentStep = screen.getByTestId(stepId);
+    const hasError = within(currentStep).getByTestId('hasError');
+    expect(hasError.textContent).toEqual('false');
+  });
 });
 
 function getStoreBuilder(): FakeStoreBuilder {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/__tests__/index.spec.tsx
@@ -344,6 +344,41 @@ describe('Factory Loader container, step CREATE_WORKSPACE__APPLYING_RESOURCES', 
 
     expect(hasError.textContent).toEqual('false');
   });
+
+  test('handle warning when creating a workspace', async () => {
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withUID('workspace-uid')
+      .withName(resourceDevworkspaceName)
+      .withNamespace('user-che')
+      .build();
+    const warningMessage = 'This is a warning';
+
+    const store = getStoreBuilder()
+      .withDevWorkspaces({
+        workspaces: [devWorkspace],
+        warnings: { 'workspace-uid': warningMessage },
+      })
+      .withDevfileRegistries({
+        devWorkspaceResources: {
+          [resourcesUrl]: {
+            resources,
+          },
+        },
+      })
+      .build();
+
+    renderComponent(store, loaderSteps, searchParams, currentStepIndex);
+
+    jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
+
+    await waitFor(() => expect(screen.getByText(`Warning: ${warningMessage}`)).toBeTruthy());
+
+    await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
+
+    const currentStep = screen.getByTestId(stepId);
+    const hasError = within(currentStep).getByTestId('hasError');
+    expect(hasError.textContent).toEqual('false');
+  });
 });
 
 function getStoreBuilder(): FakeStoreBuilder {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Resources/index.tsx
@@ -39,6 +39,7 @@ import { buildFactoryParams, FactoryParams } from '../../../../buildFactoryParam
 import { MIN_STEP_DURATION_MS, TIMEOUT_TO_CREATE_SEC } from '../../../../const';
 import findTargetWorkspace from '../../../../findTargetWorkspace';
 import prepareResources from './prepareResources';
+import { selectDevWorkspaceWarnings } from '../../../../../../store/Workspaces/devWorkspaces/selectors';
 
 export type Props = MappedProps &
   LoaderStepProps & {
@@ -49,6 +50,7 @@ export type State = LoaderStepState & {
   newWorkspaceName?: string;
   resources?: DevWorkspaceResources;
   shouldCreate: boolean; // should the loader create a workspace
+  warning?: string; // the devWorkspace warning to show
 };
 
 class StepApplyResources extends AbstractLoaderStep<Props, State> {
@@ -100,6 +102,16 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
       return true;
     }
 
+    // a warning appeared
+    if (
+      workspace !== undefined &&
+      nextWorkspace !== undefined &&
+      this.props.devWorkspaceWarnings[workspace.uid] !==
+        nextProps.devWorkspaceWarnings[nextWorkspace.uid]
+    ) {
+      return true;
+    }
+
     return false;
   }
 
@@ -115,6 +127,13 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
       this.setState({
         shouldCreate: false,
       });
+
+      const warning = this.props.devWorkspaceWarnings[workspace.uid];
+      if (warning) {
+        this.setState({
+          warning,
+        });
+      }
     }
 
     this.prepareAndRun();
@@ -132,9 +151,20 @@ class StepApplyResources extends AbstractLoaderStep<Props, State> {
   protected async runStep(): Promise<boolean> {
     await delay(MIN_STEP_DURATION_MS);
 
-    const { devWorkspaceResources } = this.props;
-    const { factoryParams, shouldCreate, resources } = this.state;
+    const { devWorkspaceResources, loaderSteps, currentStepIndex } = this.props;
+    const { factoryParams, shouldCreate, resources, warning } = this.state;
     const { cheEditor, factoryId, sourceUrl, storageType, policiesCreate } = factoryParams;
+
+    if (warning) {
+      // update step title
+      const currentStep = loaderSteps.get(currentStepIndex).value;
+      const newTitle = `Warning: ${warning}`;
+      if (newTitle !== currentStep.title) {
+        currentStep.title = newTitle;
+        currentStep.hasWarning = true;
+        this.forceUpdate();
+      }
+    }
 
     const targetWorkspace = this.findTargetWorkspace(this.props, this.state);
     if (targetWorkspace) {
@@ -250,6 +280,7 @@ const mapStateToProps = (state: AppState) => ({
   factoryResolver: selectFactoryResolver(state),
   factoryResolverConverted: selectFactoryResolverConverted(state),
   devWorkspaceResources: selectDevWorkspaceResources(state),
+  devWorkspaceWarnings: selectDevWorkspaceWarnings(state),
 });
 
 const connector = connect(

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/Modals/__tests__/RevokeRegistriesModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/Modals/__tests__/RevokeRegistriesModal.spec.tsx
@@ -14,7 +14,6 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import RevokeRegistriesModal from '../RevokeGitServicesModal';
-import { GitOauthProvider } from '@eclipse-che/common/lib/dto/api';
 import { api } from '@eclipse-che/common';
 
 describe('Revoke Registries Modal', () => {
@@ -23,7 +22,7 @@ describe('Revoke Registries Modal', () => {
 
   function getComponent(
     isRevokeModalOpen: boolean,
-    selectedItems: GitOauthProvider[],
+    selectedItems: api.GitOauthProvider[],
     gitOauth?: api.GitOauthProvider,
   ): React.ReactElement {
     return (

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
@@ -16,15 +16,17 @@ import devfileApi, { IDevWorkspacesList } from '../devfileApi';
 import { prefix } from './const';
 import { JSONSchema7 } from 'json-schema';
 
+export type Headers = { [key: string]: string };
+
 export async function createWorkspace(
   devworkspace: devfileApi.DevWorkspace,
-): Promise<devfileApi.DevWorkspace> {
+): Promise<{ devWorkspace: devfileApi.DevWorkspace; headers: Headers }> {
   try {
     const response = await axios.post(
       `${prefix}/namespace/${devworkspace.metadata.namespace}/devworkspaces`,
       { devworkspace },
     );
-    return response.data;
+    return { devWorkspace: response.data, headers: response.headers };
   } catch (e) {
     const errorMessage = helpers.errors.getMessage(e);
     if (errorMessage.startsWith('Unable to create devworkspace')) {
@@ -65,13 +67,13 @@ export async function patchWorkspace(
   namespace: string,
   workspaceName: string,
   patch: api.IPatch[],
-): Promise<devfileApi.DevWorkspace> {
+): Promise<{ devWorkspace: devfileApi.DevWorkspace; headers: Headers }> {
   try {
     const response = await axios.patch(
       `${prefix}/namespace/${namespace}/devworkspaces/${workspaceName}`,
       patch,
     );
-    return response.data;
+    return { devWorkspace: response.data, headers: response.headers };
   } catch (e) {
     throw new Error(
       `Failed to update workspace '${workspaceName}'. ${helpers.errors.getMessage(e)}`,

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/devworkspaceResourcesApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/devworkspaceResourcesApi.ts
@@ -14,7 +14,7 @@ import { api, helpers } from '@eclipse-che/common';
 import axios from 'axios';
 import { prefix } from './const';
 
-export async function fetchResources(params: api.IDevworkspaceResources): Promise<string> {
+export async function fetchResources(params: api.IDevWorkspaceResources): Promise<string> {
   try {
     const response = await axios.post(`${prefix}/devworkspace-resources`, params);
     return response.data;

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/websocketClient/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/websocketClient/__tests__/index.spec.ts
@@ -15,6 +15,10 @@ import WS from 'jest-websocket-mock';
 import { ConnectionEvent, WebsocketClient } from '..';
 import { delay } from '../../../helpers/delay';
 
+// mute console logs
+console.log = jest.fn();
+console.warn = jest.fn();
+
 describe('websocketClient', () => {
   beforeEach(() => {
     // do not use fake timers, because it causes issues with jest-websocket-mock

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
@@ -49,7 +49,7 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
 
     const spyPatchWorkspace = jest
       .spyOn(DwApi, 'patchWorkspace')
-      .mockResolvedValueOnce(testWorkspace);
+      .mockResolvedValueOnce({ devWorkspace: testWorkspace, headers: {} });
 
     jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
 
@@ -84,7 +84,7 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
 
     const spyPatchWorkspace = jest
       .spyOn(DwApi, 'patchWorkspace')
-      .mockResolvedValueOnce(testWorkspace);
+      .mockResolvedValueOnce({ devWorkspace: testWorkspace, headers: {} });
 
     jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
 
@@ -114,7 +114,7 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
 
     const spyPatchWorkspace = jest
       .spyOn(DwApi, 'patchWorkspace')
-      .mockResolvedValueOnce(testWorkspace);
+      .mockResolvedValueOnce({ devWorkspace: testWorkspace, headers: {} });
 
     jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -11,9 +11,7 @@
  */
 
 import { container } from '../../../../inversify.config';
-import { DevWorkspaceBuilder } from '../../../../store/__mocks__/devWorkspaceBuilder';
 import { DevWorkspaceClient } from '../devWorkspaceClient';
-import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
 import * as DwtApi from '../../../dashboard-backend-client/devWorkspaceTemplateApi';
 import devfileApi from '../../../devfileApi';
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -37,15 +37,13 @@ describe('DevWorkspace client, create', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     window.Date = dateConstructor;
   });
 
   describe('Create from resources', () => {
     let testDevWorkspace: devfileApi.DevWorkspace;
     let testDevWorkspaceTemplate: devfileApi.DevWorkspaceTemplate;
-    let spyPatchWorkspace: jest.SpyInstance;
-    let spyCreateWorkspace: jest.SpyInstance;
     let spyCreateWorkspaceTemplate: jest.SpyInstance;
 
     beforeEach(() => {
@@ -60,9 +58,18 @@ describe('DevWorkspace client, create', () => {
         },
         spec: {
           started: false,
-          template: {},
+          template: {
+            components: [
+              {
+                name: 'test-component-name',
+                container: {
+                  image: 'test.image',
+                },
+              },
+            ],
+          },
         },
-      };
+      } as devfileApi.DevWorkspace;
       testDevWorkspaceTemplate = {
         apiVersion: 'workspace.devfile.io/v1alpha2',
         kind: 'DevWorkspaceTemplate',
@@ -82,60 +89,24 @@ describe('DevWorkspace client, create', () => {
             },
           ],
         },
-      };
-      spyPatchWorkspace = jest
-        .spyOn(DwApi, 'patchWorkspace')
-        .mockResolvedValueOnce(testDevWorkspace);
-      const workspace = new DevWorkspaceBuilder()
-        .withMetadata({
-          namespace,
-          name: 'wksp-name-cvbn',
-          uid: 'uid-asdfgh12345',
-        })
-        .build();
-      spyCreateWorkspace = jest.spyOn(DwApi, 'createWorkspace').mockResolvedValueOnce(workspace);
+      } as devfileApi.DevWorkspaceTemplate;
       spyCreateWorkspaceTemplate = jest
         .spyOn(DwtApi, 'createTemplate')
         .mockResolvedValueOnce(testDevWorkspaceTemplate);
     });
 
-    afterEach(() => {
-      spyPatchWorkspace.mockClear();
-      spyCreateWorkspace.mockClear();
-      spyCreateWorkspaceTemplate.mockClear();
-    });
-
-    it('should add annotation of last update time', async () => {
-      await client.createFromResources(
-        namespace,
-        testDevWorkspace,
-        testDevWorkspaceTemplate,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-      );
-
-      expect(spyCreateWorkspace).toBeCalledWith(
-        expect.objectContaining({
-          metadata: expect.objectContaining({
-            annotations: {
-              'che.eclipse.org/last-updated-timestamp': timestampNew,
-            },
-          }),
-        }),
-      );
-    });
-
     it('should add pluginRegistry and dashboard URLs as environment variables', async () => {
-      await client.createFromResources(
+      const pluginRegistryUrl = 'http://plugin.registry.url';
+      const internalPluginRegistryUrl = 'http://internal.plugin.registry.url';
+      const openVSXUrl = 'http://openvsx.url';
+
+      await client.createDevWorkspaceTemplate(
         namespace,
         testDevWorkspace,
         testDevWorkspaceTemplate,
-        undefined,
-        'http://plugin.registry.url',
-        'http://internal.plugin.registry.url',
-        undefined,
+        pluginRegistryUrl,
+        internalPluginRegistryUrl,
+        openVSXUrl,
       );
 
       expect(spyCreateWorkspaceTemplate).toBeCalledWith(
@@ -153,6 +124,10 @@ describe('DevWorkspace client, create', () => {
                       name: 'CHE_PLUGIN_REGISTRY_INTERNAL_URL',
                       value: 'http://internal.plugin.registry.url',
                     },
+                    {
+                      name: 'OPENVSX_REGISTRY_URL',
+                      value: openVSXUrl,
+                    },
                   ]),
                 }),
               }),
@@ -163,14 +138,17 @@ describe('DevWorkspace client, create', () => {
     });
 
     it('should add owner reference to devWorkspace template to allow automatic cleanup', async () => {
-      await client.createFromResources(
+      const pluginRegistryUrl = 'http://plugin.registry.url';
+      const internalPluginRegistryUrl = 'http://internal.plugin.registry.url';
+      const openVSXUrl = 'http://openvsx.url';
+
+      await client.createDevWorkspaceTemplate(
         namespace,
         testDevWorkspace,
         testDevWorkspaceTemplate,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
+        pluginRegistryUrl,
+        internalPluginRegistryUrl,
+        openVSXUrl,
       );
 
       expect(spyCreateWorkspaceTemplate).toBeCalledWith(
@@ -178,8 +156,8 @@ describe('DevWorkspace client, create', () => {
           metadata: expect.objectContaining({
             ownerReferences: expect.arrayContaining([
               expect.objectContaining({
-                name: 'wksp-name-cvbn',
-                uid: 'uid-asdfgh12345',
+                name: testDevWorkspace.metadata.name,
+                uid: testDevWorkspace.metadata.uid,
               }),
             ]),
           }),

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
@@ -50,7 +50,7 @@ describe('DevWorkspace client, update', () => {
     jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
     const spyPatchWorkspace = jest
       .spyOn(DwApi, 'patchWorkspace')
-      .mockResolvedValueOnce(testWorkspace);
+      .mockResolvedValueOnce({ devWorkspace: testWorkspace, headers: {} });
 
     await client.update(testWorkspace);
 
@@ -84,7 +84,7 @@ describe('DevWorkspace client, update', () => {
     jest.spyOn(DwApi, 'getWorkspaceByName').mockResolvedValueOnce(testWorkspace);
     const spyPatchWorkspace = jest
       .spyOn(DwApi, 'patchWorkspace')
-      .mockResolvedValueOnce(testWorkspace);
+      .mockResolvedValueOnce({ devWorkspace: testWorkspace, headers: {} });
 
     await client.update(testWorkspace);
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -53,7 +53,9 @@ metadata:
 // DevWorkspaceClient mocks
 const mockChangeWorkspaceStatus = jest.fn();
 const mockCheckForDevWorkspaceError = jest.fn();
-const mockCreateFromResources = jest.fn();
+const mockCreateDevWorkspace = jest.fn();
+const mockCreateDevWorkspaceTemplate = jest.fn();
+const mockUpdateDevWorkspace = jest.fn();
 const mockDelete = jest.fn();
 const mockGetAllWorkspaces = jest.fn();
 const mockGetWorkspaceByName = jest.fn();
@@ -74,7 +76,9 @@ describe('DevWorkspace store, actions', () => {
     container.snapshot();
     devWorkspaceClient.changeWorkspaceStatus = mockChangeWorkspaceStatus;
     devWorkspaceClient.checkForDevWorkspaceError = mockCheckForDevWorkspaceError;
-    devWorkspaceClient.createFromResources = mockCreateFromResources;
+    devWorkspaceClient.createDevWorkspace = mockCreateDevWorkspace;
+    devWorkspaceClient.createDevWorkspaceTemplate = mockCreateDevWorkspaceTemplate;
+    devWorkspaceClient.updateDevWorkspace = mockUpdateDevWorkspace;
     devWorkspaceClient.delete = mockDelete;
     devWorkspaceClient.getAllWorkspaces = mockGetAllWorkspaces;
     devWorkspaceClient.getWorkspaceByName = mockGetWorkspaceByName;
@@ -119,7 +123,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE, RECEIVE_DEVWORKSPACE and UPDATE_DEVWORKSPACE when fetching DevWorkspaces', async () => {
@@ -158,7 +162,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when fails to fetch DevWorkspaces', async () => {
@@ -183,7 +187,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -216,7 +220,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when fails to fetch a DevWorkspace', async () => {
@@ -243,7 +247,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -289,7 +293,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when failed to start a DevWorkspace', async () => {
@@ -329,7 +333,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -345,7 +349,7 @@ describe('DevWorkspace store, actions', () => {
 
       const expectedActions: Array<testStore.KnownAction> = [];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create RECEIVE_DEVWORKSPACE_ERROR when fails to stop DevWorkspace', async () => {
@@ -368,7 +372,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -390,7 +394,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create RECEIVE_DEVWORKSPACE_ERROR when fails to terminate a DevWorkspace', async () => {
@@ -413,7 +417,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -438,7 +442,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when fails to update a workspace annotation', async () => {
@@ -465,7 +469,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -490,7 +494,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when fails to update a workspace annotation', async () => {
@@ -517,7 +521,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -534,7 +538,13 @@ describe('DevWorkspace store, actions', () => {
         },
       };
 
-      mockCreateFromResources.mockResolvedValueOnce(devWorkspace);
+      mockCreateDevWorkspace.mockResolvedValueOnce({
+        headers: { warning: '299 - Unsupported Devfile feature' },
+        devWorkspace,
+      });
+      mockCreateDevWorkspaceTemplate.mockResolvedValueOnce({ headers: {}, devWorkspaceTemplate });
+      mockCreateDevWorkspace.mockResolvedValueOnce({ headers: {}, devWorkspace });
+      mockUpdateDevWorkspace.mockResolvedValueOnce({ headers: {}, devWorkspace });
       mockOnStart.mockResolvedValueOnce(undefined);
 
       await store.dispatch(
@@ -545,12 +555,21 @@ describe('DevWorkspace store, actions', () => {
 
       const expectedActions: Array<testStore.KnownAction> = [
         {
+          type: testStore.Type.REQUEST_DEVWORKSPACE,
+          check: AUTHORIZED,
+        },
+        {
+          type: testStore.Type.UPDATE_WARNING,
+          workspace: devWorkspace,
+          warning: '299 - Unsupported Devfile feature',
+        },
+        {
           type: testStore.Type.ADD_DEVWORKSPACE,
           workspace: devWorkspace,
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create RECEIVE_DEVWORKSPACE_ERROR when fails to create a new workspace from resources', async () => {
@@ -565,7 +584,7 @@ describe('DevWorkspace store, actions', () => {
         },
       };
 
-      mockCreateFromResources.mockRejectedValueOnce(new Error('Something unexpected happened.'));
+      mockCreateDevWorkspace.mockRejectedValueOnce(new Error('Something unexpected happened.'));
 
       try {
         await store.dispatch(
@@ -579,12 +598,16 @@ describe('DevWorkspace store, actions', () => {
 
       const expectedActions: Array<testStore.KnownAction> = [
         {
+          type: testStore.Type.REQUEST_DEVWORKSPACE,
+          check: AUTHORIZED,
+        },
+        {
           error: `Failed to create a new workspace, reason: Something unexpected happened.`,
           type: testStore.Type.RECEIVE_DEVWORKSPACE_ERROR,
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -599,15 +622,18 @@ describe('DevWorkspace store, actions', () => {
         },
       };
 
-      mockCreateFromResources.mockResolvedValueOnce(devWorkspace);
+      mockCreateDevWorkspace.mockResolvedValueOnce({ devWorkspace, headers: {} });
+      mockUpdateDevWorkspace.mockResolvedValueOnce({ devWorkspace, headers: {} });
 
-      await store.dispatch(
-        testStore.actionCreators.createWorkspaceFromDevfile(devfile, {}, undefined, undefined, {}),
-      );
+      await store.dispatch(testStore.actionCreators.createWorkspaceFromDevfile(devfile, {}, {}));
 
       const actions = store.getActions();
 
       const expectedActions: Array<testStore.KnownAction> = [
+        {
+          type: testStore.Type.REQUEST_DEVWORKSPACE,
+          check: AUTHORIZED,
+        },
         {
           type: testStore.Type.REQUEST_DEVWORKSPACE,
           check: AUTHORIZED,
@@ -618,7 +644,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when fails to create a new workspace from devfile', async () => {
@@ -631,18 +657,10 @@ describe('DevWorkspace store, actions', () => {
         },
       };
 
-      mockCreateFromResources.mockRejectedValueOnce(new Error('Something unexpected happened.'));
+      mockCreateDevWorkspace.mockRejectedValueOnce(new Error('Something unexpected happened.'));
 
       try {
-        await store.dispatch(
-          testStore.actionCreators.createWorkspaceFromDevfile(
-            devfile,
-            {},
-            undefined,
-            undefined,
-            {},
-          ),
-        );
+        await store.dispatch(testStore.actionCreators.createWorkspaceFromDevfile(devfile, {}, {}));
       } catch (e) {
         // no-op
       }
@@ -655,12 +673,16 @@ describe('DevWorkspace store, actions', () => {
           check: AUTHORIZED,
         },
         {
-          error: 'Something unexpected happened.',
+          type: testStore.Type.REQUEST_DEVWORKSPACE,
+          check: AUTHORIZED,
+        },
+        {
+          error: 'Failed to create a new workspace, reason: Something unexpected happened.',
           type: testStore.Type.RECEIVE_DEVWORKSPACE_ERROR,
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
   });
 
@@ -688,7 +710,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create UPDATE_DEVWORKSPACE when event phase equals MODIFIED', async () => {
@@ -714,7 +736,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create DELETE_DEVWORKSPACE when event phase equals DELETED', async () => {
@@ -740,7 +762,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE and resubscribe to channel', async () => {
@@ -789,7 +811,7 @@ describe('DevWorkspace store, actions', () => {
         },
       ];
 
-      expect(actions).toEqual(expectedActions);
+      expect(actions).toStrictEqual(expectedActions);
       expect(unsubscribeFromChannelSpy).toHaveBeenCalledWith(api.webSocket.Channel.DEV_WORKSPACE);
       expect(subscribeToChannelSpy).toHaveBeenCalledWith(
         api.webSocket.Channel.DEV_WORKSPACE,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -539,7 +539,7 @@ describe('DevWorkspace store, actions', () => {
       };
 
       mockCreateDevWorkspace.mockResolvedValueOnce({
-        headers: { warning: '299 - Unsupported Devfile feature' },
+        headers: { warning: 'Unsupported Devfile feature' },
         devWorkspace,
       });
       mockCreateDevWorkspaceTemplate.mockResolvedValueOnce({ headers: {}, devWorkspaceTemplate });
@@ -561,7 +561,7 @@ describe('DevWorkspace store, actions', () => {
         {
           type: testStore.Type.UPDATE_WARNING,
           workspace: devWorkspace,
-          warning: '299 - Unsupported Devfile feature',
+          warning: 'Unsupported Devfile feature',
         },
         {
           type: testStore.Type.ADD_DEVWORKSPACE,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/reducers.spec.ts
@@ -284,7 +284,7 @@ describe('DevWorkspace, reducers', () => {
     const incomingAction: testStore.UpdateWarningAction = {
       type: testStore.Type.UPDATE_WARNING,
       workspace: devWorkspace,
-      warning: '299 - Unsupported Devfile feature',
+      warning: 'Unsupported Devfile feature',
     };
 
     const newState = testStore.reducer(initialState, incomingAction);
@@ -295,7 +295,7 @@ describe('DevWorkspace, reducers', () => {
       startedWorkspaces: {},
       resourceVersion: '0',
       warnings: {
-        [WorkspaceAdapter.getUID(devWorkspace)]: '299 - Unsupported Devfile feature',
+        [WorkspaceAdapter.getUID(devWorkspace)]: 'Unsupported Devfile feature',
       },
     };
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/reducers.spec.ts
@@ -40,9 +40,10 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
-    expect(initialState).toEqual(expectedState);
+    expect(initialState).toStrictEqual(expectedState);
   });
 
   it('should return state if action type is not matched', () => {
@@ -51,6 +52,7 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [devWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
     const incomingAction = {
       type: 'OTHER_ACTION',
@@ -62,8 +64,9 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [devWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
   });
 
   it('should handle REQUEST_DEVWORKSPACE', () => {
@@ -73,6 +76,7 @@ describe('DevWorkspace, reducers', () => {
       startedWorkspaces: {},
       error: 'unexpected error',
       resourceVersion: '0',
+      warnings: {},
     };
     const incomingAction: testStore.RequestDevWorkspacesAction = {
       type: testStore.Type.REQUEST_DEVWORKSPACE,
@@ -86,9 +90,11 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
+      error: undefined,
     };
 
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
   });
 
   it('should handle RECEIVE_DEVWORKSPACE', () => {
@@ -97,6 +103,7 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
     const incomingAction: testStore.ReceiveWorkspacesAction = {
       type: testStore.Type.RECEIVE_DEVWORKSPACE,
@@ -111,9 +118,10 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [devWorkspace],
       startedWorkspaces: {},
       resourceVersion: '1',
+      warnings: {},
     };
 
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
   });
 
   it('should handle RECEIVE_DEVWORKSPACE_ERROR', () => {
@@ -122,6 +130,7 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
     const incomingAction: testStore.ReceiveErrorAction = {
       type: testStore.Type.RECEIVE_DEVWORKSPACE_ERROR,
@@ -136,9 +145,10 @@ describe('DevWorkspace, reducers', () => {
       startedWorkspaces: {},
       error: 'Error',
       resourceVersion: '0',
+      warnings: {},
     };
 
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
   });
 
   it('should handle UPDATE_DEVWORKSPACE', () => {
@@ -147,6 +157,7 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [devWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
     const updatedWorkspace = cloneDeep(devWorkspace);
@@ -167,9 +178,10 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [updatedWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
   });
 
   it('should handle ADD_DEVWORKSPACE', () => {
@@ -178,6 +190,7 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
     const incomingAction: testStore.AddWorkspaceAction = {
@@ -192,9 +205,10 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [devWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
   });
 
   it('should handle TERMINATE_DEVWORKSPACE', () => {
@@ -203,6 +217,7 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [devWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
     const incomingAction: testStore.TerminateWorkspaceAction = {
@@ -224,9 +239,10 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [updatedWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
   });
 
   it('should handle DELETE_DEVWORKSPACE', () => {
@@ -235,6 +251,7 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [devWorkspace],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
     const incomingAction: testStore.DeleteWorkspaceAction = {
@@ -249,8 +266,39 @@ describe('DevWorkspace, reducers', () => {
       workspaces: [],
       startedWorkspaces: {},
       resourceVersion: '0',
+      warnings: {},
     };
 
-    expect(newState).toEqual(expectedState);
+    expect(newState).toStrictEqual(expectedState);
+  });
+
+  it('should handle UPDATE_WARNING', () => {
+    const initialState: testStore.State = {
+      isLoading: false,
+      workspaces: [],
+      startedWorkspaces: {},
+      resourceVersion: '0',
+      warnings: {},
+    };
+
+    const incomingAction: testStore.UpdateWarningAction = {
+      type: testStore.Type.UPDATE_WARNING,
+      workspace: devWorkspace,
+      warning: '299 - Unsupported Devfile feature',
+    };
+
+    const newState = testStore.reducer(initialState, incomingAction);
+
+    const expectedState: testStore.State = {
+      isLoading: false,
+      workspaces: [],
+      startedWorkspaces: {},
+      resourceVersion: '0',
+      warnings: {
+        [WorkspaceAdapter.getUID(devWorkspace)]: '299 - Unsupported Devfile feature',
+      },
+    };
+
+    expect(newState).toStrictEqual(expectedState);
   });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -514,10 +514,13 @@ export const actionCreators: ActionCreators = {
         );
 
         if (createResp.headers.warning) {
+          // get rid of the status code
+          const warning = createResp.headers.warning.replace(/^\d+\s*?-\s*?/g, '');
+
           dispatch({
             type: Type.UPDATE_WARNING,
             workspace: createResp.devWorkspace,
-            warning: createResp.headers.warning,
+            warning,
           });
         }
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -45,8 +45,6 @@ import { checkRunningWorkspacesLimit } from './checkRunningWorkspacesLimit';
 import { selectDevWorkspacesResourceVersion } from './selectors';
 import { EDITOR_ATTR } from '../../../containers/Loader/const';
 
-const devWorkspaceClient = container.get(DevWorkspaceClient);
-
 export const onStatusChangeCallbacks = new Map<string, (status: DevWorkspaceStatus) => void>();
 
 export interface State {
@@ -55,6 +53,9 @@ export interface State {
   resourceVersion: string;
   error?: string;
   startedWorkspaces: {
+    [workspaceUID: string]: string;
+  };
+  warnings: {
     [workspaceUID: string]: string;
   };
 }
@@ -75,6 +76,7 @@ export enum Type {
   TERMINATE_DEVWORKSPACE = 'TERMINATE_DEVWORKSPACE',
   ADD_DEVWORKSPACE = 'ADD_DEVWORKSPACE',
   UPDATE_STARTED_WORKSPACES = 'UPDATE_STARTED_WORKSPACES',
+  UPDATE_WARNING = 'UPDATE_WARNING',
 }
 
 export interface RequestDevWorkspacesAction extends Action, SanityCheckAction {
@@ -118,6 +120,12 @@ export interface UpdateStartedWorkspaceAction extends Action {
   workspaces: devfileApi.DevWorkspace[];
 }
 
+export interface UpdateWarningAction extends Action {
+  type: Type.UPDATE_WARNING;
+  workspace: devfileApi.DevWorkspace;
+  warning: string;
+}
+
 export type KnownAction =
   | RequestDevWorkspacesAction
   | ReceiveErrorAction
@@ -126,7 +134,8 @@ export type KnownAction =
   | DeleteWorkspaceAction
   | TerminateWorkspaceAction
   | AddWorkspaceAction
-  | UpdateStartedWorkspaceAction;
+  | UpdateStartedWorkspaceAction
+  | UpdateWarningAction;
 
 export type ResourceQueryParams = {
   'debug-workspace-start': boolean;
@@ -148,16 +157,14 @@ export type ActionCreators = {
   updateWorkspace: (workspace: devfileApi.DevWorkspace) => AppThunk<KnownAction, Promise<void>>;
   createWorkspaceFromDevfile: (
     devfile: devfileApi.Devfile,
+    attributes: { [key: string]: string },
     optionalFilesContent: {
       [fileName: string]: string;
     },
-    pluginRegistryUrl: string | undefined,
-    pluginRegistryInternalUrl: string | undefined,
-    attributes: { [key: string]: string },
   ) => AppThunk<KnownAction, Promise<void>>;
   createWorkspaceFromResources: (
-    devworkspace: devfileApi.DevWorkspace,
-    devworkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+    devWorkspace: devfileApi.DevWorkspace,
+    devWorkspaceTemplate: devfileApi.DevWorkspaceTemplate,
     editor?: string,
   ) => AppThunk<KnownAction, Promise<void>>;
 
@@ -479,12 +486,15 @@ export const actionCreators: ActionCreators = {
 
   createWorkspaceFromResources:
     (
-      devworkspace: devfileApi.DevWorkspace,
-      devworkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+      devWorkspaceResource: devfileApi.DevWorkspace,
+      devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate,
       editorId?: string,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       const state = getState();
+
+      await dispatch({ type: Type.REQUEST_DEVWORKSPACE, check: AUTHORIZED });
+
       const defaultKubernetesNamespace = selectDefaultNamespace(state);
       const openVSXUrl = selectOpenVSXUrl(state);
       const defaultNamespace = defaultKubernetesNamespace.name;
@@ -494,26 +504,54 @@ export const actionCreators: ActionCreators = {
           state.workspacesSettings.settings['cheWorkspacePluginRegistryUrl'];
         const pluginRegistryInternalUrl =
           state.workspacesSettings.settings['cheWorkspacePluginRegistryInternalUrl'];
-        const workspace = await getDevWorkspaceClient().createFromResources(
+
+        /* create a new DevWorkspace (without components) */
+
+        const createResp = await getDevWorkspaceClient().createDevWorkspace(
           defaultNamespace,
-          devworkspace,
-          devworkspaceTemplate,
+          devWorkspaceResource,
           cheEditor,
+        );
+
+        if (createResp.headers.warning) {
+          dispatch({
+            type: Type.UPDATE_WARNING,
+            workspace: createResp.devWorkspace,
+            warning: createResp.headers.warning,
+          });
+        }
+
+        /* create a new DevWorkspaceTemplate */
+
+        await getDevWorkspaceClient().createDevWorkspaceTemplate(
+          defaultNamespace,
+          createResp.devWorkspace,
+          devWorkspaceTemplateResource,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
           openVSXUrl,
         );
 
-        if (workspace.spec.started) {
-          const editor = workspace.metadata.annotations
-            ? workspace.metadata.annotations[DEVWORKSPACE_CHE_EDITOR]
-            : undefined;
-          const defaultPlugins = getState().dwPlugins.defaultPlugins;
-          await getDevWorkspaceClient().onStart(workspace, defaultPlugins, editor);
+        /* update the DevWorkspace with components */
+
+        const updateResp = await getDevWorkspaceClient().updateDevWorkspace(
+          createResp.devWorkspace,
+          pluginRegistryUrl,
+          pluginRegistryInternalUrl,
+          openVSXUrl,
+        );
+
+        if (updateResp.headers.warning) {
+          dispatch({
+            type: Type.UPDATE_WARNING,
+            workspace: updateResp.devWorkspace,
+            warning: updateResp.headers.warning,
+          });
         }
+
         dispatch({
           type: Type.ADD_DEVWORKSPACE,
-          workspace,
+          workspace: updateResp.devWorkspace,
         });
       } catch (e) {
         const errorMessage =
@@ -529,76 +567,65 @@ export const actionCreators: ActionCreators = {
   createWorkspaceFromDevfile:
     (
       devfile: devfileApi.Devfile,
+      attributes: { [key: string]: string },
       optionalFilesContent: {
         [fileName: string]: string;
       },
-      pluginRegistryUrl: string | undefined,
-      pluginRegistryInternalUrl: string | undefined,
-      attributes: { [key: string]: string },
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       const state = getState();
-      const defaultEditorEntry = state.dwServerConfig.config.defaults.editor;
-
-      let editorEntry: string | undefined;
-      let editorContent: string | undefined;
-      // do we have an optional editor parameter ?
-      if (attributes[EDITOR_ATTR]) {
-        editorEntry = attributes[EDITOR_ATTR];
-        editorContent = undefined;
-        if (editorEntry !== defaultEditorEntry) {
-          console.log(
-            `User specified a different editor than the current default. Loading ${editorEntry} definition instead of ${defaultEditorEntry}.`,
-          );
-        }
-      } else {
-        // do we have the custom editor in `.che/che-editor.yaml` ?
-        editorContent = await getCustomEditor(pluginRegistryUrl, optionalFilesContent);
-        if (!editorContent) {
-          editorEntry = defaultEditorEntry;
-          console.debug(`Using default editor ${defaultEditorEntry}`);
-        }
-      }
 
       await dispatch({ type: Type.REQUEST_DEVWORKSPACE, check: AUTHORIZED });
+
+      let editorId: string | undefined;
+      let devWorkspaceResource: devfileApi.DevWorkspace;
+      let devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate;
+
       try {
-        const defaultNamespace = selectDefaultNamespace(state);
+        const defaultEditorId = state.dwServerConfig.config.defaults.editor;
+        const pluginRegistryUrl =
+          state.workspacesSettings.settings['cheWorkspacePluginRegistryUrl'];
+
+        let editorContent: string | undefined;
+        // do we have an optional editor parameter ?
+        if (attributes[EDITOR_ATTR]) {
+          editorId = attributes[EDITOR_ATTR];
+          editorContent = undefined;
+          if (editorId !== defaultEditorId) {
+            console.log(
+              `User specified a different editor than the current default. Loading ${editorId} definition instead of ${defaultEditorId}.`,
+            );
+          }
+        } else {
+          // do we have the custom editor in `.che/che-editor.yaml` ?
+          editorContent = await getCustomEditor(pluginRegistryUrl, optionalFilesContent);
+          if (!editorContent) {
+            editorId = defaultEditorId;
+            console.debug(`Using default editor ${defaultEditorId}`);
+          }
+        }
+
         const resourcesContent = await fetchResources({
           devfileContent: dump(devfile),
           editorPath: undefined,
           pluginRegistryUrl,
-          editorEntry,
+          editorId,
           editorContent,
         });
         const resources = loadResourcesContent(resourcesContent);
-        const devWorkspace = resources.find(
+        devWorkspaceResource = resources.find(
           resource => resource.kind === 'DevWorkspace',
         ) as devfileApi.DevWorkspace;
-        if (!devWorkspace) {
+        if (devWorkspaceResource === undefined) {
           throw new Error('Failed to find a DevWorkspace in the fetched resources.');
         }
 
-        const devWorkspaceTemplate = resources.find(
+        devWorkspaceTemplateResource = resources.find(
           resource => resource.kind === 'DevWorkspaceTemplate',
         ) as devfileApi.DevWorkspaceTemplate;
-        if (!devWorkspaceTemplate) {
+        if (devWorkspaceTemplateResource === undefined) {
           throw new Error('Failed to find a DevWorkspaceTemplate in the fetched resources.');
         }
-
-        const openVSXUrl = selectOpenVSXUrl(state);
-        const workspace = await devWorkspaceClient.createFromResources(
-          defaultNamespace.name,
-          devWorkspace,
-          devWorkspaceTemplate,
-          editorEntry,
-          pluginRegistryUrl,
-          pluginRegistryInternalUrl,
-          openVSXUrl,
-        );
-        dispatch({
-          type: Type.ADD_DEVWORKSPACE,
-          workspace,
-        });
       } catch (e) {
         const errorMessage = common.helpers.errors.getMessage(e);
         dispatch({
@@ -607,6 +634,14 @@ export const actionCreators: ActionCreators = {
         });
         throw errorMessage;
       }
+
+      await dispatch(
+        actionCreators.createWorkspaceFromResources(
+          devWorkspaceResource,
+          devWorkspaceTemplateResource,
+          editorId,
+        ),
+      );
     },
 
   handleWebSocketMessage:
@@ -717,6 +752,7 @@ const unloadedState: State = {
   isLoading: false,
   resourceVersion: '0',
   startedWorkspaces: {},
+  warnings: {},
 };
 
 export const reducer: Reducer<State> = (
@@ -822,6 +858,12 @@ export const reducer: Reducer<State> = (
           acc[WorkspaceAdapter.getUID(workspace)] = workspace.metadata.resourceVersion;
           return acc;
         }, state.startedWorkspaces),
+      });
+    case Type.UPDATE_WARNING:
+      return createObject(state, {
+        warnings: {
+          [WorkspaceAdapter.getUID(action.workspace)]: action.warning,
+        },
       });
     default:
       return state;

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/selectors.ts
@@ -18,9 +18,10 @@ import { selectRunningWorkspacesLimit } from '../../ClusterConfig/selectors';
 const selectState = (state: AppState) => state.devWorkspaces;
 export const selectDevWorkspacesState = selectState;
 
-export const selectDevWorkspacesResourceVersion = createSelector(selectState, state => {
-  return state.resourceVersion;
-});
+export const selectDevWorkspacesResourceVersion = createSelector(
+  selectState,
+  state => state.resourceVersion,
+);
 
 export const selectAllDevWorkspaces = createSelector(selectState, state => {
   return state.workspaces;
@@ -28,13 +29,13 @@ export const selectAllDevWorkspaces = createSelector(selectState, state => {
 
 export const selectDevWorkspacesError = createSelector(selectState, state => state.error);
 
-export const selectRunningDevWorkspaces = createSelector(selectState, state => {
-  return state.workspaces.filter(
+export const selectRunningDevWorkspaces = createSelector(selectState, state =>
+  state.workspaces.filter(
     workspace =>
       workspace.status?.phase === DevWorkspaceStatus.STARTING ||
       workspace.status?.phase === DevWorkspaceStatus.RUNNING,
-  );
-});
+  ),
+);
 
 export const selectRunningDevWorkspacesLimitExceeded = createSelector(
   selectRunningDevWorkspaces,
@@ -47,3 +48,5 @@ export const selectStartedWorkspaces = createSelector(
   selectState,
   state => state.startedWorkspaces,
 );
+
+export const selectDevWorkspaceWarnings = createSelector(selectState, state => state.warnings);

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -244,21 +244,14 @@ export const actionCreators: ActionCreators = {
         [fileName: string]: string;
       },
     ): AppThunk<KnownAction, Promise<void>> =>
-    async (dispatch, getState): Promise<void> => {
+    async (dispatch): Promise<void> => {
       dispatch({ type: 'REQUEST_WORKSPACES' });
       try {
-        const state = getState();
-        const pluginRegistryUrl =
-          state.workspacesSettings.settings['cheWorkspacePluginRegistryUrl'];
-        const pluginRegistryInternalUrl =
-          state.workspacesSettings.settings['cheWorkspacePluginRegistryInternalUrl'];
         await dispatch(
           DevWorkspacesStore.actionCreators.createWorkspaceFromDevfile(
             devfile,
-            optionalFilesContent || {},
-            pluginRegistryUrl,
-            pluginRegistryInternalUrl,
             attributes,
+            optionalFilesContent || {},
           ),
         );
         dispatch({ type: 'ADD_WORKSPACE' });

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -102,6 +102,7 @@ export class FakeStoreBuilder {
       workspaces: [],
       resourceVersion: '0',
       startedWorkspaces: {},
+      warnings: {},
     },
     workspacesSettings: {
       isLoading: false,
@@ -301,6 +302,7 @@ export class FakeStoreBuilder {
     options: {
       workspaces?: devfileApi.DevWorkspace[];
       startedWorkspaces?: { [uid: string]: string };
+      warnings?: { [uid: string]: string };
     },
     isLoading = false,
     error?: string,
@@ -310,6 +312,9 @@ export class FakeStoreBuilder {
     }
     if (options.startedWorkspaces) {
       this.state.devWorkspaces.startedWorkspaces = Object.assign({}, options.startedWorkspaces);
+    }
+    if (options.warnings) {
+      this.state.devWorkspaces.warnings = Object.assign({}, options.warnings);
     }
     this.state.devWorkspaces.isLoading = isLoading;
     this.state.devWorkspaces.error = error;


### PR DESCRIPTION

### What does this PR do?

This PR show warnings that may happen during workspace creation when the devfile uses unsupported features.

![Screenshot 2023-03-03 at 18 44 54](https://user-images.githubusercontent.com/16220722/222778872-d82a0d64-96bc-48db-bb6e-46f706a8c6f3.png)


### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/21873

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

Try creating a workspace using the following devfile: 

```yaml
schemaVersion: 2.1.0
metadata:
  generateName: unsupported-feature-
components:
  - name: web-terminal
    container:
      image: quay.io/wto/web-terminal-tooling:next
      memoryLimit: 512Mi
      mountSources: true
      command:
       - "tail"
       - "-f"
       - "/dev/null"
      dedicatedPod: true # This feature is unsupported
```

