### PR TITLE
[Backport] fix: apply default plugins to spec.contributions 

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
@@ -72,7 +72,7 @@ describe('DevWorkspace client, start', () => {
     await client.onStart(testWorkspace, defaults, editor);
 
     // expect that no plug-in has been added
-    expect(testWorkspace.spec.template.components).toBeUndefined();
+    expect(testWorkspace.spec.contributions).toBeUndefined();
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 
@@ -96,7 +96,7 @@ describe('DevWorkspace client, start', () => {
     await client.onStart(testWorkspace, defaults, editor);
 
     // expect that no plug-in has been added
-    expect(testWorkspace.spec.template.components).toBeUndefined();
+    expect(testWorkspace.spec.contributions).toBeUndefined();
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 
@@ -108,15 +108,13 @@ describe('DevWorkspace client, start', () => {
         name,
         namespace,
       })
-      .withTemplate({
-        components: [
-          {
-            name: 'default',
-            attributes: { 'che.eclipse.org/default-plugin': true },
-            plugin: { uri: 'https://test.com/devfile.yaml' },
-          },
-        ],
-      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: 'https://test.com/devfile.yaml',
+          attributes: { 'che.eclipse.org/default-plugin': true },
+        },
+      ])
       .build();
 
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
@@ -125,11 +123,38 @@ describe('DevWorkspace client, start', () => {
 
     await client.onStart(testWorkspace, defaults, editor);
 
-    expect(testWorkspace.spec.template.components?.length).toBe(0);
+    expect(testWorkspace.spec.contributions?.length).toBe(0);
     expect(patchWorkspace).toHaveBeenCalled();
   });
 
   it('should remove default plugin uri when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: 'https://test.com/devfile.yaml',
+          attributes: { 'che.eclipse.org/default-plugin': true },
+        },
+      ])
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = {};
+    const editor = 'eclipse/theia/next';
+
+    await client.onStart(testWorkspace, defaults, editor);
+
+    expect(testWorkspace.spec.contributions?.length).toBe(0);
+    expect(patchWorkspace).toHaveBeenCalled();
+  });
+
+  it('should remove default plugin uri in spec.template.components and add to spec.contributions', async () => {
     const namespace = 'che';
     const name = 'wksp-test';
     const testWorkspace = new DevWorkspaceBuilder()
@@ -149,16 +174,55 @@ describe('DevWorkspace client, start', () => {
       .build();
 
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
-    const defaults = {};
+    const defaultPluginUri = 'https://test.com/devfile.yaml';
+    const defaults = { 'eclipse/theia/next': [defaultPluginUri] };
     const editor = 'eclipse/theia/next';
 
     await client.onStart(testWorkspace, defaults, editor);
 
     expect(testWorkspace.spec.template.components?.length).toBe(0);
-    expect(patchWorkspace).toHaveBeenCalled();
+
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(defaultPluginUri);
+    expect(
+      (testWorkspace.spec.contributions![0].attributes as any)['che.eclipse.org/default-plugin'],
+    ).toBe(true);
+
+    expect(patchWorkspace).toHaveBeenCalledTimes(2);
   });
 
-  it('should not remove non default plugin uri when no default plugins exist', async () => {
+  it('should not remove non default plugin component', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withTemplate({
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+            },
+          },
+        ],
+      })
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = { 'eclipse/theia/next': [] };
+    const editor = 'eclipse/theia/next';
+
+    await client.onStart(testWorkspace, defaults, editor);
+
+    expect(testWorkspace.spec.template.components?.length).toBe(1);
+    expect(testWorkspace.spec.template.components![0].name).toBe('universal-developer-image');
+    expect(patchWorkspace).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not remove non default plugin uri component', async () => {
     const namespace = 'che';
     const name = 'wksp-test';
     const uri = 'https://test.com/devfile.yaml';
@@ -189,6 +253,35 @@ describe('DevWorkspace client, start', () => {
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 
+  it('should not remove non default plugin uri contribution when no default plugins exist', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const uri = 'https://test.com/devfile.yaml';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withContributions([
+        {
+          name: 'some-plugin',
+          uri: 'https://test.com/devfile.yaml',
+        },
+      ])
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+    const defaults = { 'eclipse/theia/next': [] };
+    const editor = 'eclipse/theia/next';
+
+    await client.onStart(testWorkspace, defaults, editor);
+
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(uri);
+    expect(testWorkspace.spec.contributions![0].attributes).toBeUndefined();
+    expect(patchWorkspace).toHaveBeenCalledTimes(0);
+  });
+
   it('should not remove plugin uri if attribute is false', async () => {
     const namespace = 'che';
     const name = 'wksp-test';
@@ -198,15 +291,13 @@ describe('DevWorkspace client, start', () => {
         name,
         namespace,
       })
-      .withTemplate({
-        components: [
-          {
-            name: 'default',
-            attributes: { 'che.eclipse.org/default-plugin': false },
-            plugin: { uri },
-          },
-        ],
-      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: 'https://test.com/devfile.yaml',
+          attributes: { 'che.eclipse.org/default-plugin': false },
+        },
+      ])
       .build();
 
     const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
@@ -215,8 +306,70 @@ describe('DevWorkspace client, start', () => {
 
     await client.onStart(testWorkspace, defaults, editor);
 
-    expect(testWorkspace.spec.template.components?.length).toBe(1);
-    expect(testWorkspace.spec.template.components![0].plugin!.uri!).toBe(uri);
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(uri);
+    expect(patchWorkspace).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not do anything if default uri plugin already exists', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: 'https://test.com/devfile.yaml',
+          attributes: { 'che.eclipse.org/default-plugin': true },
+        },
+      ])
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+
+    const defaultUri = 'https://test.com/devfile.yaml';
+    const editor = 'eclipse/theia/next';
+    const defaults = { [editor]: [defaultUri] };
+
+    await client.onStart(testWorkspace, defaults, editor);
+
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(defaultUri);
+    expect(patchWorkspace).toHaveBeenCalledTimes(0);
+  });
+
+  it('should ignore default uri plugin if uri is not valid', async () => {
+    const namespace = 'che';
+    const name = 'wksp-test';
+    const validUri = 'https://test.com/devfile.yaml';
+    const testWorkspace = new DevWorkspaceBuilder()
+      .withMetadata({
+        name,
+        namespace,
+      })
+      .withContributions([
+        {
+          name: 'default',
+          uri: validUri,
+          attributes: { 'che.eclipse.org/default-plugin': true },
+        },
+      ])
+      .build();
+
+    const patchWorkspace = jest.spyOn(DwApi, 'patchWorkspace');
+
+    const editor = 'eclipse/theia/next';
+    const invalidUri = '1234';
+    const defaults = { [editor]: [invalidUri, validUri] };
+
+    await client.onStart(testWorkspace, defaults, editor);
+
+    // invalid uri is ignored, valid uri default plugin remains in workspace
+    expect(testWorkspace.spec.contributions?.length).toBe(1);
+    expect(testWorkspace.spec.contributions![0].uri!).toBe(validUri);
     expect(patchWorkspace).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -505,7 +505,7 @@ export const actionCreators: ActionCreators = {
       const openVSXUrl = selectOpenVSXUrl(state);
       const defaultNamespace = defaultKubernetesNamespace.name;
       try {
-        const cheEditor = editorId ? editorId : devWorkspaceTemplateResource.metadata.name;
+        const cheEditor = editorId ? editorId : state.dwPlugins.defaultEditorName;
         const pluginRegistryUrl =
           state.workspacesSettings.settings['cheWorkspacePluginRegistryUrl'];
         const pluginRegistryInternalUrl =

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -14,6 +14,7 @@ import { V1alpha2DevWorkspaceStatusConditions } from '@devfile/api';
 import devfileApi from '../../services/devfileApi';
 import getRandomString from '../../services/helpers/random';
 import { DevWorkspaceStatus } from '../../services/helpers/types';
+import { DevWorkspacePlugin } from '../../services/devfileApi/devWorkspace';
 
 export class DevWorkspaceBuilder {
   private workspace: devfileApi.DevWorkspace = {
@@ -77,6 +78,11 @@ export class DevWorkspaceBuilder {
 
   withTemplate(template: devfileApi.DevWorkspaceSpecTemplate): DevWorkspaceBuilder {
     this.workspace.spec.template = template;
+    return this;
+  }
+
+  withContributions(contributions: DevWorkspacePlugin[]): DevWorkspaceBuilder {
+    this.workspace.spec.contributions = contributions;
     return this;
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Backport for https://github.com/eclipse-che/che-dashboard/pull/815

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
