### PR TITLE
chore: show authorized git services based on existed OAuth token secrets

### DIFF
--- a/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+import { MockStoreEnhanced } from 'redux-mock-store';
+import { ThunkDispatch } from 'redux-thunk';
+
+import { AppState } from '@/store';
+import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
+import { IGitOauth } from '@/store/GitOauthConfig/types';
+import { AUTHORIZED } from '@/store/sanityCheckMiddleware';
+
+import * as TestStore from '..';
+
+const gitOauth = [
+  {
+    name: 'github',
+    endpointUrl: 'https://github.com',
+  },
+  {
+    name: 'gitlab',
+    endpointUrl: 'https://gitlab.com',
+  },
+  {
+    name: 'azure-devops',
+    endpointUrl: 'https://dev.azure.com',
+  },
+] as IGitOauth[];
+
+const mockGetOAuthProviders = jest.fn().mockResolvedValue(gitOauth);
+const mockGetDevWorkspacePreferences = jest.fn().mockResolvedValue({});
+const mockGetOAuthToken = jest.fn().mockImplementation(provider => {
+  if (provider === 'github') {
+    return new Promise(resolve => resolve('github-token'));
+  }
+  return new Promise((_resolve, reject) => reject(new Error('Token not found')));
+});
+const mockFetchTokens = jest.fn().mockResolvedValue([
+  {
+    tokenName: 'github-personal-access-token',
+    gitProvider: 'oauth2-token',
+    gitProviderEndpoint: 'https://dev.azure.com/',
+  },
+] as any[]);
+
+jest.mock('../../../services/backend-client/oAuthApi', () => {
+  return {
+    getOAuthProviders: (...args: unknown[]) => mockGetOAuthProviders(...args),
+    getOAuthToken: (...args: unknown[]) => mockGetOAuthToken(...args),
+    getDevWorkspacePreferences: (...args: unknown[]) => mockGetDevWorkspacePreferences(...args),
+  };
+});
+jest.mock('../../../services/backend-client/personalAccessTokenApi', () => {
+  return {
+    fetchTokens: (...args: unknown[]) => mockFetchTokens(...args),
+  };
+});
+
+// mute the outputs
+console.error = jest.fn();
+
+describe('GitOauthConfig store, actions', () => {
+  let store: MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, TestStore.KnownAction>>;
+
+  beforeEach(() => {
+    store = new FakeStoreBuilder()
+      .withInfrastructureNamespace([{ name: 'user-che', attributes: { phase: 'Active' } }])
+      .build();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should request GitOauthConfig', async () => {
+    await store.dispatch(TestStore.actionCreators.requestGitOauthConfig());
+
+    const actions = store.getActions();
+
+    const expectedAction: TestStore.KnownAction = {
+      supportedGitOauth: gitOauth,
+      providersWithToken: ['github', 'azure-devops'],
+      type: TestStore.Type.RECEIVE_GIT_OAUTH_PROVIDERS,
+    };
+
+    expect(actions).toContainEqual(expectedAction);
+  });
+});

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
@@ -9,13 +9,13 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
+
 import { MockStoreEnhanced } from 'redux-mock-store';
 import { ThunkDispatch } from 'redux-thunk';
 
 import { AppState } from '@/store';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 import { IGitOauth } from '@/store/GitOauthConfig/types';
-import { AUTHORIZED } from '@/store/sanityCheckMiddleware';
 
 import * as TestStore from '..';
 

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
@@ -154,6 +154,8 @@ export const actionCreators: ActionCreators = {
                 providersWithToken.push(gitOauth.name);
               })
 
+              // if `api/oauth/token` doesn't return a user's token,
+              // then check if there is the user's token in a Kubernetes Secret
               .catch(() => {
                 const normalizedGitOauthEndpoint = gitOauth.endpointUrl.endsWith('/')
                   ? gitOauth.endpointUrl.slice(0, -1)

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
@@ -20,6 +20,7 @@ import {
   getOAuthProviders,
   getOAuthToken,
 } from '@/services/backend-client/oAuthApi';
+import { fetchTokens } from '@/services/backend-client/personalAccessTokenApi';
 import { IGitOauth } from '@/store/GitOauthConfig/types';
 import { createObject } from '@/store/helpers';
 import { selectDefaultNamespace } from '@/store/InfrastructureNamespaces/selectors';
@@ -141,12 +142,38 @@ export const actionCreators: ActionCreators = {
       const providersWithToken: api.GitOauthProvider[] = [];
       try {
         const supportedGitOauth = await getOAuthProviders();
+
+        const defaultKubernetesNamespace = selectDefaultNamespace(getState());
+        const tokens = await fetchTokens(defaultKubernetesNamespace.name);
+
         const promises: Promise<void>[] = [];
-        for (const { name } of supportedGitOauth) {
+        for (const gitOauth of supportedGitOauth) {
           promises.push(
-            getOAuthToken(name).then(() => {
-              providersWithToken.push(name);
-            }),
+            getOAuthToken(gitOauth.name)
+              .then(() => {
+                providersWithToken.push(gitOauth.name);
+              })
+
+              .catch(() => {
+                const normalizedGitOauthEndpoint = gitOauth.endpointUrl.endsWith('/')
+                  ? gitOauth.endpointUrl.slice(0, -1)
+                  : gitOauth.endpointUrl;
+
+                for (const token of tokens) {
+                  const normalizedTokenGitProviderEndpoint = token.gitProviderEndpoint.endsWith('/')
+                    ? token.gitProviderEndpoint.slice(0, -1)
+                    : token.gitProviderEndpoint;
+
+                  // compare Git OAuth Endpoint url ONLY with OAuth tokens
+                  if (
+                    token.gitProvider.startsWith('oauth2') &&
+                    normalizedGitOauthEndpoint === normalizedTokenGitProviderEndpoint
+                  ) {
+                    providersWithToken.push(gitOauth.name);
+                    break;
+                  }
+                }
+              }),
           );
         }
         promises.push(dispatch(actionCreators.requestSkipAuthorizationProviders()));


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
chore: show authorized git services based on existed OAuth token secrets

### Reference issue 
https://github.com/eclipse/che/issues/22631

### Related PR
https://github.com/eclipse-che/che-server/pull/608

![screenshot-192 168 59 254 nip io-2023 11 14-12_54_36](https://github.com/eclipse-che/che-dashboard/assets/1640675/10b33596-264c-4241-930c-8f08cd2b46f3)
