### PR TITLE
fix: workspace URL parameters after the user accepts the OAuth authorization

### DIFF
--- a/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
+++ b/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
@@ -34,7 +34,7 @@ describe('Factory Acceptance Redirect', () => {
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
-  it('should redirect "/f?url=factoryUrl"', async () => {
+  it('should redirect "/f?factoryLink=url%3DfactoryUrl"', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
       url: `/f?factoryLink=${encodeURIComponent('url=' + factoryUrl)}`,
@@ -43,32 +43,52 @@ describe('Factory Acceptance Redirect', () => {
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
-  it('should redirect "/dashboard/f?url=factoryUrl"', async () => {
+  it('should redirect "/f?url=factoryUrl"', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
-      url: `/dashboard/f?url=${factoryUrl}`,
+      url: `/f?url=${factoryUrl}`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
-  it('should redirect "/dashboard/f?factoryLink%3Durl%3DfactoryUrl"', async () => {
+  it('should redirect "/f?factoryLink%3Durl%3DfactoryUrl"', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
-      url: `/dashboard/f?factoryLink%3Durl%3D${factoryUrl}`,
+      url: `/f?factoryLink%3Durl%3D${factoryUrl}`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
-  it('should redirect "/dashboard/f?factoryLink%3Durl%3DfactoryUrl%26error_code%3Daccess_denied"', async () => {
+  it('should redirect "/f?factoryLink%3Durl%3DfactoryUrl%26error_code%3Daccess_denied"', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
-      url: `/dashboard/f?factoryLink%3Durl%3D${factoryUrl}%26error_code%3Daccess_denied`,
+      url: `/f?factoryLink%3Durl%3D${factoryUrl}%26error_code%3Daccess_denied`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(
       `/dashboard/#/load-factory?url=${factoryUrl}&error_code=access_denied`,
+    );
+  });
+
+  it('should redirect "/f?factoryLink=url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git"', async () => {
+    const res = await app.inject({
+      url: `/f?factoryLink=url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git`,
+    });
+    expect(res.statusCode).toEqual(302);
+    expect(res.headers.location).toEqual(
+      `/dashboard/#/load-factory?url=https%3A%2F%2Fgithub.com%2Folexii4%2Fhelloworld.git`,
+    );
+  });
+
+  it('should redirect "/f?factoryLink=override.devfileFilename%3Ddevfile2.yaml%26url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git"', async () => {
+    const res = await app.inject({
+      url: `/f?factoryLink=override.devfileFilename%3Ddevfile2.yaml%26url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git`,
+    });
+    expect(res.statusCode).toEqual(302);
+    expect(res.headers.location).toEqual(
+      `/dashboard/#/load-factory?override.devfileFilename=devfile2.yaml&url=https%3A%2F%2Fgithub.com%2Folexii4%2Fhelloworld.git`,
     );
   });
 });

--- a/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
+++ b/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
@@ -43,6 +43,19 @@ describe('Factory Acceptance Redirect', () => {
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
+  it('should redirect "/f?factoryLink=che-editor=che-incubator/.che-code/insiders&override.devfileFilename=my.devfile.yaml&url=factoryUr"', async () => {
+    const factoryUrl = 'factoryUrl';
+    const res = await app.inject({
+      url: `/f?${encodeURIComponent(
+        'factoryLink=che-editor=che-incubator/.che-code/insiders&override.devfileFilename=my.devfile.yaml&url=factoryUrl',
+      )}`,
+    });
+    expect(res.statusCode).toEqual(302);
+    expect(res.headers.location).toEqual(
+      `/dashboard/#/load-factory?che-editor=che-incubator%2F.che-code%2Finsiders&override.devfileFilename=my.devfile.yaml&url=${factoryUrl}`,
+    );
+  });
+
   it('should redirect "/f?url=factoryUrl"', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({

--- a/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
@@ -19,7 +19,10 @@ export function registerFactoryAcceptanceRedirect(instance: FastifyInstance): vo
   function redirectFactoryFlow(path: string) {
     instance.register(async server => {
       server.get(path, async (request: FastifyRequest, reply: FastifyReply) => {
-        let factoryLinkStr = request.url.replace(path, '').replace(/^\?/, '');
+        let factoryLinkStr = request.url
+          .replace(path, '')
+          .replace(/^\?/, '')
+          .replace(`${FACTORY_LINK_ATTR}%3D`, `${FACTORY_LINK_ATTR}=`);
         if (!factoryLinkStr.includes('=')) {
           factoryLinkStr = decodeURIComponent(factoryLinkStr);
         }

--- a/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
@@ -20,11 +20,13 @@ export function registerFactoryAcceptanceRedirect(instance: FastifyInstance): vo
     instance.register(async server => {
       server.get(path, async (request: FastifyRequest, reply: FastifyReply) => {
         let factoryLinkStr = request.url.replace(path, '').replace(/^\?/, '');
-
-        const query = querystring.parse(decodeURIComponent(factoryLinkStr));
+        if (!factoryLinkStr.includes('=')) {
+          factoryLinkStr = decodeURIComponent(factoryLinkStr);
+        }
+        const query = querystring.parse(factoryLinkStr);
         if (query[FACTORY_LINK_ATTR] !== undefined) {
           // restore the factory link from the query string
-          factoryLinkStr = querystring.unescape(query[FACTORY_LINK_ATTR] as string);
+          factoryLinkStr = decodeURIComponent(query[FACTORY_LINK_ATTR] as string);
         }
 
         const params = new URLSearchParams(factoryLinkStr);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix workspace URL parameters after the user accepts the OAuth authorization.

### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-4955

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
