### PR TITLE
chore: Mount kubeconfig into users containers

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,6 +20,7 @@ export { helpers, api };
 
 export const FACTORY_LINK_ATTR = 'factoryLink';
 export const ERROR_CODE_ATTR = 'error_code';
+export const KUBECONFIG_MOUNT_PATH = '/tmp/.kube';
 
 const common = {
   helpers,

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -29,11 +29,8 @@ export const namespacedKubeConfigSchema: JSONSchema7 = {
     namespace: {
       type: 'string',
     },
-    devworkspaceId: {
-      type: 'string',
-    },
   },
-  required: ['namespace', 'devworkspaceId'],
+  required: ['namespace'],
 };
 
 export const namespacedWorkspaceSchema: JSONSchema7 = {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
@@ -14,8 +14,9 @@
 
 import * as mockClient from '@kubernetes/client-node';
 import { CoreV1Api, HttpError } from '@kubernetes/client-node';
-import { KubeConfigApiService } from '../kubeConfigApi';
 import { IncomingMessage } from 'http';
+
+import { KubeConfigApiService } from '@/devworkspaceClient/services/kubeConfigApi';
 
 const namespace = 'user-che';
 

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
@@ -13,137 +13,66 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import * as mockClient from '@kubernetes/client-node';
-import { CoreV1Api, V1PodList } from '@kubernetes/client-node';
-
-import * as helper from '@/devworkspaceClient/services/helpers/exec';
-import { KubeConfigApiService } from '@/devworkspaceClient/services/kubeConfigApi';
-
-const homeUserDir = '/home/user';
-const kubeConfigDir = `${homeUserDir}/.kube`;
-const mockExecPrintenvHome = jest.fn().mockReturnValue({
-  stdOut: homeUserDir,
-  stdError: '',
-});
-const spyExec = jest
-  .spyOn(helper, 'exec')
-  .mockImplementation((...args: Parameters<typeof helper.exec>) => {
-    const [, , , command] = args;
-    if (command.some(c => c === 'printenv HOME')) {
-      // directory where to create the kubeconfig
-      return mockExecPrintenvHome();
-    } else if (command.some(c => c.startsWith('mkdir -p'))) {
-      // crete the directory
-      return Promise.resolve();
-    } else if (command.some(c => c.startsWith(`[ -f ${homeUserDir}`))) {
-      // sync config
-      return Promise.resolve();
-    }
-    return Promise.reject({
-      stdOut: '',
-      stdError: 'command executing error',
-    });
-  });
+import { CoreV1Api, HttpError } from '@kubernetes/client-node';
+import { KubeConfigApiService } from '../kubeConfigApi';
+import { IncomingMessage } from 'http';
 
 const namespace = 'user-che';
-const workspaceName = 'workspace-1';
-const containerName = 'container-1';
-const config = JSON.stringify({
-  apiVersion: 'v1',
-  kind: 'Config',
-  'current-context': 'logged-user',
-});
 
 describe('Kubernetes Config API Service', () => {
   let kubeConfigService: KubeConfigApiService;
+  let spyCreateNamespacedSecret: jest.SpyInstance;
+  let spyReadNamespacedSecret: jest.SpyInstance;
+  let spyReplaceNamespacedSecret: jest.SpyInstance;
 
-  beforeEach(() => {
+  console.error = jest.fn();
+  console.warn = jest.fn();
+
+  function initMocks(readNamespacedSecretReturnPromise: Promise<any>): void {
+    const stubCoreV1Api = {
+      createNamespacedSecret: (_namespace: string, secret: any) => {
+        return Promise.resolve({ body: secret });
+      },
+      readNamespacedSecret: () => {
+        return readNamespacedSecretReturnPromise;
+      },
+      replaceNamespacedSecret: (_name: string, _namespace: string, secret: any) => {
+        return Promise.resolve({ body: secret });
+      },
+    } as unknown as CoreV1Api;
+
+    spyCreateNamespacedSecret = jest.spyOn(stubCoreV1Api, 'createNamespacedSecret');
+    spyReadNamespacedSecret = jest.spyOn(stubCoreV1Api, 'readNamespacedSecret');
+    spyReplaceNamespacedSecret = jest.spyOn(stubCoreV1Api, 'replaceNamespacedSecret');
+
     const { KubeConfig } = mockClient;
     const kubeConfig = new KubeConfig();
-
-    kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => {
-      return {
-        listNamespacedPod: namespace => {
-          return Promise.resolve(buildListNamespacedPod());
-        },
-      } as CoreV1Api;
-    });
-    kubeConfig.exportConfig = jest.fn().mockReturnValue(config);
-    kubeConfig.getCurrentCluster = jest.fn().mockReturnValue('');
-    kubeConfig.applyToRequest = jest.fn();
+    kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => stubCoreV1Api);
 
     kubeConfigService = new KubeConfigApiService(kubeConfig);
-  });
+  }
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('injecting kubeconfig', async () => {
-    // mute output
-    console.error = jest.fn();
-    console.warn = jest.fn();
+  test('create kubeconfig Secret', async () => {
+    initMocks(Promise.reject(new HttpError({} as IncomingMessage, undefined, 404)));
 
-    await kubeConfigService.injectKubeConfig(namespace, 'wksp-id');
-    expect(spyExec).toHaveBeenCalledTimes(4);
+    await kubeConfigService.applyKubeConfigSecret(namespace);
 
-    // should attempt to resolve the KUBECONFIG env variable
-    expect(spyExec).toHaveBeenNthCalledWith(
-      1,
-      workspaceName,
-      namespace,
-      containerName,
-      ['sh', '-c', 'printenv KUBECONFIG'],
-      expect.anything(),
-    );
+    expect(spyReadNamespacedSecret).toBeCalled();
+    expect(spyCreateNamespacedSecret).toBeCalled();
+    expect(spyReplaceNamespacedSecret).toBeCalledTimes(0);
+  });
 
-    // should attempt to resolve the HOME env variable
-    expect(spyExec).toHaveBeenNthCalledWith(
-      2,
-      workspaceName,
-      namespace,
-      containerName,
-      ['sh', '-c', 'printenv HOME'],
-      expect.anything(),
-    );
+  test('replace kubeconfig Secret', async () => {
+    initMocks(Promise.resolve({} as any));
 
-    // should create the directory
-    expect(spyExec).toHaveBeenNthCalledWith(
-      3,
-      workspaceName,
-      namespace,
-      containerName,
-      ['sh', '-c', `mkdir -p ${kubeConfigDir}`],
-      expect.anything(),
-    );
+    await kubeConfigService.applyKubeConfigSecret(namespace);
 
-    // should sync the kubeconfig to the container
-    expect(spyExec).toHaveBeenNthCalledWith(
-      4,
-      workspaceName,
-      namespace,
-      containerName,
-      ['sh', '-c', `[ -f ${kubeConfigDir}/config ] || echo '${config}' > ${kubeConfigDir}/config`],
-      expect.anything(),
-    );
+    expect(spyReadNamespacedSecret).toBeCalled();
+    expect(spyCreateNamespacedSecret).toBeCalledTimes(0);
+    expect(spyReplaceNamespacedSecret).toBeCalled();
   });
 });
-
-function buildListNamespacedPod(): { body: V1PodList } {
-  return {
-    body: {
-      apiVersion: 'v1',
-      items: [
-        {
-          metadata: {
-            name: workspaceName,
-            namespace,
-          },
-          spec: {
-            containers: [{ name: containerName }],
-          },
-        },
-      ],
-      kind: 'PodList',
-    },
-  };
-}

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -10,17 +10,14 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { helpers } from '@eclipse-che/common';
 import * as k8s from '@kubernetes/client-node';
+import { IKubeConfigApi } from '../types';
+import { helpers, KUBECONFIG_MOUNT_PATH } from '@eclipse-che/common';
+import { ServerConfig } from './helpers/exec';
+import { CoreV1API, prepareCoreV1API } from './helpers/prepareCoreV1API';
+import { V1Secret } from '@kubernetes/client-node';
 
-import { exec, ServerConfig } from '@/devworkspaceClient/services/helpers/exec';
-import {
-  CoreV1API,
-  prepareCoreV1API,
-} from '@/devworkspaceClient/services/helpers/prepareCoreV1API';
-import { IKubeConfigApi } from '@/devworkspaceClient/types';
-
-const EXCLUDED_CONTAINERS = ['che-gateway', 'che-machine-exec'];
+const KUBECONFIG_SECRET_NAME = 'kubeconfig';
 
 export class KubeConfigApiService implements IKubeConfigApi {
   private readonly corev1API: CoreV1API;
@@ -39,156 +36,46 @@ export class KubeConfigApiService implements IKubeConfigApi {
   }
 
   /**
-   * Inject the kubeconfig into all containers with the given name in the namespace
+   * Creates or replaces kubeconfig Secret to be mounted into all containers in a namespace.
    * @param namespace The namespace where the pod lives
-   * @param devworkspaceId The id of the devworkspace
    */
-  async injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void> {
-    const currentPod = await this.getPodByDevWorkspaceId(namespace, devworkspaceId);
-    const podName = currentPod.metadata?.name || '';
-    const currentPodContainers = currentPod.spec?.containers || [];
+  async applyKubeConfigSecret(namespace: string): Promise<void> {
+    const kubeConfig = this.setNamespaceInContext(this.kubeConfig, namespace);
+    const kubeConfigSecret = {
+      apiVersion: 'v1',
+      data: { config: Buffer.from(kubeConfig, 'binary').toString('base64') },
+      metadata: {
+        name: KUBECONFIG_SECRET_NAME,
+        labels: {
+          'controller.devfile.io/mount-to-devworkspace': 'true',
+          'controller.devfile.io/watch-secret': 'true',
+        },
+        annotations: {
+          'controller.devfile.io/mount-as': 'file',
+          'controller.devfile.io/mount-path': KUBECONFIG_MOUNT_PATH,
+        },
+      },
+      kind: 'Secret',
+    } as V1Secret;
 
-    let resolved = false;
-    for (const container of currentPodContainers) {
-      const containerName = container.name;
-      if (EXCLUDED_CONTAINERS.indexOf(containerName) !== -1) {
-        continue;
-      }
-
-      try {
-        // find the directory where we should create the kubeconfig
-        const kubeConfigDirectory = await this.resolveDirectory(podName, namespace, containerName);
-        if (kubeConfigDirectory === '') {
-          console.log(
-            `Could not find appropriate kubeconfig directory for ${namespace}/${podName}/${containerName}`,
-          );
-          continue;
-        }
-
-        // then create the directory if it doesn't exist
-        await exec(
-          podName,
-          namespace,
-          containerName,
-          ['sh', '-c', `mkdir -p ${kubeConfigDirectory}`],
-          this.getServerConfig(),
-        );
-
-        // if -f ${kubeConfigDirectory}/config is not found then sync kubeconfig to the container
-        const kubeConfig = this.setNamespaceInContext(this.kubeConfig, namespace);
-        await exec(
-          podName,
-          namespace,
-          containerName,
-          [
-            'sh',
-            '-c',
-            `[ -f ${kubeConfigDirectory}/config ] || echo '${kubeConfig}' > ${kubeConfigDirectory}/config`,
-          ],
-          this.getServerConfig(),
-        );
-
-        if (!resolved) {
-          resolved = true;
-        }
-      } catch (e) {
-        console.warn(helpers.errors.getMessage(e));
-      }
-    }
-    if (!resolved) {
-      throw new Error(`Could not add kubeconfig into containers in ${namespace}`);
-    }
-  }
-
-  /**
-   * Given a namespace, find a pod that has the label controller.devfile.io/devworkspace_id=${devworkspaceId}
-   * @param namespace The namespace to look in
-   * @param devworkspaceId The id of the devworkspace
-   * @returns The containers for the first pod with given devworkspaceId
-   */
-  private async getPodByDevWorkspaceId(
-    namespace: string,
-    devworkspaceId: string,
-  ): Promise<k8s.V1Pod> {
     try {
-      const resp = await this.corev1API.listNamespacedPod(
+      await this.corev1API.readNamespacedSecret(KUBECONFIG_SECRET_NAME, namespace);
+      await this.corev1API.replaceNamespacedSecret(
+        KUBECONFIG_SECRET_NAME,
         namespace,
-        undefined,
-        false,
-        undefined,
-        undefined,
-        `controller.devfile.io/devworkspace_id=${devworkspaceId}`,
+        kubeConfigSecret,
       );
-      if (resp.body.items.length === 0) {
-        throw new Error(
-          `Could not find requested devworkspace with id ${devworkspaceId} in ${namespace}`,
-        );
+    } catch (error) {
+      if (helpers.errors.isKubeClientError(error) && error.statusCode === 404) {
+        await this.corev1API.createNamespacedSecret(namespace, kubeConfigSecret);
+        return;
       }
-      return resp.body.items[0];
-    } catch (e: any) {
+
+      console.error('Failed to create kubeconfig Secret', error);
       throw new Error(
-        `Error occurred when attempting to retrieve pod. ${helpers.errors.getMessage(e)}`,
+        `Could not create ${KUBECONFIG_SECRET_NAME} Secret in ${namespace} namespace`,
       );
     }
-  }
-
-  /**
-   * Resolve the directory where the kubeconfig is going to live. First it looks for the $KUBECONFIG env variable if
-   * that is found then use that. If that is not found then the default directory is $HOME/.kube
-   * @param name The name of the pod
-   * @param namespace The namespace where the pod lives
-   * @param containerName The name of the container to resolve the directory for
-   * @returns A promise of the directory where the kubeconfig is going to live
-   */
-  private async resolveDirectory(
-    name: string,
-    namespace: string,
-    containerName: string,
-  ): Promise<string> {
-    try {
-      // attempt to resolve the kubeconfig env variable
-      const kubeConfigEnvResolver = await exec(
-        name,
-        namespace,
-        containerName,
-        ['sh', '-c', 'printenv KUBECONFIG'],
-        this.getServerConfig(),
-      );
-
-      if (kubeConfigEnvResolver.stdOut) {
-        return kubeConfigEnvResolver.stdOut.replace(new RegExp('/config$'), '');
-      }
-    } catch (e) {
-      const message = helpers.errors.getMessage(e);
-      console.error(
-        `Failed to run command 'printenv KUBECONFIG' in '${namespace}/${name}/${containerName}' with message: '${message}'`,
-      );
-    }
-
-    try {
-      // attempt to resolve the home directory
-      const homeEnvResolution = await exec(
-        name,
-        namespace,
-        containerName,
-        ['sh', '-c', 'printenv HOME'],
-        this.getServerConfig(),
-      );
-
-      if (homeEnvResolution.stdOut) {
-        if (homeEnvResolution.stdOut.substr(-1) === '/') {
-          return homeEnvResolution.stdOut + '.kube';
-        } else {
-          return homeEnvResolution.stdOut + '/.kube';
-        }
-      }
-    } catch (e) {
-      const message = helpers.errors.getMessage(e);
-      console.error(
-        `Failed to run command 'printenv HOME' in '${namespace}/${name}/${containerName}' with message: '${message}'`,
-      );
-    }
-    return '';
   }
 
   private setNamespaceInContext(kubeConfig: string, namespace: string): string {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -10,12 +10,16 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import * as k8s from '@kubernetes/client-node';
-import { IKubeConfigApi } from '../types';
 import { helpers, KUBECONFIG_MOUNT_PATH } from '@eclipse-che/common';
-import { ServerConfig } from './helpers/exec';
-import { CoreV1API, prepareCoreV1API } from './helpers/prepareCoreV1API';
+import * as k8s from '@kubernetes/client-node';
 import { V1Secret } from '@kubernetes/client-node';
+
+import { ServerConfig } from '@/devworkspaceClient/services/helpers/exec';
+import {
+  CoreV1API,
+  prepareCoreV1API,
+} from '@/devworkspaceClient/services/helpers/prepareCoreV1API';
+import { IKubeConfigApi } from '@/devworkspaceClient/types';
 
 const KUBECONFIG_SECRET_NAME = 'kubeconfig';
 

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -262,9 +262,9 @@ export interface IServerConfigApi {
 
 export interface IKubeConfigApi {
   /**
-   * Inject the kubeconfig into all containers with the given devworkspaceId in a namespace.
+   * Creates or replaces kubeconfig Secret to be mounted into all containers in a namespace.
    */
-  injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void>;
+  applyKubeConfigSecret(namespace: string): Promise<void>;
 }
 
 export interface IPodmanApi {

--- a/packages/dashboard-backend/src/routes/api/__tests__/kubeConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/kubeConfig.spec.ts
@@ -30,11 +30,10 @@ describe('Kube Config Route', () => {
     teardown(app);
   });
 
-  test('POST ${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig', async () => {
-    const devworkspaceId = 'wksp-id';
+  test('POST ${baseApiPath}/namespace/:namespace/kubeconfig', async () => {
     const res = await app
       .inject()
-      .post(`${baseApiPath}/namespace/${namespace}/devworkspaceId/${devworkspaceId}/kubeconfig`)
+      .post(`${baseApiPath}/namespace/${namespace}/kubeconfig`)
       .payload({});
 
     expect(res.statusCode).toEqual(204);

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -149,7 +149,7 @@ export function getDevWorkspaceClient(
       update: (_namespace, _dockerCfg) => Promise.resolve(stubDockerConfig),
     } as IDockerConfigApi,
     kubeConfigApi: {
-      injectKubeConfig: (_namespace, _devworkspaceId) => Promise.resolve(undefined),
+      applyKubeConfigSecret: _namespace => Promise.resolve(undefined),
     } as IKubeConfigApi,
     devWorkspaceTemplateApi: {
       create: _template => Promise.resolve(stubDevWorkspaceTemplate),

--- a/packages/dashboard-backend/src/routes/api/kubeConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/kubeConfig.ts
@@ -24,7 +24,7 @@ const tags = ['Kube Config'];
 export function registerKubeConfigRoute(instance: FastifyInstance) {
   instance.register(async server => {
     server.post(
-      `${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig`,
+      `${baseApiPath}/namespace/:namespace/kubeconfig`,
       getSchema({
         tags,
         params: namespacedKubeConfigSchema,
@@ -38,8 +38,8 @@ export function registerKubeConfigRoute(instance: FastifyInstance) {
       async function (request: FastifyRequest, reply: FastifyReply) {
         const token = getToken(request);
         const { kubeConfigApi } = getDevWorkspaceClient(token);
-        const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParams;
-        await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
+        const { namespace } = request.params as restParams.INamespacedPodParams;
+        await kubeConfigApi.applyKubeConfigSecret(namespace);
         reply.code(204);
         return reply.send();
       },

--- a/packages/dashboard-frontend/src/services/backend-client/devWorkspaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devWorkspaceApi.ts
@@ -123,16 +123,6 @@ export async function putDockerConfig(
   }
 }
 
-export async function injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void> {
-  try {
-    await AxiosWrapper.createToRetryMissedBearerTokenError().post(
-      `${dashboardBackendPrefix}/namespace/${namespace}/devworkspaceId/${devworkspaceId}/kubeconfig`,
-    );
-  } catch (e) {
-    throw new Error(`Failed to inject kubeconfig. ${helpers.errors.getMessage(e)}`);
-  }
-}
-
 export async function podmanLogin(namespace: string, devworkspaceId: string): Promise<void> {
   try {
     await AxiosWrapper.createToRetryMissedBearerTokenError().post(

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -14,6 +14,8 @@ import common, { api, ApplicationId } from '@eclipse-che/common';
 import { Store } from 'redux';
 
 import { lazyInject } from '@/inversify.config';
+import { AxiosWrapper } from '@/services/backend-client/axiosWrapper';
+import { dashboardBackendPrefix } from '@/services/backend-client/const';
 import { WebsocketClient } from '@/services/backend-client/websocketClient';
 import { ChannelListener } from '@/services/backend-client/websocketClient/messageHandler';
 import {
@@ -56,8 +58,6 @@ import * as UserProfileStore from '@/store/User/Profile';
 import * as WorkspacesStore from '@/store/Workspaces';
 import * as DevWorkspacesStore from '@/store/Workspaces/devWorkspaces';
 import { selectDevWorkspacesResourceVersion } from '@/store/Workspaces/devWorkspaces/selectors';
-import { AxiosWrapper } from '../backend-client/axiosWrapper';
-import { dashboardBackendPrefix } from '../backend-client/const';
 
 /**
  * This class executes a few initial instructions

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -56,6 +56,8 @@ import * as UserProfileStore from '@/store/User/Profile';
 import * as WorkspacesStore from '@/store/Workspaces';
 import * as DevWorkspacesStore from '@/store/Workspaces/devWorkspaces';
 import { selectDevWorkspacesResourceVersion } from '@/store/Workspaces/devWorkspaces/selectors';
+import { AxiosWrapper } from '../backend-client/axiosWrapper';
+import { dashboardBackendPrefix } from '../backend-client/const';
 
 /**
  * This class executes a few initial instructions
@@ -113,6 +115,7 @@ export default class Bootstrap {
         this.watchWebSocketPods();
       }),
       this.fetchClusterConfig(),
+      this.createKubeConfigSecret(),
     ]);
 
     const errors = results
@@ -252,6 +255,13 @@ export default class Bootstrap {
     this.websocketClient.subscribeToChannel(api.webSocket.Channel.POD, namespace, {
       getResourceVersion,
     });
+  }
+
+  private async createKubeConfigSecret(): Promise<void> {
+    const defaultKubernetesNamespace = selectDefaultNamespace(this.store.getState());
+    await AxiosWrapper.createToRetryMissedBearerTokenError().post(
+      `${dashboardBackendPrefix}/namespace/${defaultKubernetesNamespace.name}/kubeconfig`,
+    );
   }
 
   private async fetchWorkspaces(): Promise<void> {

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
@@ -45,6 +45,10 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
                 value: 'http://localhost',
               },
               {
+                name: 'KUBECONFIG',
+                value: '/tmp/.kube/config',
+              },
+              {
                 name: 'CHE_PLUGIN_REGISTRY_URL',
                 value: 'plugin-registry-url',
               },
@@ -84,6 +88,10 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
                 value: 'http://localhost',
               },
               {
+                name: 'KUBECONFIG',
+                value: '/tmp/.kube/config',
+              },
+              {
                 name: 'CHE_PLUGIN_REGISTRY_URL',
                 value: 'plugin-registry-url',
               },
@@ -111,6 +119,10 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
               {
                 name: 'CHE_DASHBOARD_URL',
                 value: 'http://localhost',
+              },
+              {
+                name: 'KUBECONFIG',
+                value: '/tmp/.kube/config',
               },
               {
                 name: 'CHE_PLUGIN_REGISTRY_URL',

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -16,7 +16,7 @@ import {
   V1alpha2DevWorkspaceTemplateSpecComponents,
   V221DevfileComponentsItemsContainer,
 } from '@devfile/api';
-import { api } from '@eclipse-che/common';
+import { api, KUBECONFIG_MOUNT_PATH } from '@eclipse-che/common';
 import { inject, injectable } from 'inversify';
 import { load } from 'js-yaml';
 import { cloneDeep, isEqual } from 'lodash';
@@ -85,6 +85,7 @@ export class DevWorkspaceClient {
   private readonly clusterConsoleTitleEnvName: string;
   private readonly openVSXUrlEnvName: string;
   private readonly dashboardUrlEnvName: string;
+  private readonly kubeconfigEnvName: string;
   private readonly defaultPluginsHandler: DevWorkspaceDefaultPluginsHandler;
 
   constructor(
@@ -98,6 +99,7 @@ export class DevWorkspaceClient {
     this.dashboardUrlEnvName = 'CHE_DASHBOARD_URL';
     this.clusterConsoleUrlEnvName = 'CLUSTER_CONSOLE_URL';
     this.clusterConsoleTitleEnvName = 'CLUSTER_CONSOLE_TITLE';
+    this.kubeconfigEnvName = 'KUBECONFIG';
     this.defaultPluginsHandler = defaultPluginsHandler;
   }
 
@@ -265,11 +267,16 @@ export class DevWorkspaceClient {
           env.name !== this.pluginRegistryInternalUrlEnvName &&
           env.name !== this.clusterConsoleUrlEnvName &&
           env.name !== this.clusterConsoleTitleEnvName &&
-          env.name !== this.openVSXUrlEnvName,
+          env.name !== this.openVSXUrlEnvName &&
+          env.name !== this.kubeconfigEnvName,
       );
       envs.push({
         name: this.dashboardUrlEnvName,
         value: dashboardUrl,
+      });
+      envs.push({
+        name: this.kubeconfigEnvName,
+        value: `${KUBECONFIG_MOUNT_PATH}/config`,
       });
       if (pluginRegistryUrl !== undefined) {
         envs.push({

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -539,6 +539,10 @@ describe('DevWorkspace store, actions', () => {
                       value: 'http://localhost',
                     },
                     {
+                      name: 'KUBECONFIG',
+                      value: '/tmp/.kube/config',
+                    },
+                    {
                       name: 'CHE_PLUGIN_REGISTRY_URL',
                       value: 'https://dummy.registry',
                     },

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -15,7 +15,7 @@ import { dump } from 'js-yaml';
 import { Action, Reducer } from 'redux';
 
 import { container } from '@/inversify.config';
-import { injectKubeConfig, podmanLogin } from '@/services/backend-client/devWorkspaceApi';
+import { podmanLogin } from '@/services/backend-client/devWorkspaceApi';
 import * as DwApi from '@/services/backend-client/devWorkspaceApi';
 import { fetchResources } from '@/services/backend-client/devworkspaceResourcesApi';
 import * as DwtApi from '@/services/backend-client/devWorkspaceTemplateApi';
@@ -1015,8 +1015,6 @@ export const actionCreators: ActionCreators = {
           devworkspaceId !== undefined
         ) {
           try {
-            // inject the kube config
-            await injectKubeConfig(workspace.metadata.namespace, devworkspaceId);
             // inject the 'podman login'
             await podmanLogin(workspace.metadata.namespace, devworkspaceId);
           } catch (e) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
chore: Mount kubeconfig into users containers

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4332

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Manual tests on OpenShift and Minikube clusters

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
