### PR TITLE
feat: exponential retries for axiosWrapper

### DIFF
--- a/packages/dashboard-frontend/src/services/axios-wrapper/axiosWrapper.ts
+++ b/packages/dashboard-frontend/src/services/axios-wrapper/axiosWrapper.ts
@@ -23,7 +23,8 @@ export const bearerTokenAuthorizationIsRequiredErrorMsg = 'Bearer Token Authoriz
 
 export class AxiosWrapper {
   protected readonly retryCount = 3;
-  protected readonly retryDelay = 500;
+  protected readonly base = 2;
+  protected readonly initialDelay = 500;
   protected readonly axiosInstance: AxiosInstance;
   protected readonly errorMessagesToRetry?: string;
 
@@ -105,9 +106,11 @@ export class AxiosWrapper {
         throw err;
       }
 
-      // Retry the request after a delay.
-      console.warn(`Retrying request to ${url} in ${this.retryDelay} ms, ${retry} left`);
-      await delay(this.retryDelay);
+      // Retry the request after an exponential delay.
+      const exp = this.retryCount - retry;
+      const expDelay = this.initialDelay * this.base ** exp;
+      console.warn(`Retrying request to ${url} in ${expDelay} ms, ${retry} left`);
+      await delay(expDelay);
 
       return await this.doRetryFunc(fun, url, --retry);
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Tweaks the axiosWrapper retries functionality to have exponential retries with a base of 2, and an initial delay of 500ms. 

As a result, with 3 retries, the first retry has a delay of 500ms, second has a delay of 1000ms and third with 2000ms.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22652

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
To simulate 401 errors and test this PR, checkout the PR branch and apply this patch:
```
diff --git a/packages/dashboard-backend/src/routes/api/helpers/getToken.ts b/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
index 59e8d76f..cd44ec45 100644
--- a/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
@@ -18,6 +18,9 @@ const authorizationBearerPrefix = /^Bearer /;
 
 export function getToken(request: FastifyRequest): string {
   const authorization = request.headers?.authorization;
+  if (Math.random() <= 0.9) {
+    throw createFastifyError('FST_UNAUTHORIZED', 'Bearer Token Authorization is required', 401);
+  }
   if (!authorization || !authorizationBearerPrefix.test(authorization)) {
     throw createFastifyError('FST_UNAUTHORIZED', 'Bearer Token Authorization is required', 401);
   }
```
and build the image.

Next follow these steps:
1. Deploy Che and set the che-dashboard image to the new image.
2. Go to the dashboard and open your web browser web developer tools
3. Refresh the page
4. The console should print statements like the following:
![Screenshot from 2023-11-07 14-47-01](https://github.com/eclipse-che/che-dashboard/assets/83611742/1d2b3d1b-e862-450c-968b-55409a8f909f)

5. Confirm that the retries delay is 500ms for the first retry, 1000ms for the second, and 1500ms for the third

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
