### PR TITLE
Ask to start a workpspace from the default devfile, if the factory URL is unsupported

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -17,7 +17,7 @@ import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Action, Store } from 'redux';
-import StepFetchDevfile, { State } from '..';
+import StepFetchDevfile, { State, UnsupportedGitProviderError } from '..';
 import { List, LoaderStep, LoadingStep } from '../../../../../../../components/Loader/Step';
 import {
   buildLoaderSteps,
@@ -132,6 +132,24 @@ describe('Factory Loader container, step CREATE_WORKSPACE__FETCH_DEVFILE', () =>
     userEvent.click(restartButton);
 
     expect(mockOnRestart).toHaveBeenCalled();
+  });
+
+  test('unsupported git provider', async () => {
+    const localState: Partial<State> = {
+      lastError: new UnsupportedGitProviderError('Failed to fetch devfile'),
+      factoryParams: buildFactoryParams(searchParams),
+    };
+    renderComponent(store, loaderSteps, searchParams, currentStepIndex, localState);
+
+    jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
+
+    const defaultDevfileButton = await screen.findByRole('button', {
+      name: 'Continue with the default devfile',
+    });
+    expect(defaultDevfileButton).toBeDefined();
+    userEvent.click(defaultDevfileButton);
+
+    await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
   });
 
   test('no project url, remotes exist', async () => {

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -44,6 +44,13 @@ export class ApplyingDevfileError extends Error {
   }
 }
 
+class UnsupportedGitProviderError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'UnsupportedGitProviderError';
+  }
+}
+
 const RELOADS_LIMIT = 2;
 type ReloadsInfo = {
   [url: string]: number;
@@ -190,6 +197,9 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
       if (errorMessage.includes('schema validation failed')) {
         throw new ApplyingDevfileError(errorMessage);
       }
+      if (errorMessage === 'Failed to fetch devfile') {
+        throw new UnsupportedGitProviderError(errorMessage);
+      }
       throw e;
     }
     if (!resolveDone) {
@@ -311,6 +321,32 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="If you continue it will be ignored and a regular workspace will be created.
             You will have a chance to fix the Devfile from the IDE once it is started."
+          />
+        ),
+        actionCallbacks: [
+          {
+            title: 'Continue with the default devfile',
+            callback: () => this.handleDevfileError(),
+          },
+          {
+            title: 'Reload',
+            callback: () => this.clearStepError(),
+          },
+        ],
+      };
+    }
+    if (error instanceof UnsupportedGitProviderError) {
+      return {
+        key: 'factory-loader-devfile-error',
+        title: 'Warning',
+        variant: AlertVariant.warning,
+        children: (
+          <ExpandableWarning
+            textBefore="Looking for a Devfile in the git repository failed."
+            errorMessage={helpers.errors.getMessage(error)}
+            textAfter="The git provider may not be supported by Eclipse Che (or the git server hasn't been configured
+            appropriately). Note that the git cloning of the repository will succeed if it's public or it's private
+            and the developer git credentials secret has been configured."
           />
         ),
         actionCallbacks: [

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -44,7 +44,7 @@ export class ApplyingDevfileError extends Error {
   }
 }
 
-class UnsupportedGitProviderError extends Error {
+export class UnsupportedGitProviderError extends Error {
   constructor(message) {
     super(message);
     this.name = 'UnsupportedGitProviderError';


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Improve the error when the Factory URL is not supported or restricted.
* Ask to create a workspace from the default devfile.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21997

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy che via the test image: chectl server:deploy -p=minikube -i=quay.io/ivinokur/che-server:next
  For the testing purpose I disabled gitlab factory handler in the image.
2. Apply the dashboard changes.
3. Pass a gitlab public repo with a devfile to start a workspace e.g. 'https://gitlab.com/ivinokur/test.git'
4. See the specific error:
![screenshot-localhost_8080-2023 03 10-14_06_55](https://user-images.githubusercontent.com/7668752/224312136-08e8cf63-5600-435a-a0dc-13e00febcd58.png)
 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
