### PR TITLE
increase the axios request timeout

### DIFF
--- a/packages/dashboard-frontend/src/services/axios-wrapper/getAxiosInstance.ts
+++ b/packages/dashboard-frontend/src/services/axios-wrapper/getAxiosInstance.ts
@@ -17,7 +17,7 @@ class CheAxiosInstance {
   private readonly axiosInstance: AxiosInstance;
 
   private constructor() {
-    this.axiosInstance = axios.create({ timeout: 5000 });
+    this.axiosInstance = axios.create({ timeout: 15000 });
   }
 
   public static getInstance(): CheAxiosInstance {

--- a/packages/dashboard-frontend/src/store/SanityCheck/index.ts
+++ b/packages/dashboard-frontend/src/store/SanityCheck/index.ts
@@ -27,7 +27,7 @@ import { createObject } from '@/store/helpers';
 
 import { AppThunk } from '..';
 
-const secToStale = 5;
+const secToStale = 15;
 const timeToStale = secToStale * 1000;
 const maxAttemptsNumber = 2;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Increase the timeout in order to not to repeat the `provisionKubernetesNamespace` requests when che-server executes the provision request lasts less then 15 sec.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5338

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy che with the custom image: quay.io/ivinokur/che-server:[CRW-5338](https://issues.redhat.com//browse/CRW-5338). A delay is added to the GitHub user request.
2. Add a GitHub PAT token via the dashboard user preferences page.

see: The token item loads for a while, but finally appears in the list.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
