### PR TITLE
Restore the navbar and topbar when return to the quick start page

### DIFF
--- a/packages/dashboard-frontend/src/components/DevfileEditor/index.tsx
+++ b/packages/dashboard-frontend/src/components/DevfileEditor/index.tsx
@@ -197,25 +197,6 @@ export class DevfileEditor extends React.PureComponent<Props, State> {
       // init language server validation
       this.initLanguageServerValidation(this.editor);
     }
-
-    const handleMessage = (event: MessageEvent): void => {
-      if (typeof event.data !== 'string') {
-        return;
-      }
-      const { data } = event;
-      if (
-        (data === 'show-navbar' || data === 'hide-navbar' || data === 'toggle-navbar') &&
-        this.handleResize
-      ) {
-        this.handleResize();
-      }
-    };
-    window.addEventListener('message', handleMessage, false);
-    this.toDispose.push({
-      dispose: () => {
-        window.removeEventListener('message', handleMessage, false);
-      },
-    });
   }
 
   // This method is called when the component is removed from the document

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/Tools/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/Tools/index.tsx
@@ -16,6 +16,7 @@ import { CompressIcon, DownloadIcon, ExpandIcon } from '@patternfly/react-icons'
 import { getBlobUrl } from '../../../services/helpers/tools';
 
 import styles from './index.module.css';
+import { ToggleBarsContext } from '../../../contexts/ToggleBars';
 
 type Props = {
   logs: string[] | undefined;
@@ -28,6 +29,9 @@ type State = {
 };
 
 class WorkspaceLogsTools extends React.PureComponent<Props, State> {
+  static contextType = ToggleBarsContext;
+  readonly context: React.ContextType<typeof ToggleBarsContext>;
+
   private readonly handleExpand: () => void;
 
   constructor(props: Props) {
@@ -39,16 +43,12 @@ class WorkspaceLogsTools extends React.PureComponent<Props, State> {
 
     this.handleExpand = () => {
       if (this.state.isExpanded) {
-        if (this.props.shouldToggleNavbar === true) {
-          window.postMessage('show-navbar', '*');
-        }
+        this.context.showAll();
         const isExpanded = false;
         this.setState({ isExpanded });
         this.props.handleExpand(isExpanded);
       } else {
-        if (this.props.shouldToggleNavbar === true) {
-          window.postMessage('hide-navbar', '*');
-        }
+        this.context.hideAll();
         const isExpanded = true;
         this.setState({ isExpanded });
         this.props.handleExpand(isExpanded);

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/CheckRunningWorkspacesLimit/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/CheckRunningWorkspacesLimit/index.tsx
@@ -38,6 +38,7 @@ import {
 import { selectRunningDevWorkspacesLimitExceeded } from '../../../../../store/Workspaces/devWorkspaces/selectors';
 import findTargetWorkspace from '../../../findTargetWorkspace';
 import { selectRunningWorkspacesLimit } from '../../../../../store/ClusterConfig/selectors';
+import { ToggleBarsContext } from '../../../../../contexts/ToggleBars';
 
 export type Props = MappedProps &
   LoaderStepProps & {
@@ -53,6 +54,9 @@ export type State = LoaderStepState & {
 };
 
 class StepCheckRunningWorkspacesLimit extends AbstractLoaderStep<Props, State> {
+  static contextType = ToggleBarsContext;
+  readonly context: React.ContextType<typeof ToggleBarsContext>;
+
   protected readonly toDispose = new DisposableCollection();
 
   constructor(props: Props) {
@@ -228,6 +232,8 @@ class StepCheckRunningWorkspacesLimit extends AbstractLoaderStep<Props, State> {
   }
 
   private handleOpenDashboard(): void {
+    this.context.showAll();
+
     const homeLocation = buildHomeLocation();
     this.props.history.push(homeLocation);
   }


### PR DESCRIPTION

### What does this PR do?

This PR fixes the dashboard behavior when the user clicks the "Return to Dashboard" button on the workspace startup page, so both the navigation bar and the top bar gets shown after return.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/21950
