### PR TITLE
fix: disable provenance to fix creating multiarch manifest with lates…

### DIFF
--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -41,8 +41,6 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
         uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.9.1
       -
         name: "Docker quay.io Login"
         uses: docker/login-action@v2
@@ -67,6 +65,7 @@ jobs:
           file: ./build/dockerfiles/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: true
+          provenance: false
           tags: ${{ env.IMAGE }}:${{ matrix.arch }}-next
       -
         id: result

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.arch }}"
         uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.9.1
       -
         name: "Docker quay.io Login"
         uses: docker/login-action@v2
@@ -54,6 +52,7 @@ jobs:
           file: ./build/dockerfiles/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: true
+          provenance: false
           tags: ${{ env.IMAGE }}:${{ github.event.inputs.version }}-${{ matrix.arch }}
       -
         id: result


### PR DESCRIPTION
…t buildx version

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
'docker manifest create' won't work with images build from latest buildx extension, because of provenance attestations.
the solution is to disable provenance attestations in buildx configuration.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21954

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
tested in forked repo

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
