### PR TITLE
fix: fix next version updating during release

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -75,9 +75,15 @@ function update_pkgs_versions() {
   npm --no-git-tag-version version --allow-same-version "${VER}"
   # update each package version
   lerna version --no-git-tag-version -y "${VER}"
-  # update devworkspace generator version
-  jq ".\"dependencies\".\"@eclipse-che/che-devworkspace-generator\" = \"${VER}\"" packages/dashboard-backend/package.json > packages/dashboard-backend/package.json.update
-  mv packages/dashboard-backend/package.json.update packages/dashboard-backend/package.json
+  if [[ ${VER} != *"-next" ]]; then
+    # update devworkspace generator version for release
+    jq ".\"dependencies\".\"@eclipse-che/che-devworkspace-generator\" = \"${VER}\"" packages/dashboard-backend/package.json > packages/dashboard-backend/package.json.update
+    mv packages/dashboard-backend/package.json.update packages/dashboard-backend/package.json
+  elif [[ "${BASEBRANCH}" == "${BRANCH}" ]]; then
+    # update devworkspace generator version only for bugfix branch version bump
+    jq ".\"dependencies\".\"@eclipse-che/che-devworkspace-generator\" = \"next-${BRANCH}\"" packages/dashboard-backend/package.json > packages/dashboard-backend/package.json.update
+    mv packages/dashboard-backend/package.json.update packages/dashboard-backend/package.json
+  fi
   # update excluded dependencies vesion
   sed_in_place -e "s/@eclipse-che\/dashboard-backend@.*\`/@eclipse-che\/dashboard-backend@${VER}\`/" .deps/EXCLUDED/prod.md
   sed_in_place -e "s/@eclipse-che\/dashboard-frontend@.*\`/@eclipse-che\/dashboard-frontend@${VER}\`/" .deps/EXCLUDED/prod.md


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
fix incorrect condition for bumping version - only bump "next-7.x.y" https://www.npmjs.com/package/@eclipse-che/che-devworkspace-generator?activeTab=versions for bugfix release branch, while main branch will always reference "next"
this way branch alings with following dependency version of of devworkpace generator:

- main branch -> "next" dwo generator
- "7.77.0" release tag --> "7.77.0" dwo generator
- "7.77 x" bugfix branch -> "next-7.77.x" dwo generator
### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
