### PR TITLE
chore: Use https://bitbucket.org as default server endpoint url for PAT

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/index.tsx
@@ -14,7 +14,7 @@ import { api } from '@eclipse-che/common';
 import { Form } from '@patternfly/react-core';
 import React from 'react';
 
-import { DEFAULT_GIT_PROVIDER, PROVIDER_ENDPOINTS } from '@/pages/UserPreferences/const';
+import { DEFAULT_GIT_PROVIDER, GIT_PROVIDER_ENDPOINTS } from '@/pages/UserPreferences/const';
 import { GitProviderEndpoint } from '@/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint';
 import { GitProviderOrganization } from '@/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization';
 import { GitProviderSelector } from '@/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector';
@@ -54,7 +54,7 @@ export class AddEditModalForm extends React.PureComponent<Props, State> {
 
     this.state = {
       gitProvider,
-      defaultGitProviderEndpoint: PROVIDER_ENDPOINTS[DEFAULT_GIT_PROVIDER],
+      defaultGitProviderEndpoint: GIT_PROVIDER_ENDPOINTS[DEFAULT_GIT_PROVIDER],
       gitProviderEndpoint,
       // next field is initially valid because a default value should be used instead of an empty string
       gitProviderEndpointIsValid: true,
@@ -115,7 +115,7 @@ export class AddEditModalForm extends React.PureComponent<Props, State> {
   private handleChangeGitProvider(gitProvider: api.GitProvider): void {
     this.updateChangeToken({
       gitProvider,
-      defaultGitProviderEndpoint: PROVIDER_ENDPOINTS[gitProvider],
+      defaultGitProviderEndpoint: GIT_PROVIDER_ENDPOINTS[gitProvider],
     });
   }
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
@@ -36,11 +36,9 @@ export const GIT_PROVIDERS: Record<api.GitProvider, string> = {
 
 export const DEFAULT_GIT_PROVIDER: api.GitProvider = 'github';
 
-export const PROVIDER_ENDPOINTS: Record<api.GitOauthProvider | api.GitProvider, string> = {
+export const GIT_PROVIDER_ENDPOINTS: Record<api.GitProvider, string> = {
   'azure-devops': 'https://dev.azure.com',
-  'bitbucket-server': '',
-  bitbucket: '',
+  'bitbucket-server': 'https://bitbucket.org',
   github: 'https://github.com',
-  github_2: 'https://github.com',
   gitlab: 'https://gitlab.com',
 } as const;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
chore: Use https://bitbucket.org as default server endpoint url for PAT

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5291

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
N/A

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
