### PR TITLE
feat: 'podman login' to the OpenShift internal registry during worksp…

### DIFF
--- a/packages/dashboard-backend/src/app.ts
+++ b/packages/dashboard-backend/src/app.ts
@@ -26,6 +26,7 @@ import { registerDevWorkspaceTemplates } from './routes/api/devworkspaceTemplate
 import { registerWebsocket } from './routes/api/websocket';
 import { registerDockerConfigRoutes } from './routes/api/dockerConfig';
 import { registerKubeConfigRoute } from './routes/api/kubeConfig';
+import { registerPodmanLoginRoute } from './routes/api/podmanLogin';
 import { registerNamespacesRoute } from './routes/api/namespaces';
 import { registerServerConfigRoute } from './routes/api/serverConfig';
 import { registerUserProfileRoute } from './routes/api/userProfile';
@@ -99,6 +100,8 @@ export default async function buildApp(server: FastifyInstance): Promise<void> {
   registerPodsRoutes(server);
 
   registerKubeConfigRoute(server);
+
+  registerPodmanLoginRoute(server);
 
   registerServerConfigRoute(server);
 

--- a/packages/dashboard-backend/src/devworkspaceClient/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/index.ts
@@ -16,11 +16,13 @@ import { DevWorkspaceTemplateApiService } from './services/devWorkspaceTemplateA
 import { DockerConfigApiService } from './services/dockerConfigApi';
 import { EventApiService } from './services/eventApi';
 import { KubeConfigApiService } from './services/kubeConfigApi';
+import { PodmanApiService } from './services/podmanApi';
 import { LogsApiService } from './services/logsApi';
 import { NamespaceApiService } from './services/namespaceApi';
 import { PodApiService } from './services/podApi';
 import { ServerConfigApiService } from './services/serverConfigApi';
 import { UserProfileApiService } from './services/userProfileApi';
+import { IPodmanApi } from './types/index';
 import {
   IDevWorkspaceApi,
   IDevWorkspaceClient,
@@ -70,6 +72,10 @@ export class DevWorkspaceClient implements IDevWorkspaceClient {
 
   get kubeConfigApi(): IKubeConfigApi {
     return new KubeConfigApiService(this.kubeConfig);
+  }
+
+  get podmanApi(): IPodmanApi {
+    return new PodmanApiService(this.kubeConfig);
   }
 
   get namespaceApi(): INamespaceApi {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import { IPodmanApi } from '../types';
+import { helpers } from '@eclipse-che/common';
+import { exec, ServerConfig } from './helpers/exec';
+import { CoreV1API, prepareCoreV1API } from './helpers/prepareCoreV1API';
+
+const EXCLUDED_CONTAINERS = ['che-gateway', 'che-machine-exec'];
+
+export class PodmanApiService implements IPodmanApi {
+  private readonly corev1API: CoreV1API;
+  private readonly kubeConfig: string;
+  private readonly getServerConfig: () => ServerConfig;
+
+  constructor(kc: k8s.KubeConfig) {
+    this.corev1API = prepareCoreV1API(kc);
+
+    this.kubeConfig = kc.exportConfig();
+
+    const server = kc.getCurrentCluster()?.server || '';
+    const opts = {};
+    kc.applyToRequest(opts as any);
+    this.getServerConfig = () => ({ opts, server });
+  }
+
+  /**
+   * Executes the 'podman login' command to the OpenShift internal registry
+   * @param namespace The namespace where the pod lives
+   * @param devworkspaceId The id of the devworkspace
+   */
+  async podmanLogin(namespace: string, devworkspaceId: string): Promise<void> {
+    const currentPod = await this.getPodByDevWorkspaceId(namespace, devworkspaceId);
+    const podName = currentPod.metadata?.name || '';
+    const currentPodContainers = currentPod.spec?.containers || [];
+
+    let resolved = false;
+    for (const container of currentPodContainers) {
+      const containerName = container.name;
+      if (EXCLUDED_CONTAINERS.indexOf(containerName) !== -1) {
+        continue;
+      }
+
+      try {
+        await exec(
+          podName,
+          namespace,
+          containerName,
+          [
+            'sh',
+            '-c',
+            `podman login --cert-dir /var/run/secrets/kubernetes.io/serviceaccount -u $(oc whoami) -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000`,
+          ],
+          this.getServerConfig(),
+        );
+        if (!resolved) {
+          resolved = true;
+        }
+      } catch (e) {
+        console.warn(helpers.errors.getMessage(e));
+      }
+    }
+    if (!resolved) {
+      throw new Error(`Could not 'podman login' into containers in ${namespace}`);
+    }
+  }
+
+  /**
+   * Given a namespace, find a pod that has the label controller.devfile.io/devworkspace_id=${devworkspaceId}
+   * @param namespace The namespace to look in
+   * @param devworkspaceId The id of the devworkspace
+   * @returns The containers for the first pod with given devworkspaceId
+   */
+  private async getPodByDevWorkspaceId(
+    namespace: string,
+    devworkspaceId: string,
+  ): Promise<k8s.V1Pod> {
+    try {
+      const resp = await this.corev1API.listNamespacedPod(
+        namespace,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        `controller.devfile.io/devworkspace_id=${devworkspaceId}`,
+      );
+      if (resp.body.items.length === 0) {
+        throw new Error(
+          `Could not find requested devworkspace with id ${devworkspaceId} in ${namespace}`,
+        );
+      }
+      return resp.body.items[0];
+    } catch (e: any) {
+      throw new Error(
+        `Error occurred when attempting to retrieve pod. ${helpers.errors.getMessage(e)}`,
+      );
+    }
+  }
+}

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -222,6 +222,13 @@ export interface IKubeConfigApi {
   injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void>;
 }
 
+export interface IPodmanApi {
+  /**
+   * Executes the 'podman login' command to the OpenShift internal registry.
+   */
+  podmanLogin(namespace: string, devworkspaceId: string): Promise<void>;
+}
+
 export interface IUserProfileApi {
   /**
    * Returns user profile object that contains username and email.

--- a/packages/dashboard-backend/src/routes/api/podmanLogin.ts
+++ b/packages/dashboard-backend/src/routes/api/podmanLogin.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { baseApiPath } from '../../constants/config';
+import { getDevWorkspaceClient } from './helpers/getDevWorkspaceClient';
+import { getToken } from './helpers/getToken';
+import { getSchema } from '../../services/helpers';
+import { restParams } from '../../models';
+import { namespacedKubeConfigSchema } from '../../constants/schemas';
+
+const tags = ['Podman Login'];
+
+export function registerPodmanLoginRoute(server: FastifyInstance) {
+  server.post(
+    `${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/podmanlogin`,
+    getSchema({
+      tags,
+      params: namespacedKubeConfigSchema,
+      response: {
+        204: {
+          description:
+            'The podman login command to the internal OpenShift registry has been successfully executed',
+          type: 'null',
+        },
+      },
+    }),
+    async function (request: FastifyRequest, reply: FastifyReply) {
+      const token = getToken(request);
+      const { podmanApi } = getDevWorkspaceClient(token);
+      const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParams;
+      await podmanApi.podmanLogin(namespace, devworkspaceId);
+      reply.code(204);
+      return reply.send();
+    },
+  );
+}

--- a/packages/dashboard-frontend/src/Layout/Navigation/index.module.css
+++ b/packages/dashboard-frontend/src/Layout/Navigation/index.module.css
@@ -18,7 +18,7 @@
   white-space: nowrap;
 }
 
-.navItem [class*="nav__link"] {
+.navItem [class*='nav__link'] {
   padding-left: 45px;
 }
 
@@ -39,7 +39,7 @@
   color: inherit !important;
 }
 
-.navItem > div:not([class*="expanded"]) {
+.navItem > div:not([class*='expanded']) {
   display: none;
 }
 

--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -23,6 +23,6 @@
   padding: 0 !important;
 }
 
-span[class*="label-required"] {
+span[class*='label-required'] {
   color: var(--pf-global--palette--red-100);
 }

--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/devWorkspaceApi.ts
@@ -122,6 +122,16 @@ export async function injectKubeConfig(namespace: string, devworkspaceId: string
   }
 }
 
+export async function podmanLogin(namespace: string, devworkspaceId: string): Promise<void> {
+  try {
+    await axios.post(
+      `${prefix}/namespace/${namespace}/devworkspaceId/${devworkspaceId}/podmanLogin`,
+    );
+  } catch (e) {
+    throw new Error(`Failed to podman login. ${helpers.errors.getMessage(e)}`);
+  }
+}
+
 export async function getDevfileSchema(
   schemaVersion: string,
 ): Promise<JSONSchema7 | { [key: string]: any }> {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -757,15 +757,15 @@ export const actionCreators: ActionCreators = {
           }
         }
 
-        // inject the kube config and 'podman login' to the OpenShift internal registry
+        // inject the 'podman login' and kube config to the OpenShift internal registry
         if (
           phase === DevWorkspaceStatus.RUNNING &&
           phase !== prevPhase &&
           devworkspaceId !== undefined
         ) {
           try {
-            await injectKubeConfig(workspace.metadata.namespace, devworkspaceId);
             await podmanLogin(workspace.metadata.namespace, devworkspaceId);
+            await injectKubeConfig(workspace.metadata.namespace, devworkspaceId);
           } catch (e) {
             console.error(e);
           }

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -15,6 +15,7 @@ import { Action, Reducer } from 'redux';
 import { AppThunk } from '../..';
 import { container } from '../../../inversify.config';
 import { injectKubeConfig } from '../../../services/dashboard-backend-client/devWorkspaceApi';
+import { podmanLogin } from '../../../services/dashboard-backend-client/devWorkspaceApi';
 import { WebsocketClient } from '../../../services/dashboard-backend-client/websocketClient';
 import devfileApi, { isDevWorkspace } from '../../../services/devfileApi';
 import { devWorkspaceKind } from '../../../services/devfileApi/devWorkspace';
@@ -756,7 +757,7 @@ export const actionCreators: ActionCreators = {
           }
         }
 
-        // inject the kube config
+        // inject the kube config and 'podman login' to the OpenShift internal registry
         if (
           phase === DevWorkspaceStatus.RUNNING &&
           phase !== prevPhase &&
@@ -764,6 +765,7 @@ export const actionCreators: ActionCreators = {
         ) {
           try {
             await injectKubeConfig(workspace.metadata.namespace, devworkspaceId);
+            await podmanLogin(workspace.metadata.namespace, devworkspaceId);
           } catch (e) {
             console.error(e);
           }


### PR DESCRIPTION


### What does this PR do?
`podman login' to the OpenShift internal registry during workspase startup

Swagger reference:
![image](https://user-images.githubusercontent.com/1461122/233628682-3dd4dc7e-e2a1-48fb-8af5-06a1c48bbccc.png)

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/22140

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
