### PR TITLE
fix: retry request for '"system:anonymous" cannot get resource' error

### DIFF
--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.tsx
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.tsx
@@ -53,7 +53,7 @@ describe('Kubernetes namespace API', () => {
       await provisionKubernetesNamespace();
 
       expect(mockGet).not.toBeCalled();
-      expect(mockPost).toBeCalledWith('/api/kubernetes/namespace/provision');
+      expect(mockPost).toBeCalledWith('/api/kubernetes/namespace/provision', undefined, undefined);
     });
 
     it('should return a list of namespaces', async () => {

--- a/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
@@ -18,6 +18,8 @@ type AxiosFunc = (url: string, config?: AxiosRequestConfig) => Promise<any>;
 type AxiosFuncWithData = (url: string, data?: any, config?: AxiosRequestConfig) => Promise<any>;
 
 export const bearerTokenAuthorizationIsRequiredErrorMsg = 'Bearer Token Authorization is required';
+export const cannotGetResourceErrorMessage =
+  'users.user.openshift.io "~" is forbidden: User "system:anonymous" cannot get resource "users" in API group "user.openshift.io" at the cluster scope';
 
 export class AxiosWrapper {
   protected readonly retryCount = 3;
@@ -32,6 +34,10 @@ export class AxiosWrapper {
 
   static createToRetryMissedBearerTokenError(): AxiosWrapper {
     return new AxiosWrapper(axios.create(), bearerTokenAuthorizationIsRequiredErrorMsg);
+  }
+
+  static createToRetryCannotGetResourceErrors(): AxiosWrapper {
+    return new AxiosWrapper(axios.create(), cannotGetResourceErrorMessage);
   }
 
   static createToRetryAnyErrors(): AxiosWrapper {

--- a/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
@@ -18,8 +18,6 @@ type AxiosFunc = (url: string, config?: AxiosRequestConfig) => Promise<any>;
 type AxiosFuncWithData = (url: string, data?: any, config?: AxiosRequestConfig) => Promise<any>;
 
 export const bearerTokenAuthorizationIsRequiredErrorMsg = 'Bearer Token Authorization is required';
-export const cannotGetResourceErrorMessage =
-  'users.user.openshift.io "~" is forbidden: User "system:anonymous" cannot get resource "users" in API group "user.openshift.io" at the cluster scope';
 
 export class AxiosWrapper {
   protected readonly retryCount = 3;
@@ -34,10 +32,6 @@ export class AxiosWrapper {
 
   static createToRetryMissedBearerTokenError(): AxiosWrapper {
     return new AxiosWrapper(axios.create(), bearerTokenAuthorizationIsRequiredErrorMsg);
-  }
-
-  static createToRetryCannotGetResourceErrors(): AxiosWrapper {
-    return new AxiosWrapper(axios.create(), cannotGetResourceErrorMessage);
   }
 
   static createToRetryAnyErrors(): AxiosWrapper {

--- a/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
@@ -24,7 +24,7 @@ export async function getKubernetesNamespace(): Promise<che.KubernetesNamespace[
 }
 
 export async function provisionKubernetesNamespace(): Promise<che.KubernetesNamespace> {
-  const response = await AxiosWrapper.createToRetryCannotGetResourceErrors().post(
+  const response = await AxiosWrapper.createToRetryAnyErrors().post(
     `${cheServerPrefix}/kubernetes/namespace/provision`,
   );
 

--- a/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
@@ -10,8 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import axios from 'axios';
-
 import { AxiosWrapper } from '@/services/backend-client/axiosWrapper';
 import { cheServerPrefix } from '@/services/backend-client/const';
 

--- a/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
@@ -24,7 +24,9 @@ export async function getKubernetesNamespace(): Promise<che.KubernetesNamespace[
 }
 
 export async function provisionKubernetesNamespace(): Promise<che.KubernetesNamespace> {
-  const response = await axios.post(`${cheServerPrefix}/kubernetes/namespace/provision`);
+  const response = await AxiosWrapper.createToRetryCannotGetResourceErrors().post(
+    `${cheServerPrefix}/kubernetes/namespace/provision`,
+  );
 
   return response.data;
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Extension of https://github.com/eclipse-che/che-dashboard/pull/946 to cover the case where a 403 error happens for the `provision` request:
<img width="1198" alt="image" src="https://github.com/eclipse-che/che-dashboard/assets/83611742/c4a2df69-dd18-481f-9da9-829a289776ad">

<img width="369" alt="image" src="https://github.com/eclipse-che/che-dashboard/assets/83611742/b528ef7d-84a2-4d61-92ec-5343d285dd37">


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22352

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
The issue this PR aims to fix is difficult to reproduce. To test this PR, you can apply this patch:
```
diff --git a/packages/dashboard-backend/src/routes/api/helpers/getToken.ts b/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
index 59e8d76f..1d5fcbf8 100644
--- a/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
@@ -17,9 +17,5 @@ import { createFastifyError } from '@/services/helpers';
 const authorizationBearerPrefix = /^Bearer /;
 
 export function getToken(request: FastifyRequest): string {
-  const authorization = request.headers?.authorization;
-  if (!authorization || !authorizationBearerPrefix.test(authorization)) {
-    throw createFastifyError('FST_UNAUTHORIZED', 'Bearer Token Authorization is required', 401);
-  }
-  return authorization.replace(authorizationBearerPrefix, '').trim();
+  throw createFastifyError('FST_UNAUTHORIZED', 'users.user.openshift.io "~" is forbidden: User "system:anonymous" cannot get resource "users" in API group "user.openshift.io" at the cluster scope', 401);
 }
```

build the dashboard image, and verify that there are console warning messages notifying of request retries:
![retryverify](https://github.com/eclipse-che/che-dashboard/assets/83611742/26e77aa8-7959-4c99-88d7-7048ca9c4b69)



#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
