### PR TITLE
Add console logging che-server exception messages

### DIFF
--- a/packages/dashboard-frontend/src/store/SanityCheck/index.ts
+++ b/packages/dashboard-frontend/src/store/SanityCheck/index.ts
@@ -107,7 +107,7 @@ export const actionCreators: ActionCreators = {
             delay(1000);
           }
         }
-      } catch (e) {
+      } catch (e: any) {
         let errorMessage =
           'Backend is not available. Try to refresh the page or re-login to the Dashboard.';
         if (isUnauthorized(e) || isForbidden(e)) {
@@ -118,6 +118,12 @@ export const actionCreators: ActionCreators = {
           type: Type.RECEIVED_BACKEND_CHECK_ERROR,
           error: errorMessage,
         });
+        if (e.message) {
+          console.error(e.message);
+        }
+        if (e.response && e.response.data && e.response.data.trace) {
+          console.error(e.response.data.trace.join('\n'));
+        }
         throw new Error(errorMessage);
       }
     },

--- a/packages/dashboard-frontend/src/store/SanityCheck/index.ts
+++ b/packages/dashboard-frontend/src/store/SanityCheck/index.ts
@@ -12,6 +12,7 @@
 
 import { Action, Reducer } from 'redux';
 import { AppThunk } from '..';
+import { helpers } from '@eclipse-che/common';
 import { container } from '../../inversify.config';
 import { getDefer } from '../../services/helpers/deferred';
 import { delay } from '../../services/helpers/delay';
@@ -118,9 +119,7 @@ export const actionCreators: ActionCreators = {
           type: Type.RECEIVED_BACKEND_CHECK_ERROR,
           error: errorMessage,
         });
-        if (e.message) {
-          console.error(e.message);
-        }
+        console.error(helpers.errors.getMessage(e));
         if (e.response && e.response.data && e.response.data.trace) {
           console.error(e.response.data.trace.join('\n'));
         }

--- a/packages/dashboard-frontend/src/store/SanityCheck/index.ts
+++ b/packages/dashboard-frontend/src/store/SanityCheck/index.ts
@@ -108,7 +108,7 @@ export const actionCreators: ActionCreators = {
             delay(1000);
           }
         }
-      } catch (e: any) {
+      } catch (e) {
         let errorMessage =
           'Backend is not available. Try to refresh the page or re-login to the Dashboard.';
         if (isUnauthorized(e) || isForbidden(e)) {
@@ -120,7 +120,11 @@ export const actionCreators: ActionCreators = {
           error: errorMessage,
         });
         console.error(helpers.errors.getMessage(e));
-        if (e.response && e.response.data && e.response.data.trace) {
+        if (
+          helpers.errors.includesAxiosResponse(e) &&
+          e.response.data.trace &&
+          Array.isArray(e.response.data.trace)
+        ) {
           console.error(e.response.data.trace.join('\n'));
         }
         throw new Error(errorMessage);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add console error logging on `che-server` failure:
![Screenshot 2023-09-05 at 10 58 40](https://github.com/eclipse-che/che-dashboard/assets/7668752/e6131f4f-8d07-4ba0-86b9-e06b743b99e2)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22423

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy che from `quay.io/ivinokur/che-server:next` image (throws an error on token provisioning).
2. Add a PAT from the dashboard page
3. Refresh the page and see an error.
4. Open the browser console and see the original exception message and trace.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
