### PR TITLE
fix: don't inject ENVs into devworkspace

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -208,22 +208,7 @@ export class DevWorkspaceClient {
 
   async updateDevWorkspace(
     devWorkspace: devfileApi.DevWorkspace,
-    pluginRegistryUrl: string | undefined,
-    pluginRegistryInternalUrl: string | undefined,
-    openVSXUrl: string | undefined,
-    clusterConsole?: {
-      url: string;
-      title: string;
-    },
   ): Promise<{ headers: DwApi.Headers; devWorkspace: devfileApi.DevWorkspace }> {
-    this.addEnvVarsToContainers(
-      devWorkspace.spec.template.components,
-      pluginRegistryUrl,
-      pluginRegistryInternalUrl,
-      openVSXUrl,
-      clusterConsole,
-    );
-
     return await DwApi.patchWorkspace(devWorkspace.metadata.namespace, devWorkspace.metadata.name, [
       {
         op: 'replace',

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -584,10 +584,6 @@ export const actionCreators: ActionCreators = {
 
         const updateResp = await getDevWorkspaceClient().updateDevWorkspace(
           createResp.devWorkspace,
-          pluginRegistryUrl,
-          pluginRegistryInternalUrl,
-          openVSXUrl,
-          clusterConsole,
         );
 
         if (updateResp.headers.warning) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Don't inject additional environment variables into each component in DevWorkspace.

We still adding ENVs into DevWorkspaceTemplate and when devworkspace-operator merges DevWorkspace and DevWorkspaceTemplate, it'll add ENVs from DWT to the main development container.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22614

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
It was tested on OS cluster with custom dashboard image: [quay.io/vsvydenk/che-dashboard:no-env2](url)

I've checked that an **original.devworkspace.yaml** doesn't contain additional ENV's but flattened.devworkspace.yaml does (they were added from the DevWorkspaceTemplate that defines the editor):
 
![screenshot-eclipse-che apps ci-ln-b3g13l2-76ef8 aws-2 ci openshift [org-2023](https://issues.redhat.com//browse/org-2023) 11 21-14_39_47](https://github.com/eclipse-che/che-dashboard/assets/1271546/f221b307-50b2-467c-9b00-a29af0b1b31d)

I see that ENV's are present in the main development container:
![screenshot-eclipse-che apps ci-ln-b3g13l2-76ef8 aws-2 ci openshift [org-2023](https://issues.redhat.com//browse/org-2023) 11 21-14_41_56](https://github.com/eclipse-che/che-dashboard/assets/1271546/1332e5c9-55ef-43e2-98c1-ae4c16cd1712)

Also I've tried to restart the workspace using a local devfile.yaml and it works as well.
 
**For reviewers:**
- deploy Che and override dashboard image with an image from this pr (quay.io/eclipse/che-dashboard:pr-998)
- check workspace starting
- check possibility to install plugins from openvsx.org and embedded plugin registries
- check **Restart Workspace from Local Devfile** action from IDE
- check **Open Dashboard** action from IDE
- check **Open OpenShift Console** action from IDE