### PR TITLE
Do not throw other then unauthorised error on token refresh

### DIFF
--- a/packages/dashboard-frontend/src/services/oauth/index.ts
+++ b/packages/dashboard-frontend/src/services/oauth/index.ts
@@ -62,8 +62,8 @@ export default class OAuthService {
           response.data.attributes.oauth_authentication_url,
           redirectUrl.toString(),
         );
+        throw e;
       }
-      throw e;
     }
   }
 }

--- a/packages/dashboard-frontend/src/services/oauth/index.ts
+++ b/packages/dashboard-frontend/src/services/oauth/index.ts
@@ -62,8 +62,10 @@ export default class OAuthService {
           response.data.attributes.oauth_authentication_url,
           redirectUrl.toString(),
         );
+        // Interrupt the workspace start. The workspace should start again after the authentication.
         throw e;
       }
+      // Skip other exceptions to proceed the workspace start.
     }
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Do not throw exceptions other then unauthorised exception on token refresh request when starting a workspace.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5015

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Make sure GitHub oauth is **NOT** configured
2. Start a workspace from a public GitHub repository.
3. Stop the workspace and start it again.

See: workspace starts without any issues.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
