### PR TITLE
fix: apply default plugins to spec.contributions

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
@@ -15,8 +15,12 @@ import devfileApi from '../../devfileApi';
 import { api } from '@eclipse-che/common';
 import { createHash } from 'crypto';
 import { injectable } from 'inversify';
-import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import {
+  V1alpha2DevWorkspaceSpecContributions,
+  V1alpha2DevWorkspaceSpecTemplateComponents,
+} from '@devfile/api';
 import { WorkspacesDefaultPlugins } from 'dashboard-frontend/src/store/Plugins/devWorkspacePlugins';
+import { DevWorkspacePlugin } from '../../devfileApi/devWorkspace';
 
 const DEFAULT_PLUGIN_ATTRIBUTE = 'che.eclipse.org/default-plugin';
 
@@ -31,9 +35,13 @@ export class DevWorkspaceDefaultPluginsHandler {
     editorId: string,
     defaultPlugins: WorkspacesDefaultPlugins,
   ): Promise<void> {
-    const componentsUpdated = this.handleUriPlugins(workspace, defaultPlugins[editorId]);
+    const componentsUpdated = this.removeDefaultUriPluginsComponents(workspace);
+    const contributionsUpdated = this.handleUriPlugins(workspace, defaultPlugins[editorId]);
     if (componentsUpdated) {
       await this.patchWorkspaceComponents(workspace);
+    }
+    if (contributionsUpdated) {
+      await this.patchWorkspaceContributions(workspace);
     }
   }
 
@@ -41,7 +49,7 @@ export class DevWorkspaceDefaultPluginsHandler {
    * Manages the default uri plugins from the devworkspace's spec.template.components
    * @param workspace A devworkspace to manage default plugins for
    * @param defaultPlugins The set of current default plugins uris
-   * @returns true if the devworkspace's spec.template.components has been updated
+   * @returns true if the devworkspace's spec.contributions has been updated
    */
   private handleUriPlugins(
     workspace: devfileApi.DevWorkspace,
@@ -57,14 +65,15 @@ export class DevWorkspaceDefaultPluginsHandler {
       }),
     );
 
-    let componentsUpdated = this.removeDefaultUriPlugins(workspace, defaultUriPlugins);
+    let contributionsUpdated = this.removeDefaultUriPlugins(workspace, defaultUriPlugins);
+
     defaultUriPlugins.forEach(plugin => {
       const hash = createHash('MD5').update(plugin).digest('hex').substring(0, 20).toLowerCase();
       const added = this.addDefaultPluginByUri(workspace, 'default-' + hash, plugin);
-      componentsUpdated = added || componentsUpdated;
+      contributionsUpdated = added || contributionsUpdated;
     });
 
-    return componentsUpdated;
+    return contributionsUpdated;
   }
 
   private isUri(str: string): boolean {
@@ -74,6 +83,25 @@ export class DevWorkspaceDefaultPluginsHandler {
     } catch (err) {
       return false;
     }
+  }
+
+  /**
+   * Removes all default uri plugins in spec.template.components since they should now
+   * be defined in spec.contributions
+   * @param workspace workspace to remove old default plugins for
+   * @returns true if a default plugin has been removed, false otherwise
+   */
+  private removeDefaultUriPluginsComponents(workspace: devfileApi.DevWorkspace): boolean {
+    if (!workspace.spec.template.components) {
+      return false;
+    }
+    const components = workspace.spec.template.components.filter(component => {
+      const isNotUrlPlugin = !component.plugin?.uri;
+      return !this.isDefaultPluginComponent(component) || isNotUrlPlugin;
+    });
+    const removed = workspace.spec.template.components.length !== components.length;
+    workspace.spec.template.components = components;
+    return removed;
   }
 
   /**
@@ -87,20 +115,20 @@ export class DevWorkspaceDefaultPluginsHandler {
     workspace: devfileApi.DevWorkspace,
     allowlist: Set<string> = new Set(),
   ): boolean {
-    if (!workspace.spec.template.components) {
+    if (!workspace.spec.contributions) {
       return false;
     }
 
-    const components = workspace.spec.template.components.filter(component => {
-      if (!this.isDefaultPluginComponent(component) || !component.plugin?.uri) {
+    const contributions = workspace.spec.contributions?.filter(contribution => {
+      if (!this.isDefaultPluginContribution(contribution) || !contribution.uri) {
         // component is not a default uri plugin, keep component.
         return true;
       }
-      return allowlist.has(component.plugin.uri);
-    });
+      return allowlist.has(contribution.uri);
+    }) as DevWorkspacePlugin[];
 
-    const removed = workspace.spec.template.components.length !== components.length;
-    workspace.spec.template.components = components;
+    const removed = workspace.spec.contributions.length !== contributions.length;
+    workspace.spec.contributions = contributions;
     return removed;
   }
 
@@ -112,6 +140,19 @@ export class DevWorkspaceDefaultPluginsHandler {
   private isDefaultPluginComponent(component: V1alpha2DevWorkspaceSpecTemplateComponents): boolean {
     return component.attributes && component.attributes[DEFAULT_PLUGIN_ATTRIBUTE]
       ? component.attributes[DEFAULT_PLUGIN_ATTRIBUTE].toString() === 'true'
+      : false;
+  }
+
+  /**
+   * Returns true if provided contribution is a default plugin managed by this class
+   * @param contribution The contribution to check
+   * @returns true if contribution is a default plugin managed by this class
+   */
+  private isDefaultPluginContribution(
+    contribution: V1alpha2DevWorkspaceSpecContributions,
+  ): boolean {
+    return contribution.attributes && contribution.attributes[DEFAULT_PLUGIN_ATTRIBUTE]
+      ? contribution.attributes[DEFAULT_PLUGIN_ATTRIBUTE].toString() === 'true'
       : false;
   }
 
