### PR TITLE
fix: avoid workspaces page blinking

### DIFF
--- a/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
@@ -30,13 +30,6 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
   @lazyInject(AppAlerts)
   private appAlerts: AppAlerts;
 
-  public componentDidMount(): void {
-    const { isLoading, requestWorkspaces } = this.props;
-    if (!isLoading) {
-      requestWorkspaces();
-    }
-  }
-
   render() {
     const { branding, history, allWorkspaces, isLoading } = this.props;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The workspaces list page is not blinking.

#### before

https://github.com/eclipse-che/che-dashboard/assets/16220722/c7150fe7-9cdf-4133-8f80-6042e7d87ba9

#### after



https://github.com/eclipse-che/che-dashboard/assets/16220722/6fc17d00-f123-40c0-a7fb-87c1a0c9bb28



### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/21972
