### PR TITLE
fix: creating a new workspace from the remote registry

### DIFF
--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -143,7 +143,7 @@ export const yamlResolverSchema: JSONSchema7 = {
   properties: {
     url: {
       type: 'string',
-      pattern: '^http.*.yaml$',
+      pattern: '^http.*',
     },
   },
   required: ['url'],

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -142,10 +142,34 @@ export const actionCreators: ActionCreators = {
             error_code: factoryParams?.errorCode,
           })
         : undefined;
+      const isDevfileRegistryLocation = (location: string): boolean => {
+        const devfileRegistries = [
+          `${window.location.protocol}//${window.location.host}${DEFAULT_REGISTRY}`,
+        ];
+        if (state.dwServerConfig.config.devfileRegistryURL) {
+          devfileRegistries.push(state.dwServerConfig.config.devfileRegistryURL);
+        }
+        const externalDevfileRegistries =
+          state.dwServerConfig.config.devfileRegistry.externalDevfileRegistries.map(
+            externalDevfileRegistriy => externalDevfileRegistriy.url,
+          );
+        if (externalDevfileRegistries.length) {
+          devfileRegistries.push(...externalDevfileRegistries);
+        }
+        let isRegistryLocation = false;
+        devfileRegistries.every(registry => {
+          if (location.startsWith(registry)) {
+            isRegistryLocation = true;
+            return false;
+          }
+          return true;
+        });
+        return isRegistryLocation;
+      };
 
       try {
         let data: FactoryResolver;
-        if (location.includes(DEFAULT_REGISTRY) && location.endsWith('.yaml')) {
+        if (isDevfileRegistryLocation(location)) {
           data = await getYamlResolver(namespace, location);
         } else {
           data = await WorkspaceClient.restApiClient.getFactoryResolver<FactoryResolver>(

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -156,15 +156,7 @@ export const actionCreators: ActionCreators = {
         if (externalDevfileRegistries.length) {
           devfileRegistries.push(...externalDevfileRegistries);
         }
-        let isRegistryLocation = false;
-        devfileRegistries.every(registry => {
-          if (location.startsWith(registry)) {
-            isRegistryLocation = true;
-            return false;
-          }
-          return true;
-        });
-        return isRegistryLocation;
+        return devfileRegistries.some(registry => location.startsWith(registry));
       };
 
       try {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix creating a new workspace from the remote registry.

### What issues does this PR fix or reference?
it needs for https://github.com/eclipse/che/issues/22326

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-CHE with an image from the current PR.
2. Update CR accordingly:
```
    devfileRegistry:
      disableInternalRegistry: true
      externalDevfileRegistries:
        - url: https://registry.devfile.io/
``` 
3. Open the 'Create Workspace' page.
![Знімок екрана 2023-05-16 о 02 42 20](https://github.com/eclipse-che/che-dashboard/assets/6310786/4e62d886-4152-4c46-81d8-5c809552a248)
4. Create a new workspace from the UDI sample.
![Знімок екрана 2023-05-16 о 02 43 48](https://github.com/eclipse-che/che-dashboard/assets/6310786/d59e79f1-8e0c-42df-a1fd-aacbf4c9bd08)
