### PR TITLE
Add Openshift console URL as env variable to a component

### DIFF
--- a/packages/common/src/dto/cluster-info.ts
+++ b/packages/common/src/dto/cluster-info.ts
@@ -19,4 +19,5 @@ export interface ApplicationInfo {
   title: string;
   icon: string;
   group?: string;
+  id?: string;
 }

--- a/packages/common/src/dto/cluster-info.ts
+++ b/packages/common/src/dto/cluster-info.ts
@@ -14,10 +14,14 @@ export interface ClusterInfo {
   applications: ApplicationInfo[];
 }
 
+export enum ApplicationId {
+  CLUSTER_CONSOLE = 'cluster-console',
+}
+
 export interface ApplicationInfo {
   url: string;
   title: string;
   icon: string;
   group?: string;
-  id?: string;
+  id?: ApplicationId;
 }

--- a/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
@@ -40,6 +40,7 @@ describe('Cluster Info Route', () => {
           icon: `${clusterConsoleUrl}/static/assets/redhat.svg`,
           title: 'OpenShift console',
           url: clusterConsoleUrl,
+          id: 'clusterConsole',
         },
       ],
     });

--- a/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { ApplicationId } from '@eclipse-che/common';
 import { FastifyInstance } from 'fastify';
 import { baseApiPath } from '../../../constants/config';
 import { setup, teardown } from '../../../helpers/tests/appBuilder';
@@ -40,7 +41,7 @@ describe('Cluster Info Route', () => {
           icon: `${clusterConsoleUrl}/static/assets/redhat.svg`,
           title: 'OpenShift console',
           url: clusterConsoleUrl,
-          id: 'clusterConsole',
+          id: ApplicationId.CLUSTER_CONSOLE,
         },
       ],
     });

--- a/packages/dashboard-backend/src/routes/api/clusterInfo.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterInfo.ts
@@ -11,7 +11,7 @@
  */
 
 import { FastifyInstance } from 'fastify';
-import { ApplicationInfo, ClusterInfo } from '@eclipse-che/common';
+import { ApplicationId, ApplicationInfo, ClusterInfo } from '@eclipse-che/common';
 import { baseApiPath } from '../../constants/config';
 import { getSchema } from '../../services/helpers';
 