@@ -151,6 +192,17 @@ export class DevWorkspaceDefaultPluginsHandler {
         op: 'replace',
         path: '/spec/template/components',
         value: workspace.spec.template.components,
+      },
+    ];
+    return DwApi.patchWorkspace(workspace.metadata.namespace, workspace.metadata.name, patch);
+  }
+
+  private async patchWorkspaceContributions(workspace: devfileApi.DevWorkspace) {
+    const patch: api.IPatch[] = [
+      {
+        op: 'replace',
+        path: '/spec/contributions',
+        value: workspace.spec.contributions,
       },
     ];
     return DwApi.patchWorkspace(workspace.metadata.namespace, workspace.metadata.name, patch);

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
@@ -72,7 +72,7 @@ describe('DevWorkspace client, start', () => {
     await client.onStart(testWorkspace, defaults, editor);
 
     // expect that no plug-in has been added
-    expect(testWorkspace.spec.template.components).toBeUndefined();
+    expect(testWorkspace.spec.contributions).toBeUndefined();
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 
@@ -96,7 +96,7 @@ describe('DevWorkspace client, start', () => {
     await client.onStart(testWorkspace, defaults, editor);
 
     // expect that no plug-in has been added
-    expect(testWorkspace.spec.template.components).toBeUndefined();
+    expect(testWorkspace.spec.contributions).toBeUndefined();
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 
@@ -108,15 +108,13 @@ describe('DevWorkspace client, start', () => {
         name,
         namespace,
       })
-      .withTemplate({
-        components: [
-          {
-            name: 'default',
-            attributes: { 'che.eclipse.org/default-plugin': true },
-            plugin: { uri: 'https://test.com/devfile.yaml' },
-          },
-        ],
-      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: 'https://test.com/devfile.yaml',
+          attributes: { 'che.eclipse.org/default-plugin': true },
+        },
+      ])
       .build();
 
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
@@ -125,11 +123,38 @@ describe('DevWorkspace client, start', () => {
 
     await client.onStart(testWorkspace, defaults, editor);
 
-    expect(testWorkspace.spec.template.components?.length).toBe(0);
+    expect(testWorkspace.spec.contributions?.length).toBe(0);
     expect(patchWorkspace).toHaveBeenCalled();
   });
 
   it('should remove default plugin uri when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: 'https://test.com/devfile.yaml',
+          attributes: { 'che.eclipse.org/default-plugin': true },
+        },
+      ])
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = {};
+    const editor = 'eclipse/theia/next';
+
+    await client.onStart(testWorkspace, defaults, editor);
+
+    expect(testWorkspace.spec.contributions?.length).toBe(0);
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+
+  it('should remove default plugin uri in spec.template.components and add to spec.contributions', async () => {
     const namespace = 'che';
     const name = 'wksp-test';
     const testWorkspace = new DevWorkspaceBuilder()
@@ -149,16 +174,24 @@ describe('DevWorkspace client, start', () => {
       .build();
 
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
-    const defaults = {};
+    const defaultPluginUri = 'https://test.com/devfile.yaml';
+    const defaults = { 'eclipse/theia/next': [defaultPluginUri] };
     const editor = 'eclipse/theia/next';
 
     await client.onStart(testWorkspace, defaults, editor);
 
     expect(testWorkspace.spec.template.components?.length).toBe(0);
-    expect(patchWorkspace).toHaveBeenCalled();
+
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(defaultPluginUri);
+    expect(
+      (testWorkspace.spec.contributions![0].attributes as any)['che.eclipse.org/default-plugin'],
+    ).toBe(true);
+
+    expect(patchWorkspace).toHaveBeenCalledTimes(2);
   });
 
-  it('should not remove non default plugin uri when no default plugins exist', async () => {
+  it('should not remove non default plugin uri component', async () => {
     const namespace = 'che';
     const name = 'wksp-test';
     const uri = 'https://test.com/devfile.yaml';
@@ -189,6 +222,35 @@ describe('DevWorkspace client, start', () => {
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 
+  it('should not remove non default plugin uri contribution when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const uri = 'https://test.com/devfile.yaml';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withContributions([
+        {
+          name: 'some-plugin',
+          uri: 'https://test.com/devfile.yaml',
+        },
+      ])
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = { 'eclipse/theia/next': [] };
+    const editor = 'eclipse/theia/next';
+
+    await client.onStart(testWorkspace, defaults, editor);
+
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(uri);
+    expect(testWorkspace.spec.contributions![0].attributes).toBeUndefined();
+    expect(patchWorkspace).toHaveBeenCalledTimes(0);
+  });
+
   it('should not remove plugin uri if attribute is false', async () => {
     const namespace = 'che';
     const name = 'wksp-test';
@@ -198,15 +260,13 @@ describe('DevWorkspace client, start', () => {
         name,
         namespace,
       })
-      .withTemplate({
-        components: [
-          {
-            name: 'default',
-            attributes: { 'che.eclipse.org/default-plugin': false },
-            plugin: { uri },
-          },
-        ],
-      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: 'https://test.com/devfile.yaml',
+          attributes: { 'che.eclipse.org/default-plugin': false },
+        },
+      ])
       .build();
 
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
@@ -215,8 +275,8 @@ describe('DevWorkspace client, start', () => {
 
     await client.onStart(testWorkspace, defaults, editor);
 
-    expect(testWorkspace.spec.template.components?.length).toBe(1);
-    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(uri);
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -505,7 +505,7 @@ export const actionCreators: ActionCreators = {
       const openVSXUrl = selectOpenVSXUrl(state);
       const defaultNamespace = defaultKubernetesNamespace.name;
       try {
-        const cheEditor = editorId ? editorId : devWorkspaceTemplateResource.metadata.name;
+        const cheEditor = editorId ? editorId : state.dwPlugins.defaultEditorName;
         const pluginRegistryUrl =
           state.workspacesSettings.settings['cheWorkspacePluginRegistryUrl'];
         const pluginRegistryInternalUrl =

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -14,6 +14,7 @@ import { V1alpha2DevWorkspaceStatusConditions } from '@devfile/api';
 import devfileApi from '../../services/devfileApi';
 import getRandomString from '../../services/helpers/random';
 import { DevWorkspaceStatus } from '../../services/helpers/types';
+import { DevWorkspacePlugin } from '../../services/devfileApi/devWorkspace';
 
 export class DevWorkspaceBuilder {
   private workspace: devfileApi.DevWorkspace = {
@@ -77,6 +78,11 @@ export class DevWorkspaceBuilder {
 
   withTemplate(template: devfileApi.DevWorkspaceSpecTemplate): DevWorkspaceBuilder {
     this.workspace.spec.template = template;
+    return this;
+  }
+
+  withContributions(contributions: DevWorkspacePlugin[]): DevWorkspaceBuilder {
+    this.workspace.spec.contributions = contributions;
     return this;
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes the defaultPlugin support: https://github.com/eclipse/che/issues/22017

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22017

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Che and set the dashboard image in the Che CR to `quay.io/dkwon17/che-dashboard:defaultPlugins`
```
spec:
  components:
    dashboard:
      deployment:
        containers:
          - image: quay.io/dkwon17/che-dashboard:defaultPlugins
```
2. Set the `devworkspace-telemetry-woopra-plugin` as a default plugin for the `che-incubator/che-code/latest` editor in the CheCluster CR:
```
spec:
  devEnvironments:
    defaultPlugins:
      - editor: che-incubator/che-code/latest
        plugins:
          - >-
            https://static.developers.redhat.com/crw/stg/plugins/devworkspace-telemetry-woopra-plugin/0.0.1/devfile.yaml
```
3. Start an empty workspace from the dashboard
4. When the workspace pod is running, verify that the default plugin (highlighted in screenshot) is included:
<img width="792" alt="image" src="https://github.com/eclipse-che/che-dashboard/assets/83611742/dff3e163-6315-408b-8464-acb974161e93">
5. In the CheCluster CR, remove the default plugin by removing the `spec.devEnvironments.defaultPlugins` field
6. Restart the workspace created from step 3
7. Verify that the default plugin is not included in the workspace pod (ie. verify the opposite of step 4)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
