### PR TITLE
Prevent overwriting the DevWorkspace Operator Config by the Dashboard

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.managePvcStrategy.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.managePvcStrategy.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+
+import { container } from '@/inversify.config';
+import * as DwApi from '@/services/backend-client/devWorkspaceApi';
+import devfileApi from '@/services/devfileApi';
+import { DEVWORKSPACE_CONFIG_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
+import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+
+describe('DevWorkspace client, managePvcStrategy', () => {
+  const name = 'wksp-test';
+  const namespace = 'user-che';
+  let client: DevWorkspaceClient;
+  let devWorkspaceBuilder: DevWorkspaceBuilder;
+  let spyPatchWorkspace: jest.SpyInstance;
+
+  beforeEach(() => {
+    client = container.get(DevWorkspaceClient);
+    devWorkspaceBuilder = new DevWorkspaceBuilder().withMetadata({ name, namespace });
+
+    spyPatchWorkspace = jest
+      .spyOn(DwApi, 'patchWorkspace')
+      .mockResolvedValue({ devWorkspace: {} as devfileApi.DevWorkspace, headers: {} });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should update devWorkspace config', async () => {
+    const devWorkspace = devWorkspaceBuilder
+      .withSpec({
+        template: {
+          attributes: {
+            [DEVWORKSPACE_CONFIG_ATTR]: undefined,
+          },
+        },
+      })
+      .build();
+    const config = {
+      defaults: {},
+      cheNamespace: namespace,
+    } as api.IServerConfig;
+
+    await client.managePvcStrategy(devWorkspace, config);
+
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'add',
+        path: '/spec/template/attributes/controller.devfile.io~1devworkspace-config',
+        value: { name: 'devworkspace-config', namespace: 'user-che' },
+      },
+    ]);
+  });
+
+  it('should update devWorkspace storage type', async () => {
+    const devWorkspace = devWorkspaceBuilder
+      .withSpec({
+        template: {
+          attributes: {
+            [DEVWORKSPACE_CONFIG_ATTR]: 'custom-config',
+          },
+        },
+      })
+      .build();
+    const config = {
+      defaults: {
+        pvcStrategy: 'custom-pvc-strategy',
+      },
+      cheNamespace: namespace,
+    } as api.IServerConfig;
+
+    await client.managePvcStrategy(devWorkspace, config);
+
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'add',
+        path: '/spec/template/attributes/controller.devfile.io~1storage-type',
+        value: 'custom-pvc-strategy',
+      },
+    ]);
+  });
+
+  it('should update devWorkspace template components', async () => {
+    const devWorkspace = devWorkspaceBuilder
+      .withSpec({
+        template: {
+          attributes: {
+            [DEVWORKSPACE_CONFIG_ATTR]: 'custom-config',
+          },
+          components: [
+            {
+              name: 'component1',
+              container: {
+                env: [
+                  {
+                    name: 'OPENVSX_REGISTRY_URL',
+                    value: 'https://open-vsx.org',
+                  },
+                ],
+                image: 'container1-image',
+              },
+            },
+            {
+              name: 'component2',
+            },
+          ],
+        },
+      })
+      .build();
+    const config = {
+      defaults: {},
+      cheNamespace: namespace,
+      pluginRegistry: {
+        openVSXURL: 'custom-openvsx-url',
+      },
+    } as api.IServerConfig;
+
+    await client.managePvcStrategy(devWorkspace, config);
+
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'replace',
+        path: '/spec/template/components',
+        value: [
+          {
+            container: {
+              env: [{ name: 'OPENVSX_REGISTRY_URL', value: 'custom-openvsx-url' }],
+              image: 'container1-image',
+            },
+            name: 'component1',
+          },
+          {
+            name: 'component2',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should NOT update devWorkspace config nor devWorkspace storage type', async () => {
+    const devWorkspace = devWorkspaceBuilder
+      .withSpec({
+        template: {
+          attributes: {
+            [DEVWORKSPACE_CONFIG_ATTR]: 'custom-config',
+          },
+        },
+      })
+      .build();
+    const config = {
+      defaults: {},
+      cheNamespace: namespace,
+    } as api.IServerConfig;
+
+    await client.managePvcStrategy(devWorkspace, config);
+
+    expect(spyPatchWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -458,23 +458,15 @@ export class DevWorkspaceClient {
     const cheNamespace = config.cheNamespace;
     let attributes = workspace.spec.template.attributes;
     if (cheNamespace) {
-      const devworkspaceConfig = { name: 'devworkspace-config', namespace: cheNamespace };
-      const devworkspaceConfigPath = `/spec/template/attributes/${this.escape(
-        DEVWORKSPACE_CONFIG_ATTR,
-      )}`;
-      if (attributes) {
-        if (attributes[DEVWORKSPACE_CONFIG_ATTR]) {
-          if (attributes[DEVWORKSPACE_CONFIG_ATTR] !== devworkspaceConfig) {
-            patch.push({ op: 'replace', path: devworkspaceConfigPath, value: devworkspaceConfig });
-          }
-        } else {
-          patch.push({ op: 'add', path: devworkspaceConfigPath, value: devworkspaceConfig });
-        }
-      } else {
+      if (attributes?.[DEVWORKSPACE_CONFIG_ATTR] === undefined) {
+        const devworkspaceConfig = { name: 'devworkspace-config', namespace: cheNamespace };
+        const devworkspaceConfigPath = `/spec/template/attributes/${this.escape(
+          DEVWORKSPACE_CONFIG_ATTR,
+        )}`;
         patch.push({
           op: 'add',
-          path: '/spec/template/attributes',
-          value: { [DEVWORKSPACE_CONFIG_ATTR]: devworkspaceConfig },
+          path: devworkspaceConfigPath,
+          value: devworkspaceConfig,
         });
         attributes = {};
       }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes the workspace startup process to prevent the Dashboard from overwriting the DevWorkspace Operator Config attribute every time the workspace starts.


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/22573

### Is it tested? How?

1. Create a DWOC object in your workspaces namespace:
	```yaml
	apiVersion: controller.devfile.io/v1alpha1
	kind: DevWorkspaceOperatorConfig
	metadata:
	  name: custom-dwoc
	  namespace: <your-namespace>
	config:
	  workspace:
	    persistUserHome:
	      enabled: true
	```
2. Reference the DWOC from a devfile:
	```diff
	schemaVersion: 2.2.0
	metadata:
	  name: my-app
	+ attributes:
	+   controller.devfile.io/devworkspace-config:
	+     name: custom-dwoc
	+     namespace: <your-namespace>
	components:
	```
3. Create the workspace and verify it has a correct reference to the DWOC specified:
	```sh
	$ kubectl get dw -o json | jq '.items[0].spec.template.attributes."controller.devfile.io/devworkspace-config"'
	{
	  "name": "custom-dwoc",
	  "namespace": "<your-namespace>"
	}
	```
