### PR TITLE
fix: prevent preload page bundle from being split

### DIFF
--- a/packages/dashboard-frontend/webpack.config.common.js
+++ b/packages/dashboard-frontend/webpack.config.common.js
@@ -40,7 +40,10 @@ const config = {
   },
   optimization: {
     splitChunks: {
-      chunks: 'all',
+      chunks: (chunk) => {
+        // exclude `accept-factory-link` from being split
+        return chunk.name !== 'accept-factory-link';
+      },
       maxAsyncRequests: 30,
       maxInitialRequests: 30,
       minChunks: 1,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes the blank page issue when trying to open the Dashboard using the `<CHE-HOST>` URL.


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/22476
fixes https://github.com/eclipse/che/issues/22478

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


