### PR TITLE
Backport 'Redirect to workspace if it is running or starting'

### DIFF
--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/workspaceStoppedDetector.spec.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/workspaceStoppedDetector.spec.ts
@@ -92,10 +92,8 @@ describe('WorkspaceStoppedDetector', () => {
       const mainUrlPath = '/workspaced5858247cc74458d/';
       SessionStorageService.update(SessionStorageKey.ORIGINAL_LOCATION_PATH, mainUrlPath);
 
-      const devWorkspaceId = 'dev-wksp-0';
-
       const devWorkspace = new DevWorkspaceBuilder()
-        .withId(devWorkspaceId)
+        .withId('dev-wksp-0')
         .withName('dev-wksp-0')
         .withNamespace('user-dev')
         .withStatus({ mainUrl: mainUrlPath, phase: 'RUNNING' })
@@ -111,6 +109,26 @@ describe('WorkspaceStoppedDetector', () => {
 
       expect(checkWorkspaceStopped).toThrow(WorkspaceRunningError);
     });
+  });
+
+  it('should throw error if matching workspace exists, but it is starting', () => {
+    const mainUrlPath = '/workspaced5858247cc74458d/universal-developer-image/3100/';
+    SessionStorageService.update(SessionStorageKey.ORIGINAL_LOCATION_PATH, mainUrlPath);
+
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withId('workspaced5858247cc74458d')
+      .withName('dev-wksp-0')
+      .withNamespace('user-dev')
+      .withStatus({ mainUrl: mainUrlPath, phase: 'RUNNING' })
+      .build();
+    devWorkspace.spec.started = true;
+
+    const store = new FakeStoreBuilder().withDevWorkspaces({ workspaces: [devWorkspace] }).build();
+    const checkWorkspaceStopped = () => {
+      new WorkspaceStoppedDetector().checkWorkspaceStopped(store.getState());
+    };
+
+    expect(checkWorkspaceStopped).toThrow(WorkspaceRunningError);
   });
 
   describe('getWorkspaceStoppedError()', () => {

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -325,9 +325,8 @@ export default class Bootstrap {
       this.issuesReporterService.registerIssue(type, error, workspaceData);
     } catch (e) {
       if (e instanceof WorkspaceRunningError) {
-        // workspace is running, redirect to workspace url
-        if (stoppedWorkspace?.ideUrl) {
-          window.location.href = stoppedWorkspace.ideUrl;
+        if (e.workspace.ideUrl) {
+          window.location.href = e.workspace.ideUrl;
           return;
         }
       } else {

--- a/packages/dashboard-frontend/src/services/bootstrap/workspaceStoppedDetector.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/workspaceStoppedDetector.ts
@@ -20,9 +20,25 @@ import { Workspace } from '../workspace-adapter';
 import { IssueType } from './issuesReporter';
 
 export class WorkspaceRunningError extends Error {
-  constructor(message) {
+  public workspace: Workspace;
+
+  /**
+   * Check if workspace is running or is about to run.
+   * If it is, throw error.
+   *
+   * @param workspace the workspace to check
+   */
+  public static throwIfNeeded(workspace) {
+    if (workspace.isRunning || workspace.isStarting) {
+      const state = workspace.isRunning ? 'running' : 'starting';
+      throw new WorkspaceRunningError(`The workspace is ${state}.`, workspace);
+    }
+  }
+
+  constructor(message: string, workspace: Workspace) {
     super(message);
     this.name = 'WorkspaceRunningError';
+    this.workspace = workspace;
   }
 }
 
@@ -60,9 +76,7 @@ export class WorkspaceStoppedDetector {
       return;
     }
 
-    if (workspace.isRunning) {
-      throw new WorkspaceRunningError('The workspace is running.');
-    }
+    WorkspaceRunningError.throwIfNeeded(workspace);
 
     return workspace;
   }
@@ -74,9 +88,7 @@ export class WorkspaceStoppedDetector {
    * @returns an appropriate Error describing the stopped workspace if applicable
    */
   public getWorkspaceStoppedError(workspace: Workspace, issueType: IssueType): Error {
-    if (workspace.isRunning) {
-      throw new WorkspaceRunningError('The workspace is running.');
-    }
+    WorkspaceRunningError.throwIfNeeded(workspace);
 
     if (issueType === 'workspaceStoppedError') {
       const devworkspace = workspace.ref as devfileApi.DevWorkspace;
@@ -95,9 +107,7 @@ export class WorkspaceStoppedDetector {
    * @returns the reason why the workspace has stopped
    */
   public getWorkspaceStoppedIssueType(workspace: Workspace): IssueType {
-    if (workspace.isRunning) {
-      throw new WorkspaceRunningError('The workspace is running.');
-    }
+    WorkspaceRunningError.throwIfNeeded(workspace);
 
     const devworkspace = workspace.ref as devfileApi.DevWorkspace;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Backports https://github.com/eclipse-che/che-dashboard/pull/730 to 7.60.x


### What issues does this PR fix or reference?
Please see https://github.com/eclipse-che/che-dashboard/pull/730

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
