### PR TITLE
CRW-4644 Fix downstream brew build

### DIFF
--- a/build/dockerfiles/brew.Dockerfile
+++ b/build/dockerfiles/brew.Dockerfile
@@ -12,6 +12,9 @@
 FROM ubi8/nodejs-16:1-111.1689167503 as builder
 USER 0
 RUN dnf -y -q update --exclude=unbound-libs 
+# https://docs.engineering.redhat.com/pages/viewpage.action?pageId=228017926#UpstreamSources%28Cachito,ContainerFirst%29-CachitoIntegrationforyarn
+# CRW-4644 Use RedHat nodejs headers to prevent node-gyp from trying to download them
+RUN dnf module install -y nodejs:16/development
 
 # cachito:yarn step 1: copy cachito sources where we can use them; source env vars; set working dir
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR


### PR DESCRIPTION
### What does this PR do?
Update the brew.Dockerfile to install nodejs 16 development module to get Red Hat supplied headers so node-gyp doesn't try to download them during the brew build.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4644

### Is it tested? How?
Created a test branch with these changes in pkgs.devel and started a brew build, which succeeded.


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
