### PR TITLE
fix: support devfiles without metadata

### DIFF
--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/normalizeDevfileV2.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/normalizeDevfileV2.spec.ts
@@ -101,6 +101,24 @@ describe('Normalize Devfile V2', () => {
     );
   });
 
+  it('should apply metadata name and namespace', () => {
+    const devfileLike = {
+      schemaVersion: '2.1.0',
+    } as devfileApi.DevfileLike;
+
+    const targetDevfile = normalizeDevfileV2(
+      devfileLike,
+      {} as FactoryResolver,
+      'http://dummy-registry/devfiles/empty.yaml',
+      [],
+      'che',
+      {},
+    );
+
+    expect(targetDevfile.metadata.name).toEqual(expect.stringContaining('empty-yaml'));
+    expect(targetDevfile.metadata.namespace).toEqual(expect.stringContaining('che'));
+  });
+
   it('should apply defaultComponents', () => {
     const devfileLike = {
       schemaVersion: '2.1.0',

--- a/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
@@ -45,10 +45,13 @@ export default function normalizeDevfileV2(
   const scmInfo = data['scm_info'];
 
   const projectName = getProjectName(scmInfo?.clone_url || location);
-  const prefix = devfileLike.metadata?.generateName
+  if (!devfileLike.metadata) {
+    devfileLike.metadata = {};
+  }
+  const prefix = devfileLike.metadata.generateName
     ? devfileLike.metadata.generateName
     : projectName;
-  const name = devfileLike.metadata?.name || generateWorkspaceName(prefix);
+  const name = devfileLike.metadata.name || generateWorkspaceName(prefix);
 
   // set mandatory fields
   const devfile = cloneDeep(devfileLike) as devfileApi.Devfile;

--- a/run/prepare-local-run.sh
+++ b/run/prepare-local-run.sh
@@ -47,7 +47,7 @@ fi
 CHE_HOST=http://localhost:8080
 CHE_HOST_ORIGIN=$(kubectl get checluster -n "$CHE_NAMESPACE" eclipse-che -o=json | jq -r '.status.cheURL')
 
-if [[ -z "$CHE_HOST_ORIGIN=" ]]; then
+if [[ -z "$CHE_HOST_ORIGIN" ]]; then
   echo '[ERROR] Cannot find cheURL.'
   exit 1
 fi


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixed the ability to support a Devfile without metadata.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22350

### Is it tested? How?
1. Deploy Eclipse-CHE with an image from the current PR.
2. Open the 'Create Workspace' page. Create a new workspace with URL ```{CHE-Server}#https://gist.githubusercontent.com/olexii4/fc3b757806e660dee0fbe1bc131df3d1/raw/f0d6fdddadf4c39073b30a958790ba8f40a33cf7/devfile.yaml```.
3. A new workspace should be created without any errors.
