### PR TITLE
Fix the index URL for external devfile registries

### DIFF
--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -86,6 +86,16 @@ export function updateObjectLinks(object: any, baseUrl): any {
   return object;
 }
 
+export function getRegistryIndexUrl(registryUrl: string, isExternal: boolean): URL {
+  registryUrl = registryUrl[registryUrl.length - 1] === '/' ? registryUrl : registryUrl + '/';
+  if (isExternal) {
+    if (new URL(registryUrl).host === 'registry.devfile.io') {
+      return new URL('index', registryUrl);
+    }
+  }
+  return new URL('devfiles/index.json', registryUrl);
+}
+
 export async function fetchRegistryMetadata(
   registryUrl: string,
   isExternal: boolean,
@@ -93,9 +103,7 @@ export async function fetchRegistryMetadata(
   registryUrl = registryUrl[registryUrl.length - 1] === '/' ? registryUrl : registryUrl + '/';
 
   try {
-    const registryIndexUrl = isExternal
-      ? new URL('/index', registryUrl)
-      : new URL('devfiles/index.json', registryUrl);
+    const registryIndexUrl = getRegistryIndexUrl(registryUrl, isExternal);
     if (isExternal) {
       const devfileMetaDataArr = getExternalRegistryMetadataFromStorage(registryIndexUrl.href);
       if (devfileMetaDataArr !== undefined) {

--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -87,7 +87,6 @@ export function updateObjectLinks(object: any, baseUrl): any {
 }
 
 export function getRegistryIndexUrl(registryUrl: string, isExternal: boolean): URL {
-  registryUrl = registryUrl[registryUrl.length - 1] === '/' ? registryUrl : registryUrl + '/';
   if (isExternal) {
     if (new URL(registryUrl).host === 'registry.devfile.io') {
       return new URL('index', registryUrl);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixed the index URL for external devfile registries.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-CHE with an image from the current PR.
2. Update CR accordingly:
```
    devfileRegistry:
      disableInternalRegistry: true
      externalDevfileRegistries:
        - url: https://registry.devfile.io/
        - url: https://eclipse-che.github.io/che-devfile-registry/7.71.0/
``` 
![Знімок екрана 2023-07-24 о 18 20 49](https://github.com/eclipse-che/che-dashboard/assets/6310786/d0b2ec0f-1e3f-4cfa-a38f-dbee3a3f364e)

3. Open the 'Create Workspace' page.
![Знімок екрана 2023-07-24 о 18 20 04](https://github.com/eclipse-che/che-dashboard/assets/6310786/0c5e3cf8-ec4d-4990-8c11-45cde3a6b995)
