### PR TITLE
Show the detailed message of a startup timeout error

### DIFF
--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/OpenWorkspace/index.tsx
@@ -98,7 +98,11 @@ class StepOpenWorkspace extends AbstractLoaderStep<Props, State> {
     }
 
     if (!workspace.isRunning) {
-      throw new Error(`The workspace status changed unexpectedly to "${workspace.status}".`);
+      if (workspace.hasError && workspace.ref.status?.message) {
+        throw new Error(`${workspace.ref.status.message}`);
+      } else {
+        throw new Error(`The workspace status changed unexpectedly to "${workspace.status}".`);
+      }
     }
     if (!workspace.ideUrl) {
       // wait for the IDE url to be set

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/__tests__/index.spec.tsx
@@ -604,7 +604,10 @@ describe('Workspace Loader, step START_WORKSPACE', () => {
           new DevWorkspaceBuilder()
             .withName(workspaceName)
             .withNamespace(namespace)
-            .withStatus({ phase: 'FAILED' })
+            .withStatus({
+              phase: 'FAILED',
+              message: 'Some error message...',
+            })
             .build(),
         ],
       })
@@ -620,7 +623,7 @@ describe('Workspace Loader, step START_WORKSPACE', () => {
     expect(alertTitle.textContent).toEqual('Failed to open the workspace');
 
     const alertBody = screen.getByTestId('alert-body');
-    expect(alertBody.textContent).toEqual('The workspace status changed unexpectedly to "Failed".');
+    expect(alertBody.textContent).toEqual('Some error message...');
 
     // should not start the workspace
     jest.runAllTimers();

--- a/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/Workspace/Steps/StartWorkspace/index.tsx
@@ -130,6 +130,9 @@ class StepStartWorkspace extends AbstractLoaderStep<Props, State> {
       (this.state.shouldStart === false &&
         workspaceStatusIs(workspace, DevWorkspaceStatus.STOPPED, DevWorkspaceStatus.FAILED))
     ) {
+      if (workspace.hasError && workspace.ref.status?.message) {
+        throw new Error(`${workspace.ref.status.message}`);
+      }
       const errorLogs = workspace.errorLogs.join('');
       throw new Error(
         errorLogs || `The workspace status changed unexpectedly to "${workspace.status}".`,

--- a/packages/dashboard-frontend/src/services/helpers/getWorkspaceLogs.ts
+++ b/packages/dashboard-frontend/src/services/helpers/getWorkspaceLogs.ts
@@ -32,7 +32,7 @@ export default function getWorkspaceLogs(workspace: devfileApi.DevWorkspace): st
  * Filters the workspace logs for errors.
  */
 export function getWorkspaceErrors(workspace: devfileApi.DevWorkspace): string[] {
-  const errorRe = /^[1-9]{0,5} error occurred:/i;
+  const errorRe = /^(Error|([0-9]{0,5} error occurred:))/i;
   const logs = getWorkspaceLogs(workspace);
 
   return logs.filter(log => errorRe.test(log)).map(log => log.replace(errorRe, ''));

--- a/packages/dashboard-frontend/src/services/helpers/getWorkspaceLogs.ts
+++ b/packages/dashboard-frontend/src/services/helpers/getWorkspaceLogs.ts
@@ -32,7 +32,7 @@ export default function getWorkspaceLogs(workspace: devfileApi.DevWorkspace): st
  * Filters the workspace logs for errors.
  */
 export function getWorkspaceErrors(workspace: devfileApi.DevWorkspace): string[] {
-  const errorRe = /^(Error|([0-9]{0,5} error occurred:))/i;
+  const errorRe = /^Error /i;
   const logs = getWorkspaceLogs(workspace);
 
   return logs.filter(log => errorRe.test(log)).map(log => log.replace(errorRe, ''));

--- a/run/build-and-patch.sh
+++ b/run/build-and-patch.sh
@@ -28,7 +28,7 @@ echo "Patching checluster with the new dashboard image '${CHE_DASHBOARD_IMAGE}'.
 CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
 DASHBOARD_POD_NAME=$(kubectl get pods -n $CHE_NAMESPACE -o=custom-columns=:metadata.name | grep dashboard)
 CHECLUSTER_CR_NAME=$(kubectl exec $DASHBOARD_POD_NAME -n $CHE_NAMESPACE -- printenv CHECLUSTER_CR_NAME)
-PREVIOUS_CHE_DASHBOARD_IMAGE=$(kubectl get checluster -n $CHE_NAMESPACE $CHECLUSTER_CR_NAME -o=json | jq -r '.spec.components.dashboard.deployment.containers[0].image')
+PREVIOUS_CHE_DASHBOARD_IMAGE=$(kubectl get checluster -n $CHE_NAMESPACE $CHECLUSTER_CR_NAME -o=json | jq -r '.items[0].spec.components.dashboard.deployment.containers[0].image')
 
 if [ "$PREVIOUS_CHE_DASHBOARD_IMAGE" = "null" ]; then
   kubectl patch -n "$CHE_NAMESPACE" "checluster/$CHECLUSTER_CR_NAME" --type=json -p="[{\"op\": \"replace\", \"path\": \"/spec/components/dashboard\", \"value\": {deployment: {containers: [{image: \"${CHE_DASHBOARD_IMAGE}\", name: che-dasboard}]}}}]"

--- a/run/local-run.sh
+++ b/run/local-run.sh
@@ -111,7 +111,7 @@ export CHE_WORKSPACE_DEVFILE__REGISTRY__INTERNAL__URL=$(kubectl exec $DASHBOARD_
 
 # consider renaming it to CHE_API_URL since it's not just host
 export CHE_HOST=http://localhost:8080
-export CHE_HOST_ORIGIN=$(kubectl get checluster -n $CHE_NAMESPACE $CHECLUSTER_CR_NAME -o=json | jq -r '.status.cheURL')
+export CHE_HOST_ORIGIN=$(kubectl get checluster -n $CHE_NAMESPACE $CHECLUSTER_CR_NAME -o=json | jq -r '.items[0].status.cheURL')
 
 # do nothing
 PRERUN_COMMAND="echo"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Show the detailed message of a startup timeout error.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22208

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-CHE with an image from this PR.
2. Set the 'progressTimeout', e.g., "30s". The next script could be used for patching:
```
#!/bin/bash

set -e

PROGRESS_TIMEOUT="${PROGRESS_TIMEOUT:-30}"

CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"

echo "Patching checluster with the new startTimeoutSeconds '${PROGRESS_TIMEOUT}'..."

CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
DASHBOARD_POD_NAME=$(kubectl get pods -n $CHE_NAMESPACE -o=custom-columns=:metadata.name | grep dashboard)
CHECLUSTER_CR_NAME=$(kubectl exec $DASHBOARD_POD_NAME -n $CHE_NAMESPACE -- printenv CHECLUSTER_CR_NAME)

kubectl patch -n "$CHE_NAMESPACE" "checluster/$CHECLUSTER_CR_NAME" --type=json -p="[{\"op\": \"replace\", \"path\": \"/spec/devEnvironments/startTimeoutSeconds\", \"value\":  ${PROGRESS_TIMEOUT}}]"

echo 'Done.'
```
3. Create a new workspace with a factory URL:
```<CHE-Server>#https://github.com/l0rd/inventory-quarkus/tree/post-start-issue```.
4. Wait 5 minutes for the workspace to fail. 
The failure message should be shown in the Dashboard startup panel:
 ```DevWorkspace failed to progress past step 'Waiting for workspace deployment' for longer than timeout...```

