### PR TITLE
fix: Do not set 'ephemeral' storage for the 'Safe' mode

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
@@ -225,7 +225,6 @@ describe('Creating steps, applying a devfile', () => {
         expect(prepareDevfile).toHaveBeenCalledWith(
           expect.objectContaining({
             attributes: {
-              'controller.devfile.io/storage-type': 'ephemeral',
               defaultDevfile: true,
             },
           }),
@@ -305,7 +304,6 @@ describe('Creating steps, applying a devfile', () => {
         expect(prepareDevfile).toHaveBeenCalledWith(
           expect.objectContaining({
             attributes: {
-              'controller.devfile.io/storage-type': 'ephemeral',
               defaultDevfile: true,
             },
           }),

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -233,18 +233,16 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
     }
 
     // factory resolving failed in the previous step
-    // hence we have to proceed with default devfile
+    // hence we have to proceed with the default devfile
     if (factoryResolver === undefined) {
       if (devfile === undefined) {
         if (defaultDevfile === undefined) {
           throw new Error('Failed to resolve the default devfile.');
         }
         const _devfile = cloneDeep(defaultDevfile);
-        // sets ephemeral storage type
         if (!_devfile.attributes) {
           _devfile.attributes = {};
         }
-        _devfile.attributes[DEVWORKSPACE_STORAGE_TYPE_ATTR] = 'ephemeral';
         this.updateCurrentDevfile(_devfile);
       } else {
         try {
@@ -258,21 +256,17 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
     }
 
     // the user devfile is invalid and caused creation error
-    // so we have to proceed with default devfile
+    // so we have to proceed with the default devfile
     if (continueWithDefaultDevfile === true) {
       if (defaultDevfile === undefined) {
         throw new Error('Failed to resolve the default devfile.');
       }
-
       if (devfile === undefined) {
         const _devfile = cloneDeep(defaultDevfile);
 
-        // sets ephemeral storage type
         if (!_devfile.attributes) {
           _devfile.attributes = {};
         }
-        _devfile.attributes[DEVWORKSPACE_STORAGE_TYPE_ATTR] = 'ephemeral';
-
         if (factoryResolverConverted?.devfileV2 !== undefined) {
           const { metadata, projects } = factoryResolverConverted.devfileV2;
           _devfile.projects = projects;
@@ -284,7 +278,7 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
         return false;
       }
 
-      // proceed with default devfile
+      // proceed with the default devfile
       try {
         await this.createWorkspaceFromDevfile(devfile);
       } catch (e) {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -44,7 +44,6 @@ import { TimeLimit } from '../../../TimeLimit';
 import { configureProjectRemotes } from './getGitRemotes';
 import { getProjectFromLocation } from './getProjectFromLocation';
 import { prepareDevfile } from './prepareDevfile';
-import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '../../../../../services/devfileApi/devWorkspace/spec/template';
 
 export class CreateWorkspaceError extends Error {
   constructor(message: string) {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -572,9 +572,6 @@ describe('DevWorkspace store, actions', () => {
             routingClass: 'che',
             started: false,
             template: {
-              attributes: {
-                [DEVWORKSPACE_STORAGE_TYPE_ATTR]: 'ephemeral',
-              },
               components: [],
               projects: undefined,
             },

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -667,13 +667,6 @@ export const actionCreators: ActionCreators = {
         // add projects from the origin workspace
         devWorkspaceResource.spec.template.projects = workspace.spec.template.projects;
 
-        // sets ephemeral storage type
-        const storageType: che.WorkspaceStorageType = 'ephemeral';
-        if (!devWorkspaceResource.spec.template.attributes) {
-          devWorkspaceResource.spec.template.attributes = {};
-        }
-        devWorkspaceResource.spec.template.attributes[DEVWORKSPACE_STORAGE_TYPE_ATTR] = storageType;
-
         devWorkspaceTemplateResource = resources.find(
           resource => resource.kind === 'DevWorkspaceTemplate',
         ) as devfileApi.DevWorkspaceTemplate;

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -60,7 +60,6 @@ import * as DwtApi from '../../../services/dashboard-backend-client/devWorkspace
 import { selectDefaultDevfile } from '../../DevfileRegistries/selectors';
 import * as DwApi from '../../../services/dashboard-backend-client/devWorkspaceApi';
 import { selectDefaultEditor } from '../../Plugins/devWorkspacePlugins/selectors';
-import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '../../../services/devfileApi/devWorkspace/spec/template';
 
 export const onStatusChangeCallbacks = new Map<string, (status: string) => void>();
 


### PR DESCRIPTION
### What does this PR do?
Do not set 'ephemeral' storage for the 'Safe' mode

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4969 for 3.9.1 

### Is it tested? How?

- install Eclipse Che and patch the dashboard image 

```
spec:
  components:
    dashboard:
      deployment:
        containers:
          - image: quay.io/eclipse/che-dashboard:pr-971
 ```

- Start an empty workspace
- Add a few files to the workspace and then add a devfile with an image that doesn't exist e.g.

```yaml
schemaVersion: 2.2.0
metadata:
  name: devfile-with-typo
components:
  - name: tools
    container:
      image: quay.io/does/not/exist
```

- Select restart from local Devfile
- Wait for an error message
- Click the "Restart with default devfile" button.
- Wait for the target workspace to restart and open IDE
- See that the devfile exist and the changes are not lost

#### Release Notes
'Ephemeral' storage is not used anymore when workspace is started in the 'Safe' mode

#### Docs PR
N / A
