### PR TITLE
chore:update version of devworkspace generator tool

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,7 +5,7 @@
 | [`@babel/runtime@7.17.7`](https://github.com/babel/babel.git) | MIT | #1946 |
 | [`@devfile/api@2.2.1-alpha-1667236163`](https://github.com/devfile/api.git) | Apache-2.0 | clearlydefined |
 | `@eclipse-che/api@7.44.0` | EPL-2.0 | ecd.che |
-| [`@eclipse-che/che-devworkspace-generator@0.0.1-1f238bb`](git+https://github.com/eclipse-che/che-devfile-registry.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/che-devworkspace-generator@0.0.1-638fadc`](git+https://github.com/eclipse-che/che-devfile-registry.git) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/common@7.65.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/dashboard-backend@7.65.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/dashboard-frontend@7.65.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |

--- a/packages/dashboard-backend/package.json
+++ b/packages/dashboard-backend/package.json
@@ -27,7 +27,7 @@
   "license": "EPL-2.0",
   "dependencies": {
     "@devfile/api": "^2.2.1-alpha-1667236163",
-    "@eclipse-che/che-devworkspace-generator": "0.0.1-1f238bb",
+    "@eclipse-che/che-devworkspace-generator": "0.0.1-638fadc",
     "@fastify/cors": "^7.0.0",
     "@fastify/error": "^3.0.0",
     "@fastify/http-proxy": "^7.1.0",

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -13,6 +13,7 @@
 import { container } from '../../../../inversify.config';
 import { DevWorkspaceClient } from '../devWorkspaceClient';
 import * as DwtApi from '../../../dashboard-backend-client/devWorkspaceTemplateApi';
+import * as DwApi from '../../../dashboard-backend-client/devWorkspaceApi';
 import devfileApi from '../../../devfileApi';
 
 describe('DevWorkspace client, create', () => {
@@ -43,6 +44,7 @@ describe('DevWorkspace client, create', () => {
     let testDevWorkspace: devfileApi.DevWorkspace;
     let testDevWorkspaceTemplate: devfileApi.DevWorkspaceTemplate;
     let spyCreateWorkspaceTemplate: jest.SpyInstance;
+    let spyCreateWorkspace: jest.SpyInstance;
 
     beforeEach(() => {
       testDevWorkspace = {
@@ -200,6 +202,25 @@ describe('DevWorkspace client, create', () => {
                 uid: testDevWorkspace.metadata.uid,
               }),
             ]),
+          }),
+        }),
+      );
+    });
+
+    it('should add routingClass if it does not exist', async () => {
+      const routingClass = 'che';
+      const responce = {
+        headers: {},
+        devWorkspace: testDevWorkspace,
+      };
+      spyCreateWorkspace = jest.spyOn(DwApi, 'createWorkspace').mockResolvedValueOnce(responce);
+
+      await client.createDevWorkspace(namespace, testDevWorkspace, undefined);
+
+      expect(spyCreateWorkspace).toBeCalledWith(
+        expect.objectContaining({
+          spec: expect.objectContaining({
+            routingClass: routingClass,
           }),
         }),
       );

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -144,7 +144,9 @@ export class DevWorkspaceClient extends WorkspaceClient {
     devWorkspaceResource: devfileApi.DevWorkspace,
     editorId: string | undefined,
   ): Promise<{ headers: DwApi.Headers; devWorkspace: devfileApi.DevWorkspace }> {
-    devWorkspaceResource.spec.routingClass = 'che';
+    if (!devWorkspaceResource.spec.routingClass) {
+      devWorkspaceResource.spec.routingClass = 'che';
+    }
     devWorkspaceResource.spec.started = false;
     devWorkspaceResource.metadata.namespace = defaultNamespace;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,10 +354,10 @@
   resolved "https://registry.npmjs.org/@eclipse-che/api/-/api-7.44.0.tgz"
   integrity sha512-X2vawP2Pm+WD8HswYhXU9lC1WqsRe0g0mibPSN3hYzbmKMSKuPaJG/hBtGDtdp0NI35iIoinoAfFaAtdWBko3Q==
 
-"@eclipse-che/che-devworkspace-generator@0.0.1-1f238bb":
-  version "0.0.1-1f238bb"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-0.0.1-1f238bb.tgz#f4809b7a06b407f67826e99b63e822dea54c2d1a"
-  integrity sha512-7gVrEySSpzrUqa7nvyt7a63hzkEXplkvj7fI1yE65s1dbEgnilrqpIJG7073D2ukrCFvKIsMTbnIytB/z0duFg==
+"@eclipse-che/che-devworkspace-generator@0.0.1-638fadc":
+  version "0.0.1-638fadc"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-0.0.1-638fadc.tgz#2557bde1b4f2e59e624bd763b36693cf3884d068"
+  integrity sha512-7cvugtev6MWml1MjVR8+yGjVbWrQPMrsfnDiLUtdt3gIq51Nsjx+DrfxPVURznarIqULMV4JuGKFeWgyUocwxg==
   dependencies:
     "@devfile/api" latest
     axios "0.21.2"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Updates version of devworkspace generator tool to **0.0.1-638fadc**. 
This version should automatically add `routingClass:che` into DevWorkspaces:
```
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: spring-petclinic
spec:
  started: true
  routingClass: che
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22149

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
A devWorkspace should contain `routingClass: che`

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
