### PR TITLE
fix: create multiarch image manifest with tools compatible with lates…

### DIFF
--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -41,8 +41,6 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
         uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.9.1
       -
         name: "Docker quay.io Login"
         uses: docker/login-action@v2
@@ -92,19 +90,18 @@ jobs:
           AMEND=""
           AMD64_VERSION="${{ needs['build-images'].outputs.amd64 }}"
           if [ -n "$AMD64_VERSION" ]; then
-            AMEND+=" --amend ${{ env.IMAGE }}:$AMD64_VERSION";
+            AMEND+=" ${{ env.IMAGE }}:$AMD64_VERSION";
           fi
           ARM64_VERSION="${{ needs['build-images'].outputs.arm64 }}"
           if [ -n "$ARM64_VERSION" ]; then
-            AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
+            AMEND+=" ${{ env.IMAGE }}:$ARM64_VERSION";
           fi
           PPC64LE_VERSION="${{ needs['build-images'].outputs.ppc64le }}"
           if [ -n "$PPC64LE_VERSION" ]; then
-            AMEND+=" --amend ${{ env.IMAGE }}:$PPC64LE_VERSION";
+            AMEND+=" ${{ env.IMAGE }}:$PPC64LE_VERSION";
           fi
           if [ -z "$AMEND" ]; then
             echo "[!] The job 'build-images' didn't provide any outputs. Can't create the manifest list."
             exit 1;
           fi
-          docker manifest create ${{ env.IMAGE }}:next $AMEND
-          docker manifest push ${{ env.IMAGE }}:next
+          docker buildx imagetools create -t ${{ env.IMAGE }}:next $AMEND

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
         uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.9.1
       -
         name: "Docker quay.io Login"
         uses: docker/login-action@v2
@@ -86,13 +84,9 @@ jobs:
             exit 1;
           fi
 
-          AMEND=""
-          AMEND+=" --amend ${{ env.IMAGE }}:$AMD64_VERSION";
-          AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
-          AMEND+=" --amend ${{ env.IMAGE }}:$PPC64LE_VERSION";
+          AMEND="${{ env.IMAGE }}:$AMD64_VERSION ${{ env.IMAGE }}:$ARM64_VERSION ${{ env.IMAGE }}:$PPC64LE_VERSION";
 
-          docker manifest create ${{ env.IMAGE }}:${{ github.event.inputs.version }} $AMEND
-          docker manifest push ${{ env.IMAGE }}:${{ github.event.inputs.version }}
+          docker buildx imagetools create -t ${{ env.IMAGE }}:${{ github.event.inputs.version }} $AMEND
       -
         id: result
         name: "Manifest result"


### PR DESCRIPTION
…t buildx extension

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
'docker manifest create' won't work with images build from latest buildx extension, because of provenance attestations.
the solution is to replace this command with 'build imagetools" util that can work with images built in such way

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21954

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
tested on forked repo action

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