@@ -34,7 +34,7 @@ function buildApplicationInfo(): ClusterInfo {
   const applications: ApplicationInfo[] = [];
   if (clusterConsoleUrl) {
     applications.push({
-      id: 'clusterConsole',
+      id: ApplicationId.CLUSTER_CONSOLE,
       icon: clusterConsoleIcon,
       title: clusterConsoleTitle,
       url: clusterConsoleUrl,

--- a/packages/dashboard-backend/src/routes/api/clusterInfo.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterInfo.ts
@@ -34,6 +34,7 @@ function buildApplicationInfo(): ClusterInfo {
   const applications: ApplicationInfo[] = [];
   if (clusterConsoleUrl) {
     applications.push({
+      id: 'clusterConsole',
       icon: clusterConsoleIcon,
       title: clusterConsoleTitle,
       url: clusterConsoleUrl,

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -11,7 +11,7 @@
  */
 
 import { Store } from 'redux';
-import common, { api } from '@eclipse-che/common';
+import common, { api, ApplicationId } from '@eclipse-che/common';
 import { lazyInject } from '../../inversify.config';
 import { AppState } from '../../store';
 import * as BannerAlertStore from '../../store/BannerAlert';
@@ -46,6 +46,7 @@ import { WebsocketClient } from '../dashboard-backend-client/websocketClient';
 import { selectEventsResourceVersion } from '../../store/Events/selectors';
 import { selectPodsResourceVersion } from '../../store/Pods/selectors';
 import { ChannelListener } from '../dashboard-backend-client/websocketClient/messageHandler';
+import { selectApplications } from '../../store/ClusterInfo/selectors';
 
 /**
  * This class executes a few initial instructions
@@ -83,6 +84,7 @@ export default class Bootstrap {
       this.fetchInfrastructureNamespaces(),
       this.fetchWorkspaceSettings(),
       this.fetchServerConfig(),
+      this.fetchClusterInfo(),
     ]);
 
     const results = await Promise.allSettled([
@@ -102,7 +104,6 @@ export default class Bootstrap {
       this.fetchPods().then(() => {
         this.watchWebSocketPods();
       }),
-      this.fetchClusterInfo(),
       this.fetchClusterConfig(),
     ]);
 
@@ -312,17 +313,16 @@ export default class Bootstrap {
       const settings = this.store.getState().workspacesSettings.settings;
       const pluginRegistryUrl = settings['cheWorkspacePluginRegistryUrl'];
       const pluginRegistryInternalUrl = settings['cheWorkspacePluginRegistryInternalUrl'];
-      const appInfo: { id?: string; url: string; title: string }[] =
-        state.clusterInfo.clusterInfo.applications;
-      const clusterConsoleInfo = appInfo.find(item => item.id === 'clusterConsole');
+      const clusterConsole = selectApplications(state).find(
+        app => app.id === ApplicationId.CLUSTER_CONSOLE,
+      );
       const updates = await this.devWorkspaceClient.checkForTemplatesUpdate(
         defaultNamespace,
         pluginsByUrl,
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
-        clusterConsoleInfo ? clusterConsoleInfo.url : undefined,
-        clusterConsoleInfo ? clusterConsoleInfo.title : undefined,
         openVSXUrl,
+        clusterConsole,
       );
       if (Object.keys(updates).length > 0) {
         await this.devWorkspaceClient.updateTemplates(defaultNamespace, updates);

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -312,11 +312,16 @@ export default class Bootstrap {
       const settings = this.store.getState().workspacesSettings.settings;
       const pluginRegistryUrl = settings['cheWorkspacePluginRegistryUrl'];
       const pluginRegistryInternalUrl = settings['cheWorkspacePluginRegistryInternalUrl'];
+      const appInfo: { id?: string; url: string; title: string }[] =
+        state.clusterInfo.clusterInfo.applications;
+      const clusterConsoleInfo = appInfo.find(item => item.id === 'clusterConsole');
       const updates = await this.devWorkspaceClient.checkForTemplatesUpdate(
         defaultNamespace,
         pluginsByUrl,
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
+        clusterConsoleInfo ? clusterConsoleInfo.url : undefined,
+        clusterConsoleInfo ? clusterConsoleInfo.title : undefined,
         openVSXUrl,
       );
       if (Object.keys(updates).length > 0) {

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -104,8 +104,6 @@ describe('DevWorkspace client, create', () => {
         testDevWorkspaceTemplate,
         pluginRegistryUrl,
         internalPluginRegistryUrl,
-        undefined,
-        undefined,
         openVSXUrl,
       );
 
@@ -148,8 +146,6 @@ describe('DevWorkspace client, create', () => {
         testDevWorkspaceTemplate,
         pluginRegistryUrl,
         internalPluginRegistryUrl,
-        undefined,
-        undefined,
         openVSXUrl,
       );
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -104,6 +104,8 @@ describe('DevWorkspace client, create', () => {
         testDevWorkspaceTemplate,
         pluginRegistryUrl,
         internalPluginRegistryUrl,
+        undefined,
+        undefined,
         openVSXUrl,
       );
 
@@ -146,6 +148,8 @@ describe('DevWorkspace client, create', () => {
         testDevWorkspaceTemplate,
         pluginRegistryUrl,
         internalPluginRegistryUrl,
+        undefined,
+        undefined,
         openVSXUrl,
       );
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -135,6 +135,48 @@ describe('DevWorkspace client, create', () => {
       );
     });
 
+    it('should add cluster console url and title as environment variables', async () => {
+      const clusterConsoleUrl = 'https://console-openshift-console.url';
+      const clusterConsoleTitle = 'OpenShift console';
+      const clusterConsole = {
+        url: clusterConsoleUrl,
+        title: clusterConsoleTitle,
+      };
+
+      await client.createDevWorkspaceTemplate(
+        namespace,
+        testDevWorkspace,
+        testDevWorkspaceTemplate,
+        undefined,
+        undefined,
+        undefined,
+        clusterConsole,
+      );
+
+      expect(spyCreateWorkspaceTemplate).toBeCalledWith(
+        expect.objectContaining({
+          spec: expect.objectContaining({
+            components: expect.arrayContaining([
+              expect.objectContaining({
+                container: expect.objectContaining({
+                  env: expect.arrayContaining([
+                    {
+                      name: 'CLUSTER_CONSOLE_URL',
+                      value: clusterConsoleUrl,
+                    },
+                    {
+                      name: 'CLUSTER_CONSOLE_TITLE',
+                      value: clusterConsoleTitle,
+                    },
+                  ]),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
     it('should add owner reference to devWorkspace template to allow automatic cleanup', async () => {
       const pluginRegistryUrl = 'http://plugin.registry.url';
       const internalPluginRegistryUrl = 'http://internal.plugin.registry.url';

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -49,6 +49,8 @@ describe('DevWorkspace client editor update', () => {
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
         undefined,
+        undefined,
+        undefined,
       );
 
       expect(mockPatch.mock.calls).toEqual([
@@ -86,6 +88,8 @@ describe('DevWorkspace client editor update', () => {
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
         undefined,
+        undefined,
+        undefined,
       );
 
       expect(mockPatch.mock.calls).toEqual([
@@ -115,6 +119,8 @@ describe('DevWorkspace client editor update', () => {
         {},
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
+        undefined,
+        undefined,
         undefined,
       );
 
@@ -152,6 +158,8 @@ describe('DevWorkspace client editor update', () => {
         {},
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
+        undefined,
+        undefined,
         undefined,
       );
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -49,8 +49,6 @@ describe('DevWorkspace client editor update', () => {
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
         undefined,
-        undefined,
-        undefined,
       );
 
       expect(mockPatch.mock.calls).toEqual([
@@ -88,8 +86,6 @@ describe('DevWorkspace client editor update', () => {
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
         undefined,
-        undefined,
-        undefined,
       );
 
       expect(mockPatch.mock.calls).toEqual([
@@ -119,8 +115,6 @@ describe('DevWorkspace client editor update', () => {
         {},
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
-        undefined,
-        undefined,
         undefined,
       );
 
@@ -158,8 +152,6 @@ describe('DevWorkspace client editor update', () => {
         {},
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
-        undefined,
-        undefined,
         undefined,
       );
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -78,6 +78,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
   private readonly maxStatusAttempts: number;
   private readonly pluginRegistryUrlEnvName: string;
   private readonly pluginRegistryInternalUrlEnvName: string;
+  private readonly clusterConsoleUrlEnvName: string;
+  private readonly clusterConsoleTitleEnvName: string;
   private readonly openVSXUrlEnvName: string;
   private readonly dashboardUrlEnvName: string;
   private readonly defaultPluginsHandler: DevWorkspaceDefaultPluginsHandler;
@@ -92,6 +94,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
     this.pluginRegistryInternalUrlEnvName = 'CHE_PLUGIN_REGISTRY_INTERNAL_URL';
     this.openVSXUrlEnvName = 'OPENVSX_REGISTRY_URL';
     this.dashboardUrlEnvName = 'CHE_DASHBOARD_URL';
+    this.clusterConsoleUrlEnvName = 'CLUSTER_CONSOLE_URL';
+    this.clusterConsoleTitleEnvName = 'CLUSTER_CONSOLE_TITLE';
     this.defaultPluginsHandler = defaultPluginsHandler;
   }
 
@@ -173,6 +177,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
     devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate,
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
+    clusterConsoleUrl: string | undefined,
+    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
   ): Promise<devfileApi.DevWorkspaceTemplate> {
     devWorkspaceTemplateResource.metadata.namespace = defaultNamespace;
@@ -191,6 +197,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
       devWorkspaceTemplateResource.spec?.components,
       pluginRegistryUrl,
       pluginRegistryInternalUrl,
+      clusterConsoleUrl,
+      clusterConsoleTitle,
       openVSXUrl,
     );
 
@@ -201,12 +209,16 @@ export class DevWorkspaceClient extends WorkspaceClient {
     devWorkspace: devfileApi.DevWorkspace,
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
+    clusterConsoleUrl: string | undefined,
+    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
   ): Promise<{ headers: DwApi.Headers; devWorkspace: devfileApi.DevWorkspace }> {
     this.addEnvVarsToContainers(
       devWorkspace.spec.template.components,
       pluginRegistryUrl,
       pluginRegistryInternalUrl,
+      clusterConsoleUrl,
+      clusterConsoleTitle,
       openVSXUrl,
     );
 
@@ -230,6 +242,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
       | undefined,
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
+    clusterConsoleUrl: string | undefined,
+    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
   ): void {
     if (components === undefined) {
@@ -248,6 +262,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
           env.name !== this.dashboardUrlEnvName &&
           env.name !== this.pluginRegistryUrlEnvName &&
           env.name !== this.pluginRegistryInternalUrlEnvName &&
+          env.name !== this.clusterConsoleUrlEnvName &&
+          env.name !== this.clusterConsoleTitleEnvName &&
           env.name !== this.openVSXUrlEnvName,
       );
       envs.push({
@@ -264,6 +280,18 @@ export class DevWorkspaceClient extends WorkspaceClient {
         envs.push({
           name: this.pluginRegistryInternalUrlEnvName,
           value: pluginRegistryInternalUrl,
+        });
+      }
+      if (clusterConsoleUrl !== undefined) {
+        envs.push({
+          name: this.clusterConsoleUrlEnvName,
+          value: clusterConsoleUrl,
+        });
+      }
+      if (clusterConsoleTitle !== undefined) {
+        envs.push({
+          name: this.clusterConsoleTitleEnvName,
+          value: clusterConsoleTitle,
         });
       }
       if (openVSXUrl !== undefined) {
@@ -663,6 +691,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
     pluginsByUrl: { [url: string]: devfileApi.Devfile } = {},
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
+    clusterConsoleUrl: string | undefined,
+    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
   ): Promise<{ [templateName: string]: api.IPatch[] }> {
     const templates = await DwtApi.getTemplates(namespace);
@@ -699,6 +729,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
               spec.components,
               pluginRegistryUrl,
               pluginRegistryInternalUrl,
+              clusterConsoleUrl,
+              clusterConsoleTitle,
               openVSXUrl,
             );
           } else {

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -177,9 +177,11 @@ export class DevWorkspaceClient extends WorkspaceClient {
     devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate,
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
-    clusterConsoleUrl: string | undefined,
-    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
+    clusterConsole?: {
+      url: string;
+      title: string;
+    },
   ): Promise<devfileApi.DevWorkspaceTemplate> {
     devWorkspaceTemplateResource.metadata.namespace = defaultNamespace;
 
@@ -197,9 +199,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
       devWorkspaceTemplateResource.spec?.components,
       pluginRegistryUrl,
       pluginRegistryInternalUrl,
-      clusterConsoleUrl,
-      clusterConsoleTitle,
       openVSXUrl,
+      clusterConsole,
     );
 
     return DwtApi.createTemplate(devWorkspaceTemplateResource);
@@ -209,17 +210,18 @@ export class DevWorkspaceClient extends WorkspaceClient {
     devWorkspace: devfileApi.DevWorkspace,
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
-    clusterConsoleUrl: string | undefined,
-    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
+    clusterConsole?: {
+      url: string;
+      title: string;
+    },
   ): Promise<{ headers: DwApi.Headers; devWorkspace: devfileApi.DevWorkspace }> {
     this.addEnvVarsToContainers(
       devWorkspace.spec.template.components,
       pluginRegistryUrl,
       pluginRegistryInternalUrl,
-      clusterConsoleUrl,
-      clusterConsoleTitle,
       openVSXUrl,
+      clusterConsole,
     );
 
     return await DwApi.patchWorkspace(devWorkspace.metadata.namespace, devWorkspace.metadata.name, [
@@ -242,9 +244,11 @@ export class DevWorkspaceClient extends WorkspaceClient {
       | undefined,
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
-    clusterConsoleUrl: string | undefined,
-    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
+    clusterConsole?: {
+      url: string;
+      title: string;
+    },
   ): void {
     if (components === undefined) {
       return;
@@ -282,16 +286,16 @@ export class DevWorkspaceClient extends WorkspaceClient {
           value: pluginRegistryInternalUrl,
         });
       }
-      if (clusterConsoleUrl !== undefined) {
+      if (clusterConsole?.url !== undefined) {
         envs.push({
           name: this.clusterConsoleUrlEnvName,
-          value: clusterConsoleUrl,
+          value: clusterConsole.url,
         });
       }
-      if (clusterConsoleTitle !== undefined) {
+      if (clusterConsole?.title !== undefined) {
         envs.push({
           name: this.clusterConsoleTitleEnvName,
-          value: clusterConsoleTitle,
+          value: clusterConsole.title,
         });
       }
       if (openVSXUrl !== undefined) {
@@ -691,9 +695,11 @@ export class DevWorkspaceClient extends WorkspaceClient {
     pluginsByUrl: { [url: string]: devfileApi.Devfile } = {},
     pluginRegistryUrl: string | undefined,
     pluginRegistryInternalUrl: string | undefined,
-    clusterConsoleUrl: string | undefined,
-    clusterConsoleTitle: string | undefined,
     openVSXUrl: string | undefined,
+    clusterConsole?: {
+      url: string;
+      title: string;
+    },
   ): Promise<{ [templateName: string]: api.IPatch[] }> {
     const templates = await DwtApi.getTemplates(namespace);
     const managedTemplates = templates.filter(
@@ -729,9 +735,8 @@ export class DevWorkspaceClient extends WorkspaceClient {
               spec.components,
               pluginRegistryUrl,
               pluginRegistryInternalUrl,
-              clusterConsoleUrl,
-              clusterConsoleTitle,
               openVSXUrl,
+              clusterConsole,
             );
           } else {
             spec[key] = plugin[key];

--- a/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
@@ -24,6 +24,7 @@ describe('clusterInfo store', () => {
   const clusterInfo: ClusterInfo = {
     applications: [
       {
+        id: 'clusterConsole',
         url: 'web/console/url',
         title: 'Web Console',
         icon: 'web/console/icon.png',
@@ -184,6 +185,7 @@ describe('clusterInfo store', () => {
         clusterInfo: {
           applications: [
             {
+              id: 'clusterConsole',
               url: 'web/console/url',
               title: 'Web Console',
               icon: 'web/console/icon.png',

--- a/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
@@ -14,7 +14,7 @@ import mockAxios, { AxiosError } from 'axios';
 import { MockStoreEnhanced } from 'redux-mock-store';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
-import { ClusterInfo } from '@eclipse-che/common';
+import { ApplicationId, ClusterInfo } from '@eclipse-che/common';
 import { FakeStoreBuilder } from '../../__mocks__/storeBuilder';
 import { AppState } from '../..';
 import * as testStore from '..';
@@ -24,7 +24,7 @@ describe('clusterInfo store', () => {
   const clusterInfo: ClusterInfo = {
     applications: [
       {
-        id: 'clusterConsole',
+        id: ApplicationId.CLUSTER_CONSOLE,
         url: 'web/console/url',
         title: 'Web Console',
         icon: 'web/console/icon.png',
@@ -185,7 +185,7 @@ describe('clusterInfo store', () => {
         clusterInfo: {
           applications: [
             {
-              id: 'clusterConsole',
+              id: ApplicationId.CLUSTER_CONSOLE,
               url: 'web/console/url',
               title: 'Web Console',
               icon: 'web/console/icon.png',

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import common, { api } from '@eclipse-che/common';
+import common, { api, ApplicationId } from '@eclipse-che/common';
 import { Action, Reducer } from 'redux';
 import { AppThunk } from '../..';
 import { container } from '../../../inversify.config';
@@ -47,6 +47,7 @@ import OAuthService from '../../../services/oauth';
 import { EDITOR_ATTR } from '../../../containers/Loader/const';
 import { FactoryParams } from '../../../containers/Loader/buildFactoryParams';
 import { getEditor } from '../../DevfileRegistries/getEditor';
+import { selectApplications } from '../../ClusterInfo/selectors';
 
 export const onStatusChangeCallbacks = new Map<string, (status: DevWorkspaceStatus) => void>();
 
@@ -528,9 +529,9 @@ export const actionCreators: ActionCreators = {
           });
         }
 
-        const appInfo: { id?: string; url: string; title: string }[] =
-          state.clusterInfo.clusterInfo.applications;
-        const clusterConsoleInfo = appInfo.find(item => item.id === 'clusterConsole');
+        const clusterConsole = selectApplications(state).find(
+          app => app.id === ApplicationId.CLUSTER_CONSOLE,
+        );
 
         /* create a new DevWorkspaceTemplate */
         await getDevWorkspaceClient().createDevWorkspaceTemplate(
@@ -539,9 +540,8 @@ export const actionCreators: ActionCreators = {
           devWorkspaceTemplateResource,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
-          clusterConsoleInfo ? clusterConsoleInfo.url : undefined,
-          clusterConsoleInfo ? clusterConsoleInfo.title : undefined,
           openVSXUrl,
+          clusterConsole,
         );
 
         /* update the DevWorkspace with components */
@@ -550,9 +550,8 @@ export const actionCreators: ActionCreators = {
           createResp.devWorkspace,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
-          clusterConsoleInfo ? clusterConsoleInfo.url : undefined,
-          clusterConsoleInfo ? clusterConsoleInfo.title : undefined,
           openVSXUrl,
+          clusterConsole,
         );
 
         if (updateResp.headers.warning) {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -528,14 +528,19 @@ export const actionCreators: ActionCreators = {
           });
         }
 
-        /* create a new DevWorkspaceTemplate */
+        const appInfo: { id?: string; url: string; title: string }[] =
+          state.clusterInfo.clusterInfo.applications;
+        const clusterConsoleInfo = appInfo.find(item => item.id === 'clusterConsole');
 
+        /* create a new DevWorkspaceTemplate */
         await getDevWorkspaceClient().createDevWorkspaceTemplate(
           defaultNamespace,
           createResp.devWorkspace,
           devWorkspaceTemplateResource,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
+          clusterConsoleInfo ? clusterConsoleInfo.url : undefined,
+          clusterConsoleInfo ? clusterConsoleInfo.title : undefined,
           openVSXUrl,
         );
 
@@ -545,6 +550,8 @@ export const actionCreators: ActionCreators = {
           createResp.devWorkspace,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
+          clusterConsoleInfo ? clusterConsoleInfo.url : undefined,
+          clusterConsoleInfo ? clusterConsoleInfo.title : undefined,
           openVSXUrl,
         );
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds cluster console Url and title as env variables to a component.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21822

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Editor's container should contain `CLUSTER_CONSOLE_URL` and `CLUSTER_CONSOLE_TITLE` env variables.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
