### PR TITLE
fix: external plugin registries attribute from CR

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -93,9 +93,7 @@ export interface IServerConfig {
     disableInternalRegistry: boolean;
     externalDevfileRegistries: IExternalDevfileRegistry[];
   };
-  pluginRegistry: {
-    openVSXURL: string;
-  };
+  pluginRegistry: IPluginRegistry;
   timeouts: {
     inactivityTimeout: number;
     runTimeout: number;
@@ -107,6 +105,12 @@ export interface IServerConfig {
   devfileRegistryURL: string;
   devfileRegistryInternalURL: string;
   dashboardLogo?: { base64data: string; mediatype: string };
+}
+
+export interface IPluginRegistry {
+  disableInternalRegistry?: boolean;
+  externalPluginRegistries?: { url: string }[];
+  openVSXURL: string;
 }
 
 export interface IUserProfile {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/serverConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/serverConfigApi.spec.ts
@@ -80,9 +80,9 @@ describe('Server Config API Service', () => {
     expect(res).toEqual([{ container: { image: 'component-image' }, name: 'component-name' }]);
   });
 
-  test('getting openVSXURL', () => {
-    const res = serverConfigService.getOpenVSXURL(buildCustomResource());
-    expect(res).toEqual('https://open-vsx.org');
+  test('getting pluginRegistry', () => {
+    const res = serverConfigService.getPluginRegistry(buildCustomResource());
+    expect(res).toEqual({ openVSXURL: 'https://open-vsx.org' });
   });
 
   test('getting PVC strategy', () => {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -148,15 +148,25 @@ export class ServerConfigApiService implements IServerConfigApi {
     return [];
   }
 
-  getOpenVSXURL(cheCustomResource: CustomResourceDefinition): string {
+  getPluginRegistry(cheCustomResource: CustomResourceDefinition): api.IPluginRegistry {
     // Undefined and empty value are treated in a different ways:
     //   - empty value forces to use embedded registry
     //   - undefined value means that the default value should be used
-    if (cheCustomResource.spec.components?.pluginRegistry?.openVSXURL !== undefined) {
-      return cheCustomResource.spec.components.pluginRegistry.openVSXURL;
+
+    const pluginRegistry = cheCustomResource.spec.components?.pluginRegistry
+      ? cheCustomResource.spec.components.pluginRegistry
+      : ({ openVSXURL: '' } as api.IPluginRegistry);
+
+    const openVSXURL =
+      cheCustomResource.spec.components?.pluginRegistry?.openVSXURL !== undefined
+        ? pluginRegistry.openVSXURL
+        : process.env['CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL'];
+
+    if (openVSXURL) {
+      pluginRegistry.openVSXURL = openVSXURL;
     }
 
-    return process.env['CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL'] || '';
+    return pluginRegistry;
   }
 
   getPvcStrategy(cheCustomResource: CustomResourceDefinition): string | undefined {

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -160,9 +160,7 @@ export type CustomResourceDefinitionSpecComponents = {
   devWorkspace?: {
     runningLimit?: number;
   };
-  pluginRegistry?: {
-    openVSXURL?: string;
-  };
+  pluginRegistry?: api.IPluginRegistry;
   devfileRegistry: {
     disableInternalRegistry?: boolean;
     externalDevfileRegistries?: api.IExternalDevfileRegistry[];
@@ -205,9 +203,9 @@ export interface IServerConfigApi {
    */
   getDefaultComponents(cheCustomResource: CustomResourceDefinition): V221DevfileComponents[];
   /**
-   * Returns the openVSX URL.
+   * Returns the plugin registry.
    */
-  getOpenVSXURL(cheCustomResource: CustomResourceDefinition): string;
+  getPluginRegistry(cheCustomResource: CustomResourceDefinition): api.IPluginRegistry;
   /**
    * Returns the internal registry disable status.
    */

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -43,7 +43,7 @@ export const stubDashboardWarning = 'Dashboard warning';
 export const stubDefaultComponents: V221DevfileComponents[] = [];
 export const stubDefaultEditor = undefined;
 export const stubDefaultPlugins: api.IWorkspacesDefaultPlugins[] = [];
-export const stubOpenVSXURL = 'openvsx-url';
+export const stubPluginRegistry = { openVSXURL: 'openvsx-url' };
 export const stubPvcStrategy = '';
 export const stubRunningWorkspacesLimit = 2;
 export const stubAllWorkspacesLimit = 1;
@@ -122,7 +122,7 @@ export function getDevWorkspaceClient(
       getDefaultComponents: _cheCustomResource => stubDefaultComponents,
       getDefaultEditor: _cheCustomResource => stubDefaultEditor,
       getDefaultPlugins: _cheCustomResource => stubDefaultPlugins,
-      getOpenVSXURL: _cheCustomResource => stubOpenVSXURL,
+      getPluginRegistry: _cheCustomResource => stubPluginRegistry,
       getPvcStrategy: _cheCustomResource => stubPvcStrategy,
       getRunningWorkspacesLimit: _cheCustomResource => stubRunningWorkspacesLimit,
       getAllWorkspacesLimit: _cheCustomResource => stubAllWorkspacesLimit,

--- a/packages/dashboard-backend/src/routes/api/serverConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/serverConfig.ts
@@ -39,7 +39,7 @@ export function registerServerConfigRoute(instance: FastifyInstance) {
       const inactivityTimeout = serverConfigApi.getWorkspaceInactivityTimeout(cheCustomResource);
       const runTimeout = serverConfigApi.getWorkspaceRunTimeout(cheCustomResource);
       const startTimeout = serverConfigApi.getWorkspaceStartTimeout(cheCustomResource);
-      const openVSXURL = serverConfigApi.getOpenVSXURL(cheCustomResource);
+      const pluginRegistry = serverConfigApi.getPluginRegistry(cheCustomResource);
       const pvcStrategy = serverConfigApi.getPvcStrategy(cheCustomResource);
       const pluginRegistryURL = serverConfigApi.getDefaultPluginRegistryUrl(cheCustomResource);
       const devfileRegistryURL = serverConfigApi.getDefaultDevfileRegistryUrl(cheCustomResource);
@@ -66,9 +66,7 @@ export function registerServerConfigRoute(instance: FastifyInstance) {
           disableInternalRegistry,
           externalDevfileRegistries,
         },
-        pluginRegistry: {
-          openVSXURL,
-        },
+        pluginRegistry,
         cheNamespace,
         pluginRegistryURL,
         pluginRegistryInternalURL,

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -51,7 +51,7 @@ import * as PodsStore from '@/store/Pods';
 import { selectPodsResourceVersion } from '@/store/Pods/selectors';
 import * as SanityCheckStore from '@/store/SanityCheck';
 import * as ServerConfigStore from '@/store/ServerConfig';
-import { selectOpenVSXUrl } from '@/store/ServerConfig/selectors';
+import { selectOpenVSXUrl, selectPluginRegistryUrl } from '@/store/ServerConfig/selectors';
 import * as UserProfileStore from '@/store/User/Profile';
 import * as WorkspacesStore from '@/store/Workspaces';
 import * as DevWorkspacesStore from '@/store/Workspaces/devWorkspaces';
@@ -271,7 +271,8 @@ export default class Bootstrap {
 
   private async fetchPlugins(): Promise<void> {
     const { requestPlugins } = PluginsStore.actionCreators;
-    const pluginRegistryURL = this.store.getState().dwServerConfig.config.pluginRegistryURL;
+    const state = this.store.getState();
+    const pluginRegistryURL = selectPluginRegistryUrl(state);
     await requestPlugins(pluginRegistryURL)(this.store.dispatch, this.store.getState, undefined);
   }
 
@@ -307,7 +308,7 @@ export default class Bootstrap {
         pluginsByUrl[dwEditor.url] = dwEditor.devfile;
       });
       const openVSXUrl = selectOpenVSXUrl(state);
-      const pluginRegistryUrl = state.dwServerConfig.config.pluginRegistryURL;
+      const pluginRegistryUrl = selectPluginRegistryUrl(state);
       const pluginRegistryInternalUrl = state.dwServerConfig.config.pluginRegistryInternalURL;
       const clusterConsole = selectApplications(state).find(
         app => app.id === ApplicationId.CLUSTER_CONSOLE,

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -497,7 +497,7 @@ export class DevWorkspaceClient {
       }
     }
 
-    const openVSXURL = config.pluginRegistry.openVSXURL;
+    const openVSXURL = config.pluginRegistry?.openVSXURL || '';
     const components = cloneDeep(workspace.spec.template.components);
     if (components) {
       let shouldUpdate = false;

--- a/packages/dashboard-frontend/src/store/Plugins/chePlugins/index.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/chePlugins/index.ts
@@ -60,7 +60,7 @@ export const actionCreators: ActionCreators = {
         }
         const response = await axiosInstance.request<che.Plugin[]>({
           method: 'GET',
-          url: `${registryUrl}/plugins/`,
+          url: `${registryUrl}/plugins/index.json`,
         });
         const plugins = response.data;
 

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
@@ -20,6 +20,7 @@ import { fetchData } from '@/services/registry/fetchData';
 import { AppThunk } from '@/store';
 import { createObject } from '@/store/helpers';
 import { AUTHORIZED, SanityCheckAction } from '@/store/sanityCheckMiddleware';
+import { selectPluginRegistryUrl } from '@/store/ServerConfig/selectors';
 
 export interface PluginDefinition {
   plugin?: devfileApi.Devfile;
@@ -161,7 +162,7 @@ export const actionCreators: ActionCreators = {
       if (editorName.startsWith('https://')) {
         editorUrl = editorName;
       } else {
-        const pluginRegistryUrl = getState().dwServerConfig.config.pluginRegistryURL;
+        const pluginRegistryUrl = selectPluginRegistryUrl(getState());
         editorUrl = `${pluginRegistryUrl}/plugins/${editorName}/devfile.yaml`;
 
         if (!pluginRegistryUrl) {
@@ -224,9 +225,10 @@ export const actionCreators: ActionCreators = {
         throw errorMessage;
       }
 
+      const pluginRegistryURL = selectPluginRegistryUrl(getState());
       const defaultEditorUrl = (defaultEditor as string).startsWith('https://')
         ? defaultEditor
-        : `${config.pluginRegistryURL}/plugins/${defaultEditor}/devfile.yaml`;
+        : `${pluginRegistryURL}/plugins/${defaultEditor}/devfile.yaml`;
 
       // request default editor
       await dispatch(actionCreators.requestDwEditor(defaultEditor));

--- a/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
@@ -32,10 +32,12 @@ export const selectDefaultPlugins = createSelector(
   state => state.config.defaults?.plugins || [],
 );
 
-export const selectPluginRegistryUrl = createSelector(
-  selectState,
-  state => state.config.pluginRegistryURL,
-);
+export const selectPluginRegistryUrl = createSelector(selectState, state => {
+  const pluginRegistryUrl = !state.config.pluginRegistry.disableInternalRegistry
+    ? state.config.pluginRegistryURL
+    : state.config.pluginRegistry.externalPluginRegistries?.[0]?.url;
+  return pluginRegistryUrl || '';
+});
 
 export const selectPluginRegistryInternalUrl = createSelector(
   selectState,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -821,7 +821,7 @@ export const actionCreators: ActionCreators = {
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       const state = getState();
-      const pluginRegistryUrl = state.dwServerConfig.config.pluginRegistryURL;
+      const pluginRegistryUrl = selectPluginRegistryUrl(state);
       let devWorkspaceResource: devfileApi.DevWorkspace;
       let devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate;
       let editorContent: string | undefined;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix the ability to use an external plugin registry.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22589 and https://issues.redhat.com/browse/CRW-4926

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

![Знімок екрана 2023-10-13 о 05 26 25](https://github.com/eclipse-che/che-dashboard/assets/6310786/7a425f6a-7f61-4cb0-ba61-ccbdd9a1e84e)



![Знімок екрана 2023-10-13 о 05 44 44](https://github.com/eclipse-che/che-dashboard/assets/6310786/b709d923-ea29-4d88-bb81-57d846c37349)

![Знімок екрана 2023-10-13 о 05 43 56](https://github.com/eclipse-che/che-dashboard/assets/6310786/5aa96c84-921f-4180-be0d-3daba19a96d7)
