### PR TITLE
Revert "chore: Mount kubeconfig into users containers (#950)"

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,7 +20,6 @@ export { helpers, api };
 
 export const FACTORY_LINK_ATTR = 'factoryLink';
 export const ERROR_CODE_ATTR = 'error_code';
-export const KUBECONFIG_MOUNT_PATH = '/tmp/.kube';
 
 const common = {
   helpers,

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -29,8 +29,11 @@ export const namespacedKubeConfigSchema: JSONSchema7 = {
     namespace: {
       type: 'string',
     },
+    devworkspaceId: {
+      type: 'string',
+    },
   },
-  required: ['namespace'],
+  required: ['namespace', 'devworkspaceId'],
 };
 
 export const namespacedWorkspaceSchema: JSONSchema7 = {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
@@ -13,67 +13,137 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import * as mockClient from '@kubernetes/client-node';
-import { CoreV1Api, HttpError } from '@kubernetes/client-node';
-import { IncomingMessage } from 'http';
+import { CoreV1Api, V1PodList } from '@kubernetes/client-node';
 
+import * as helper from '@/devworkspaceClient/services/helpers/exec';
 import { KubeConfigApiService } from '@/devworkspaceClient/services/kubeConfigApi';
 
+const homeUserDir = '/home/user';
+const kubeConfigDir = `${homeUserDir}/.kube`;
+const mockExecPrintenvHome = jest.fn().mockReturnValue({
+  stdOut: homeUserDir,
+  stdError: '',
+});
+const spyExec = jest
+  .spyOn(helper, 'exec')
+  .mockImplementation((...args: Parameters<typeof helper.exec>) => {
+    const [, , , command] = args;
+    if (command.some(c => c === 'printenv HOME')) {
+      // directory where to create the kubeconfig
+      return mockExecPrintenvHome();
+    } else if (command.some(c => c.startsWith('mkdir -p'))) {
+      // crete the directory
+      return Promise.resolve();
+    } else if (command.some(c => c.startsWith(`[ -f ${homeUserDir}`))) {
+      // sync config
+      return Promise.resolve();
+    }
+    return Promise.reject({
+      stdOut: '',
+      stdError: 'command executing error',
+    });
+  });
+
 const namespace = 'user-che';
+const workspaceName = 'workspace-1';
+const containerName = 'container-1';
+const config = JSON.stringify({
+  apiVersion: 'v1',
+  kind: 'Config',
+  'current-context': 'logged-user',
+});
 
 describe('Kubernetes Config API Service', () => {
   let kubeConfigService: KubeConfigApiService;
-  let spyCreateNamespacedSecret: jest.SpyInstance;
-  let spyReadNamespacedSecret: jest.SpyInstance;
-  let spyReplaceNamespacedSecret: jest.SpyInstance;
 
-  console.error = jest.fn();
-  console.warn = jest.fn();
-
-  function initMocks(readNamespacedSecretReturnPromise: Promise<any>): void {
-    const stubCoreV1Api = {
-      createNamespacedSecret: (_namespace: string, secret: any) => {
-        return Promise.resolve({ body: secret });
-      },
-      readNamespacedSecret: () => {
-        return readNamespacedSecretReturnPromise;
-      },
-      replaceNamespacedSecret: (_name: string, _namespace: string, secret: any) => {
-        return Promise.resolve({ body: secret });
-      },
-    } as unknown as CoreV1Api;
-
-    spyCreateNamespacedSecret = jest.spyOn(stubCoreV1Api, 'createNamespacedSecret');
-    spyReadNamespacedSecret = jest.spyOn(stubCoreV1Api, 'readNamespacedSecret');
-    spyReplaceNamespacedSecret = jest.spyOn(stubCoreV1Api, 'replaceNamespacedSecret');
-
+  beforeEach(() => {
     const { KubeConfig } = mockClient;
     const kubeConfig = new KubeConfig();
-    kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => stubCoreV1Api);
+
+    kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => {
+      return {
+        listNamespacedPod: namespace => {
+          return Promise.resolve(buildListNamespacedPod());
+        },
+      } as CoreV1Api;
+    });
+    kubeConfig.exportConfig = jest.fn().mockReturnValue(config);
+    kubeConfig.getCurrentCluster = jest.fn().mockReturnValue('');
+    kubeConfig.applyToRequest = jest.fn();
 
     kubeConfigService = new KubeConfigApiService(kubeConfig);
-  }
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('create kubeconfig Secret', async () => {
-    initMocks(Promise.reject(new HttpError({} as IncomingMessage, undefined, 404)));
+  test('injecting kubeconfig', async () => {
+    // mute output
+    console.error = jest.fn();
+    console.warn = jest.fn();
 
-    await kubeConfigService.applyKubeConfigSecret(namespace);
+    await kubeConfigService.injectKubeConfig(namespace, 'wksp-id');
+    expect(spyExec).toHaveBeenCalledTimes(4);
 
-    expect(spyReadNamespacedSecret).toBeCalled();
-    expect(spyCreateNamespacedSecret).toBeCalled();
-    expect(spyReplaceNamespacedSecret).toBeCalledTimes(0);
-  });
+    // should attempt to resolve the KUBECONFIG env variable
+    expect(spyExec).toHaveBeenNthCalledWith(
+      1,
+      workspaceName,
+      namespace,
+      containerName,
+      ['sh', '-c', 'printenv KUBECONFIG'],
+      expect.anything(),
+    );
 
-  test('replace kubeconfig Secret', async () => {
-    initMocks(Promise.resolve({} as any));
+    // should attempt to resolve the HOME env variable
+    expect(spyExec).toHaveBeenNthCalledWith(
+      2,
+      workspaceName,
+      namespace,
+      containerName,
+      ['sh', '-c', 'printenv HOME'],
+      expect.anything(),
+    );
 
-    await kubeConfigService.applyKubeConfigSecret(namespace);
+    // should create the directory
+    expect(spyExec).toHaveBeenNthCalledWith(
+      3,
+      workspaceName,
+      namespace,
+      containerName,
+      ['sh', '-c', `mkdir -p ${kubeConfigDir}`],
+      expect.anything(),
+    );
 
-    expect(spyReadNamespacedSecret).toBeCalled();
-    expect(spyCreateNamespacedSecret).toBeCalledTimes(0);
-    expect(spyReplaceNamespacedSecret).toBeCalled();
+    // should sync the kubeconfig to the container
+    expect(spyExec).toHaveBeenNthCalledWith(
+      4,
+      workspaceName,
+      namespace,
+      containerName,
+      ['sh', '-c', `[ -f ${kubeConfigDir}/config ] || echo '${config}' > ${kubeConfigDir}/config`],
+      expect.anything(),
+    );
   });
 });
+
+function buildListNamespacedPod(): { body: V1PodList } {
+  return {
+    body: {
+      apiVersion: 'v1',
+      items: [
+        {
+          metadata: {
+            name: workspaceName,
+            namespace,
+          },
+          spec: {
+            containers: [{ name: containerName }],
+          },
+        },
+      ],
+      kind: 'PodList',
+    },
+  };
+}

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -262,9 +262,9 @@ export interface IServerConfigApi {
 
 export interface IKubeConfigApi {
   /**
-   * Creates or replaces kubeconfig Secret to be mounted into all containers in a namespace.
+   * Inject the kubeconfig into all containers with the given devworkspaceId in a namespace.
    */
-  applyKubeConfigSecret(namespace: string): Promise<void>;
+  injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void>;
 }
 
 export interface IPodmanApi {

--- a/packages/dashboard-backend/src/routes/api/__tests__/kubeConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/kubeConfig.spec.ts
@@ -30,10 +30,11 @@ describe('Kube Config Route', () => {
     teardown(app);
   });
 
-  test('POST ${baseApiPath}/namespace/:namespace/kubeconfig', async () => {
+  test('POST ${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig', async () => {
+    const devworkspaceId = 'wksp-id';
     const res = await app
       .inject()
-      .post(`${baseApiPath}/namespace/${namespace}/kubeconfig`)
+      .post(`${baseApiPath}/namespace/${namespace}/devworkspaceId/${devworkspaceId}/kubeconfig`)
       .payload({});
 
     expect(res.statusCode).toEqual(204);

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -149,7 +149,7 @@ export function getDevWorkspaceClient(
       update: (_namespace, _dockerCfg) => Promise.resolve(stubDockerConfig),
     } as IDockerConfigApi,
     kubeConfigApi: {
-      applyKubeConfigSecret: _namespace => Promise.resolve(undefined),
+      injectKubeConfig: (_namespace, _devworkspaceId) => Promise.resolve(undefined),
     } as IKubeConfigApi,
     devWorkspaceTemplateApi: {
       create: _template => Promise.resolve(stubDevWorkspaceTemplate),

--- a/packages/dashboard-backend/src/routes/api/kubeConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/kubeConfig.ts
@@ -24,7 +24,7 @@ const tags = ['Kube Config'];
 export function registerKubeConfigRoute(instance: FastifyInstance) {
   instance.register(async server => {
     server.post(
-      `${baseApiPath}/namespace/:namespace/kubeconfig`,
+      `${baseApiPath}/namespace/:namespace/devworkspaceId/:devworkspaceId/kubeconfig`,
       getSchema({
         tags,
         params: namespacedKubeConfigSchema,
@@ -38,8 +38,8 @@ export function registerKubeConfigRoute(instance: FastifyInstance) {
       async function (request: FastifyRequest, reply: FastifyReply) {
         const token = getToken(request);
         const { kubeConfigApi } = getDevWorkspaceClient(token);
-        const { namespace } = request.params as restParams.INamespacedPodParams;
-        await kubeConfigApi.applyKubeConfigSecret(namespace);
+        const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParams;
+        await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
         reply.code(204);
         return reply.send();
       },

--- a/packages/dashboard-frontend/src/services/backend-client/devWorkspaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devWorkspaceApi.ts
@@ -123,6 +123,16 @@ export async function putDockerConfig(
   }
 }
 
+export async function injectKubeConfig(namespace: string, devworkspaceId: string): Promise<void> {
+  try {
+    await AxiosWrapper.createToRetryMissedBearerTokenError().post(
+      `${dashboardBackendPrefix}/namespace/${namespace}/devworkspaceId/${devworkspaceId}/kubeconfig`,
+    );
+  } catch (e) {
+    throw new Error(`Failed to inject kubeconfig. ${helpers.errors.getMessage(e)}`);
+  }
+}
+
 export async function podmanLogin(namespace: string, devworkspaceId: string): Promise<void> {
   try {
     await AxiosWrapper.createToRetryMissedBearerTokenError().post(

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -14,8 +14,6 @@ import common, { api, ApplicationId } from '@eclipse-che/common';
 import { Store } from 'redux';
 
 import { lazyInject } from '@/inversify.config';
-import { AxiosWrapper } from '@/services/backend-client/axiosWrapper';
-import { dashboardBackendPrefix } from '@/services/backend-client/const';
 import { WebsocketClient } from '@/services/backend-client/websocketClient';
 import { ChannelListener } from '@/services/backend-client/websocketClient/messageHandler';
 import {
@@ -115,7 +113,6 @@ export default class Bootstrap {
         this.watchWebSocketPods();
       }),
       this.fetchClusterConfig(),
-      this.createKubeConfigSecret(),
     ]);
 
     const errors = results
@@ -255,13 +252,6 @@ export default class Bootstrap {
     this.websocketClient.subscribeToChannel(api.webSocket.Channel.POD, namespace, {
       getResourceVersion,
     });
-  }
-
-  private async createKubeConfigSecret(): Promise<void> {
-    const defaultKubernetesNamespace = selectDefaultNamespace(this.store.getState());
-    await AxiosWrapper.createToRetryMissedBearerTokenError().post(
-      `${dashboardBackendPrefix}/namespace/${defaultKubernetesNamespace.name}/kubeconfig`,
-    );
   }
 
   private async fetchWorkspaces(): Promise<void> {

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
@@ -45,10 +45,6 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
                 value: 'http://localhost',
               },
               {
-                name: 'KUBECONFIG',
-                value: '/tmp/.kube/config',
-              },
-              {
                 name: 'CHE_PLUGIN_REGISTRY_URL',
                 value: 'plugin-registry-url',
               },
@@ -88,10 +84,6 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
                 value: 'http://localhost',
               },
               {
-                name: 'KUBECONFIG',
-                value: '/tmp/.kube/config',
-              },
-              {
                 name: 'CHE_PLUGIN_REGISTRY_URL',
                 value: 'plugin-registry-url',
               },
@@ -119,10 +111,6 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
               {
                 name: 'CHE_DASHBOARD_URL',
                 value: 'http://localhost',
-              },
-              {
-                name: 'KUBECONFIG',
-                value: '/tmp/.kube/config',
               },
               {
                 name: 'CHE_PLUGIN_REGISTRY_URL',

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -16,7 +16,7 @@ import {
   V1alpha2DevWorkspaceTemplateSpecComponents,
   V221DevfileComponentsItemsContainer,
 } from '@devfile/api';
-import { api, KUBECONFIG_MOUNT_PATH } from '@eclipse-che/common';
+import { api } from '@eclipse-che/common';
 import { inject, injectable } from 'inversify';
 import { load } from 'js-yaml';
 import { cloneDeep, isEqual } from 'lodash';
@@ -85,7 +85,6 @@ export class DevWorkspaceClient {
   private readonly clusterConsoleTitleEnvName: string;
   private readonly openVSXUrlEnvName: string;
   private readonly dashboardUrlEnvName: string;
-  private readonly kubeconfigEnvName: string;
   private readonly defaultPluginsHandler: DevWorkspaceDefaultPluginsHandler;
 
   constructor(
@@ -99,7 +98,6 @@ export class DevWorkspaceClient {
     this.dashboardUrlEnvName = 'CHE_DASHBOARD_URL';
     this.clusterConsoleUrlEnvName = 'CLUSTER_CONSOLE_URL';
     this.clusterConsoleTitleEnvName = 'CLUSTER_CONSOLE_TITLE';
-    this.kubeconfigEnvName = 'KUBECONFIG';
     this.defaultPluginsHandler = defaultPluginsHandler;
   }
 
@@ -267,16 +265,11 @@ export class DevWorkspaceClient {
           env.name !== this.pluginRegistryInternalUrlEnvName &&
           env.name !== this.clusterConsoleUrlEnvName &&
           env.name !== this.clusterConsoleTitleEnvName &&
-          env.name !== this.openVSXUrlEnvName &&
-          env.name !== this.kubeconfigEnvName,
+          env.name !== this.openVSXUrlEnvName,
       );
       envs.push({
         name: this.dashboardUrlEnvName,
         value: dashboardUrl,
-      });
-      envs.push({
-        name: this.kubeconfigEnvName,
-        value: `${KUBECONFIG_MOUNT_PATH}/config`,
       });
       if (pluginRegistryUrl !== undefined) {
         envs.push({

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -539,10 +539,6 @@ describe('DevWorkspace store, actions', () => {
                       value: 'http://localhost',
                     },
                     {
-                      name: 'KUBECONFIG',
-                      value: '/tmp/.kube/config',
-                    },
-                    {
                       name: 'CHE_PLUGIN_REGISTRY_URL',
                       value: 'https://dummy.registry',
                     },

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -15,7 +15,7 @@ import { dump } from 'js-yaml';
 import { Action, Reducer } from 'redux';
 
 import { container } from '@/inversify.config';
-import { podmanLogin } from '@/services/backend-client/devWorkspaceApi';
+import { injectKubeConfig, podmanLogin } from '@/services/backend-client/devWorkspaceApi';
 import * as DwApi from '@/services/backend-client/devWorkspaceApi';
 import { fetchResources } from '@/services/backend-client/devworkspaceResourcesApi';
 import * as DwtApi from '@/services/backend-client/devWorkspaceTemplateApi';
@@ -1015,6 +1015,8 @@ export const actionCreators: ActionCreators = {
           devworkspaceId !== undefined
         ) {
           try {
+            // inject the kube config
+            await injectKubeConfig(workspace.metadata.namespace, devworkspaceId);
             // inject the 'podman login'
             await podmanLogin(workspace.metadata.namespace, devworkspaceId);
           } catch (e) {


### PR DESCRIPTION
This reverts commit 2c0237c0473abe4816621f80069a64f9f144ea50.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Revert "chore: Mount kubeconfig into users containers (#950)"

