### PR TITLE
feat: drop 'state', 'session' and 'code' attributes during startup

### DIFF
--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/index.tsx
@@ -18,6 +18,7 @@ import * as DevfileRegistriesStore from '../../../../store/DevfileRegistries';
 import * as FactoryResolverStore from '../../../../store/FactoryResolver';
 import { GitRepoLocationInput } from './GitRepoLocationInput';
 import { selectWorkspacesSettings } from '../../../../store/Workspaces/Settings/selectors';
+import { sanitizeLocation } from '../../../../services/helpers/location';
 
 type Props = MappedProps & {
   onDevfileResolve: (resolverState: FactoryResolverStore.ResolverState, location: string) => void;
@@ -44,9 +45,9 @@ export class ImportFromGit extends React.PureComponent<Props, State> {
   }
 
   private async handleLocationChange(location: string): Promise<void> {
-    const factoryUrl = `${window.location.origin}/#${location}`;
+    const factoryUrl = sanitizeLocation<URL>(new window.URL(location));
     // open a new page to handle that
-    window.open(factoryUrl, '_blank');
+    window.open(`${window.location.origin}/#${factoryUrl.toString()}`, '_blank');
   }
 
   public render(): React.ReactNode {

--- a/packages/dashboard-frontend/src/preload/index.ts
+++ b/packages/dashboard-frontend/src/preload/index.ts
@@ -12,6 +12,7 @@
 
 import { PROPAGATE_FACTORY_ATTRS, REMOTES_ATTR } from '../containers/Loader/const';
 import SessionStorageService, { SessionStorageKey } from '../services/session-storage';
+import { sanitizeLocation } from '../services/helpers/location';
 
 (function acceptNewFactoryLink(): void {
   if (window.location.pathname.startsWith('/dashboard/')) {
@@ -47,7 +48,7 @@ export function storePathIfNeeded(path: string) {
 }
 
 export function buildFactoryLoaderPath(url: string, appendUrl = true): string {
-  const fullUrl = new window.URL(url);
+  const fullUrl = sanitizeLocation<URL>(new window.URL(url));
 
   const initParams = PROPAGATE_FACTORY_ATTRS.map(paramName => {
     const paramValue = extractUrlParam(fullUrl, paramName);

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/location.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/location.spec.ts
@@ -26,7 +26,7 @@ describe('location/sanitizeLocation', () => {
 
   it('should return sanitized value of location.search', () => {
     const search =
-      '?url=https%3A%2F%2Fgithub.com%2Ftest-samples&state=9284564475&session_state=45645654567&code=9844646765&storageType=persistent';
+      '?url=https%3A%2F%2Fgithub.com%2Ftest-samples&state=9284564475&session=98765&session_state=45645654567&code=9844646765&storageType=persistent';
     const pathname = '/f';
 
     const newLocation = sanitizeLocation({ search, pathname } as Location);

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -98,11 +98,14 @@ export function toHref(history: History, location: Location): string {
   return history.createHref(location);
 }
 
-const oauthParams = ['state', 'session_state', 'code'];
+const oauthParams = ['state', 'session', 'session_state', 'code'];
 /**
  * Removes oauth params.
  */
-export function sanitizeLocation(location: Location, removeParams: string[] = []): Location {
+export function sanitizeLocation<T extends { search: string; pathname: string } = Location>(
+  location: T,
+  removeParams: string[] = [],
+): T {
   const toRemove = [...oauthParams, ...removeParams];
   // clear search params
   if (location.search) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->


### What does this PR do?
Drop 'session' and 'code' attributes during startup.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21655



