### PR TITLE
chore: unpin the v0.9.1 version of buildx

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,8 +94,6 @@ jobs:
       -
         name: "Set up Docker Buildx ${{ matrix.platform }}"
         uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.9.1
       -
         name: "Cache Docker layers"
         uses: actions/cache@v3


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Unpin the v0.9.1 version of build, now that provenance is set to false ( in earlier PR )

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21954

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
