### PR TITLE
Extend the SSH validation pattern for the git URL input

### DIFF
--- a/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
@@ -33,6 +33,14 @@ describe('FactoryLocationAdapter Service', () => {
       expect(factoryLocation.isFullPathUrl).toBeFalsy();
       expect(factoryLocation.isSshLocation).toBeTruthy();
     });
+    it('should determine the Bitbucket-Server SSH location', () => {
+      const location = 'ssh://git@bitbucket-server.com:7999/~user/repo.git
+
+      factoryLocation = new FactoryLocationAdapter(location);
+
+      expect(factoryLocation.isFullPathUrl).toBeFalsy();
+      expect(factoryLocation.isSshLocation).toBeTruthy();
+    });
     it('should determine unsupported factory location', () => {
       const location = 'dummy.git';
 

--- a/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
@@ -34,7 +34,7 @@ describe('FactoryLocationAdapter Service', () => {
       expect(factoryLocation.isSshLocation).toBeTruthy();
     });
     it('should determine the Bitbucket-Server SSH location', () => {
-      const location = 'ssh://git@bitbucket-server.com:7999/~user/repo.git
+      const location = 'ssh://git@bitbucket-server.com:7999/~user/repo.git';
 
       factoryLocation = new FactoryLocationAdapter(location);
 

--- a/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
@@ -56,7 +56,7 @@ export class FactoryLocationAdapter implements FactoryLocation {
   }
 
   public static isSshLocation(href: string): boolean {
-    return /^git@[^:]+:.*\/[^/]+$/.test(href);
+    return /^(ssh:\/\/)?git@[^:]+:.*\/[^/]+$/.test(href);
   }
 
   get searchParams(): URLSearchParams {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Allow to input SSH url in the Bitbucket-server format: `ssh://git@bitbucket-server.com:7999/~user/repo.git`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22354

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Paste `ssh://git@bitbucket-server.com:7999/~user/repo.git` to the `Git Repo URL` input in the `Create Workspace` tab
See validation is passed.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
