### PR TITLE
fix: Fixing wording for 'Authorized' / 'Unauthorized' placehoolders

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/__tests__/__snapshots__/ProviderIcon.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/__tests__/__snapshots__/ProviderIcon.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`ProviderIcon component snapshot for the provider not authorized yet 1`]
     />
   </svg>
   <span>
-    User has not been authorized yet.
+    Unauthorized
   </span>
 </div>
 `;
@@ -73,7 +73,7 @@ exports[`ProviderIcon component snapshot for the successfully authorized provide
     />
   </svg>
   <span>
-    User has been authorized successfully.
+    Authorized
   </span>
 </div>
 `;

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
@@ -77,7 +77,7 @@ export class ProviderIcon extends React.PureComponent<Props, State> {
     const { hasOauthToken, isSkipOauth } = this.state;
     if (hasOauthToken) {
       return (
-        <CheTooltip content={<span>User has been authorized successfully.</span>}>
+        <CheTooltip content={<span>Authorized</span>}>
           <CheckCircleIcon color="var(--pf-global--success-color--100)" />
         </CheTooltip>
       );
@@ -90,7 +90,7 @@ export class ProviderIcon extends React.PureComponent<Props, State> {
     }
 
     return (
-      <CheTooltip content={<span>User has not been authorized yet.</span>}>
+      <CheTooltip content={<span>Unauthorized</span>}>
         <ResourcesEmptyIcon color="var(--pf-global--disabled-color--100)" />
       </CheTooltip>
     );

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
@@ -204,7 +204,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 />
               </svg>
               <span>
-                User has been authorized successfully.
+                Authorized
               </span>
             </div>
           </td>
@@ -332,7 +332,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 />
               </svg>
               <span>
-                User has not been authorized yet.
+                Unauthorized
               </span>
             </div>
           </td>
@@ -460,7 +460,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 />
               </svg>
               <span>
-                User has not been authorized yet.
+                Unauthorized
               </span>
             </div>
           </td>
@@ -588,7 +588,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 />
               </svg>
               <span>
-                User has not been authorized yet.
+                Unauthorized
               </span>
             </div>
           </td>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fixing wording to 'Authorized' / 'Unauthorized' for the following placeholders which are considered misle:

<img width="585" alt="Screenshot 2023-11-23 at 15 53 20" src="https://github.com/eclipse-che/che-dashboard/assets/1461122/04e89d13-17e5-41c2-8940-516a35492879">


### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/22600

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
