### PR TITLE
fix: use 'errors.getMessage' to determine error message in AxiosWrapper

### DIFF
--- a/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import common from '@eclipse-che/common';
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import { delay } from '@/services/helpers/delay';
@@ -97,7 +98,8 @@ export class AxiosWrapper {
     } catch (err) {
       if (
         !retry ||
-        (this.errorMessagesToRetry && !(err as Error)?.message?.includes(this.errorMessagesToRetry))
+        (this.errorMessagesToRetry &&
+          !common.helpers.errors.getMessage(err).includes(this.errorMessagesToRetry))
       ) {
         throw err;
       }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
I noticed that the `Bearer Token Authorization is required` message exists in `err.response.data.message`, rather than `err.message`:
![Screenshot from 2023-10-20 12-55-58](https://github.com/eclipse-che/che-dashboard/assets/83611742/505a0139-0aa9-484d-8bae-51172615856a)

### What issues does this PR fix or reference?
Related to 401/403 issues.

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Random 401 issues can be simulated by adding this git patch to the dashboard:
```
diff --git a/packages/dashboard-backend/src/routes/api/helpers/getToken.ts b/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
index 59e8d76f..71a5dd62 100644
--- a/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
@@ -18,6 +18,11 @@ const authorizationBearerPrefix = /^Bearer /;
 
 export function getToken(request: FastifyRequest): string {
   const authorization = request.headers?.authorization;
+
+  if (Math.random() < 0.4) {
+    throw createFastifyError('FST_UNAUTHORIZED', 'Bearer Token Authorization is required', 401);
+  }
+
   if (!authorization || !authorizationBearerPrefix.test(authorization)) {
     throw createFastifyError('FST_UNAUTHORIZED', 'Bearer Token Authorization is required', 401);
   }
```

When the 401 errors occur, there should be `Retrying request ... ` warnings in the console:
![Screenshot from 2023-10-20 15-44-24](https://github.com/eclipse-che/che-dashboard/assets/83611742/f92206ec-2e01-4c35-8d4f-a687e2929ef7)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
