### PR TITLE
fix: devfiles name conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ Currently, Dashboard uses the following che-server API:
 | GET   | /kubernetes/namespace                |
 | POST   | /factory/resolver/                  |
 | POST   | /factory/token/refresh              |
-| GET    | /workspace/settings                 |
 | GET    | /oauth                              |
 | GET    | /oauth/token                        |
 | DELETE | /oauth/token                        |

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/index.spec.tsx
@@ -625,7 +625,7 @@ describe('Factory Loader container, step CREATE_WORKSPACE__APPLYING_DEVFILE', ()
       jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
 
       await waitFor(() =>
-        expect(prepareDevfile).toHaveBeenCalledWith(devfile, factoryId, undefined, false),
+        expect(prepareDevfile).toHaveBeenCalledWith(devfile, factoryId, undefined, true),
       );
     });
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/__tests__/index.spec.tsx
@@ -486,6 +486,103 @@ describe('Factory Loader container, step CREATE_WORKSPACE__APPLYING_DEVFILE', ()
     });
   });
 
+  describe('handle an invalid devfile in the git repository', () => {
+    test('apply the default devfile', async () => {
+      const registryUrl = 'https://registry-url';
+      const sampleResourceUrl = 'https://resources-url';
+      const registryMetadata = {
+        displayName: 'Empty Workspace',
+        description: 'Start an empty remote development environment',
+        tags: ['Empty'],
+        icon: '/images/empty.svg',
+        links: {
+          v2: sampleResourceUrl,
+        },
+      } as che.DevfileMetaData;
+      const sampleContent = dump({
+        schemaVersion: '2.1.0',
+        metadata: {
+          generateName: 'empty',
+        },
+      } as devfileApi.Devfile);
+      const defaultComponents = [
+        {
+          name: 'universal-developer-image',
+          container: {
+            image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+          },
+        },
+      ];
+
+      const store = getStoreBuilder()
+        .withFactoryResolver({ resolver: undefined, converted: undefined })
+        .withDevfileRegistries({
+          registries: {
+            [registryUrl]: {
+              metadata: [registryMetadata],
+            },
+          },
+          devfiles: {
+            [sampleResourceUrl]: {
+              content: sampleContent,
+            },
+          },
+        })
+        .withDwServerConfig({
+          defaults: {
+            components: defaultComponents,
+          },
+        } as api.IServerConfig)
+        .build();
+
+      renderComponent(store, loaderSteps, searchParams);
+      jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
+
+      const expectedDevfile = {
+        schemaVersion: '2.1.0',
+        metadata: {
+          generateName: 'factory-url',
+          name: 'factory-url',
+        },
+        components: [
+          {
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+            },
+            name: 'universal-developer-image',
+          },
+        ],
+        projects: [
+          {
+            git: {
+              remotes: {
+                origin: `${factoryUrl}/.git`,
+              },
+            },
+            name: 'factory-url',
+          },
+        ],
+      };
+
+      await waitFor(() =>
+        expect(prepareDevfile).toHaveBeenCalledWith(
+          expectedDevfile,
+          `url=${factoryUrl}`,
+          undefined,
+          false,
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockCreateWorkspaceFromDevfile).toHaveBeenCalledWith(
+          expectedDevfile,
+          buildFactoryParams(new window.URLSearchParams(`url=${factoryUrl}`)),
+          {},
+        ),
+      );
+    });
+  });
+
   describe('handle name conflicts', () => {
     test('name conflict', async () => {
       const store = getStoreBuilder()
@@ -504,7 +601,7 @@ describe('Factory Loader container, step CREATE_WORKSPACE__APPLYING_DEVFILE', ()
       jest.advanceTimersByTime(MIN_STEP_DURATION_MS);
 
       await waitFor(() =>
-        expect(prepareDevfile).toHaveBeenCalledWith(devfile, factoryId, undefined, false),
+        expect(prepareDevfile).toHaveBeenCalledWith(devfile, factoryId, undefined, true),
       );
     });
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -161,7 +161,7 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
   private updateCurrentDevfile(devfile: devfileApi.Devfile): void {
     const { factoryResolver, allWorkspaces, defaultDevfile } = this.props;
     const { factoryParams } = this.state;
-    const { factoryId, sourceUrl, storageType, remotes } = factoryParams;
+    const { factoryId, policiesCreate, sourceUrl, storageType, remotes } = factoryParams;
 
     // when using the default devfile instead of a user devfile
     if (factoryResolver === undefined && isEqual(devfile, defaultDevfile)) {
@@ -186,8 +186,8 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
 
     // test the devfile name to decide if we need to append a suffix to is
     const nameConflict = allWorkspaces.some(w => devfile.metadata.name === w.name);
-
-    const updatedDevfile = prepareDevfile(devfile, factoryId, storageType, nameConflict);
+    const appendSuffix = policiesCreate === 'perclick' || nameConflict;
+    const updatedDevfile = prepareDevfile(devfile, factoryId, storageType, appendSuffix);
 
     this.setState({
       devfile: updatedDevfile,

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -260,7 +260,7 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
           const errorMessage = common.helpers.errors.getMessage(e);
           throw new CreateWorkspaceError(errorMessage);
         }
-      }q
+      }
       return false;
     }
 

--- a/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/Apply/Devfile/index.tsx
@@ -158,7 +158,10 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
     this.props.onRestart();
   }
 
-  private updateCurrentDevfile(devfile: devfileApi.Devfile): void {
+  private updateCurrentDevfile(devfile?: devfileApi.Devfile): void {
+    if (devfile === undefined) {
+      throw new Error('Failed to resolve the devfile.');
+    }
     const { factoryResolver, allWorkspaces, defaultDevfile } = this.props;
     const { factoryParams } = this.state;
     const { factoryId, policiesCreate, sourceUrl, storageType, remotes } = factoryParams;
@@ -248,19 +251,16 @@ class StepApplyDevfile extends AbstractLoaderStep<Props, State> {
         }
         return false;
       }
-      const _devfile = factoryResolverConverted?.devfileV2;
-      if (_devfile === undefined) {
-        throw new Error('Failed to resolve the devfile.');
-      }
-      this.updateCurrentDevfile(_devfile);
-      if (!this.state.restartFromError) {
+      this.updateCurrentDevfile(factoryResolverConverted?.devfileV2);
+      const { devfile, restartFromError } = this.state;
+      if (devfile && !restartFromError) {
         try {
-          await this.createWorkspaceFromDevfile(_devfile);
+          await this.createWorkspaceFromDevfile(devfile);
         } catch (e) {
           const errorMessage = common.helpers.errors.getMessage(e);
           throw new CreateWorkspaceError(errorMessage);
         }
-      }
+      }q
       return false;
     }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes regression with name conflict while creating a new workspace.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22210

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-CHE with an image from this PR.
2. Create a new workspace with a factory URL:
```<CHE>#https://gist.githubusercontent.com/olexii4/fc3b757806e660dee0fbe1bc131df3d1/raw/1fe83a212365f86b4571e7c04e1b8bb4e5a1cd91/unsupported_feature.yaml```.
3. Stop the created workspace.
4. Repeat STEP 2 one more time.
5. Two workspaces will be created.
