### PR TITLE
Fix custom editor priority

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -75,12 +75,11 @@ describe('DevWorkspace client, create', () => {
       await client.createFromDevfile(
         testDevfile,
         namespace,
-        [],
-        undefined,
         undefined,
         undefined,
         undefined,
         {},
+        undefined,
       );
 
       expect(spyCreateWorkspace).toBeCalledWith(
@@ -98,12 +97,15 @@ describe('DevWorkspace client, create', () => {
       await client.createFromDevfile(
         testDevfile,
         namespace,
-        [],
         undefined,
         undefined,
         undefined,
-        'eclipse/theia/next',
         {},
+        {
+          id: 'eclipse/theia/next',
+          default: false,
+          plugins: [],
+        },
       );
 
       expect(spyCreateWorkspace).toBeCalledWith(

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/selectors.spec.ts
@@ -48,7 +48,7 @@ describe('dwPlugins selectors', () => {
 
   it('should return all plugins and errors', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withDwPlugins(plugins, false, 'default editor fetching error')
+      .withDwPlugins({ plugins, defaultEditorError: 'default editor fetching error' }, false)
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
@@ -62,7 +62,7 @@ describe('dwPlugins selectors', () => {
 
   it('should return array of plugins', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withDwPlugins(plugins, false, 'default editor fetching error')
+      .withDwPlugins({ plugins, defaultEditorError: 'default editor fetching error' }, false)
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
@@ -89,7 +89,7 @@ describe('dwPlugins selectors', () => {
 
   it('should return an error related to default editor fetching', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withDwPlugins(plugins, false, 'default editor fetching error')
+      .withDwPlugins({ plugins, defaultEditorError: 'default editor fetching error' }, false)
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>

--- a/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
@@ -21,7 +21,14 @@ export const selectDefaultComponents = createSelector(
   state => state.config.defaults?.components || [],
 );
 
-export const selectDefaultPlugins = createSelector(
+// returns a default editor id read from CheCluster CR
+export const selectDefaultEditorCR = createSelector(
+  selectState,
+  state => state.config.defaults?.editor,
+);
+
+// returns plugin ids read from CheCluster CR
+export const selectDefaultPluginsCR = createSelector(
   selectState,
   state => state.config.defaults?.plugins || [],
 );

--- a/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
@@ -21,14 +21,7 @@ export const selectDefaultComponents = createSelector(
   state => state.config.defaults?.components || [],
 );
 
-// returns a default editor id read from CheCluster CR
-export const selectDefaultEditorCR = createSelector(
-  selectState,
-  state => state.config.defaults?.editor,
-);
-
-// returns plugin ids read from CheCluster CR
-export const selectDefaultPluginsCR = createSelector(
+export const selectDefaultPlugins = createSelector(
   selectState,
   state => state.config.defaults?.plugins || [],
 );

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -59,6 +59,9 @@ describe('DevWorkspace store, actions', () => {
       .withWorkspacesSettings({
         cheWorkspacePluginRegistryUrl: pluginRegistryUrl,
       })
+      .withDwPlugins({
+        defaultEditorName: defaultEditorId,
+      })
       .withDwServerConfig({
         defaults: {
           editor: defaultEditorId,
@@ -106,18 +109,6 @@ describe('DevWorkspace store, actions', () => {
 
       const expectedActions: Array<testStore.KnownAction | pluginRegistryStore.KnownAction> = [
         {
-          check: AUTHORIZED,
-          editorName: defaultEditorId,
-          type: 'REQUEST_DW_EDITOR',
-          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
-        },
-        {
-          editorName: 'default-editor-id',
-          plugin: expect.anything(),
-          type: 'RECEIVE_DW_EDITOR',
-          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
-        },
-        {
           type: 'REQUEST_DEVWORKSPACE',
           check: AUTHORIZED,
         },
@@ -159,18 +150,6 @@ describe('DevWorkspace store, actions', () => {
       const actions = store.getActions();
 
       const expectedActions: Array<testStore.KnownAction | pluginRegistryStore.KnownAction> = [
-        {
-          check: AUTHORIZED,
-          editorName: defaultEditorId,
-          type: 'REQUEST_DW_EDITOR',
-          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
-        },
-        {
-          editorName: 'default-editor-id',
-          plugin: expect.anything(),
-          type: 'RECEIVE_DW_EDITOR',
-          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
-        },
         {
           type: 'REQUEST_DEVWORKSPACE',
           check: AUTHORIZED,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { AnyAction } from 'redux';
+import { MockStoreEnhanced } from 'redux-mock-store';
+import { ThunkDispatch } from 'redux-thunk';
+import * as testStore from '../';
+import { AppState } from '../../..';
+import { container } from '../../../../inversify.config';
+import devfileApi from '../../../../services/devfileApi';
+import { DevWorkspaceClient } from '../../../../services/workspace-client/devworkspace/devWorkspaceClient';
+import { AUTHORIZED } from '../../../sanityCheckMiddleware';
+import { DevWorkspaceBuilder } from '../../../__mocks__/devWorkspaceBuilder';
+import { FakeStoreBuilder } from '../../../__mocks__/storeBuilder';
+import { api } from '@eclipse-che/common';
+import * as pluginRegistryStore from '../../../Plugins/devWorkspacePlugins';
+
+jest.mock('../../../../services/registry/fetchData', () => ({
+  fetchData: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../../../services/dashboard-backend-client/serverConfigApi.ts');
+jest.mock('../../../../services/helpers/delay', () => ({
+  delay: jest.fn().mockResolvedValue(undefined),
+}));
+
+// DevWorkspaceClient mocks
+const mockCreateFromDevfile = jest.fn();
+
+describe('DevWorkspace store, actions', () => {
+  const devWorkspaceClient = container.get(DevWorkspaceClient);
+
+  let storeBuilder: FakeStoreBuilder;
+  let store: MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, AnyAction>>;
+
+  const defaultEditorId = 'default-editor-id';
+  const defaultEditorPlugins = ['default-plugin-id-1', 'default-plugin-id-2'];
+  const pluginRegistryUrl = 'plugin-registry-url';
+
+  beforeEach(() => {
+    container.snapshot();
+    devWorkspaceClient.createFromDevfile = mockCreateFromDevfile;
+
+    store = new FakeStoreBuilder()
+      .withInfrastructureNamespace([
+        { name: 'user-che', attributes: { default: 'true', phase: 'Active' } },
+      ])
+      .withWorkspacesSettings({
+        cheWorkspacePluginRegistryUrl: pluginRegistryUrl,
+      })
+      .withDwServerConfig({
+        defaults: {
+          editor: defaultEditorId,
+          plugins: [{ editor: defaultEditorId, plugins: defaultEditorPlugins }],
+          components: [],
+          pvcStrategy: undefined,
+        },
+        cheNamespace: 'user-che',
+        containerBuild: {},
+        pluginRegistry: {
+          openVSXURL: 'open-vsx',
+        },
+        timeouts: {
+          inactivityTimeout: 0,
+          runTimeout: 0,
+          startTimeout: 0,
+        },
+      } as api.IServerConfig)
+      .build() as MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, AnyAction>>;
+  });
+
+  afterEach(() => {
+    container.restore();
+    jest.resetAllMocks();
+  });
+
+  describe('createWorkspaceFromDevfile', () => {
+    it('should create REQUEST_DEVWORKSPACE and ADD_DEVWORKSPACE when creating a new workspace from devfile', async () => {
+      const devWorkspace = new DevWorkspaceBuilder().build();
+      const devfile: devfileApi.Devfile = {
+        schemaVersion: '2.1.0',
+        metadata: {
+          name: 'test',
+          namespace: 'user-che',
+        },
+      };
+
+      mockCreateFromDevfile.mockResolvedValueOnce(devWorkspace);
+
+      await store.dispatch(
+        testStore.actionCreators.createWorkspaceFromDevfile(devfile, {}, undefined, undefined, {}),
+      );
+
+      const actions = store.getActions();
+
+      const expectedActions: Array<testStore.KnownAction | pluginRegistryStore.KnownAction> = [
+        {
+          check: AUTHORIZED,
+          editorName: defaultEditorId,
+          type: 'REQUEST_DW_EDITOR',
+          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
+        },
+        {
+          editorName: 'default-editor-id',
+          plugin: expect.anything(),
+          type: 'RECEIVE_DW_EDITOR',
+          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
+        },
+        {
+          type: 'REQUEST_DEVWORKSPACE',
+          check: AUTHORIZED,
+        },
+        {
+          type: 'ADD_DEVWORKSPACE',
+          workspace: devWorkspace,
+        },
+      ];
+
+      expect(actions).toEqual(expectedActions);
+    });
+
+    it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when fails to create a new workspace from devfile', async () => {
+      const devWorkspace = new DevWorkspaceBuilder().build();
+      const devfile: devfileApi.Devfile = {
+        schemaVersion: '2.1.0',
+        metadata: {
+          name: 'test',
+          namespace: 'user-che',
+        },
+      };
+
+      mockCreateFromDevfile.mockRejectedValueOnce(new Error('Something unexpected happened.'));
+
+      try {
+        await store.dispatch(
+          testStore.actionCreators.createWorkspaceFromDevfile(
+            devfile,
+            {},
+            undefined,
+            undefined,
+            {},
+          ),
+        );
+      } catch (e) {
+        // no-op
+      }
+
+      const actions = store.getActions();
+
+      const expectedActions: Array<testStore.KnownAction | pluginRegistryStore.KnownAction> = [
+        {
+          check: AUTHORIZED,
+          editorName: defaultEditorId,
+          type: 'REQUEST_DW_EDITOR',
+          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
+        },
+        {
+          editorName: 'default-editor-id',
+          plugin: expect.anything(),
+          type: 'RECEIVE_DW_EDITOR',
+          url: `${pluginRegistryUrl}/plugins/${defaultEditorId}/devfile.yaml`,
+        },
+        {
+          type: 'REQUEST_DEVWORKSPACE',
+          check: AUTHORIZED,
+        },
+        {
+          error: `Something unexpected happened.`,
+          type: 'RECEIVE_DEVWORKSPACE_ERROR',
+        },
+      ];
+
+      expect(actions).toEqual(expectedActions);
+    });
+
+    describe('specifying editor', () => {
+      it('should proceed creating a workspace with a custom editor specified in URL', async () => {
+        const devWorkspace = new DevWorkspaceBuilder().build();
+        const devfile: devfileApi.Devfile = {
+          schemaVersion: '2.1.0',
+          metadata: {
+            name: 'test',
+            namespace: 'user-che',
+          },
+        };
+
+        mockCreateFromDevfile.mockResolvedValueOnce(devWorkspace);
+
+        const customEditorId = 'custom-editor-id';
+        await store.dispatch(
+          testStore.actionCreators.createWorkspaceFromDevfile(devfile, {}, undefined, undefined, {
+            'che-editor': customEditorId,
+          }),
+        );
+
+        const expectedEditorDefinition = {
+          default: false,
+          id: customEditorId,
+          plugins: [],
+        };
+        expect(mockCreateFromDevfile).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          undefined,
+          undefined,
+          expect.anything(),
+          expect.anything(),
+          expectedEditorDefinition,
+        );
+      });
+
+      it('should proceed creating a workspace with a default editor', async () => {
+        const devWorkspace = new DevWorkspaceBuilder().build();
+        const devfile: devfileApi.Devfile = {
+          schemaVersion: '2.1.0',
+          metadata: {
+            name: 'test',
+            namespace: 'user-che',
+          },
+        };
+
+        mockCreateFromDevfile.mockResolvedValueOnce(devWorkspace);
+
+        await store.dispatch(
+          testStore.actionCreators.createWorkspaceFromDevfile(
+            devfile,
+            {},
+            undefined,
+            undefined,
+            {},
+          ),
+        );
+
+        const expectedEditorDefinition = {
+          default: true,
+          id: defaultEditorId,
+          plugins: [],
+        };
+        expect(mockCreateFromDevfile).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          undefined,
+          undefined,
+          expect.anything(),
+          expect.anything(),
+          expectedEditorDefinition,
+        );
+      });
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -31,16 +31,20 @@ import { WorkspaceAdapter } from '../../../services/workspace-adapter';
 import {
   DevWorkspaceClient,
   DEVWORKSPACE_NEXT_START_ANNOTATION,
+  EditorDefinition,
   IStatusUpdate,
 } from '../../../services/workspace-client/devworkspace/devWorkspaceClient';
 import { selectRunningWorkspacesLimit } from '../../ClusterConfig/selectors';
 import { createObject } from '../../helpers';
 import { selectDefaultNamespace } from '../../InfrastructureNamespaces/selectors';
-import * as DwPluginsStore from '../../Plugins/devWorkspacePlugins';
-import { selectDwEditorsPluginsList } from '../../Plugins/devWorkspacePlugins/selectors';
+import * as PluginsStore from '../../Plugins/devWorkspacePlugins';
+import {
+  selectDefaultEditor,
+  selectDwEditorsPluginsList,
+} from '../../Plugins/devWorkspacePlugins/selectors';
 import { AUTHORIZED, SanityCheckAction } from '../../sanityCheckMiddleware';
 import * as DwServerConfigStore from '../../ServerConfig';
-import { selectOpenVSXUrl } from '../../ServerConfig/selectors';
+import { selectDefaultEditorCR, selectOpenVSXUrl } from '../../ServerConfig/selectors';
 import { deleteLogs, mergeLogs } from '../logs';
 import { selectRunningDevWorkspacesLimitExceeded } from './selectors';
 
@@ -119,7 +123,7 @@ interface AddWorkspaceAction extends Action {
   workspace: devfileApi.DevWorkspace;
 }
 
-type KnownAction =
+export type KnownAction =
   | RequestDevWorkspacesAction
   | ReceiveErrorAction
   | ReceiveWorkspacesAction
@@ -590,56 +594,57 @@ export const actionCreators: ActionCreators = {
       attributes: { [key: string]: string },
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
-      let state = getState();
+      let editor: EditorDefinition | undefined;
 
-      // do we have an optional editor parameter ?
-      let cheEditor: string | undefined = attributes?.['che-editor'];
-      if (cheEditor) {
-        // if the editor is different than the current default one, need to load a specific one
-        if (cheEditor !== state.dwPlugins.defaultEditorName) {
-          console.log(
-            `User specified a different editor than the current default. Loading ${cheEditor} definition instead of ${state.dwPlugins.defaultEditorName}.`,
-          );
-          await dispatch(
-            DwPluginsStore.actionCreators.requestDwEditor(
-              state.workspacesSettings.settings,
-              cheEditor,
-            ),
-          );
-        }
-      } else {
-        // take the default editor name
-        console.log(`Using default editor ${state.dwPlugins.defaultEditorName}`);
-        cheEditor = state.dwPlugins.defaultEditorName;
+      const urlEditorId = attributes?.['che-editor'];
+      const crDefaultEditorId = selectDefaultEditorCR(getState());
+      const registryDefaultEditorId = selectDefaultEditor(getState());
+      if (urlEditorId !== undefined) {
+        editor = {
+          default: false,
+          id: urlEditorId,
+          plugins: [],
+        };
+      } else if (crDefaultEditorId !== undefined) {
+        editor = {
+          default: true,
+          id: crDefaultEditorId,
+          plugins: [],
+        };
+      } else if (registryDefaultEditorId !== undefined) {
+        editor = {
+          default: true,
+          id: registryDefaultEditorId,
+          plugins: selectDwEditorsPluginsList(registryDefaultEditorId)(getState()),
+        };
+      }
+      // fetch editor if needed
+      if (editor !== undefined) {
+        await dispatch(
+          PluginsStore.actionCreators.requestDwEditor(
+            getState().workspacesSettings.settings,
+            editor.id,
+          ),
+        );
+        const plugins = selectDwEditorsPluginsList(editor.id)(getState());
+        editor.plugins.push(...plugins);
       }
 
-      if (state.dwPlugins.defaultEditorError) {
-        throw `Required sources failed when trying to create the workspace: ${state.dwPlugins.defaultEditorError}`;
-      }
-
-      // refresh state
-      state = getState();
       await dispatch({ type: 'REQUEST_DEVWORKSPACE', check: AUTHORIZED });
       try {
         // If the devworkspace doesn't have a namespace then we assign it to the default kubernetesNamespace
         const devWorkspaceDevfile = devfile as devfileApi.Devfile;
-        const defaultNamespace = selectDefaultNamespace(state);
-        const openVSXURL = selectOpenVSXUrl(state);
-        const dwEditorsList = selectDwEditorsPluginsList(cheEditor)(state);
+        const defaultNamespace = selectDefaultNamespace(getState());
+        const openVSXURL = selectOpenVSXUrl(getState());
         const workspace = await devWorkspaceClient.createFromDevfile(
           devWorkspaceDevfile,
           defaultNamespace.name,
-          dwEditorsList,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
           openVSXURL,
-          cheEditor,
           optionalFilesContent,
+          editor,
         );
-        if (workspace.spec.started) {
-          const defaultPlugins = getState().dwPlugins.defaultPlugins;
-          await devWorkspaceClient.onStart(workspace, defaultPlugins, cheEditor as string);
-        }
         dispatch({
           type: 'ADD_DEVWORKSPACE',
           workspace,

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -330,18 +330,22 @@ export class FakeStoreBuilder {
   }
 
   public withDwPlugins(
-    plugins: {
-      [location: string]: {
-        plugin?: devfileApi.Devfile;
-        url: string;
-        error?: string;
+    options: {
+      plugins?: {
+        [location: string]: {
+          plugin?: devfileApi.Devfile;
+          url: string;
+          error?: string;
+        };
       };
+      defaultEditorName?: string;
+      defaultEditorError?: string;
     },
     isLoading = false,
-    defaultEditorError?: string,
   ) {
-    this.state.dwPlugins.defaultEditorError = defaultEditorError;
-    this.state.dwPlugins.plugins = Object.assign({}, plugins);
+    this.state.dwPlugins.defaultEditorError = options?.defaultEditorError;
+    this.state.dwPlugins.plugins = Object.assign({}, options?.plugins);
+    this.state.dwPlugins.defaultEditorName = options?.defaultEditorName;
     this.state.dwPlugins.isLoading = isLoading;
 
     return this;


### PR DESCRIPTION
### What does this PR do?

This PR fixes the priority of defining a custom editor. 
So the lowest priority has the `defaultEditor` parameter set in the CheCluster CR. The next option with higher priority is `.che/che-editor.yaml` file. The highest priority has the `che-editor` URL parameter of a factory link.


### What issues does this PR fix or reference?

fixes https://issues.redhat.com/browse/CRW-3921

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Try `https://<che-host>#https://github.com/akurinnoy/vigilant-umbrella?che-editor=eclipse/che-theia/latest`. In this case Che-Theia editor will be used because the URL param has the highest priority.
2. Try `https://<che-host>#https://github.com/akurinnoy/vigilant-umbrella`. You'll get the Che-Idea because it's defined in the `.che/che-editor.yaml` file.
3. Try `https://<che-host>#https://github.com/eclipse-che/che-dashboard`. The default editor will be used.
