### PR TITLE
feat: Allow to configure 2 github providers simultaneously

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -18,10 +18,14 @@ export { webSocket };
 
 export type GitOauthProvider =
   | 'github'
+  | 'github_2'
   | 'gitlab'
   | 'bitbucket'
+  | 'bitbucket-server'
   | 'azure-devops';
 
+// The list of available Git providers for PAT
+// https://eclipse.dev/che/docs/stable/end-user-guide/using-a-git-provider-access-token/
 export type GitProvider =
   | 'github'
   | 'gitlab'

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
@@ -365,7 +365,7 @@ exports[`GitServices should correctly render the component which contains four g
             data-label="Name"
             onMouseEnter={[Function]}
           >
-            Bitbucket Server
+            Bitbucket Server (OAuth 1.0)
             <span>
               Provided API does not support the automatic token revocation. You can revoke it manually on  
               <a

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
@@ -27,7 +27,7 @@ import { AppState } from '@/store';
 import * as GitOauthConfig from '@/store/GitOauthConfig';
 import { selectGitOauth, selectIsLoading } from '@/store/GitOauthConfig/selectors';
 
-export const enabledProviders: api.GitOauthProvider[] = ['github'];
+export const enabledProviders: api.GitOauthProvider[] = ['github', 'github_2'];
 
 type Props = MappedProps;
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
@@ -14,8 +14,14 @@ import { api } from '@eclipse-che/common';
 
 export const GIT_OAUTH_PROVIDERS: Record<api.GitOauthProvider, string> = {
   'azure-devops': 'Microsoft Azure DevOps',
-  bitbucket: 'Bitbucket Server',
+  // Either Bitbucket Cloud or Bitbucket Server
+  // https://github.com/eclipse-che/che-server/blob/main/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+  'bitbucket-server': 'Bitbucket',
+  // Bitbucket Server only
+  // https://github.com/eclipse-che/che-server/blob/main/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/BitbucketServerOAuthAuthenticator.java
+  bitbucket: 'Bitbucket Server (OAuth 1.0)',
   github: 'GitHub',
+  github_2: 'GitHub (The second provider)',
   gitlab: 'GitLab',
 } as const;
 
@@ -35,5 +41,6 @@ export const PROVIDER_ENDPOINTS: Record<api.GitOauthProvider | api.GitProvider, 
   'bitbucket-server': '',
   bitbucket: '',
   github: 'https://github.com',
+  github_2: 'https://github.com',
   gitlab: 'https://gitlab.com',
 } as const;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Allow to configure 2 github providers simultaneously

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4840

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
![Screenshot from 2023-10-27 15-29-30](https://github.com/eclipse-che/che-dashboard/assets/1640675/c5623f64-6496-4967-a584-1404eb2d8723)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
