### PR TITLE
Add a new URL parameter to specify the Workspace image

### DIFF
--- a/packages/dashboard-frontend/src/Layout/Navigation/index.module.css
+++ b/packages/dashboard-frontend/src/Layout/Navigation/index.module.css
@@ -18,7 +18,7 @@
   white-space: nowrap;
 }
 
-.navItem [class*="nav__link"] {
+.navItem [class*='nav__link'] {
   padding-left: 45px;
 }
 
@@ -39,7 +39,7 @@
   color: inherit !important;
 }
 
-.navItem > div:not([class*="expanded"]) {
+.navItem > div:not([class*='expanded']) {
   display: none;
 }
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -309,7 +309,12 @@ describe('Factory Loader container, step CREATE_WORKSPACE__FETCH_DEVFILE', () =>
       jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
 
       await waitFor(() =>
-        expect(mockRequestFactoryResolver).toHaveBeenCalledWith(factoryUrl, expectedOverrideParams),
+        expect(mockRequestFactoryResolver).toHaveBeenCalledWith(
+          factoryUrl,
+          expect.objectContaining({
+            overrides: expectedOverrideParams,
+          }),
+        ),
       );
     });
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -231,12 +231,9 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
    */
   private async resolveDevfile(factoryUrl: string): Promise<boolean> {
     const { factoryParams } = this.state;
-    const params = Object.assign({}, factoryParams.overrides, {
-      error_code: factoryParams.errorCode,
-    });
 
     try {
-      await this.props.requestFactoryResolver(factoryUrl, params);
+      await this.props.requestFactoryResolver(factoryUrl, factoryParams);
       this.clearNumberOfTries();
       return true;
     } catch (e) {

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/__tests__/index.spec.tsx
@@ -157,7 +157,7 @@ describe('Workspace Loader, step OPEN_WORKSPACE', () => {
     await waitFor(() => expect(hasError.textContent).toEqual('false'));
 
     // wait a bit more than necessary to end the timeout
-    const time = (TIMEOUT_TO_GET_URL_SEC + 1) * 1000;
+    const time = (TIMEOUT_TO_GET_URL_SEC + 5) * 1000;
     jest.advanceTimersByTime(time);
 
     // there should be the error message

--- a/packages/dashboard-frontend/src/containers/Loader/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/containers/Loader/buildFactoryParams.ts
@@ -20,6 +20,7 @@ import {
   POLICIES_CREATE_ATTR,
   REMOTES_ATTR,
   STORAGE_TYPE_ATTR,
+  IMAGE_ATTR,
 } from './const';
 
 export type FactoryParams = {
@@ -33,6 +34,7 @@ export type FactoryParams = {
   storageType: che.WorkspaceStorageType | undefined;
   cheEditor: string | undefined;
   remotes: string | undefined;
+  image: string | undefined;
 };
 
 export type PoliciesCreate = 'perclick' | 'peruser';
@@ -51,6 +53,7 @@ export function buildFactoryParams(searchParams: URLSearchParams): FactoryParams
     storageType: getStorageType(searchParams),
     remotes: getRemotes(searchParams),
     useDevworkspaceResources: getDevworkspaceResourcesUrl(searchParams) !== undefined,
+    image: getImage(searchParams),
   };
 }
 
@@ -123,4 +126,8 @@ function buildOverrideParams(searchParams: URLSearchParams): Record<string, stri
 
 function isOverrideAttr(attr: string): attr is string {
   return attr.startsWith(OVERRIDE_ATTR_PREFIX);
+}
+
+function getImage(searchParams: URLSearchParams): string | undefined {
+  return searchParams.get(IMAGE_ATTR) || undefined;
 }

--- a/packages/dashboard-frontend/src/containers/Loader/const.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/const.tsx
@@ -17,6 +17,7 @@ export const FACTORY_URL_ATTR = 'url';
 export const POLICIES_CREATE_ATTR = 'policies.create';
 export const STORAGE_TYPE_ATTR = 'storageType';
 export const REMOTES_ATTR = 'remotes';
+export const IMAGE_ATTR = 'image';
 export const PROPAGATE_FACTORY_ATTRS = [
   'workspaceDeploymentAnnotations',
   'workspaceDeploymentLabels',

--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -23,6 +23,6 @@
   padding: 0 !important;
 }
 
-span[class*="label-required"] {
+span[class*='label-required'] {
   color: var(--pf-global--palette--red-100);
 }

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -88,7 +88,9 @@ describe('FactoryResolver store', () => {
       >;
 
       const location = 'http://factory-link';
-      await store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location));
+      await store.dispatch(
+        factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
+      );
 
       const actions = store.getActions();
       expect(actions).toEqual(
@@ -118,7 +120,9 @@ describe('FactoryResolver store', () => {
       >;
 
       const location = 'http://factory-link';
-      await store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location));
+      await store.dispatch(
+        factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
+      );
 
       const actions = store.getActions();
       expect(actions).toEqual(
@@ -172,7 +176,7 @@ describe('FactoryResolver store', () => {
 
       const location = 'http://factory-link';
       await expect(
-        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
+        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location, {})),
       ).rejects.toMatch('Unexpected error');
       expect(actions).toEqual(expectedActions);
 
@@ -204,7 +208,7 @@ describe('FactoryResolver store', () => {
 
       const location = 'http://factory-link';
       await expect(
-        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
+        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location, {})),
       ).rejects.toMatch('The specified link does not contain a valid Devfile.');
       expect(actions).toEqual(expectedActions);
     });
@@ -241,7 +245,7 @@ describe('FactoryResolver store', () => {
 
       const location = 'http://factory-link';
       await expect(
-        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location)),
+        store.dispatch(factoryResolverStore.actionCreators.requestFactoryResolver(location, {})),
       ).rejects.toEqual({
         attributes: {
           oauth_provider: 'oauth_provider',

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/normalizeDevfileV2.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/normalizeDevfileV2.spec.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import normalizeDevfileV2 from '../normalizeDevfileV2';
+import devfileApi from '../../../services/devfileApi';
+import { FactoryResolver } from '../../../services/helpers/types';
+import { V220DevfileComponents } from '@devfile/api';
+
+describe('Normalize Devfile V2', () => {
+  let defaultComponents: V220DevfileComponents[];
+
+  beforeEach(() => {
+    defaultComponents = [
+      {
+        container: {
+          image: 'quay.io/devfile/universal-developer-image:latest',
+        },
+        name: 'universal-developer-image',
+      },
+    ];
+  });
+
+  it('should not apply defaultComponents', () => {
+    const devfileLike = {
+      schemaVersion: '2.1.0',
+      metadata: {
+        generateName: 'empty',
+      },
+      components: [
+        {
+          container: {
+            image: 'quay.io/devfile/custom-developer-image:custom',
+          },
+          name: 'custom-image',
+        },
+      ],
+    } as devfileApi.DevfileLike;
+
+    const targetDevfile = normalizeDevfileV2(
+      devfileLike,
+      {} as FactoryResolver,
+      'http://dummy-registry/devfiles/empty.yaml',
+      defaultComponents,
+      'che',
+      {},
+    );
+
+    expect(targetDevfile).not.toEqual(
+      expect.objectContaining({
+        components: defaultComponents,
+      }),
+    );
+    expect(targetDevfile).toEqual(
+      expect.objectContaining({
+        components: devfileLike.components,
+      }),
+    );
+  });
+
+  it('should apply defaultComponents', () => {
+    const devfileLike = {
+      schemaVersion: '2.1.0',
+      metadata: {
+        generateName: 'empty',
+      },
+    } as devfileApi.DevfileLike;
+    const defaultComponents = [
+      {
+        container: {
+          image: 'quay.io/devfile/universal-developer-image:latest',
+        },
+        name: 'universal-developer-image',
+      },
+    ] as V220DevfileComponents[];
+
+    const targetDevfile = normalizeDevfileV2(
+      devfileLike,
+      {} as FactoryResolver,
+      'http://dummy-registry/devfiles/empty.yaml',
+      defaultComponents,
+      'che',
+      {},
+    );
+
+    expect(targetDevfile).not.toEqual(
+      expect.objectContaining({
+        components: devfileLike.components,
+      }),
+    );
+    expect(targetDevfile).toEqual(
+      expect.objectContaining({
+        components: defaultComponents,
+      }),
+    );
+  });
+
+  it('should apply the custom image from factory params', () => {
+    const devfileLike = {
+      schemaVersion: '2.1.0',
+      metadata: {
+        generateName: 'empty',
+      },
+      components: [
+        {
+          container: {
+            image: 'quay.io/devfile/custom-developer-image:custom',
+          },
+          name: 'developer-image',
+        },
+      ],
+    } as devfileApi.DevfileLike;
+    const factoryParams = {
+      image: 'quay.io/devfile/universal-developer-image:test',
+    };
+
+    const targetDevfile = normalizeDevfileV2(
+      devfileLike,
+      {} as FactoryResolver,
+      'http://dummy-registry/devfiles/empty.yaml',
+      defaultComponents,
+      'che',
+      factoryParams,
+    );
+
+    expect(targetDevfile).toEqual(
+      expect.objectContaining({
+        components: [
+          {
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:test',
+            },
+            name: 'developer-image',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('should apply defaultComponents and then the custom image from factory params', () => {
+    const devfileLike = {
+      schemaVersion: '2.1.0',
+      metadata: {
+        generateName: 'empty',
+      },
+    } as devfileApi.DevfileLike;
+    const factoryParams = {
+      image: 'quay.io/devfile/universal-developer-image:test',
+    };
+
+    const targetDevfile = normalizeDevfileV2(
+      devfileLike,
+      {} as FactoryResolver,
+      'http://dummy-registry/devfiles/empty.yaml',
+      defaultComponents,
+      'che',
+      factoryParams,
+    );
+
+    expect(targetDevfile).toEqual(
+      expect.objectContaining({
+        components: [
+          {
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:test',
+            },
+            name: 'universal-developer-image',
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
@@ -21,6 +21,7 @@ import {
   DEVWORKSPACE_METADATA_ANNOTATION,
 } from '../../services/workspace-client/devworkspace/devWorkspaceClient';
 import { generateWorkspaceName } from '../../services/helpers/generateName';
+import { FactoryParams } from '../../containers/Loader/buildFactoryParams';
 
 /**
  * Returns a devfile from the FactoryResolver object.
@@ -29,6 +30,8 @@ import { generateWorkspaceName } from '../../services/helpers/generateName';
  * @param location a source location.
  * @param defaultComponents Default components. These default components
  * are meant to be used when a Devfile does not contain any components.
+ * @param namespace the namespace where the pod lives.
+ * @param factoryParams a Partial<FactoryParams> object.
  */
 export default function normalizeDevfileV2(
   devfileLike: devfileApi.DevfileLike,
@@ -36,6 +39,7 @@ export default function normalizeDevfileV2(
   location: string,
   defaultComponents: V220DevfileComponents[],
   namespace: string,
+  factoryParams: Partial<FactoryParams>,
 ): devfileApi.Devfile {
   const scmInfo = data['scm_info'];
 
@@ -55,7 +59,12 @@ export default function normalizeDevfileV2(
 
   // propagate default components
   if (!devfile.components || devfile.components.length === 0) {
-    devfile.components = defaultComponents;
+    devfile.components = cloneDeep(defaultComponents);
+  }
+
+  // apply the custom image from factory params
+  if (factoryParams.image && devfile.components[0].container?.image) {
+    devfile.components[0].container.image = factoryParams.image;
   }
 
   // temporary solution for fix che-server serialization bug with empty volume


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add a new URL parameter to specify the Workspace image.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21990

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse CHE
2. Create a new workspace from URL ```{CHE}/dashboard/#/load-factory?url=https://raw.githubusercontent.com/eclipse-che/che-dashboard/main/packages/devfile-registry/devfiles/empty.yaml&image=docker.io/olexii4dockerid/universal-developer-image:test```. 
3. Open created workspace(workspace details) and the Devfile should contain an updated image 
```
...
        container: {
            image: 'docker.io/olexii4dockerid/universal-developer-image:test',
        },
...
```

![Знімок екрана 2023-03-23 о 18 11 17](https://user-images.githubusercontent.com/6310786/227265949-209576d6-d100-40a9-8c84-896de2af184a.png)
