### PR TITLE
Changes to the workspace status indicator to fix the happy-path test

### DIFF
--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Workspace indicator component Che Workspaces should render ERROR status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is ERROR"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -40,6 +41,7 @@ exports[`Workspace indicator component Che Workspaces should render ERROR status
 exports[`Workspace indicator component Che Workspaces should render RUNNING status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is RUNNING"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -77,6 +79,7 @@ exports[`Workspace indicator component Che Workspaces should render RUNNING stat
 exports[`Workspace indicator component Che Workspaces should render STARTING status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is STARTING"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -115,6 +118,7 @@ exports[`Workspace indicator component Che Workspaces should render STARTING sta
 exports[`Workspace indicator component Che Workspaces should render STOPPED status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is STOPPED"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -122,7 +126,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPED stat
       className="pf-c-icon pf-m-inline"
     >
       <span
-        className="pf-c-icon__content"
+        className="pf-c-icon__content pf-m-default"
       >
         <svg
           aria-hidden="true"
@@ -158,6 +162,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPED stat
 exports[`Workspace indicator component Che Workspaces should render STOPPING status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is STOPPING"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -165,7 +170,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPING sta
       className="pf-c-icon pf-m-inline"
     >
       <span
-        className="pf-c-icon__content"
+        className="pf-c-icon__content pf-m-default"
       >
         <svg
           aria-hidden={true}
@@ -196,6 +201,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPING sta
 exports[`Workspace indicator component Deprecated workspaces should render "Deprecated" status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is Deprecated"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -233,6 +239,7 @@ exports[`Workspace indicator component Deprecated workspaces should render "Depr
 exports[`Workspace indicator component DevWorkspaces should render FAILED status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is Failed"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -270,6 +277,7 @@ exports[`Workspace indicator component DevWorkspaces should render FAILED status
 exports[`Workspace indicator component DevWorkspaces should render FAILING status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is Failing"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -308,6 +316,7 @@ exports[`Workspace indicator component DevWorkspaces should render FAILING statu
 exports[`Workspace indicator component DevWorkspaces should render RUNNING status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is Running"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -345,6 +354,7 @@ exports[`Workspace indicator component DevWorkspaces should render RUNNING statu
 exports[`Workspace indicator component DevWorkspaces should render STOPPED status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is Stopped"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -352,7 +362,7 @@ exports[`Workspace indicator component DevWorkspaces should render STOPPED statu
       className="pf-c-icon pf-m-inline"
     >
       <span
-        className="pf-c-icon__content"
+        className="pf-c-icon__content pf-m-default"
       >
         <svg
           aria-hidden="true"
@@ -388,6 +398,7 @@ exports[`Workspace indicator component DevWorkspaces should render STOPPED statu
 exports[`Workspace indicator component should render default status correctly 1`] = `
 <div>
   <span
+    aria-label="Workspace status is STOPPING"
     className="statusIndicator"
     data-testid="workspace-status-indicator"
   >
@@ -395,7 +406,7 @@ exports[`Workspace indicator component should render default status correctly 1`
       className="pf-c-icon pf-m-inline"
     >
       <span
-        className="pf-c-icon__content"
+        className="pf-c-icon__content pf-m-default"
       >
         <svg
           aria-hidden={true}

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
@@ -35,7 +35,11 @@ export class WorkspaceStatusIndicator extends React.PureComponent<Props> {
 
     return (
       <CheTooltip content={tooltip}>
-        <span className={styles.statusIndicator} data-testid="workspace-status-indicator">
+        <span
+          className={styles.statusIndicator}
+          data-testid="workspace-status-indicator"
+          aria-label={`Workspace status is ${status}`}
+        >
           {icon}
         </span>
       </CheTooltip>

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Label/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Label/__tests__/__snapshots__/index.spec.tsx.snap
@@ -105,7 +105,7 @@ exports[`The workspace status label component Che Workspaces should render STOPP
           className="pf-c-icon pf-m-inline"
         >
           <span
-            className="pf-c-icon__content"
+            className="pf-c-icon__content pf-m-default"
           >
             <svg
               aria-hidden="true"
@@ -337,7 +337,7 @@ exports[`The workspace status label component DevWorkspaces should render STOPPE
           className="pf-c-icon pf-m-inline"
         >
           <span
-            className="pf-c-icon__content"
+            className="pf-c-icon__content pf-m-default"
           >
             <svg
               aria-hidden="true"
@@ -388,7 +388,7 @@ exports[`The workspace status label component should render default status corre
           className="pf-c-icon pf-m-inline"
         >
           <span
-            className="pf-c-icon__content"
+            className="pf-c-icon__content pf-m-default"
           >
             <svg
               aria-hidden={true}

--- a/packages/dashboard-frontend/src/components/Workspace/Status/getStatusIcon.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/getStatusIcon.tsx
@@ -28,7 +28,7 @@ export function getStatusIcon(status: string) {
     case DevWorkspaceStatus.STOPPED:
     case WorkspaceStatus.STOPPED:
       icon = (
-        <Icon isInline>
+        <Icon status="default" isInline>
           <StoppedIcon />
         </Icon>
       );
@@ -67,7 +67,7 @@ export function getStatusIcon(status: string) {
       break;
     default:
       icon = (
-        <Icon isInline>
+        <Icon status="default" isInline>
           <InProgressIcon className={styles.rotate} color={greyCssVariable} />
         </Icon>
       );


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Adds `aria-label` attr with the workspace's current status to the workspace status icon.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/22698
