### PR TITLE
Redirect to workspace if it is running or starting

### DIFF
--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/workspaceStoppedDetector.spec.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/workspaceStoppedDetector.spec.ts
@@ -92,10 +92,8 @@ describe('WorkspaceStoppedDetector', () => {
       const mainUrlPath = '/workspaced5858247cc74458d/';
       SessionStorageService.update(SessionStorageKey.ORIGINAL_LOCATION_PATH, mainUrlPath);
 
-      const devWorkspaceId = 'dev-wksp-0';
-
       const devWorkspace = new DevWorkspaceBuilder()
-        .withId(devWorkspaceId)
+        .withId('dev-wksp-0')
         .withName('dev-wksp-0')
         .withNamespace('user-dev')
         .withStatus({ mainUrl: mainUrlPath, phase: 'RUNNING' })
@@ -111,6 +109,26 @@ describe('WorkspaceStoppedDetector', () => {
 
       expect(checkWorkspaceStopped).toThrow(WorkspaceRunningError);
     });
+  });
+
+  it('should throw error if matching workspace exists, but it is starting', () => {
+    const mainUrlPath = '/workspaced5858247cc74458d/universal-developer-image/3100/';
+    SessionStorageService.update(SessionStorageKey.ORIGINAL_LOCATION_PATH, mainUrlPath);
+
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withId('workspaced5858247cc74458d')
+      .withName('dev-wksp-0')
+      .withNamespace('user-dev')
+      .withStatus({ mainUrl: mainUrlPath, phase: 'RUNNING' })
+      .build();
+    devWorkspace.spec.started = true;
+
+    const store = new FakeStoreBuilder().withDevWorkspaces({ workspaces: [devWorkspace] }).build();
+    const checkWorkspaceStopped = () => {
+      new WorkspaceStoppedDetector().checkWorkspaceStopped(store.getState());
+    };
+
+    expect(checkWorkspaceStopped).toThrow(WorkspaceRunningError);
   });
 
   describe('getWorkspaceStoppedError()', () => {

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -415,9 +415,8 @@ export default class Bootstrap {
       this.issuesReporterService.registerIssue(type, error, workspaceData);
     } catch (e) {
       if (e instanceof WorkspaceRunningError) {
-        // workspace is running, redirect to workspace url
-        if (stoppedWorkspace?.ideUrl) {
-          window.location.href = stoppedWorkspace.ideUrl;
+        if (e.workspace.ideUrl) {
+          window.location.href = e.workspace.ideUrl;
           return;
         }
       } else {

--- a/packages/dashboard-frontend/src/services/bootstrap/workspaceStoppedDetector.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/workspaceStoppedDetector.ts
@@ -20,9 +20,25 @@ import { Workspace } from '../workspace-adapter';
 import { IssueType } from './issuesReporter';
 
 export class WorkspaceRunningError extends Error {
-  constructor(message) {
+  public workspace: Workspace;
+
+  /**
+   * Check if workspace is running or is about to run.
+   * If it is, throw error.
+   *
+   * @param workspace the workspace to check
+   */
+  public static throwIfNeeded(workspace) {
+    if (workspace.isRunning || workspace.isStarting) {
+      const state = workspace.isRunning ? 'running' : 'starting';
+      throw new WorkspaceRunningError(`The workspace is ${state}.`, workspace);
+    }
+  }
+
+  constructor(message: string, workspace: Workspace) {
     super(message);
     this.name = 'WorkspaceRunningError';
+    this.workspace = workspace;
   }
 }
 
@@ -60,9 +76,7 @@ export class WorkspaceStoppedDetector {
       return;
     }
 
-    if (workspace.isRunning) {
-      throw new WorkspaceRunningError('The workspace is running.');
-    }
+    WorkspaceRunningError.throwIfNeeded(workspace);
 
     return workspace;
   }
@@ -74,9 +88,7 @@ export class WorkspaceStoppedDetector {
    * @returns an appropriate Error describing the stopped workspace if applicable
    */
   public getWorkspaceStoppedError(workspace: Workspace, issueType: IssueType): Error {
-    if (workspace.isRunning) {
-      throw new WorkspaceRunningError('The workspace is running.');
-    }
+    WorkspaceRunningError.throwIfNeeded(workspace);
 
     if (issueType === 'workspaceStoppedError') {
       const devworkspace = workspace.ref as devfileApi.DevWorkspace;
@@ -95,9 +107,7 @@ export class WorkspaceStoppedDetector {
    * @returns the reason why the workspace has stopped
    */
   public getWorkspaceStoppedIssueType(workspace: Workspace): IssueType {
-    if (workspace.isRunning) {
-      throw new WorkspaceRunningError('The workspace is running.');
-    }
+    WorkspaceRunningError.throwIfNeeded(workspace);
 
     const devworkspace = workspace.ref as devfileApi.DevWorkspace;
 

--- a/packages/dashboard-frontend/src/store/Events/index.ts
+++ b/packages/dashboard-frontend/src/store/Events/index.ts
@@ -13,7 +13,6 @@
 import { api, helpers } from '@eclipse-che/common';
 import { CoreV1Event } from '@kubernetes/client-node';
 import { Action, Reducer } from 'redux';
-import { cli } from 'webpack';
 import { AppThunk } from '..';
 import { container } from '../../inversify.config';
 import { fetchEvents } from '../../services/dashboard-backend-client/eventsApi';


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Further alleviates https://github.com/eclipse/che/issues/21796. This PR does not solve the root problem however, the root problem is described in https://github.com/eclipse/che/issues/22008

Previously, dashboard tried to go back to the mainUrl of the workspace if the user was redirected to the dashboard via traefik errors middleware https://github.com/eclipse-che/che-operator/pull/1392 if the dashboard detects the DW `status.phase` to be RUNNING.

This PR tries to go back to the mainUrl if the dashboard detects the DW `status.phase` to be `RUNNING` or `STARTING`.

<details><summary>Demo</summary>

https://user-images.githubusercontent.com/83611742/219205265-e625f556-9953-486a-9ad0-7076c5459400.mov

</details>


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21796

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. On a clusterbot cluster (`launch 4.12`), deploy Che `next` version:
```
chectl server:deploy -p openshift
```

2. In the Che CR, set the dashboard image:
```
spec:
  components:
    ...
    dashboard:
      deployment:
        containers:
          - image: 'quay.io/eclipse/che-dashboard:pr-730'
            name: che-dashboard
```

3. From the dashboard, start an empty VS code workspace
4. On workspace startup the two following scenarios should not happen:





<details><summary>Redirect to dashboard</summary>

https://user-images.githubusercontent.com/83611742/219465314-23324227-5725-4125-8d40-c32c44776da5.mov

</details>

<details><summary>Redirect to dashboard with `Workspace is not running` message</summary>

https://user-images.githubusercontent.com/83611742/219465783-53c5d035-e0c9-434d-8c78-a0e046b5c468.mov

</details>

Note, this PR does not fix the 404 error on workspace startup since this error is not dashboard related.
<img width="345" alt="image" src="https://user-images.githubusercontent.com/83611742/219472276-e89ac8e5-87d7-402b-9d13-6d90c05d97e8.png">



#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
