### PR TITLE
Change the token data input type to password in the add/edit PAT popup

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/__snapshots__/index.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`TokenData snapshot w/o token data 1`] = `
     <div
       className="pf-c-form__group-control"
     >
-      <textarea
+      <input
         aria-describedby="token-data-label"
         aria-invalid={false}
         aria-label="Token"
@@ -34,7 +34,7 @@ exports[`TokenData snapshot w/o token data 1`] = `
         onChange={[Function]}
         placeholder="Enter a Token"
         required={false}
-        type="text"
+        type="password"
         value=""
       />
       

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/__snapshots__/index.spec.tsx.snap
@@ -31,7 +31,13 @@ exports[`TokenData snapshot w/o token data 1`] = `
         aria-invalid={false}
         aria-label="Token"
         className="pf-c-form-control"
+        data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe={true}
+        disabled={false}
+        onBlur={[Function]}
         onChange={[Function]}
+        onFocus={[Function]}
         placeholder="Enter a Token"
         required={false}
         type="password"
@@ -69,15 +75,21 @@ exports[`TokenData snapshot with token data 1`] = `
     <div
       className="pf-c-form__group-control"
     >
-      <textarea
+      <input
         aria-describedby="token-data-label"
         aria-invalid={false}
         aria-label="Token"
         className="pf-c-form-control"
+        data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe={true}
+        disabled={false}
+        onBlur={[Function]}
         onChange={[Function]}
+        onFocus={[Function]}
         placeholder="Replace Token"
         required={false}
-        type="text"
+        type="password"
         value=""
       />
       

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/index.spec.tsx
@@ -53,7 +53,7 @@ describe('TokenData', () => {
 
     expect(mockOnChange).not.toHaveBeenCalled();
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByPlaceholderText('Enter a Token');
 
     const tokenData = 'token-data';
     fireEvent.change(input, { target: { value: tokenData } });
@@ -67,7 +67,7 @@ describe('TokenData', () => {
 
     expect(mockOnChange).not.toHaveBeenCalled();
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByPlaceholderText('Enter a Token');
 
     // fill the token data field
     const tokenData = 'token-data';

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/index.tsx
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, TextArea, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
+import { FormGroup, TextInput, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
 import React from 'react';
 
 const REQUIRED_ERROR = 'This field is required.';
@@ -71,12 +71,12 @@ export class TokenData extends React.PureComponent<Props, State> {
         label="Token"
         validated={validated}
       >
-        <TextArea
+        <TextInput
           aria-describedby="token-data-label"
           aria-label="Token"
           onChange={tokenData => this.onChange(tokenData)}
           placeholder={placeholder}
-          type={TextInputTypes.text}
+          type={TextInputTypes.password}
           value={tokenData}
         />
       </FormGroup>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Hide the token input in the PAT popup with a password input type:
![screenshot-eclipse-che apps rosa gx976-76x7c-y6f kjuu p3 openshiftapps com-2023 11 28-10_20_13](https://github.com/eclipse-che/che-dashboard/assets/7668752/3f02b953-7bd2-4f43-967b-5bdfc1d2aeff)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5335

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Go to the **User Preferences** -> **Personal Access Tokens** tab and add a new token or edit existed.
See: the token input is hidden.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
