### PR TITLE
chore: refresh access token when workspace is starting

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -227,7 +227,6 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
     });
 
     try {
-      OAuthService.setOauthStartedState();
       await this.props.requestFactoryResolver(factoryUrl, params);
       this.clearNumberOfTries();
       return true;

--- a/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
@@ -31,8 +31,24 @@ OAuthService.openOAuthPage = mockOpenOAuthPage;
 console.log = jest.fn();
 
 describe('OAuth service', () => {
-  it('should not refresh token if no projects section in devworkspace', async () => {
+  it('should not refresh token if no status section in devworkspace', async () => {
     const devWorkspace = new DevWorkspaceBuilder().build();
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
+  });
+  it('should not refresh token if no mainUrl in status', async () => {
+    const status = {};
+    const devWorkspace = new DevWorkspaceBuilder().withStatus(status).build();
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
+  });
+  it('should not refresh token if no projects section in devworkspace', async () => {
+    const status = { mainUrl: 'https://mainUrl' };
+    const devWorkspace = new DevWorkspaceBuilder().withStatus(status).build();
 
     OAuthService.refreshTokenIfNeeded(devWorkspace);
 
@@ -41,7 +57,11 @@ describe('OAuth service', () => {
 
   it('should not refresh token if devworkspace does not have any project', async () => {
     const projects = [{}];
-    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+    const status = { mainUrl: 'https://mainUrl' };
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withStatus(status)
+      .withProjects(projects)
+      .build();
 
     OAuthService.refreshTokenIfNeeded(devWorkspace);
 
@@ -49,6 +69,7 @@ describe('OAuth service', () => {
   });
 
   it('should not refresh token if no git project', async () => {
+    const status = { mainUrl: 'https://mainUrl' };
     const projects = [
       {
         name: 'project',
@@ -57,7 +78,10 @@ describe('OAuth service', () => {
         },
       },
     ];
-    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withStatus(status)
+      .withProjects(projects)
+      .build();
 
     OAuthService.refreshTokenIfNeeded(devWorkspace);
 
@@ -65,6 +89,7 @@ describe('OAuth service', () => {
   });
 
   it('should refresh token', async () => {
+    const status = { mainUrl: 'https://mainUrl' };
     const projects = [
       {
         name: 'project',
@@ -75,7 +100,10 @@ describe('OAuth service', () => {
         },
       },
     ];
-    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withStatus(status)
+      .withProjects(projects)
+      .build();
 
     refreshFactoryOauthTokenSpy.mockResolvedValueOnce();
 
@@ -85,6 +113,7 @@ describe('OAuth service', () => {
   });
 
   it('should not redirect to oauth window if an error does not include axios responce', async () => {
+    const status = { mainUrl: 'https://mainUrl' };
     const projects = [
       {
         name: 'project',
@@ -95,7 +124,10 @@ describe('OAuth service', () => {
         },
       },
     ];
-    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withStatus(status)
+      .withProjects(projects)
+      .build();
 
     refreshFactoryOauthTokenSpy.mockRejectedValueOnce({
       isAxiosError: false,
@@ -116,6 +148,7 @@ describe('OAuth service', () => {
   });
 
   it('should not redirect to oauth window if status code is not 401', async () => {
+    const status = { mainUrl: 'https://mainUrl' };
     const projects = [
       {
         name: 'project',
@@ -126,7 +159,10 @@ describe('OAuth service', () => {
         },
       },
     ];
-    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withStatus(status)
+      .withProjects(projects)
+      .build();
 
     refreshFactoryOauthTokenSpy.mockRejectedValueOnce({
       isAxiosError: false,
@@ -153,6 +189,7 @@ describe('OAuth service', () => {
   });
 
   it('should not redirect to oauth window if error does not provide OAuth response', async () => {
+    const status = { mainUrl: 'https://mainUrl' };
     const projects = [
       {
         name: 'project',
@@ -163,7 +200,10 @@ describe('OAuth service', () => {
         },
       },
     ];
-    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withStatus(status)
+      .withProjects(projects)
+      .build();
 
     refreshFactoryOauthTokenSpy.mockRejectedValueOnce({
       isAxiosError: false,

--- a/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { AxiosError } from 'axios';
+import common from '@eclipse-che/common';
+import OAuthService from '..';
+import { container } from '../../../inversify.config';
+import { DevWorkspaceBuilder } from '../../../store/__mocks__/devWorkspaceBuilder';
+import { CheWorkspaceClient } from '../../workspace-client/cheworkspace/cheWorkspaceClient';
+
+const cheWorkspaceClient = container.get(CheWorkspaceClient);
+
+const refreshFactoryOauthTokenSpy = jest.spyOn(
+  cheWorkspaceClient.restApiClient,
+  'refreshFactoryOauthToken',
+);
+
+const mockOpenOAuthPage = jest.fn().mockImplementation();
+OAuthService.openOAuthPage = mockOpenOAuthPage;
+
+// mute the outputs
+console.log = jest.fn();
+
+describe('OAuth service', () => {
+  it('should not refresh token if no projects section in devworkspace', async () => {
+    const devWorkspace = new DevWorkspaceBuilder().build();
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not refresh token if devworkspace does not have any project', async () => {
+    const projects = [{}];
+    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not refresh token if no git project', async () => {
+    const projects = [
+      {
+        name: 'project',
+        zip: {
+          url: 'project',
+        },
+      },
+    ];
+    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
+  });
+
+  it('should refresh token', async () => {
+    const projects = [
+      {
+        name: 'project',
+        git: {
+          remotes: {
+            origin: 'origin:project',
+          },
+        },
+      },
+    ];
+    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+
+    refreshFactoryOauthTokenSpy.mockResolvedValueOnce();
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
+  });
+
+  it('should not redirect to oauth window if an error does not include axios responce', async () => {
+    const projects = [
+      {
+        name: 'project',
+        git: {
+          remotes: {
+            origin: 'origin:project',
+          },
+        },
+      },
+    ];
+    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+
+    refreshFactoryOauthTokenSpy.mockRejectedValueOnce({
+      isAxiosError: false,
+      code: '500',
+      response: {
+        data: {
+          message: 'Something unexpected happened.',
+        },
+      },
+    } as AxiosError);
+
+    jest.spyOn(common.helpers.errors, 'includesAxiosResponse').mockImplementation(() => false);
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
+    expect(mockOpenOAuthPage).not.toHaveBeenCalled();
+  });
+
+  it('should not redirect to oauth window if status code is not 401', async () => {
+    const projects = [
+      {
+        name: 'project',
+        git: {
+          remotes: {
+            origin: 'origin:project',
+          },
+        },
+      },
+    ];
+    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+
+    refreshFactoryOauthTokenSpy.mockRejectedValueOnce({
+      isAxiosError: false,
+      code: '500',
+      response: {
+        status: 500,
+        data: {
+          responseData: {
+            attributes: {
+              oauth_provider: 'git-lab',
+              oauth_authentication_url: 'https://git-lub/oauth/url',
+            },
+          },
+        },
+      },
+    } as AxiosError);
+
+    jest.spyOn(common.helpers.errors, 'includesAxiosResponse').mockImplementation(() => true);
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
+    expect(mockOpenOAuthPage).not.toHaveBeenCalled();
+  });
+
+  it('should not redirect to oauth window if error does not provide OAuth response', async () => {
+    const projects = [
+      {
+        name: 'project',
+        git: {
+          remotes: {
+            origin: 'origin:project',
+          },
+        },
+      },
+    ];
+    const devWorkspace = new DevWorkspaceBuilder().withProjects(projects).build();
+
+    refreshFactoryOauthTokenSpy.mockRejectedValueOnce({
+      isAxiosError: false,
+      code: '401',
+      response: {
+        status: 401,
+        data: {
+          responseData: {
+            attributes: {},
+          },
+        },
+      },
+    } as AxiosError);
+
+    jest.spyOn(common.helpers.errors, 'includesAxiosResponse').mockImplementation(() => true);
+
+    OAuthService.refreshTokenIfNeeded(devWorkspace);
+
+    expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
+    expect(mockOpenOAuthPage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard-frontend/src/services/oauth/index.ts
+++ b/packages/dashboard-frontend/src/services/oauth/index.ts
@@ -12,7 +12,6 @@
 
 import common, { helpers } from '@eclipse-che/common';
 import { OAuthResponse } from '../../store/FactoryResolver';
-import SessionStorageService, { SessionStorageKey } from '../session-storage';
 import { container } from '../../inversify.config';
 import { CheWorkspaceClient } from '../workspace-client/cheworkspace/cheWorkspaceClient';
 import devfileApi from '../devfileApi';
@@ -31,6 +30,10 @@ export default class OAuthService {
   }
 
   static async refreshTokenIfNeeded(workspace: devfileApi.DevWorkspace): Promise<void> {
+    // if workspace is not created yet, do not refresh token
+    if (!workspace.status || !workspace.status.mainUrl) {
+      return;
+    }
     if (!workspace.spec.template.projects) {
       return;
     }
@@ -63,10 +66,6 @@ export default class OAuthService {
         );
       }
     }
-  }
-
-  static setOauthStartedState(): void {
-    SessionStorageService.update(SessionStorageKey.AUTHENTICATION_STATUS, 'started');
   }
 }
 

--- a/packages/dashboard-frontend/src/services/session-storage/index.ts
+++ b/packages/dashboard-frontend/src/services/session-storage/index.ts
@@ -13,7 +13,6 @@
 export enum SessionStorageKey {
   PRIVATE_FACTORY_RELOADS = 'private-factory-reloads-number',
   ORIGINAL_LOCATION_PATH = 'original-location-path',
-  AUTHENTICATION_STATUS = 'authentication-status',
 }
 
 export default class SessionStorageService {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -43,6 +43,7 @@ import { dump } from 'js-yaml';
 import { loadResourcesContent } from '../../../services/registry/resources';
 import { checkRunningWorkspacesLimit } from './checkRunningWorkspacesLimit';
 import { selectDevWorkspacesResourceVersion } from './selectors';
+import OAuthService from '../../../services/oauth';
 import { EDITOR_ATTR } from '../../../containers/Loader/const';
 
 const devWorkspaceClient = container.get(DevWorkspaceClient);
@@ -262,6 +263,7 @@ export const actionCreators: ActionCreators = {
         console.warn(`Workspace ${_workspace.metadata.name} already started`);
         return;
       }
+      await OAuthService.refreshTokenIfNeeded(workspace);
       await dispatch({ type: Type.REQUEST_DEVWORKSPACE, check: AUTHORIZED });
       try {
         checkRunningWorkspacesLimit(getState());

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -16,8 +16,6 @@ import { createObject } from '../helpers';
 import devfileApi from '../../services/devfileApi';
 import { Workspace } from '../../services/workspace-adapter';
 import * as DevWorkspacesStore from './devWorkspaces';
-import common from '@eclipse-che/common';
-import OAuthService, { isOAuthResponse } from '../../services/oauth';
 
 // This state defines the type of data maintained in the Redux store.
 export interface State {
@@ -156,29 +154,6 @@ export const actionCreators: ActionCreators = {
     (workspace: Workspace, params?: ResourceQueryParams): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch): Promise<void> => {
       dispatch({ type: 'REQUEST_WORKSPACES' });
-      try {
-        await OAuthService.refreshTokenIfNeeded(workspace);
-      } catch (e) {
-        if (common.helpers.errors.includesAxiosResponse(e)) {
-          const response = e.response;
-          if (response.status === 401 && isOAuthResponse(response.data)) {
-            // build redirect URL
-            const redirectUrl = new URL(
-              'dashboard/w',
-              window.location.protocol + '//' + window.location.host,
-            );
-            redirectUrl.searchParams.set(
-              'params',
-              `{"namespace":"${workspace.namespace}","workspace":"${workspace.name}"}`,
-            );
-            OAuthService.openOAuthPage(
-              response.data.attributes.oauth_authentication_url,
-              redirectUrl.toString(),
-            );
-            return;
-          }
-        }
-      }
       const debugWorkspace = params && params['debug-workspace-start'];
       await dispatch(
         DevWorkspacesStore.actionCreators.startWorkspace(workspace.ref, debugWorkspace),


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Refreshes OAuth access token when the devWorkspace is starting/restarting.
It does in a few steps:
- sends a request to che-server to check the OAuth token
- if che-server returns an error, open an authentication page to authenticate

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3928

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Update CheCluster CR with `vsvydenko/che-dashboard:7` dashboard image.
2. Configure GitLab Oauth as per the documentation https://www.eclipse.org/che/docs/stable/administration-guide/configuring-oauth-2-for-gitlab/
3. Use factory to start a workspace with private project
4. Wait 2 hours when the access token is expired 
5. Try to restart the workspace and execute `git pull` in the workspace


https://user-images.githubusercontent.com/1271546/221356558-5e2e87ec-e665-4293-b4e3-72f357d80826.mp4


