### PR TITLE
fix: logo for the About modal window

### DIFF
--- a/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/Modal.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/Modal.tsx
@@ -29,9 +29,9 @@ type Props = {
 };
 
 export class AboutModal extends React.PureComponent<Props> {
-  private browserVersion: string | undefined | null;
-  private browserOS: string | undefined | null;
-  private browserName: string | undefined;
+  private readonly browserVersion: string | undefined | null;
+  private readonly browserOS: string | undefined | null;
+  private readonly browserName: string | undefined;
 
   constructor(props: Props) {
     super(props);

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/index.tsx
@@ -23,6 +23,7 @@ import { BrandingData } from '../../../../services/bootstrap/branding.constant';
 type Props = {
   branding: BrandingData;
   username: string;
+  dashboardLogo?: { base64data: string; mediatype: string };
 };
 type State = {
   isLauncherOpen: boolean;
@@ -88,10 +89,15 @@ export class AboutMenu extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { username } = this.props;
+    const { username, dashboardLogo } = this.props;
     const { isLauncherOpen, isModalOpen } = this.state;
 
     const { logoFile, name, productVersion } = this.props.branding;
+
+    const logoSrc =
+      dashboardLogo !== undefined
+        ? `data:${dashboardLogo.mediatype};base64,${dashboardLogo.base64data}`
+        : logoFile;
 
     return (
       <>
@@ -107,7 +113,7 @@ export class AboutMenu extends React.PureComponent<Props, State> {
           isOpen={isModalOpen}
           closeModal={() => this.closeModal()}
           username={username}
-          logo={logoFile}
+          logo={logoSrc}
           productName={name}
           serverVersion={productVersion}
         />

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/index.tsx
@@ -27,6 +27,7 @@ import { AboutMenu } from './AboutMenu';
 import UserMenu from './UserMenu';
 import { ApplicationsMenu } from './ApplicationsMenu';
 import { selectApplications } from '../../../store/ClusterInfo/selectors';
+import { selectDashboardLogo } from '../../../store/ServerConfig/selectors';
 
 type Props = MappedProps & {
   history: History;
@@ -50,7 +51,11 @@ export class HeaderTools extends React.PureComponent<Props> {
           <PageHeaderToolsGroup>
             {applications.length !== 0 && <ApplicationsMenu applications={applications} />}
             <PageHeaderToolsItem>
-              <AboutMenu branding={this.props.branding} username={username} />
+              <AboutMenu
+                branding={this.props.branding}
+                dashboardLogo={this.props.dashboardLogo}
+                username={username}
+              />
             </PageHeaderToolsItem>
             {isUserAuthenticated && (
               <PageHeaderToolsItem>
@@ -73,6 +78,7 @@ export class HeaderTools extends React.PureComponent<Props> {
 const mapStateToProps = (state: AppState) => ({
   userProfile: selectUserProfile(state),
   branding: selectBranding(state),
+  dashboardLogo: selectDashboardLogo(state),
   applications: selectApplications(state),
 });
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes the Eclipse Che logo for the About modal window.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22477

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Eclipse CHE with an image from the current PR.
2. Added a logo as a base64 encoded image into Custom Resource.
```
spec:
  components:
    dashboard:
       branding:
         logo:
           base64data: 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iNzBweCIgd2lkdGg9IjcwcHgiIHZlcnNpb249IjEuMSIgdmlld0JveD0iMCAwIDQ3IDU3Ij4KICAgIDxnIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiPgogICAgICAgIDxwYXRoIGQ9Ik0wLjAzMjIyNywzMC44OGwtMC4wMzIyMjctMTcuMDg3LDIzLjg1My0xMy43OTMsMjMuNzk2LDEzLjc4NC0xNC42OTEsOC41MS05LjA2Mi01LjEwOS0yMy44NjQsMTMuNjk1eiIKICAgICAgICAgICAgICBmaWxsPSIjZmRiOTQwIi8+CiAgICAgICAgPHBhdGggZD0iTTAsNDMuMzU1bDIzLjg3NiwxMy42MjIsMjMuOTc0LTEzLjkzN3YtMTYuOTAybC0yMy45NzQsMTMuNTA2LTIzLjg3Ni0xMy41MDZ2MTcuMjE3eiIgZmlsbD0iIzUyNWM4NiIvPgogICAgPC9nPgo8L3N2Zz4K'
           mediatype: 'image/svg+xml'
```
3. Press 'f5' to reload the CHE-dashboard page and open the `About` modal window.
4. You should see a new logo:
![Знімок екрана 2023-09-07 о 17 18 35](https://github.com/eclipse-che/che-dashboard/assets/6310786/b44add8f-2b80-4177-bd2b-3f08d728d7fa)
