### PR TITLE
fix: remotes url parameter in factory url

### DIFF
--- a/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
@@ -111,6 +111,22 @@ describe('FactoryLocationAdapter Service', () => {
     });
   });
 
+  describe('test FactoryLocationAdapter.isHttpLocation', () => {
+    it('should return true for https git url', () => {
+      const location = 'https://git-test.com/dummy.git';
+      expect(FactoryLocationAdapter.isHttpLocation(location)).toBeTruthy();
+    });
+    it('should return true when git remote specified', () => {
+      const location = 'https://git-test.com/dummy.git?remotes={https://git-test.com/remote.git}';
+      expect(FactoryLocationAdapter.isHttpLocation(location)).toBeTruthy();
+    });
+    it('should return true when git remotes and remote names are specified', () => {
+      const location =
+        'https://git-test.com/dummy.git?remotes={{origin,https://git-test.com/origin.git},{upstream,https://git-test.com/upstream.git}}';
+      expect(FactoryLocationAdapter.isHttpLocation(location)).toBeTruthy();
+    });
+  });
+
   it('should return factory reference without oauth params', () => {
     const fullPathUrl = 'https://github.com/eclipse-che/che-dashboard.git';
     const oauthParams = 'session_state=63273265623765783252378';

--- a/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
@@ -52,7 +52,7 @@ export class FactoryLocationAdapter implements FactoryLocation {
   }
 
   public static isHttpLocation(href: string): boolean {
-    return /^(https?:\/\/.)[-a-zA-Z0-9@:%._+~#=]{2,}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)$/.test(href);
+    return /^(https?:\/\/.)[-a-zA-Z0-9@:%._+~#=]{2,}\b([-a-zA-Z0-9@:%_+.~#?&/={},]*)$/.test(href);
   }
 
   public static isSshLocation(href: string): boolean {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes https://github.com/eclipse/che/issues/22530 by allowing redirect to workspace creation page when `window.location.hash` contains the following characters: `{`, `}`, and `,`.

See: https://github.com/eclipse-che/che-dashboard/blob/333d6cf1142994533f6eea7f0d7568e5e6f45245/packages/dashboard-frontend/src/preload/main.ts#L30-L35


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22530

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che, and set the following in the Che CR to test out this PR:
```
spec:
  components:
    dashboard:
      deployment:
        containers:
          - image: quay.io/dkwon17/che-dashboard:fixRemotesUrlParam
```
2. Access the following url to start a new workspace:
```
{che-host}/#https://github.com/dkwon17/quarkus-api-example?remotes={https://github.com/che-incubator/quarkus-api-example}
```
and verify that the resulting dev workspace has the following:
```
    projects:
      - git:
          checkoutFrom:
            remote: origin
          remotes:
            origin: 'https://github.com/che-incubator/quarkus-api-example'
        name: quarkus-api-example
```
3. Access the following url to start a new workspace:
```
{che-host}/#https://github.com/eclipse-che/che-plugin-registry?remotes={{origin,https://github.com/dkwon17/che-plugin-registry},{upstream,https://github.com/eclipse-che/che-plugin-registry}}
```
and verify that the resulting dev workspace has the following:
```
    projects:
      - git:
          checkoutFrom:
            remote: origin
          remotes:
            origin: 'https://github.com/dkwon17/che-plugin-registry'
            upstream: 'https://github.com/eclipse-che/che-plugin-registry'
        name: che-plugin-registry
```

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
