### PR TITLE
22407 - Remove Mattermost notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,17 +139,17 @@ jobs:
           git config --global pull.rebase true
           export GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
           /bin/bash make-release.sh --version ${{ github.event.inputs.version }} --tag-release
-      - name: Create failure MM message
-        if: ${{ failure() }}
-        run: |
-          echo "{\"text\":\":no_entry_sign: Che Dashboard ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse/che-dashboard/actions/workflows/release.yml\"}" > mattermost.json
-      - name: Create success MM message
-        run: |
-          echo "{\"text\":\":white_check_mark: Che Dashboard ${{ github.event.inputs.version }} has been released: https://quay.io/eclipse/che-dashboard:${{ github.event.inputs.version }}\"}" > mattermost.json
-      - name: Send MM message
-        if: ${{ success() }} || ${{ failure() }}
-        uses: mattermost/action-mattermost-notify@1.1.0
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: eclipse-che-releases
-          MATTERMOST_USERNAME: che-bot
+      #- name: Create failure MM message
+        #if: ${{ failure() }}
+        #run: |
+          #echo "{\"text\":\":no_entry_sign: Che Dashboard ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse/che-dashboard/actions/workflows/release.yml\"}" > mattermost.json
+      #- name: Create success MM message
+        #run: |
+          #echo "{\"text\":\":white_check_mark: Che Dashboard ${{ github.event.inputs.version }} has been released: https://quay.io/eclipse/che-dashboard:${{ github.event.inputs.version }}\"}" > mattermost.json
+      #- name: Send MM message
+        #if: ${{ success() }} || ${{ failure() }}
+        #uses: mattermost/action-mattermost-notify@1.1.0
+        #env:
+          #MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          #MATTERMOST_CHANNEL: eclipse-che-releases
+          #MATTERMOST_USERNAME: che-bot


### PR DESCRIPTION
https://github.com/eclipse/che/issues/22407
Comment out the mattermost notification so it doesn't fail the release workflow, but leaving it in the file so I remember to replace it.
