### PR TITLE
feat: linking mounted certificates from '/var/run/secrets/kubernetes.io/serviceaccount' to '/$HOME/.config/containers/certs.d' before podman login

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
@@ -63,6 +63,7 @@ export class PodmanApiService implements IPodmanApi {
             'sh',
             '-c',
             `
+            command -v oc >/dev/null 2>&1 && command -v podman >/dev/null 2>&1 && [[ -n "$HOME" ]] || { echo "oc, podman, or HOME is not set"; exit 1; }
             export CERTS_SRC="/var/run/secrets/kubernetes.io/serviceaccount"
             export CERTS_DEST="$HOME/.config/containers/certs.d/image-registry.openshift-image-registry.svc:5000"
             mkdir -p "$CERTS_DEST"

--- a/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
@@ -65,10 +65,12 @@ export class PodmanApiService implements IPodmanApi {
             `
             export CERTS_SRC="/var/run/secrets/kubernetes.io/serviceaccount"
             export CERTS_DEST="$HOME/.config/containers/certs.d/image-registry.openshift-image-registry.svc:5000"
-            mkdir -p $CERTS_DEST
-            ln -s $CERTS_SRC/service-ca.crt $CERTS_DEST/service-ca.crt
-            ln -s $CERTS_SRC/ca.crt $CERTS_DEST/ca.crt
-            podman login -u $(oc whoami) -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
+            mkdir -p "$CERTS_DEST"
+            ln -s "$CERTS_SRC/service-ca.crt" "$CERTS_DEST/service-ca.crt"
+            ln -s "$CERTS_SRC/ca.crt" "$CERTS_DEST/ca.crt"
+            export OC_USER=$(oc whoami)
+            [[ "$OC_USER" == "kube:admin" ]] && export OC_USER="kubeadmin"
+            podman login -u "$OC_USER" -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
             `,
           ],
           this.getServerConfig(),


### PR DESCRIPTION
### What does this PR do?
Linking mounted certificates from '/var/run/secrets/kubernetes.io/serviceaccount' to '/$HOME/.config/containers/certs.d' before podman login

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/22140

### Is it tested? How?
Install Eclipse Che and replace the dashboard image related to the PR

```
spec:
  components:
    dashboard:
      deployment:
        containers:
          - image: quay.io/eclipse/che-dashboard:pr-851
 ```

Create an empty workspace, open the terminal, and execute `podman pull image-registry.openshift-image-registry.svc:5000/openshift/cli:latest`

![image](https://github.com/eclipse-che/che-dashboard/assets/1461122/ba55b0f2-50e6-46bf-a871-b6ee51131033)

N.B. symbolic links for `ca.crt` and `service-ca.crt` are in the  `$HOME/.config/containers/certs.d/image-registry.openshift-image-registry.svc:5000` folder

#### Release Notes

#### Docs PR
Related info - https://manpages.ubuntu.com/manpages/impish/man5/containers-certs.d.5.html

