### PR TITLE
fix: Do not set 'ephemeral' storage for the 'Safe' mode

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
@@ -227,7 +227,6 @@ describe('Creating steps, applying a devfile', () => {
         expect(prepareDevfile).toHaveBeenCalledWith(
           expect.objectContaining({
             attributes: {
-              'controller.devfile.io/storage-type': 'ephemeral',
               defaultDevfile: true,
             },
           }),
@@ -307,7 +306,6 @@ describe('Creating steps, applying a devfile', () => {
         expect(prepareDevfile).toHaveBeenCalledWith(
           expect.objectContaining({
             attributes: {
-              'controller.devfile.io/storage-type': 'ephemeral',
               defaultDevfile: true,
             },
           }),

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -30,7 +30,6 @@ import {
 import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
 import devfileApi from '@/services/devfileApi';
-import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
 import {
   buildFactoryParams,
   FactoryParams,

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -238,18 +238,16 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
     }
 
     // factory resolving failed in the previous step
-    // hence we have to proceed with default devfile
+    // hence we have to proceed with the default devfile
     if (factoryResolver === undefined) {
       if (devfile === undefined) {
         if (defaultDevfile === undefined) {
           throw new Error('Failed to resolve the default devfile.');
         }
         const _devfile = cloneDeep(defaultDevfile);
-        // sets ephemeral storage type
         if (!_devfile.attributes) {
           _devfile.attributes = {};
         }
-        _devfile.attributes[DEVWORKSPACE_STORAGE_TYPE_ATTR] = 'ephemeral';
         this.updateCurrentDevfile(_devfile);
       } else {
         try {
@@ -263,21 +261,17 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
     }
 
     // the user devfile is invalid and caused creation error
-    // so we have to proceed with default devfile
+    // so we have to proceed with the default devfile
     if (continueWithDefaultDevfile === true) {
       if (defaultDevfile === undefined) {
         throw new Error('Failed to resolve the default devfile.');
       }
-
       if (devfile === undefined) {
         const _devfile = cloneDeep(defaultDevfile);
 
-        // sets ephemeral storage type
         if (!_devfile.attributes) {
           _devfile.attributes = {};
         }
-        _devfile.attributes[DEVWORKSPACE_STORAGE_TYPE_ATTR] = 'ephemeral';
-
         if (factoryResolverConverted?.devfileV2 !== undefined) {
           const { metadata, projects } = factoryResolverConverted.devfileV2;
           _devfile.projects = projects;
@@ -289,7 +283,7 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
         return false;
       }
 
-      // proceed with default devfile
+      // proceed with the default devfile
       try {
         await this.createWorkspaceFromDevfile(devfile);
       } catch (e) {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -574,9 +574,6 @@ describe('DevWorkspace store, actions', () => {
             routingClass: 'che',
             started: false,
             template: {
-              attributes: {
-                [DEVWORKSPACE_STORAGE_TYPE_ATTR]: 'ephemeral',
-              },
               components: [],
               projects: undefined,
             },

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -15,8 +15,8 @@ import { dump } from 'js-yaml';
 import { Action, Reducer } from 'redux';
 
 import { container } from '@/inversify.config';
-import { injectKubeConfig, podmanLogin } from '@/services/backend-client/devWorkspaceApi';
 import * as DwApi from '@/services/backend-client/devWorkspaceApi';
+import { injectKubeConfig, podmanLogin } from '@/services/backend-client/devWorkspaceApi';
 import { fetchResources } from '@/services/backend-client/devworkspaceResourcesApi';
 import * as DwtApi from '@/services/backend-client/devWorkspaceTemplateApi';
 import { WebsocketClient } from '@/services/backend-client/websocketClient';
@@ -26,7 +26,6 @@ import {
   DEVWORKSPACE_CHE_EDITOR,
   DEVWORKSPACE_UPDATING_TIMESTAMP_ANNOTATION,
 } from '@/services/devfileApi/devWorkspace/metadata';
-import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
 import { getDefer, IDeferred } from '@/services/helpers/deferred';
 import { delay } from '@/services/helpers/delay';
 import { DisposableCollection } from '@/services/helpers/disposable';
@@ -689,13 +688,6 @@ export const actionCreators: ActionCreators = {
 
         // add projects from the origin workspace
         devWorkspaceResource.spec.template.projects = workspace.spec.template.projects;
-
-        // sets ephemeral storage type
-        const storageType: che.WorkspaceStorageType = 'ephemeral';
-        if (!devWorkspaceResource.spec.template.attributes) {
-          devWorkspaceResource.spec.template.attributes = {};
-        }
-        devWorkspaceResource.spec.template.attributes[DEVWORKSPACE_STORAGE_TYPE_ATTR] = storageType;
 
         devWorkspaceTemplateResource = resources.find(
           resource => resource.kind === 'DevWorkspaceTemplate',


### PR DESCRIPTION
### What does this PR do?
Do not set 'ephemeral' storage for the 'Safe' mode 

### What issues does this PR fix or reference?

- https://github.com/eclipse/che/issues/22638
- https://issues.redhat.com/browse/CRW-4969 

### Is it tested? How?

- install Eclipse Che and patch the dashboard image 

```
spec:
  components:
    dashboard:
      deployment:
        containers:
          - image: quay.io/eclipse/che-dashboard:pr-967
 ```

- Start an empty workspace
- Add a few files to the workspace and then add a devfile with an image that doesn't exist e.g.

```yaml
schemaVersion: 2.2.0
metadata:
  name: devfile-with-typo
components:
  - name: tools
    container:
      image: quay.io/does/not/exist
```

- Select restart from local Devfile
- Wait for an error message
- Click the "Restart with default devfile" button.
- Wait for the target workspace to restart and open IDE
- See that the devfile exist and the changes are not lost


#### Release Notes
N/A

#### Docs PR
N/A
