### PR TITLE
fix: enable automatic revoke for GitHub only

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
@@ -77,24 +77,15 @@ Array [
           data-ouia-safe={true}
           hidden={false}
         >
-          <td
-            className="pf-c-table__check"
+          <th
+            className=""
             data-key={0}
             data-label=""
             onMouseEnter={[Function]}
             scope={null}
           >
-            <label>
-              <input
-                aria-label="Select all rows"
-                checked={false}
-                name="check-all"
-                onChange={[Function]}
-                type="checkbox"
-              />
-            </label>
             
-          </td>
+          </th>
           <th
             className=""
             data-key={1}
@@ -244,6 +235,7 @@ Array [
               <input
                 aria-label="Select row 1"
                 checked={false}
+                disabled={true}
                 name="checkrow1"
                 onChange={[Function]}
                 type="checkbox"
@@ -294,7 +286,7 @@ Array [
                 aria-haspopup={true}
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
-                disabled={false}
+                disabled={true}
                 id="pf-dropdown-toggle-id-3"
                 onClick={[Function]}
                 onKeyDown={[Function]}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
@@ -22,6 +22,8 @@ import { api } from '@eclipse-che/common';
 import * as GitOauthConfig from '../../../store/GitOauthConfig';
 import GitServicesToolbar, { GitServicesToolbar as Toolbar } from './GitServicesToolbar';
 
+export const enabledProviders: api.GitOauthProvider[] = ['github'];
+
 export const providersMap = {
   github: 'GitHub',
   gitlab: 'GitLab',
@@ -97,6 +99,10 @@ export class GitServicesTab extends React.PureComponent<Props, State> {
     this.gitServicesToolbarRef.current?.showOnRevokeGitOauthModal(rowIndex);
   }
 
+  private isDisabled(providerName: api.GitOauthProvider): boolean {
+    return !enabledProviders.includes(providerName);
+  }
+
   render(): React.ReactNode {
     const { isLoading, gitOauth } = this.props;
     const { selectedItems } = this.state;
@@ -112,6 +118,8 @@ export class GitServicesTab extends React.PureComponent<Props, State> {
         ? gitOauth.map(provider => ({
             cells: this.buildGitOauthRow(provider.name, provider.endpointUrl),
             selected: selectedItems.includes(provider.name),
+            disableSelection: this.isDisabled(provider.name),
+            disableActions: this.isDisabled(provider.name),
           }))
         : [];
 
@@ -131,11 +139,12 @@ export class GitServicesTab extends React.PureComponent<Props, State> {
               <Table
                 cells={columns}
                 actions={actions}
+                areActionsDisabled={rowData => !!rowData.disableActions}
                 rows={rows}
                 onSelect={(event, isSelected, rowIndex) => {
                   this.onChangeSelection(isSelected, rowIndex);
                 }}
-                canSelectAll={true}
+                canSelectAll={false}
                 aria-label="Git services"
                 variant="compact"
               >


### PR DESCRIPTION
### What does this PR do?
cherry-picking https://github.com/eclipse-che/che-dashboard/pull/746 to 7.60.x

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
