### PR TITLE
Do not start a workspace on SCM unauthorised error

### DIFF
--- a/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
@@ -30,7 +30,7 @@ describe('OAuth service', () => {
   it('should not refresh token if no status section in devworkspace', async () => {
     const devWorkspace = new DevWorkspaceBuilder().build();
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    await OAuthService.refreshTokenIfNeeded(devWorkspace);
 
     expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
   });
@@ -38,7 +38,7 @@ describe('OAuth service', () => {
     const status = {};
     const devWorkspace = new DevWorkspaceBuilder().withStatus(status).build();
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    await OAuthService.refreshTokenIfNeeded(devWorkspace);
 
     expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
   });
@@ -46,7 +46,7 @@ describe('OAuth service', () => {
     const status = { mainUrl: 'https://mainUrl' };
     const devWorkspace = new DevWorkspaceBuilder().withStatus(status).build();
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    await OAuthService.refreshTokenIfNeeded(devWorkspace);
 
     expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
   });
@@ -59,7 +59,7 @@ describe('OAuth service', () => {
       .withProjects(projects)
       .build();
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    await OAuthService.refreshTokenIfNeeded(devWorkspace);
 
     expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
   });
@@ -79,7 +79,7 @@ describe('OAuth service', () => {
       .withProjects(projects)
       .build();
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    await OAuthService.refreshTokenIfNeeded(devWorkspace);
 
     expect(refreshFactoryOauthTokenSpy).not.toHaveBeenCalled();
   });
@@ -103,7 +103,7 @@ describe('OAuth service', () => {
 
     refreshFactoryOauthTokenSpy.mockResolvedValueOnce();
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    await OAuthService.refreshTokenIfNeeded(devWorkspace);
 
     expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
   });
@@ -137,7 +137,7 @@ describe('OAuth service', () => {
 
     jest.spyOn(common.helpers.errors, 'includesAxiosResponse').mockImplementation(() => false);
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    await OAuthService.refreshTokenIfNeeded(devWorkspace);
 
     expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
     expect(mockOpenOAuthPage).not.toHaveBeenCalled();
@@ -178,7 +178,13 @@ describe('OAuth service', () => {
 
     jest.spyOn(common.helpers.errors, 'includesAxiosResponse').mockImplementation(() => true);
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    try {
+      await OAuthService.refreshTokenIfNeeded(devWorkspace);
+    } catch (e: any) {
+      expect(e.response.data.responseData.attributes.oauth_authentication_url).toBe(
+        'https://git-lub/oauth/url',
+      );
+    }
 
     expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
     expect(mockOpenOAuthPage).not.toHaveBeenCalled();
@@ -216,7 +222,11 @@ describe('OAuth service', () => {
 
     jest.spyOn(common.helpers.errors, 'includesAxiosResponse').mockImplementation(() => true);
 
-    OAuthService.refreshTokenIfNeeded(devWorkspace);
+    try {
+      await OAuthService.refreshTokenIfNeeded(devWorkspace);
+    } catch (e: any) {
+      expect(e.response.status).toBe(401);
+    }
 
     expect(refreshFactoryOauthTokenSpy).toHaveBeenCalledWith('origin:project');
     expect(mockOpenOAuthPage).not.toHaveBeenCalled();

--- a/packages/dashboard-frontend/src/services/oauth/index.ts
+++ b/packages/dashboard-frontend/src/services/oauth/index.ts
@@ -63,6 +63,7 @@ export default class OAuthService {
           redirectUrl.toString(),
         );
       }
+      throw e;
     }
   }
 }

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -365,6 +365,7 @@ export const actionCreators: ActionCreators = {
 
         getDevWorkspaceClient().checkForDevWorkspaceError(startingWorkspace);
       } catch (e) {
+        // Skip unauthorised errors. The page is redirecting to an SCM authentication page.
         if (common.helpers.errors.includesAxiosResponse(e) && isOAuthResponse(e.response.data)) {
           return;
         }

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -32,7 +32,7 @@ import { DisposableCollection } from '@/services/helpers/disposable';
 import { FactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { getNewerResourceVersion } from '@/services/helpers/resourceVersion';
 import { DevWorkspaceStatus } from '@/services/helpers/types';
-import OAuthService from '@/services/oauth';
+import OAuthService, { isOAuthResponse } from '@/services/oauth';
 import { loadResourcesContent } from '@/services/registry/resources';
 import { WorkspaceAdapter } from '@/services/workspace-adapter';
 import {
@@ -292,8 +292,8 @@ export const actionCreators: ActionCreators = {
         console.warn(`Workspace ${_workspace.metadata.name} already started`);
         return;
       }
-      await OAuthService.refreshTokenIfNeeded(workspace);
       try {
+        await OAuthService.refreshTokenIfNeeded(workspace);
         await dispatch({ type: Type.REQUEST_DEVWORKSPACE, check: AUTHORIZED });
         if (!(await selectAsyncIsAuthorized(getState()))) {
           const error = selectSanityCheckError(getState());
@@ -365,6 +365,9 @@ export const actionCreators: ActionCreators = {
 
         getDevWorkspaceClient().checkForDevWorkspaceError(startingWorkspace);
       } catch (e) {
+        if (common.helpers.errors.includesAxiosResponse(e) && isOAuthResponse(e.response.data)) {
+          return;
+        }
         const errorMessage =
           `Failed to start the workspace ${workspace.metadata.name}, reason: ` +
           common.helpers.errors.getMessage(e);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* If an unauthorised error occurs on workspace start, throw the error in order to prevent the workspace to start. 
* Do not display the authorisation error on workspace start as the page is reloaded to the SCM authorisation page.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4957

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy che from the `che-server` related PR image: `quay.io/eclipse/che-server:pr-597` see: https://github.com/eclipse-che/che-server/pull/597
2. Configure GitHub (or other) oAuth2 flow.
3. Start a workspace from the GitHub repository, accept the authorisation page.
4. Go to the GitHub settings and revoke the authorisation.
5. Remove the GitHub token in the user settings page.
6. Stop the workspace and start it again.

See: Authorisation appears and token secret is updated in the user namespace after accepting the authorization.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
