### PR TITLE
[BACKPORT] fix: retry request for '"system:anonymous" cannot get resource' error #955

### DIFF
--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.tsx
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.tsx
@@ -53,7 +53,7 @@ describe('Kubernetes namespace API', () => {
       await provisionKubernetesNamespace();
 
       expect(mockGet).not.toBeCalled();
-      expect(mockPost).toBeCalledWith('/api/kubernetes/namespace/provision');
+      expect(mockPost).toBeCalledWith('/api/kubernetes/namespace/provision', undefined, undefined);
     });
 
     it('should return a list of namespaces', async () => {

--- a/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
@@ -10,8 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import axios from 'axios';
-
 import { AxiosWrapper } from '@/services/backend-client/axiosWrapper';
 import { cheServerPrefix } from '@/services/backend-client/const';
 
@@ -24,7 +22,9 @@ export async function getKubernetesNamespace(): Promise<che.KubernetesNamespace[
 }
 
 export async function provisionKubernetesNamespace(): Promise<che.KubernetesNamespace> {
-  const response = await axios.post(`${cheServerPrefix}/kubernetes/namespace/provision`);
+  const response = await AxiosWrapper.createToRetryAnyErrors().post(
+    `${cheServerPrefix}/kubernetes/namespace/provision`,
+  );
 
   return response.data;
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Backport change introduced in https://github.com/eclipse-che/che-dashboard/pull/955

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
