### PR TITLE
Fix the GettingStarted samples route

### DIFF
--- a/packages/dashboard-backend/src/app.ts
+++ b/packages/dashboard-backend/src/app.ts
@@ -112,5 +112,5 @@ export default async function buildApp(server: FastifyInstance): Promise<void> {
 
   registerPersonalAccessTokenRoutes(server);
 
-  registerGettingStartedSamplesRoutes(server);
+  registerGettingStartedSamplesRoutes(isLocalRun(), server);
 }

--- a/packages/dashboard-backend/src/routes/api/gettingStartedSample.ts
+++ b/packages/dashboard-backend/src/routes/api/gettingStartedSample.ts
@@ -18,9 +18,15 @@ import { getServiceAccountToken } from './helpers/getServiceAccountToken';
 
 const tags = ['Getting Started Samples'];
 
-export function registerGettingStartedSamplesRoutes(instance: FastifyInstance) {
+export function registerGettingStartedSamplesRoutes(
+  isLocalRun: boolean,
+  instance: FastifyInstance,
+) {
   instance.register(async server => {
     server.get(`${baseApiPath}/getting-started-sample`, getSchema({ tags }), async () => {
+      if (isLocalRun) {
+        return [];
+      }
       const token = getServiceAccountToken();
       const { gettingStartedSampleApi } = getDevWorkspaceClient(token);
       return gettingStartedSampleApi.list();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR Fixes the GettingStarted samples route for local runs for dogfooding.

### What issues does this PR fix or reference?
We faced an error during the start of local runs from the main branch with dogfooding instance.
![Знімок екрана 2023-09-11 о 16 19 45](https://github.com/eclipse-che/che-dashboard/assets/6310786/4a223b85-ed9f-46f2-ae4b-4de55ce1f62d)
![Знімок екрана 2023-09-11 о 16 49 22](https://github.com/eclipse-che/che-dashboard/assets/6310786/8fb47b98-9dd9-4b3b-b5a1-c0694fe563c1)

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Create a new workspace with `https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/dashboard/#/load-factory?url=https://github.com/eclipse-che/che-dashboard/tree/quick_fixes`
2. Execute the command 
```
yarn install --non-interactive && yarn build && oc project dogfooding && export CHE_NAMESPACE='dogfooding' && export NAMESPACE='dogfooding' && yarn start:prepare && yarn start -c
```
3. Local runs should start without errors.
