### PR TITLE
Do not wrap factory resolver rquest exception

### DIFF
--- a/packages/dashboard-frontend/src/services/dashboard-backend-client/factoryResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/dashboard-backend-client/factoryResolverApi.ts
@@ -11,7 +11,6 @@
  */
 
 import axios from 'axios';
-import { helpers } from '@eclipse-che/common';
 import { cheServerPrefix } from './const';
 import { FactoryResolver } from '../helpers/types';
 
@@ -21,14 +20,10 @@ export async function getFactoryResolver(
   url: string,
   overrideParams: { [params: string]: string } = {},
 ): Promise<FactoryResolver> {
-  try {
-    const response = await axios.post(
-      `${cheServerPrefix}${factoryResolverEndpoint}`,
-      Object.assign({}, overrideParams, { url }),
-    );
+  const response = await axios.post(
+    `${cheServerPrefix}${factoryResolverEndpoint}`,
+    Object.assign({}, overrideParams, { url }),
+  );
 
-    return response.data;
-  } catch (e) {
-    throw new Error(`Failed to fetch factory resolver'. ${helpers.errors.getMessage(e)}`);
-  }
+  return response.data;
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove the `try catch` wrap from the factory resolver request as the exception contains data with url to redirect to oauth page.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22518

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Setup GitHub oauth flow, [see](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/)
2. Start a factory from a GitHub repository
see: authentication page appears.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
