### PR TITLE
chore: load all dashboard-related chunks

### DIFF
--- a/packages/dashboard-frontend/src/Routes/index.tsx
+++ b/packages/dashboard-frontend/src/Routes/index.tsx
@@ -13,14 +13,14 @@
 import React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router';
 
+import WorkspaceDetailsContainer from '@/containers/WorkspaceDetails';
+import WorkspacesListContainer from '@/containers/WorkspacesList';
+import CreateWorkspace from '@/pages/GetStarted';
+import UserPreferences from '@/pages/UserPreferences';
 import { buildFactoryLoaderPath } from '@/preload/main';
 import { ROUTE } from '@/Routes/routes';
 
-const CreateWorkspace = React.lazy(() => import('../pages/GetStarted'));
-const WorkspacesListContainer = React.lazy(() => import('../containers/WorkspacesList'));
-const WorkspaceDetailsContainer = React.lazy(() => import('../containers/WorkspaceDetails'));
 const LoaderContainer = React.lazy(() => import('../containers/Loader'));
-const UserPreferences = React.lazy(() => import('../pages/UserPreferences'));
 // temporary hidden, https://github.com/eclipse/che/issues/21595
 // const UserAccount = React.lazy(() => import('../pages/UserAccount'));
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Loads all dashboard UI chunks when accessing the dashboard. This will prevent the user from seeing this error: https://github.com/eclipse/che/issues/22230

When comparing to lazy loading, there is a 0.09mb of difference in terms of resource transfer size when loading: `{CHE-HOST}/dashboard/#/create-workspace`
Lazy loading (left):  3.04mb
No lazy loading (right): 3.15mb
![Screenshot from 2023-10-27 13-04-06](https://github.com/eclipse-che/che-dashboard/assets/83611742/3c76d260-b209-4a77-9a58-b4c500358f68)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22230

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to `{CHE-HOST}/dashboard/#/create-workspace`
2. In a new tab, log out of the dashboard
3. Go back to the first tab (ie from step 1) and on the left-hand side, click, 'Workspaces'.
4. There should be no `Error: Loading CSS chunk (...) failed.` error 

[lazyload.webm](https://github.com/eclipse-che/che-dashboard/assets/83611742/5df0db01-a373-44a4-a000-47abe8fe9bce)

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
