### PR TITLE
Fix duplicating requests

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/helpers.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/helpers.spec.ts
@@ -10,18 +10,17 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { api } from '@eclipse-che/common';
+import k8s from '@kubernetes/client-node';
 import {
   buildLabelSelector,
+  DUMMY_TOKEN_DATA,
+  isPatSecret,
+  PersonalAccessTokenSecret,
   toSecret,
   toSecretName,
   toToken,
-  isPatSecret,
-  PersonalAccessTokenSecret,
-  TokenName,
-  DUMMY_TOKEN_DATA,
 } from '../helpers';
-import k8s from '@kubernetes/client-node';
-import { api } from '@eclipse-che/common';
 
 describe('Helpers for Personal Access Token API', () => {
   test('buildLabelSelector', () => {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.module.css
@@ -10,6 +10,10 @@
 *   Red Hat, Inc. - initial API and implementation
 */
 
+.pf-c-wizard__nav {
+  color: var(--pf-global--palette--black-1000);
+}
+
 .pf-c-wizard__nav .error {
   color: var(--pf-global--palette--black-1000);
   font-weight: bold;

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WorkspaceProgressWizard component snapshot 1`] = `
+<div
+  className="progress pf-c-wizard"
+>
+  <button
+    aria-expanded={true}
+    aria-label="Wizard Toggle"
+    className="pf-c-wizard__toggle pf-m-expanded"
+    onClick={[Function]}
+  >
+    <ol
+      className="pf-c-wizard__toggle-list"
+    >
+      <li
+        className="pf-c-wizard__toggle-list-item"
+      >
+        <span
+          className="pf-c-wizard__toggle-num"
+        />
+         
+      </li>
+    </ol>
+    <span
+      className="pf-c-wizard__toggle-icon"
+    >
+      <svg
+        aria-hidden="true"
+        aria-labelledby={null}
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style={
+          Object {
+            "verticalAlign": "-0.125em",
+          }
+        }
+        viewBox="0 0 320 512"
+        width="1em"
+      >
+        <path
+          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+        />
+      </svg>
+    </span>
+  </button>
+  <div
+    className="pf-c-wizard__outer-wrap"
+  >
+    <div
+      className="pf-c-wizard__inner-wrap"
+    >
+      <nav
+        aria-label="Workspace Progress Steps"
+        className="pf-c-wizard__nav pf-m-expanded"
+      >
+        <ol
+          className="pf-c-wizard__nav-list"
+        >
+          <li
+            className="pf-c-wizard__nav-item"
+          >
+            <button
+              aria-current={false}
+              aria-disabled={null}
+              className="pf-c-wizard__nav-link"
+              disabled={false}
+              onClick={[Function]}
+            >
+              initialize
+            </button>
+          </li>
+          <li
+            className="pf-c-wizard__nav-item"
+          >
+            <button
+              aria-current="page"
+              aria-disabled={null}
+              className="pf-c-wizard__nav-link pf-m-current"
+              disabled={false}
+              onClick={[Function]}
+            >
+              limit-check
+            </button>
+          </li>
+          <li
+            className="pf-c-wizard__nav-item"
+          >
+            <button
+              aria-current={false}
+              aria-disabled={null}
+              className="pf-c-wizard__nav-link"
+              disabled={false}
+              onClick={[Function]}
+            >
+              create
+            </button>
+            <ol
+              className="pf-c-wizard__nav-list"
+            >
+              <li
+                className="pf-c-wizard__nav-item"
+              >
+                <button
+                  aria-current={false}
+                  aria-disabled={true}
+                  className="pf-c-wizard__nav-link pf-m-disabled"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  fetch
+                </button>
+              </li>
+              <li
+                className="pf-c-wizard__nav-item"
+              >
+                <button
+                  aria-current={false}
+                  aria-disabled={true}
+                  className="pf-c-wizard__nav-link pf-m-disabled"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  conflict-check
+                </button>
+              </li>
+              <li
+                className="pf-c-wizard__nav-item"
+              >
+                <button
+                  aria-current={false}
+                  aria-disabled={true}
+                  className="pf-c-wizard__nav-link pf-m-disabled"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  apply
+                </button>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+      <div
+        aria-label={null}
+        aria-labelledby={null}
+        className="pf-c-wizard__main"
+      >
+        <div
+          className="pf-c-wizard__main-body"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/index.spec.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import WorkspaceProgressWizard, { WorkspaceProgressWizardStep } from '..';
+import { Step, StepId } from '../..';
+import getComponentRenderer, { screen } from '../../../../services/__mocks__/getComponentRenderer';
+
+const mockGoToNext = jest.fn();
+
+const { createSnapshot, renderComponent } = getComponentRenderer(getComponent);
+
+describe('WorkspaceProgressWizard', () => {
+  let steps: WorkspaceProgressWizardStep[];
+  let ref: React.RefObject<any>;
+
+  beforeEach(() => {
+    steps = [
+      {
+        id: Step.INITIALIZE,
+        name: Step.INITIALIZE,
+        component: <></>,
+      },
+      {
+        id: Step.LIMIT_CHECK,
+        name: Step.LIMIT_CHECK,
+        component: <></>,
+      },
+      {
+        id: Step.CREATE,
+        name: Step.CREATE,
+        component: <></>,
+        steps: [
+          {
+            id: Step.FETCH,
+            name: Step.FETCH,
+            component: <></>,
+          },
+          {
+            id: Step.CONFLICT_CHECK,
+            name: Step.CONFLICT_CHECK,
+            component: <></>,
+          },
+          {
+            id: Step.APPLY,
+            name: Step.APPLY,
+            component: <></>,
+          },
+        ],
+      },
+    ];
+    ref = React.createRef();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('component snapshot', () => {
+    const activeStepId: StepId = Step.LIMIT_CHECK;
+
+    const snapshot = createSnapshot(activeStepId, steps, ref);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  test('switching active step', () => {
+    const activeStepId: StepId = Step.INITIALIZE;
+
+    const { reRenderComponent } = renderComponent(activeStepId, steps, ref);
+
+    const buttonInitialize = screen.getByRole('button', { name: Step.INITIALIZE });
+    const buttonLimitCheck = screen.getByRole('button', { name: Step.LIMIT_CHECK });
+
+    expect(buttonInitialize.className.split(' ')).toEqual(expect.arrayContaining(['pf-m-current']));
+    expect(buttonLimitCheck.className.split(' ')).not.toEqual(
+      expect.arrayContaining(['pf-m-current']),
+    );
+
+    const nextActiveStepId = Step.LIMIT_CHECK;
+    reRenderComponent(nextActiveStepId, steps, ref);
+
+    const nextButtonInitialize = screen.getByRole('button', { name: Step.INITIALIZE });
+    const nextButtonLimitCheck = screen.getByRole('button', { name: Step.LIMIT_CHECK });
+
+    expect(nextButtonInitialize.className.split(' ')).not.toEqual(
+      expect.arrayContaining(['pf-m-current']),
+    );
+    expect(nextButtonLimitCheck.className.split(' ')).toEqual(
+      expect.arrayContaining(['pf-m-current']),
+    );
+  });
+
+  describe('trigger goToNext using reference', () => {
+    test('on the very first step', () => {
+      const activeStepId: StepId = Step.INITIALIZE;
+
+      renderComponent(activeStepId, steps, ref);
+
+      expect(mockGoToNext).not.toHaveBeenCalled();
+
+      ref.current?.goToNext();
+
+      expect(mockGoToNext).toHaveBeenCalledWith(Step.LIMIT_CHECK, Step.INITIALIZE);
+    });
+
+    test('on the very last step', () => {
+      const activeStepId: StepId = Step.APPLY;
+
+      renderComponent(activeStepId, steps, ref);
+
+      expect(mockGoToNext).not.toHaveBeenCalled();
+
+      ref.current?.goToNext();
+
+      expect(mockGoToNext).toHaveBeenCalledWith(undefined, Step.APPLY);
+    });
+  });
+});
+
+function getComponent(
+  activeStepId: StepId,
+  steps: WorkspaceProgressWizardStep[],
+  ref: React.RefObject<any>,
+): React.ReactElement {
+  return (
+    <WorkspaceProgressWizard
+      ref={ref}
+      activeStepId={activeStepId}
+      steps={steps}
+      onNext={mockGoToNext}
+    />
+  );
+}

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.module.css
@@ -1,0 +1,40 @@
+/*
+* Copyright (c) 2018-2023 Red Hat, Inc.
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Red Hat, Inc. - initial API and implementation
+*/
+
+.progress {
+  height: 700px;
+}
+
+.progress .pf-c-wizard__nav {
+  width: 100%;
+  border: none;
+  box-shadow: none;
+}
+
+.progress .pf-c-wizard__nav-link {
+  margin-left: 8px;
+  pointer-events: none;
+}
+
+.progress .pf-c-wizard__nav-link:hover,
+.progress .pf-c-wizard__nav-link:focus {
+  --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--Color);
+  --pf-c-wizard__nav-link-toggle--Color: var(--pf-c-wizard__nav-link--Color);
+}
+
+.progress .pf-c-wizard__nav-link > svg {
+  margin-right: 5px;
+}
+
+.progress .pf-c-wizard__toggle {
+  display: none;
+}

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as PF from '@patternfly/react-core';
+import wizardStyles from '@patternfly/react-styles/css/components/Wizard/wizard';
+import React from 'react';
+import { StepId } from '..';
+import styles from './index.module.css';
+
+export interface WorkspaceProgressWizardStep extends PF.WizardStep {
+  id: StepId;
+  steps?: WorkspaceProgressWizardStep[];
+}
+
+export type Props = {
+  activeStepId: StepId;
+  steps: WorkspaceProgressWizardStep[];
+  onNext: (nextStepId: StepId | undefined, prevStepId: StepId) => void;
+};
+
+class WorkspaceProgressWizard extends React.Component<Props> {
+  private handleGoToStepById() {
+    console.warn('Not implemented: handleGoToStepById');
+    return false;
+  }
+
+  private handleGoToStepByName() {
+    console.warn('Not implemented: handleGoToStepByName');
+    return false;
+  }
+
+  private handleBack() {
+    console.warn('Not implemented: handleBack');
+    return false;
+  }
+
+  private handleClose() {
+    console.warn('Not implemented: handleClose');
+    return false;
+  }
+
+  public goToNext(): void {
+    const flattenedSteps = this.flattenSteps(this.props.steps);
+    // find the index of the next after the current active step
+    const activeStepNumber = this.getFlattenedStepsNumber(flattenedSteps, this.props.activeStepId);
+
+    if (activeStepNumber === 0) {
+      // current step is not found by its id, do nothing
+      return;
+    }
+
+    if (activeStepNumber === flattenedSteps.length) {
+      // last step
+      this.props.onNext(undefined, this.props.activeStepId);
+      return;
+    }
+
+    const nextStep = flattenedSteps[activeStepNumber];
+    this.props.onNext(nextStep.id, this.props.activeStepId);
+  }
+
+  private handleNavToggle() {
+    console.warn('Not implemented: handleNavToggle');
+    return false;
+  }
+
+  private setDefaultValues(steps: WorkspaceProgressWizardStep[]): WorkspaceProgressWizardStep[] {
+    const withDefaults = (step: WorkspaceProgressWizardStep) =>
+      Object.assign({ canJumpTo: true }, step);
+
+    return steps.map(step => {
+      const subSteps = step.steps;
+      if (subSteps !== undefined) {
+        subSteps.map(subStep => withDefaults(subStep));
+      }
+      return withDefaults(step);
+    });
+  }
+
+  private flattenSteps(steps: WorkspaceProgressWizardStep[]): WorkspaceProgressWizardStep[] {
+    return steps.reduce((acc, step) => {
+      if (step.steps) {
+        return acc.concat(step.steps);
+      }
+      return acc.concat(step);
+    }, [] as WorkspaceProgressWizardStep[]);
+  }
+
+  /**
+   * Returns the number (index + 1) of the step in the flattened steps array
+   */
+  private getFlattenedStepsNumber(
+    flattenedSteps: WorkspaceProgressWizardStep[],
+    stepId: StepId,
+  ): number {
+    return flattenedSteps.findIndex(step => step.id === stepId) + 1;
+  }
+
+  private buildWizardNav(
+    activeStepId: StepId,
+    steps: WorkspaceProgressWizardStep[],
+  ): React.ReactElement {
+    const stepsWithDefaults = this.setDefaultValues(steps);
+    const flattenedSteps = this.flattenSteps(stepsWithDefaults);
+
+    return (
+      <PF.WizardNav aria-label="Workspace Progress Steps" isOpen={true}>
+        {stepsWithDefaults.map(step => {
+          const { canJumpTo, name, steps = [], id } = step;
+          const flattenedStepNumber = this.getFlattenedStepsNumber(flattenedSteps, id);
+
+          const hasActiveChild = steps.some(subStep => subStep.id === activeStepId);
+
+          return (
+            <PF.WizardNavItem
+              key={id}
+              content={name}
+              step={flattenedStepNumber}
+              isCurrent={activeStepId === id || hasActiveChild}
+              isDisabled={!canJumpTo}
+              onNavItemClick={() => this.handleGoToStepById()}
+            >
+              {steps.length !== 0 && (
+                <PF.WizardNav returnList>
+                  {steps.map(subStep => {
+                    if (subStep.isFinishedStep) {
+                      return;
+                    }
+
+                    const { canJumpTo, name, id } = subStep;
+                    const flattenedStepNumber = this.getFlattenedStepsNumber(flattenedSteps, id);
+                    return (
+                      <PF.WizardNavItem
+                        key={id}
+                        content={name}
+                        step={flattenedStepNumber}
+                        isCurrent={activeStepId === id}
+                        isDisabled={!canJumpTo}
+                        onNavItemClick={() => this.handleGoToStepById()}
+                      />
+                    );
+                  })}
+                </PF.WizardNav>
+              )}
+            </PF.WizardNavItem>
+          );
+        })}
+      </PF.WizardNav>
+    );
+  }
+
+  render() {
+    const { activeStepId, steps } = this.props;
+
+    const hasNoBodyPadding = false;
+
+    const activeStep = steps[0];
+
+    return (
+      <PF.WizardContextProvider
+        value={{
+          activeStep: activeStep,
+          goToStepById: () => this.handleGoToStepById(),
+          goToStepByName: () => this.handleGoToStepByName(),
+          onBack: () => this.handleBack(),
+          onClose: () => this.handleClose(),
+          onNext: () => this.goToNext(),
+        }}
+      >
+        <div className={`${styles.progress} ${wizardStyles.wizard}`}>
+          <PF.WizardToggle
+            activeStep={activeStep}
+            hasNoBodyPadding={hasNoBodyPadding}
+            isNavOpen={true}
+            nav={() => this.buildWizardNav(activeStepId, steps)}
+            onNavToggle={() => this.handleNavToggle()}
+            steps={[]}
+          >
+            <React.Fragment />
+          </PF.WizardToggle>
+        </div>
+      </PF.WizardContextProvider>
+    );
+  }
+}
+
+export default React.forwardRef<WorkspaceProgressWizard, Props>((props, ref) => (
+  <WorkspaceProgressWizard ref={ref} {...props} />
+));

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`LoaderProgress workspace creation flow snapshot 1`] = `
 <div
-  className="pf-c-wizard progress"
+  className="progress pf-c-wizard"
 >
   <button
-    aria-expanded={false}
+    aria-expanded={true}
     aria-label="Wizard Toggle"
-    className="pf-c-wizard__toggle"
+    className="pf-c-wizard__toggle pf-m-expanded"
     onClick={[Function]}
   >
     <ol
@@ -18,45 +18,8 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       >
         <span
           className="pf-c-wizard__toggle-num"
-        >
-          1
-        </span>
+        />
          
-        <div
-          data-testid="progress-step"
-        >
-          <span
-            data-testid="step-distance"
-          >
-            0
-          </span>
-          <span
-            data-testid="step-name"
-          >
-            Creating step: Initialize
-          </span>
-          <input
-            data-testid="onError"
-            name="onError"
-            onClick={[Function]}
-            type="button"
-            value="onError"
-          />
-          <input
-            data-testid="onRestart"
-            name="onRestart"
-            onClick={[Function]}
-            type="button"
-            value="onRestart"
-          />
-          <input
-            data-testid="onNextStep"
-            name=" onNextStep"
-            onClick={[Function]}
-            type="button"
-            value="onNextStep"
-          />
-        </div>
       </li>
     </ol>
     <span
@@ -89,9 +52,8 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       className="pf-c-wizard__inner-wrap"
     >
       <nav
-        aria-label={null}
-        aria-labelledby={null}
-        className="pf-c-wizard__nav"
+        aria-label="Workspace Progress Steps"
+        className="pf-c-wizard__nav pf-m-expanded"
       >
         <ol
           className="pf-c-wizard__nav-list"
@@ -244,9 +206,9 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               >
                 <button
                   aria-current={false}
-                  aria-disabled={null}
-                  className="pf-c-wizard__nav-link"
-                  disabled={false}
+                  aria-disabled={true}
+                  className="pf-c-wizard__nav-link pf-m-disabled"
+                  disabled={true}
                   onClick={[Function]}
                 >
                   <div
@@ -291,9 +253,9 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               >
                 <button
                   aria-current={false}
-                  aria-disabled={null}
-                  className="pf-c-wizard__nav-link"
-                  disabled={false}
+                  aria-disabled={true}
+                  className="pf-c-wizard__nav-link pf-m-disabled"
+                  disabled={true}
                   onClick={[Function]}
                 >
                   <div
@@ -338,9 +300,9 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               >
                 <button
                   aria-current={false}
-                  aria-disabled={null}
-                  className="pf-c-wizard__nav-link"
-                  disabled={false}
+                  aria-disabled={true}
+                  className="pf-c-wizard__nav-link pf-m-disabled"
+                  disabled={true}
                   onClick={[Function]}
                 >
                   <div
@@ -494,12 +456,12 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
 
 exports[`LoaderProgress workspace staring flow snapshot 1`] = `
 <div
-  className="pf-c-wizard progress"
+  className="progress pf-c-wizard"
 >
   <button
-    aria-expanded={false}
+    aria-expanded={true}
     aria-label="Wizard Toggle"
-    className="pf-c-wizard__toggle"
+    className="pf-c-wizard__toggle pf-m-expanded"
     onClick={[Function]}
   >
     <ol
@@ -510,45 +472,8 @@ exports[`LoaderProgress workspace staring flow snapshot 1`] = `
       >
         <span
           className="pf-c-wizard__toggle-num"
-        >
-          1
-        </span>
+        />
          
-        <div
-          data-testid="progress-step"
-        >
-          <span
-            data-testid="step-distance"
-          >
-            0
-          </span>
-          <span
-            data-testid="step-name"
-          >
-            Starting step: Initialize
-          </span>
-          <input
-            data-testid="onError"
-            name="onError"
-            onClick={[Function]}
-            type="button"
-            value="onError"
-          />
-          <input
-            data-testid="onRestart"
-            name="onRestart"
-            onClick={[Function]}
-            type="button"
-            value="onRestart"
-          />
-          <input
-            data-testid="onNextStep"
-            name=" onNextStep"
-            onClick={[Function]}
-            type="button"
-            value="onNextStep"
-          />
-        </div>
       </li>
     </ol>
     <span
@@ -581,9 +506,8 @@ exports[`LoaderProgress workspace staring flow snapshot 1`] = `
       className="pf-c-wizard__inner-wrap"
     >
       <nav
-        aria-label={null}
-        aria-labelledby={null}
-        className="pf-c-wizard__nav"
+        aria-label="Workspace Progress Steps"
+        className="pf-c-wizard__nav pf-m-expanded"
       >
         <ol
           className="pf-c-wizard__nav-list"

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/index.spec.tsx
@@ -238,7 +238,7 @@ describe('LoaderProgress', () => {
           const localState: Partial<State> = {
             alertItems: [],
             // active step is "check running workspaces limit"
-            activeStep: Step.LIMIT_CHECK,
+            activeStepId: Step.LIMIT_CHECK,
             // step "initialize" is done
             doneSteps: [Step.INITIALIZE],
             factoryParams,
@@ -286,7 +286,7 @@ describe('LoaderProgress', () => {
           const localState: Partial<State> = {
             alertItems: [],
             // active step is "check running workspaces limit"
-            activeStep: Step.OPEN, // <-- 8th step, active
+            activeStepId: Step.OPEN, // <-- 8th step, active
             doneSteps: [
               Step.INITIALIZE,
               Step.LIMIT_CHECK,
@@ -332,7 +332,7 @@ describe('LoaderProgress', () => {
           const localState: Partial<State> = {
             alertItems: [],
             // active step is "check running workspaces limit"
-            activeStep: Step.LIMIT_CHECK,
+            activeStepId: Step.LIMIT_CHECK,
             // step "initialize" is done
             doneSteps: [Step.INITIALIZE],
             factoryParams,
@@ -449,7 +449,6 @@ describe('LoaderProgress', () => {
 
 function getSteps() {
   const steps = screen.getAllByTestId('progress-step');
-  steps.shift(); // remove the first element which is the wizard toggle
   return steps;
 }
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import * as PF from '@patternfly/react-core';
 import { History } from 'history';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
@@ -39,8 +38,7 @@ import StartingStepStartWorkspace from './StartingSteps/StartWorkspace';
 import StartingStepWorkspaceConditions, {
   ConditionType,
 } from './StartingSteps/WorkspaceConditions';
-
-import styles from './index.module.css';
+import WorkspaceProgressWizard, { WorkspaceProgressWizardStep } from './Wizard';
 
 export type Props = MappedProps & {
   history: History;
@@ -49,7 +47,7 @@ export type Props = MappedProps & {
   onTabChange: (tab: LoaderTab) => void;
 };
 export type State = {
-  activeStep: StepId;
+  activeStepId: StepId;
   alertItems: AlertItem[];
   conditions: ConditionType[];
   doneSteps: StepId[];
@@ -68,12 +66,9 @@ export enum Step {
   OPEN = 'open',
 }
 type ConditionStepId = `condition-${string}`;
-type StepId = Step | ConditionStepId;
+export type StepId = Step | ConditionStepId;
 
 class Progress extends React.PureComponent<Props, State> {
-  static contextType = PF.WizardContext;
-  readonly context: React.ContextType<typeof PF.WizardContext>;
-
   private readonly wizardRef: React.RefObject<any>;
 
   constructor(props: Props) {
@@ -85,7 +80,7 @@ class Progress extends React.PureComponent<Props, State> {
     const factoryParams = buildFactoryParams(this.props.searchParams);
 
     this.state = {
-      activeStep: Step.INITIALIZE,
+      activeStepId: Step.INITIALIZE,
       alertItems: [],
       conditions: [],
       doneSteps: [],
@@ -143,8 +138,8 @@ class Progress extends React.PureComponent<Props, State> {
     }, 0);
   }
 
-  private handleShowStepAlert(step: StepId, alertItem: AlertItem): void {
-    if (step !== this.state.activeStep) {
+  private handleStepsShowAlert(step: StepId, alertItem: AlertItem): void {
+    if (step !== this.state.activeStepId) {
       return;
     }
 
@@ -166,16 +161,28 @@ class Progress extends React.PureComponent<Props, State> {
     });
   }
 
-  private handleGoToNextStep(step: StepId): void {
-    if (step !== this.state.activeStep) {
+  private handleStepsGoToNext(stepId: StepId): void {
+    if (stepId !== this.state.activeStepId) {
+      // filter out condition steps
       return;
     }
 
-    this.wizardRef.current?.onNext();
+    if (stepId !== Step.START) {
+      this.wizardRef.current?.goToNext();
+      return;
+    }
+
+    // because there are condition steps between `START` and `OPEN`, we need to jump over them
+    const activeStepId = Step.OPEN;
+    const doneSteps = [...this.state.doneSteps, stepId];
+    this.setState({
+      activeStepId,
+      doneSteps,
+    });
   }
 
-  private handleRestartFlow(step: StepId, tab?: LoaderTab): void {
-    if (step !== this.state.activeStep) {
+  private handleStepsRestart(step: StepId, tab?: LoaderTab): void {
+    if (step !== this.state.activeStepId) {
       return;
     }
 
@@ -195,18 +202,17 @@ class Progress extends React.PureComponent<Props, State> {
     }
 
     this.setState({
-      activeStep: newActiveStep,
+      activeStepId: newActiveStep,
       doneSteps: newDoneSteps,
       conditions: [],
     });
-    this.wizardRef.current?.goToStepById(newActiveStep);
 
     if (tab) {
       this.props.onTabChange(tab);
     }
   }
 
-  private getSteps(): PF.WizardStep[] {
+  private getSteps(): WorkspaceProgressWizardStep[] {
     const { initialLoaderMode } = this.state;
     const showFactorySteps = initialLoaderMode.mode === 'factory';
 
@@ -219,14 +225,14 @@ class Progress extends React.PureComponent<Props, State> {
   }
 
   private getDistance(stepId: StepId) {
-    const { activeStep, doneSteps } = this.state;
+    const { activeStepId, doneSteps } = this.state;
 
-    const isActive = activeStep === stepId;
+    const isActive = activeStepId === stepId;
     const isDone = doneSteps.includes(stepId);
     return isActive ? 0 : isDone ? 1 : -1;
   }
 
-  private getCreationInitStep(): PF.WizardStep {
+  private getCreationInitStep(): WorkspaceProgressWizardStep {
     const { history, searchParams } = this.props;
 
     return {
@@ -236,17 +242,17 @@ class Progress extends React.PureComponent<Props, State> {
           distance={this.getDistance(Step.INITIALIZE)}
           history={history}
           searchParams={searchParams}
-          onError={alertItem => this.handleShowStepAlert(Step.INITIALIZE, alertItem)}
+          onError={alertItem => this.handleStepsShowAlert(Step.INITIALIZE, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
-          onNextStep={() => this.handleGoToNextStep(Step.INITIALIZE)}
-          onRestart={tab => this.handleRestartFlow(Step.INITIALIZE, tab)}
+          onNextStep={() => this.handleStepsGoToNext(Step.INITIALIZE)}
+          onRestart={tab => this.handleStepsRestart(Step.INITIALIZE, tab)}
         />
       ),
       component: <></>,
     };
   }
 
-  private getStartingInitStep(): PF.WizardStep {
+  private getStartingInitStep(): WorkspaceProgressWizardStep {
     const { history } = this.props;
 
     const loaderMode = getLoaderMode(history.location);
@@ -259,17 +265,17 @@ class Progress extends React.PureComponent<Props, State> {
           distance={this.getDistance(Step.INITIALIZE)}
           history={history}
           matchParams={matchParams}
-          onError={alertItem => this.handleShowStepAlert(Step.INITIALIZE, alertItem)}
+          onError={alertItem => this.handleStepsShowAlert(Step.INITIALIZE, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
-          onNextStep={() => this.handleGoToNextStep(Step.INITIALIZE)}
-          onRestart={tab => this.handleRestartFlow(Step.INITIALIZE, tab)}
+          onNextStep={() => this.handleStepsGoToNext(Step.INITIALIZE)}
+          onRestart={tab => this.handleStepsRestart(Step.INITIALIZE, tab)}
         />
       ),
       component: <></>,
     };
   }
 
-  private getCommonSteps(): PF.WizardStep[] {
+  private getCommonSteps(): WorkspaceProgressWizardStep[] {
     const { history } = this.props;
 
     const loaderMode = getLoaderMode(history.location);
@@ -283,10 +289,10 @@ class Progress extends React.PureComponent<Props, State> {
             distance={this.getDistance(Step.LIMIT_CHECK)}
             history={history}
             matchParams={matchParams}
-            onError={alertItem => this.handleShowStepAlert(Step.LIMIT_CHECK, alertItem)}
+            onError={alertItem => this.handleStepsShowAlert(Step.LIMIT_CHECK, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
-            onNextStep={() => this.handleGoToNextStep(Step.LIMIT_CHECK)}
-            onRestart={tab => this.handleRestartFlow(Step.LIMIT_CHECK, tab)}
+            onNextStep={() => this.handleStepsGoToNext(Step.LIMIT_CHECK)}
+            onRestart={tab => this.handleStepsRestart(Step.LIMIT_CHECK, tab)}
           />
         ),
         component: <></>,
@@ -294,7 +300,7 @@ class Progress extends React.PureComponent<Props, State> {
     ];
   }
 
-  private getCreationSteps(): PF.WizardStep[] {
+  private getCreationSteps(): WorkspaceProgressWizardStep[] {
     const { history, searchParams } = this.props;
     const { factoryParams } = this.state;
 
@@ -308,10 +314,10 @@ class Progress extends React.PureComponent<Props, State> {
             distance={this.getDistance(Step.CREATE)}
             history={history}
             searchParams={searchParams}
-            onError={alertItem => this.handleShowStepAlert(Step.CREATE, alertItem)}
+            onError={alertItem => this.handleStepsShowAlert(Step.CREATE, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
-            onNextStep={() => this.handleGoToNextStep(Step.CREATE)}
-            onRestart={tab => this.handleRestartFlow(Step.CREATE, tab)}
+            onNextStep={() => this.handleStepsGoToNext(Step.CREATE)}
+            onRestart={tab => this.handleStepsRestart(Step.CREATE, tab)}
           />
         ),
         component: <></>,
@@ -324,10 +330,10 @@ class Progress extends React.PureComponent<Props, State> {
                 distance={this.getDistance(Step.CONFLICT_CHECK)}
                 history={history}
                 searchParams={searchParams}
-                onError={alertItem => this.handleShowStepAlert(Step.CONFLICT_CHECK, alertItem)}
+                onError={alertItem => this.handleStepsShowAlert(Step.CONFLICT_CHECK, alertItem)}
                 onHideError={alertId => this.handleCloseStepAlert(alertId)}
-                onNextStep={() => this.handleGoToNextStep(Step.CONFLICT_CHECK)}
-                onRestart={tab => this.handleRestartFlow(Step.CONFLICT_CHECK, tab)}
+                onNextStep={() => this.handleStepsGoToNext(Step.CONFLICT_CHECK)}
+                onRestart={tab => this.handleStepsRestart(Step.CONFLICT_CHECK, tab)}
               />
             ),
             component: <></>,
@@ -338,7 +344,7 @@ class Progress extends React.PureComponent<Props, State> {
     ];
   }
 
-  private getFactoryFetchResources(): PF.WizardStep {
+  private getFactoryFetchResources(): WorkspaceProgressWizardStep {
     const { history, searchParams } = this.props;
 
     return {
@@ -348,17 +354,17 @@ class Progress extends React.PureComponent<Props, State> {
           distance={this.getDistance(Step.FETCH)}
           history={history}
           searchParams={searchParams}
-          onError={alertItem => this.handleShowStepAlert(Step.FETCH, alertItem)}
+          onError={alertItem => this.handleStepsShowAlert(Step.FETCH, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
-          onNextStep={() => this.handleGoToNextStep(Step.FETCH)}
-          onRestart={tab => this.handleRestartFlow(Step.FETCH, tab)}
+          onNextStep={() => this.handleStepsGoToNext(Step.FETCH)}
+          onRestart={tab => this.handleStepsRestart(Step.FETCH, tab)}
         />
       ),
       component: <></>,
     };
   }
 
-  private getFactoryApplyResources(): PF.WizardStep {
+  private getFactoryApplyResources(): WorkspaceProgressWizardStep {
     const { history, searchParams } = this.props;
 
     return {
@@ -368,17 +374,17 @@ class Progress extends React.PureComponent<Props, State> {
           distance={this.getDistance(Step.APPLY)}
           history={history}
           searchParams={searchParams}
-          onError={alertItem => this.handleShowStepAlert(Step.APPLY, alertItem)}
+          onError={alertItem => this.handleStepsShowAlert(Step.APPLY, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
-          onNextStep={() => this.handleGoToNextStep(Step.APPLY)}
-          onRestart={tab => this.handleRestartFlow(Step.APPLY, tab)}
+          onNextStep={() => this.handleStepsGoToNext(Step.APPLY)}
+          onRestart={tab => this.handleStepsRestart(Step.APPLY, tab)}
         />
       ),
       component: <></>,
     };
   }
 
-  private getFactoryFetchDevfile(): PF.WizardStep {
+  private getFactoryFetchDevfile(): WorkspaceProgressWizardStep {
     const { history, searchParams } = this.props;
 
     return {
@@ -388,17 +394,17 @@ class Progress extends React.PureComponent<Props, State> {
           distance={this.getDistance(Step.FETCH)}
           history={history}
           searchParams={searchParams}
-          onError={alertItem => this.handleShowStepAlert(Step.FETCH, alertItem)}
+          onError={alertItem => this.handleStepsShowAlert(Step.FETCH, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
-          onNextStep={() => this.handleGoToNextStep(Step.FETCH)}
-          onRestart={tab => this.handleRestartFlow(Step.FETCH, tab)}
+          onNextStep={() => this.handleStepsGoToNext(Step.FETCH)}
+          onRestart={tab => this.handleStepsRestart(Step.FETCH, tab)}
         />
       ),
       component: <></>,
     };
   }
 
-  private getFactoryApplyDevfile(): PF.WizardStep {
+  private getFactoryApplyDevfile(): WorkspaceProgressWizardStep {
     const { history, searchParams } = this.props;
 
     return {
@@ -408,17 +414,17 @@ class Progress extends React.PureComponent<Props, State> {
           distance={this.getDistance(Step.APPLY)}
           history={history}
           searchParams={searchParams}
-          onError={alertItem => this.handleShowStepAlert(Step.APPLY, alertItem)}
+          onError={alertItem => this.handleStepsShowAlert(Step.APPLY, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
-          onNextStep={() => this.handleGoToNextStep(Step.APPLY)}
-          onRestart={tab => this.handleRestartFlow(Step.APPLY, tab)}
+          onNextStep={() => this.handleStepsGoToNext(Step.APPLY)}
+          onRestart={tab => this.handleStepsRestart(Step.APPLY, tab)}
         />
       ),
       component: <></>,
     };
   }
 
-  private getStartingSteps(): PF.WizardStep[] {
+  private getStartingSteps(): WorkspaceProgressWizardStep[] {
     const { history } = this.props;
 
     const loaderMode = getLoaderMode(history.location);
@@ -434,10 +440,10 @@ class Progress extends React.PureComponent<Props, State> {
         name: (
           <StartingStepStartWorkspace
             distance={this.getDistance(Step.START)}
-            onError={alertItem => this.handleShowStepAlert(Step.START, alertItem)}
+            onError={alertItem => this.handleStepsShowAlert(Step.START, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
-            onNextStep={() => this.handleGoToNextStep(Step.START)}
-            onRestart={tab => this.handleRestartFlow(Step.START, tab)}
+            onNextStep={() => this.handleStepsGoToNext(Step.START)}
+            onRestart={tab => this.handleStepsRestart(Step.START, tab)}
             history={history}
             matchParams={matchParams}
           />
@@ -449,10 +455,10 @@ class Progress extends React.PureComponent<Props, State> {
         name: (
           <StartingStepOpenWorkspace
             distance={this.getDistance(Step.OPEN)}
-            onError={alertItem => this.handleShowStepAlert(Step.OPEN, alertItem)}
+            onError={alertItem => this.handleStepsShowAlert(Step.OPEN, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
-            onNextStep={() => this.handleGoToNextStep(Step.OPEN)}
-            onRestart={tab => this.handleRestartFlow(Step.OPEN, tab)}
+            onNextStep={() => this.handleStepsGoToNext(Step.OPEN)}
+            onRestart={tab => this.handleStepsRestart(Step.OPEN, tab)}
             history={history}
             matchParams={matchParams}
           />
@@ -461,7 +467,7 @@ class Progress extends React.PureComponent<Props, State> {
     ];
   }
 
-  private buildConditionSteps(): PF.WizardStep[] {
+  private buildConditionSteps(): WorkspaceProgressWizardStep[] {
     const { history } = this.props;
     const { conditions } = this.state;
     const loaderMode = getLoaderMode(history.location);
@@ -480,45 +486,39 @@ class Progress extends React.PureComponent<Props, State> {
             condition={condition as ConditionType}
             matchParams={loaderMode.workspaceParams}
             history={history}
-            onError={alertItem => this.handleShowStepAlert(stepId, alertItem)}
+            onError={alertItem => this.handleStepsShowAlert(stepId, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
-            onNextStep={() => this.handleGoToNextStep(stepId)}
-            onRestart={tab => this.handleRestartFlow(stepId, tab)}
+            onNextStep={() => this.handleStepsGoToNext(stepId)}
+            onRestart={tab => this.handleStepsRestart(stepId, tab)}
           />
         ),
       };
     });
   }
 
-  private handleSwitchToNextStep(...params: Parameters<PF.WizardStepFunctionType>): void {
-    const [newStep, prevStep] = params;
-
-    const activeStep = newStep.id ? (newStep.id as Step) : this.state.activeStep;
-
-    const doneSteps = prevStep.prevId
-      ? [...this.state.doneSteps, prevStep.prevId as Step]
-      : this.state.doneSteps;
+  private handleSwitchToNextStep(nextStepId: StepId | undefined, prevStepId: StepId): void {
+    const activeStepId = nextStepId || this.state.activeStepId;
+    const doneSteps = [...this.state.doneSteps, prevStepId];
 
     this.setState({
-      activeStep,
+      activeStepId,
       doneSteps,
     });
   }
 
   render(): React.ReactNode {
     const { showToastAlert } = this.props;
-    const { alertItems } = this.state;
+    const { alertItems, activeStepId: activeStep } = this.state;
 
     const steps = this.getSteps();
 
     return (
       <React.Fragment>
         <ProgressAlert isToast={showToastAlert} alertItems={alertItems} />
-        <PF.Wizard
-          className={styles.progress}
-          steps={steps}
-          footer={<></>}
+        <WorkspaceProgressWizard
           ref={this.wizardRef}
+          activeStepId={activeStep}
+          steps={steps}
           onNext={(...params) => this.handleSwitchToNextStep(...params)}
         />
       </React.Fragment>


### PR DESCRIPTION

### What does this PR do?

This pull request fixes a bug that caused the Dashboard to send duplicate requests when creating or starting workspaces.


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/22326
fixes https://github.com/eclipse/che/issues/22323

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Eclipse Che
2. Update CheCluster CR to use **waiting for image** as the dashboard image:
	```yaml
	spec:
	  components:
	    dashboard:
	      deployment:
	        containers:
	          - image: <waiting for image>
	```	
4. Create a workspace either from a devfile or a sample.
5. Open Developer tools->Network, and make sure there are no requests with `409 Conflict` status.
6. Open the Dashboard workspaces list page and make sure there is only one new workspace.

