### PR TITLE
Fix the Unsupported git provider error message

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -343,7 +343,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="The git provider is either not supported or has not been configured correctly.
             Note that the git cloning of the public repository will succeed. If the repository is private a Personal Access Token secret should be configured.
-            and a Personal Access Token secret has been configured."
+            
           />
         ),
         actionCallbacks: [

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -342,7 +342,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
             textBefore="Looking for a Devfile in the git repository failed."
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="The git provider is either not supported or has not been configured correctly.
-            Note that the git cloning of the repository will succeed if it's public or it's private
+            Note that the git cloning of the public repository will succeed. If the repository is private a Personal Access Token secret should be configured.
             and a Personal Access Token secret has been configured."
           />
         ),

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -341,8 +341,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
           <ExpandableWarning
             textBefore="Could not find any devfile in the Git repository"
             errorMessage={helpers.errors.getMessage(error)}
-            textAfter="The git provider is not supported.
-            Note that the git cloning of the public repository will succeed."
+            textAfter="The git provider is not supported."
           />
         ),
         actionCallbacks: [

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -339,7 +339,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
         variant: AlertVariant.warning,
         children: (
           <ExpandableWarning
-            textBefore="Looking for a Devfile in the git repository failed."
+            textBefore="Could not find any devfile in the Git repository"
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="The git provider is either not supported or has not been configured correctly.
             Note that the git cloning of the public repository will succeed.

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -343,7 +343,6 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="The git provider is either not supported or has not been configured correctly.
             Note that the git cloning of the public repository will succeed. If the repository is private a Personal Access Token secret should be configured.
-            
           />
         ),
         actionCallbacks: [

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -341,9 +341,8 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
           <ExpandableWarning
             textBefore="Could not find any devfile in the Git repository"
             errorMessage={helpers.errors.getMessage(error)}
-            textAfter="The git provider is either not supported or has not been configured correctly.
-            Note that the git cloning of the public repository will succeed.
-            If the repository is private a Personal Access Token secret should be configured."
+            textAfter="The git provider is not supported.
+            Note that the git cloning of the public repository will succeed."
           />
         ),
         actionCallbacks: [

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -341,7 +341,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
           <ExpandableWarning
             textBefore="Looking for a Devfile in the git repository failed."
             errorMessage={helpers.errors.getMessage(error)}
-            textAfter="The git provider is not supported or the git provider hasn't been configured appropriately.
+            textAfter="The git provider is either not supported or has not been configured correctly.
             Note that the git cloning of the repository will succeed if it's public or it's private
             and a Personal Access Token secret has been configured."
           />

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -341,9 +341,9 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
           <ExpandableWarning
             textBefore="Looking for a Devfile in the git repository failed."
             errorMessage={helpers.errors.getMessage(error)}
-            textAfter="The git provider may not be supported by Eclipse Che (or the git server hasn't been configured
-            appropriately). Note that the git cloning of the repository will succeed if it's public or it's private
-            and the developer git credentials secret has been configured."
+            textAfter="The git provider is not supported or the git provider hasn't been configured appropriately.
+            Note that the git cloning of the repository will succeed if it's public or it's private
+            and a Personal Access Token secret has been configured."
           />
         ),
         actionCallbacks: [

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -342,7 +342,8 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
             textBefore="Looking for a Devfile in the git repository failed."
             errorMessage={helpers.errors.getMessage(error)}
             textAfter="The git provider is either not supported or has not been configured correctly.
-            Note that the git cloning of the public repository will succeed. If the repository is private a Personal Access Token secret should be configured.
+            Note that the git cloning of the public repository will succeed.
+            If the repository is private a Personal Access Token secret should be configured."
           />
         ),
         actionCallbacks: [

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Fetch/Devfile/index.tsx
@@ -341,7 +341,7 @@ class StepFetchDevfile extends AbstractLoaderStep<Props, State> {
           <ExpandableWarning
             textBefore="Could not find any devfile in the Git repository"
             errorMessage={helpers.errors.getMessage(error)}
-            textAfter="The git provider is not supported."
+            textAfter="The Git provider is not supported."
           />
         ),
         actionCallbacks: [


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Avoid using the `Eclipse Che` name in the Unsupported git provider error message. Minor message fixups.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4357

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy che via the test image: `chectl server:deploy -p=minikube -i=quay.io/ivinokur/che-server:next`
  For the testing purpose I disabled gitlab factory handler in the image.
2. Apply the dashboard changes.
3. Pass a gitlab public repo with a devfile to start a workspace e.g. `https://gitlab.com/ivinokur/test.git`
4. See the specific error:
![screenshot-localhost_8080-2023 05 16-15_48_53](https://github.com/eclipse-che/che-dashboard/assets/7668752/36b2585b-64de-4ec7-ba18-107234428ae5)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
