### PR TITLE
Fix: switch from hub to gh for Che #22646

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -64,7 +64,6 @@ bump_version () {
         git checkout "${PR_BRANCH}"
         git pull origin "${PR_BRANCH}"
         git push origin "${PR_BRANCH}"
-        lastCommitComment="$(git log -1 --pretty=%B)"
         gh pr create -f -B "${BUMP_BRANCH}" -H "${PR_BRANCH}"
     fi
     set -e

--- a/make-release.sh
+++ b/make-release.sh
@@ -65,7 +65,7 @@ bump_version () {
         git pull origin "${PR_BRANCH}"
         git push origin "${PR_BRANCH}"
         lastCommitComment="$(git log -1 --pretty=%B)"
-        hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"
+        gh pr create -f -B "${BUMP_BRANCH}" -H "${PR_BRANCH}"
     fi
     set -e
   fi


### PR DESCRIPTION
### What does this PR do?
Update make-release.sh to use gh instead of hub.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22646