### PR TITLE
[BACKPORT] fix: use 'errors.getMessage' to determine error message in AxiosWrapper #958

### DIFF
--- a/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/axiosWrapper.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import common from '@eclipse-che/common';
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import { delay } from '@/services/helpers/delay';
@@ -97,7 +98,8 @@ export class AxiosWrapper {
     } catch (err) {
       if (
         !retry ||
-        (this.errorMessagesToRetry && !(err as Error)?.message?.includes(this.errorMessagesToRetry))
+        (this.errorMessagesToRetry &&
+          !common.helpers.errors.getMessage(err).includes(this.errorMessagesToRetry))
       ) {
         throw err;
       }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Backports the fix introduced in fix: use 'errors.getMessage' to determine error message in AxiosWrapper #958

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
