### PR TITLE
fix: registry index location

### DIFF
--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -178,10 +178,7 @@ export async function fetchRegistryMetadata(
           throw new DevfileMetaDataIsNotArrayError(location);
         }
       } catch (e) {
-        if (
-          e instanceof DevfileMetaDataIsNotArrayError ||
-          index === registryIndexLocations.length - 1
-        ) {
+        if (index === registryIndexLocations.length - 1) {
           throw e;
         }
       }

--- a/packages/dashboard-frontend/src/services/registry/fetchData.ts
+++ b/packages/dashboard-frontend/src/services/registry/fetchData.ts
@@ -16,7 +16,7 @@ import axios from 'axios';
 export async function fetchData<T>(url: string): Promise<T> {
   try {
     const response = await axios.get<T>(url);
-    return response.data;
+    return response?.data;
   } catch (e) {
     throw new Error(common.helpers.errors.getMessage(e));
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix registry index location.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22643

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. deploy Eclipse-CHE.
2. add the target external registry:
```yaml
devfileRegistry:
  disableInternalRegistry: true
  externalDevfileRegistries:
  - url: https://eclipse-che.github.io/che-devfile-registry/7.74.0/
```
3. refresh samples page
![Знімок екрана 2023-10-31 о 15 14 55](https://github.com/eclipse-che/che-dashboard/assets/6310786/22d3118a-61fc-4577-aecc-d3cc3fecaddf)

