### PR TITLE
Increate IdentityProvider set-up timeout, decrease check frequency

### DIFF
--- a/.ci/oci-dashboard-happy-path.sh
+++ b/.ci/oci-dashboard-happy-path.sh
@@ -108,12 +108,12 @@ function provisionOpenShiftOAuthUser() {
   oc rollout status -n openshift-authentication deployment/oauth-openshift
   echo -e "[INFO] Waiting for htpasswd auth to be working up to 5 minutes"
   CURRENT_TIME=$(date +%s)
-  ENDTIME=$(($CURRENT_TIME + 300))
+  ENDTIME=$(($CURRENT_TIME + 900))
   while [ $(date +%s) -lt $ENDTIME ]; do
       if oc login -u happypath-dev -p dev --kubeconfig $TMP_KUBECONFIG; then
           return 0
       fi
-      sleep 10
+      sleep 15
   done
   echo "[ERROR] Che htpasswd changes are not affected after timeout."
   exit 1


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Multiplies default identity provider installation timeout three times (300s -> 900s)
* Decreases check frequency to prevent console spam (10s -> 15s)

### What issues does this PR fix or reference?
follow-up of https://github.com/eclipse-che/che-dashboard/pull/862

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
will be in the pipeline on this PR

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A