### PR TITLE
fix: read index from the remote registry

### DIFF
--- a/packages/dashboard-backend/src/app.ts
+++ b/packages/dashboard-backend/src/app.ts
@@ -23,6 +23,7 @@ import { registerSwagger } from '@/plugins/swagger';
 import { registerWebSocket } from '@/plugins/webSocket';
 import { registerClusterConfigRoute } from '@/routes/api/clusterConfig';
 import { registerClusterInfoRoute } from '@/routes/api/clusterInfo';
+import { registerDataResolverRoute } from '@/routes/api/dataResolver';
 import { registerDevworkspaceResourcesRoute } from '@/routes/api/devworkspaceResources';
 import { registerDevworkspacesRoutes } from '@/routes/api/devworkspaces';
 import { registerDevWorkspaceTemplates } from '@/routes/api/devworkspaceTemplates';
@@ -39,7 +40,6 @@ import { registerSShKeysRoutes } from '@/routes/api/sshKeys';
 import { registerUserProfileRoute } from '@/routes/api/userProfile';
 import { registerWebsocket } from '@/routes/api/websocket';
 import { registerWorkspacePreferencesRoute } from '@/routes/api/workspacePreferences';
-import { registerYamlResolverRoute } from '@/routes/api/yamlResolver';
 import { registerFactoryAcceptanceRedirect } from '@/routes/factoryAcceptanceRedirect';
 import { registerWorkspaceRedirect } from '@/routes/workspaceRedirect';
 
@@ -107,7 +107,7 @@ export default async function buildApp(server: FastifyInstance): Promise<unknown
 
     registerUserProfileRoute(server),
 
-    registerYamlResolverRoute(server),
+    registerDataResolverRoute(server),
 
     registerDevworkspaceResourcesRoute(server),
 

--- a/packages/dashboard-backend/src/constants/examples.ts
+++ b/packages/dashboard-backend/src/constants/examples.ts
@@ -32,6 +32,12 @@ export const dockerConfigExample = {
   },
 };
 
+export const dataResolverSchemaExample = {
+  get url() {
+    return 'http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json';
+  },
+};
+
 export const devWorkspaceResourcesExample = {
   get devfileContent() {
     const devfile = {

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -12,7 +12,7 @@
 
 import { JSONSchema7 } from 'json-schema';
 
-import { devWorkspaceResourcesExample, dockerConfigExample } from '@/constants/examples';
+import { devWorkspaceResourcesExample, dockerConfigExample, dataResolverSchemaExample } from '@/constants/examples';
 
 export const authenticationHeaderSchema: JSONSchema7 = {
   type: 'object',
@@ -178,7 +178,7 @@ export const devfileVersionSchema: JSONSchema7 = {
   required: ['version'],
 };
 
-export const yamlResolverSchema: JSONSchema7 = {
+export const dataResolverSchema: JSONSchema7 = {
   type: 'object',
   properties: {
     url: {
@@ -187,6 +187,7 @@ export const yamlResolverSchema: JSONSchema7 = {
     },
   },
   required: ['url'],
+  examples: [dataResolverSchemaExample],
 };
 
 export const devWorkspaceResourcesSchema: JSONSchema7 = {

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -12,7 +12,11 @@
 
 import { JSONSchema7 } from 'json-schema';
 
-import { devWorkspaceResourcesExample, dockerConfigExample, dataResolverSchemaExample } from '@/constants/examples';
+import {
+  dataResolverSchemaExample,
+  devWorkspaceResourcesExample,
+  dockerConfigExample,
+} from '@/constants/examples';
 
 export const authenticationHeaderSchema: JSONSchema7 = {
   type: 'object',

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -16,16 +16,15 @@ import { baseApiPath } from '@/constants/config';
 import { axiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
 import { setup, teardown } from '@/utils/appBuilder';
 
-jest.mock('../helpers/getDevWorkspaceClient.ts');
-jest.mock('../helpers/getToken.ts');
+jest.mock('@/routes/api/helpers/getDevWorkspaceClient.ts');
+jest.mock('@/routes/api/helpers/getToken.ts');
 
 jest.mock('@/routes/api/helpers/getCertificateAuthority');
 const getAxiosInstanceMock = jest.fn();
 (axiosInstance.get as jest.Mock).mockImplementation(getAxiosInstanceMock);
 
-describe('Server Config Route', () => {
+describe('Data Resolver Route', () => {
   let app: FastifyInstance;
-  const namespace = 'user-che';
 
   beforeAll(async () => {
     app = await setup();
@@ -45,7 +44,7 @@ describe('Server Config Route', () => {
 
       const res = await app
         .inject()
-        .post(`${baseApiPath}/namespace/${namespace}/data/resolver`)
+        .post(`${baseApiPath}/data/resolver`)
         .payload({ url: 'https://devfile.yaml' });
 
       expect(res.statusCode).toEqual(200);
@@ -61,7 +60,7 @@ describe('Server Config Route', () => {
 
       const res = await app
         .inject()
-        .post(`${baseApiPath}/namespace/${namespace}/data/resolver`)
+        .post(`${baseApiPath}/data/resolver`)
         .payload({ url: 'https://devfile.yaml' });
 
       expect(res.statusCode).toEqual(404);

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -34,7 +34,7 @@ describe('Data Resolver Route', () => {
     teardown(app);
   });
 
-  describe('POST ${baseApiPath}/namespace/:namespace/data/resolver', () => {
+  describe('POST ${baseApiPath}/data/resolver', () => {
     test('file exists', async () => {
       const devfileContent = 'devfile content';
       getAxiosInstanceMock.mockResolvedValue({

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -35,7 +35,7 @@ describe('Server Config Route', () => {
     teardown(app);
   });
 
-  describe('POST ${baseApiPath}/namespace/:namespace/yaml/resolver', () => {
+  describe('POST ${baseApiPath}/namespace/:namespace/data/resolver', () => {
     test('file exists', async () => {
       const devfileContent = 'devfile content';
       getAxiosInstanceMock.mockResolvedValue({
@@ -45,7 +45,7 @@ describe('Server Config Route', () => {
 
       const res = await app
         .inject()
-        .post(`${baseApiPath}/namespace/${namespace}/yaml/resolver`)
+        .post(`${baseApiPath}/namespace/${namespace}/data/resolver`)
         .payload({ url: 'https://devfile.yaml' });
 
       expect(res.statusCode).toEqual(200);
@@ -61,7 +61,7 @@ describe('Server Config Route', () => {
 
       const res = await app
         .inject()
-        .post(`${baseApiPath}/namespace/${namespace}/yaml/resolver`)
+        .post(`${baseApiPath}/namespace/${namespace}/data/resolver`)
         .payload({ url: 'https://devfile.yaml' });
 
       expect(res.statusCode).toEqual(404);

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -14,7 +14,7 @@ import { helpers } from '@eclipse-che/common';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import { baseApiPath } from '@/constants/config';
-import { namespacedSchema, yamlResolverSchema } from '@/constants/schemas';
+import { namespacedSchema, dataResolverSchema } from '@/constants/schemas';
 import { restParams } from '@/models';
 import { axiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
 import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
@@ -27,7 +27,7 @@ export function registerDataResolverRoute(instance: FastifyInstance) {
   instance.register(async server => {
     server.post(
       `${baseApiPath}/namespace/:namespace/data/resolver`,
-      getSchema({ tags, params: namespacedSchema, body: yamlResolverSchema }),
+      getSchema({ tags, params: namespacedSchema, body: dataResolverSchema }),
       async function (request: FastifyRequest, reply: FastifyReply): Promise<string | void> {
         const { url } = request.body as restParams.IYamlResolverParams;
         const { namespace } = request.params as restParams.INamespacedParams;

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -21,12 +21,12 @@ import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClien
 import { getToken } from '@/routes/api/helpers/getToken';
 import { getSchema } from '@/services/helpers';
 
-const tags = ['Yaml Resolver'];
+const tags = ['Data Resolver'];
 
-export function registerYamlResolverRoute(instance: FastifyInstance) {
+export function registerDataResolverRoute(instance: FastifyInstance) {
   instance.register(async server => {
     server.post(
-      `${baseApiPath}/namespace/:namespace/yaml/resolver`,
+      `${baseApiPath}/namespace/:namespace/data/resolver`,
       getSchema({ tags, params: namespacedSchema, body: yamlResolverSchema }),
       async function (request: FastifyRequest, reply: FastifyReply): Promise<string | void> {
         const { url } = request.body as restParams.IYamlResolverParams;

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -14,7 +14,7 @@ import { helpers } from '@eclipse-che/common';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import { baseApiPath } from '@/constants/config';
-import { namespacedSchema, dataResolverSchema } from '@/constants/schemas';
+import { dataResolverSchema, namespacedSchema } from '@/constants/schemas';
 import { restParams } from '@/models';
 import { axiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
 import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -10,15 +10,12 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { helpers } from '@eclipse-che/common';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import { baseApiPath } from '@/constants/config';
-import { dataResolverSchema, namespacedSchema } from '@/constants/schemas';
+import { dataResolverSchema } from '@/constants/schemas';
 import { restParams } from '@/models';
 import { axiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
-import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
-import { getToken } from '@/routes/api/helpers/getToken';
 import { getSchema } from '@/services/helpers';
 
 const tags = ['Data Resolver'];
@@ -26,20 +23,10 @@ const tags = ['Data Resolver'];
 export function registerDataResolverRoute(instance: FastifyInstance) {
   instance.register(async server => {
     server.post(
-      `${baseApiPath}/namespace/:namespace/data/resolver`,
-      getSchema({ tags, params: namespacedSchema, body: dataResolverSchema }),
+      `${baseApiPath}/data/resolver`,
+      getSchema({ tags, body: dataResolverSchema }),
       async function (request: FastifyRequest, reply: FastifyReply): Promise<string | void> {
         const { url } = request.body as restParams.IYamlResolverParams;
-        const { namespace } = request.params as restParams.INamespacedParams;
-        const token = getToken(request);
-        const { dockerConfigApi } = getDevWorkspaceClient(token);
-
-        try {
-          // check user permissions
-          await dockerConfigApi.read(namespace);
-        } catch (e) {
-          throw new Error(`User permissions error. ${helpers.errors.getMessage(e)}`);
-        }
 
         const response = await axiosInstance.get(url, {
           headers: {

--- a/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
+++ b/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
@@ -56,7 +56,7 @@ describe('Workspace creation time', () => {
   const mockPost = mockAxios.post as jest.Mock;
 
   let execTime: number;
-  let execTimer: number | undefined = undefined;
+  let execTimer: number;
 
   beforeEach(() => {
     execTime = 0;

--- a/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
@@ -1,4 +1,3 @@
-
 .statusLabel {
   text-transform: capitalize;
 }
@@ -10,7 +9,6 @@
 .statusIndicator svg {
   overflow: visible;
 }
-
 
 svg.rotate {
   width: 17px;

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import common from '@eclipse-che/common';
+import mockAxios, { AxiosError } from 'axios';
+
+import { getDataResolver } from '@/services/backend-client/dataResolverApi';
+
+describe('Data Resolver API', () => {
+  const mockPost = mockAxios.post as jest.Mock;
+
+  const userNamespace = 'test-namespace';
+  const registryLocation = 'http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json';
+  const metaData: che.DevfileMetaData[] = [
+    {
+      displayName: 'Empty Workspace',
+      description:
+        'Start an empty remote development environment and create files or clone a git repository afterwards',
+      tags: ['Empty'],
+      icon: '/images/empty.svg',
+      links: {
+        v2: '/devfiles/empty.yaml',
+      },
+    },
+  ];
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('resolve registry metadata', () => {
+    it('should call "//dashboard/api/namespace/test-namespace/data/resolver"', async () => {
+      mockPost.mockResolvedValueOnce({
+        data: metaData,
+      });
+      const data = await getDataResolver(userNamespace, registryLocation);
+
+      expect(mockPost).toBeCalledWith('/dashboard/api/namespace/test-namespace/data/resolver', {
+        url: 'http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json',
+      });
+      expect(data).toEqual(metaData);
+    });
+
+    it('should return an error message', async () => {
+      mockPost.mockRejectedValueOnce({
+        isAxiosError: true,
+        code: '500',
+        message: 'Something unexpected happened.',
+      } as AxiosError);
+      let errorMessage: string | undefined;
+      try {
+        await getDataResolver(userNamespace, registryLocation);
+      } catch (err) {
+        errorMessage = common.helpers.errors.getMessage(err);
+      }
+
+      expect(errorMessage).toEqual('Failed to fetch data resolver. Something unexpected happened.');
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
@@ -18,7 +18,6 @@ import { getDataResolver } from '@/services/backend-client/dataResolverApi';
 describe('Data Resolver API', () => {
   const mockPost = mockAxios.post as jest.Mock;
 
-  const userNamespace = 'test-namespace';
   const registryLocation = 'http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json';
   const metaData: che.DevfileMetaData[] = [
     {
@@ -38,13 +37,13 @@ describe('Data Resolver API', () => {
   });
 
   describe('resolve registry metadata', () => {
-    it('should call "//dashboard/api/namespace/test-namespace/data/resolver"', async () => {
+    it('should call "/dashboard/api/data/resolver"', async () => {
       mockPost.mockResolvedValueOnce({
         data: metaData,
       });
-      const data = await getDataResolver(userNamespace, registryLocation);
+      const data = await getDataResolver(registryLocation);
 
-      expect(mockPost).toBeCalledWith('/dashboard/api/namespace/test-namespace/data/resolver', {
+      expect(mockPost).toBeCalledWith('/dashboard/api/data/resolver', {
         url: 'http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json',
       });
       expect(data).toEqual(metaData);
@@ -52,18 +51,17 @@ describe('Data Resolver API', () => {
 
     it('should return an error message', async () => {
       mockPost.mockRejectedValueOnce({
-        isAxiosError: true,
         code: '500',
         message: 'Something unexpected happened.',
       } as AxiosError);
       let errorMessage: string | undefined;
       try {
-        await getDataResolver(userNamespace, registryLocation);
+        await getDataResolver(registryLocation);
       } catch (err) {
         errorMessage = common.helpers.errors.getMessage(err);
       }
 
-      expect(errorMessage).toEqual('Failed to fetch data resolver. Something unexpected happened.');
+      expect(errorMessage).toEqual('Failed to resolve data. Something unexpected happened.');
     });
   });
 });

--- a/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
@@ -26,6 +26,6 @@ export async function getDataResolver<T>(namespace: string, location: string): P
 
     return response?.data;
   } catch (e) {
-    throw new Error(`Failed to fetch data resolver'. ${helpers.errors.getMessage(e)}`);
+    throw new Error(`Failed to fetch data resolver. ${helpers.errors.getMessage(e)}`);
   }
 }

--- a/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { helpers } from '@eclipse-che/common';
+import axios from 'axios';
+
+import { dashboardBackendPrefix } from '@/services/backend-client/const';
+
+export async function getDataResolver<T>(namespace: string, location: string): Promise<T> {
+  try {
+    const response = await axios.post<T>(
+      `${dashboardBackendPrefix}/namespace/${namespace}/data/resolver`,
+      {
+        url: location,
+      },
+    );
+
+    return response?.data;
+  } catch (e) {
+    throw new Error(`Failed to fetch data resolver'. ${helpers.errors.getMessage(e)}`);
+  }
+}

--- a/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
@@ -15,17 +15,14 @@ import axios from 'axios';
 
 import { dashboardBackendPrefix } from '@/services/backend-client/const';
 
-export async function getDataResolver<T>(namespace: string, location: string): Promise<T> {
+export async function getDataResolver<T>(location: string): Promise<T> {
   try {
-    const response = await axios.post<T>(
-      `${dashboardBackendPrefix}/namespace/${namespace}/data/resolver`,
-      {
-        url: location,
-      },
-    );
+    const response = await axios.post<T>(`${dashboardBackendPrefix}/data/resolver`, {
+      url: location,
+    });
 
     return response?.data;
   } catch (e) {
-    throw new Error(`Failed to fetch data resolver. ${helpers.errors.getMessage(e)}`);
+    throw new Error(`Failed to resolve data. ${helpers.errors.getMessage(e)}`);
   }
 }

--- a/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
@@ -18,16 +18,13 @@ import { dashboardBackendPrefix } from '@/services/backend-client/const';
 import devfileApi from '@/services/devfileApi';
 import { FactoryResolver } from '@/services/helpers/types';
 
-export async function getYamlResolver(
-  namespace: string,
-  location: string,
-): Promise<FactoryResolver> {
+export async function getYamlResolver(location: string): Promise<FactoryResolver> {
   try {
     const url = new URL(location);
     const response =
       url.origin === window.location.origin
         ? await axios.get(url.href)
-        : await axios.post(`${dashboardBackendPrefix}/namespace/${namespace}/data/resolver`, {
+        : await axios.post(`${dashboardBackendPrefix}/data/resolver`, {
             url: url.href,
           });
 
@@ -38,6 +35,6 @@ export async function getYamlResolver(
       links: [],
     };
   } catch (e) {
-    throw new Error(`Failed to fetch yaml resolver'. ${helpers.errors.getMessage(e)}`);
+    throw new Error(`Failed to resolve yaml'. ${helpers.errors.getMessage(e)}`);
   }
 }

--- a/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
@@ -27,7 +27,7 @@ export async function getYamlResolver(
     const response =
       url.origin === window.location.origin
         ? await axios.get(url.href)
-        : await axios.post(`${dashboardBackendPrefix}/namespace/${namespace}/yaml/resolver`, {
+        : await axios.post(`${dashboardBackendPrefix}/namespace/${namespace}/data/resolver`, {
             url: url.href,
           });
 

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -417,7 +417,7 @@ export default class Bootstrap {
   }
 
   private checkWorkspaceStopped(): void {
-    let stoppedWorkspace: Workspace | undefined = undefined;
+    let stoppedWorkspace: Workspace | undefined;
 
     try {
       stoppedWorkspace = this.workspaceStoppedDetector.checkWorkspaceStopped(this.store.getState());

--- a/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
+++ b/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
@@ -32,8 +32,8 @@ jest.mock('@/services/registry/fetchData', () => {
 const mockFetchRemoteData = jest.fn();
 jest.mock('@/services/backend-client/dataResolverApi', () => {
   return {
-    getDataResolver: async (namespace: string, href: string) => {
-      return mockFetchRemoteData(namespace, href);
+    getDataResolver: async (href: string) => {
+      return mockFetchRemoteData(href);
     },
   };
 });
@@ -66,7 +66,7 @@ describe('fetch registry metadata', () => {
       } as che.DevfileMetaData;
       mockFetchData.mockResolvedValue([metadata]);
 
-      const resolved = await fetchRegistryMetadata(baseUrl, false, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, false);
 
       expect(mockSessionStorageServiceGet).not.toHaveBeenCalled();
       expect(mockFetchData).toHaveBeenCalledTimes(1);
@@ -86,14 +86,14 @@ describe('fetch registry metadata', () => {
       mockFetchRemoteData.mockRejectedValueOnce(new Error('Unsupported index URL'));
       mockFetchRemoteData.mockResolvedValueOnce([]);
 
-      await fetchRegistryMetadata(baseUrl, true, 'test');
+      await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockFetchData).toBeCalledWith(
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(mockFetchRemoteData.mock.calls).toEqual([
-        ['test', `https://eclipse-che.github.io/che-devfile-registry/7.71.0/index`],
-        ['test', `https://eclipse-che.github.io/che-devfile-registry/7.71.0/devfiles/index.json`],
+        [`https://eclipse-che.github.io/che-devfile-registry/7.71.0/index`],
+        [`https://eclipse-che.github.io/che-devfile-registry/7.71.0/devfiles/index.json`],
       ]);
     });
 
@@ -110,13 +110,12 @@ describe('fetch registry metadata', () => {
       mockFetchRemoteData.mockResolvedValue([metadata]);
       mockSessionStorageServiceGet.mockReturnValue(undefined);
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData).toBeCalledWith(
-        `test`,
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
@@ -146,7 +145,6 @@ describe('fetch registry metadata', () => {
         const resolved = await fetchRegistryMetadata(
           `${baseUrl}/dashboard/api/getting-started-sample`,
           false,
-          'test',
         );
 
         expect(mockSessionStorageServiceGet).not.toHaveBeenCalled();
@@ -164,7 +162,7 @@ describe('fetch registry metadata', () => {
 
       let errorMessage: string | undefined;
       try {
-        await fetchRegistryMetadata(baseUrl, true, 'test');
+        await fetchRegistryMetadata(baseUrl, true);
       } catch (err) {
         errorMessage = common.helpers.errors.getMessage(err);
       }
@@ -173,8 +171,8 @@ describe('fetch registry metadata', () => {
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData.mock.calls).toEqual([
-        ['test', 'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index'],
-        ['test', 'https://eclipse-che.github.io/che-devfile-registry/7.71.0/devfiles/index.json'],
+        ['https://eclipse-che.github.io/che-devfile-registry/7.71.0/index'],
+        ['https://eclipse-che.github.io/che-devfile-registry/7.71.0/devfiles/index.json'],
       ]);
       expect(mockSessionStorageServiceUpdate).not.toHaveBeenCalled();
       expect(errorMessage).toEqual(
@@ -207,13 +205,12 @@ describe('fetch registry metadata', () => {
       ]);
       mockSessionStorageServiceGet.mockReturnValue(undefined);
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData).toBeCalledWith(
-        'test',
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(console.warn).toBeCalledTimes(2);
@@ -251,7 +248,7 @@ describe('fetch registry metadata', () => {
         }),
       );
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
@@ -283,13 +280,12 @@ describe('fetch registry metadata', () => {
         }),
       );
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData).toBeCalledWith(
-        'test',
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
@@ -321,12 +317,12 @@ describe('fetch registry metadata', () => {
       mockFetchRemoteData.mockResolvedValue([metadata]);
       mockSessionStorageServiceGet.mockReturnValue(undefined);
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('test', 'https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
@@ -346,7 +342,7 @@ describe('fetch registry metadata', () => {
 
       let errorMessage: string | undefined;
       try {
-        await fetchRegistryMetadata(baseUrl, true, 'test');
+        await fetchRegistryMetadata(baseUrl, true);
       } catch (err) {
         errorMessage = common.helpers.errors.getMessage(err);
       }
@@ -354,7 +350,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('test', 'https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
       expect(mockSessionStorageServiceUpdate).not.toHaveBeenCalled();
       expect(errorMessage).toEqual(
         'Failed to fetch devfiles metadata from registry URL: https://registry.devfile.io/, reason: Returned value is not array.',
@@ -386,12 +382,12 @@ describe('fetch registry metadata', () => {
       ]);
       mockSessionStorageServiceGet.mockReturnValue(undefined);
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('test', 'https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
       expect(console.warn).toBeCalledTimes(2);
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
@@ -427,7 +423,7 @@ describe('fetch registry metadata', () => {
         }),
       );
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
@@ -459,12 +455,12 @@ describe('fetch registry metadata', () => {
         }),
       );
 
-      const resolved = await fetchRegistryMetadata(baseUrl, true, 'test');
+      const resolved = await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('test', 'https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({

--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -12,10 +12,10 @@
 
 import common from '@eclipse-che/common';
 
+import { getDataResolver } from '@/services/backend-client/dataResolverApi';
 import { fetchData } from '@/services/registry/fetchData';
 import { isDevfileMetaData } from '@/services/registry/types';
 import SessionStorageService, { SessionStorageKey } from '@/services/session-storage';
-import { getDataResolver } from "@/services/backend-client/dataResolverApi";
 
 const EXPIRATION_TIME_FOR_STORED_METADATA = 60 * 60 * 1000; // expiration time in milliseconds
 

--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -142,7 +142,6 @@ export function getRegistryIndexLocations(registryUrl: string, isExternal: boole
 export async function fetchRegistryMetadata(
   registryUrl: string,
   isExternal: boolean,
-  namespace: string,
 ): Promise<che.DevfileMetaData[]> {
   try {
     const registryIndexLocations = getRegistryIndexLocations(registryUrl, isExternal);
@@ -159,7 +158,7 @@ export async function fetchRegistryMetadata(
         let data: che.DevfileMetaData[] | undefined = undefined;
         if (isExternal) {
           try {
-            data = await getDataResolver(namespace, location);
+            data = await getDataResolver(location);
           } catch (e) {
             console.error(`Failed to fetch data resolver for URL: ${location}, reason: ${e}`);
             data = await fetchData(location);

--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -155,7 +155,7 @@ export async function fetchRegistryMetadata(
     const devfileMetaDataArr: che.DevfileMetaData[] = [];
     for (const [index, location] of registryIndexLocations.entries()) {
       try {
-        let data: che.DevfileMetaData[] | undefined = undefined;
+        let data: che.DevfileMetaData[] | undefined;
         if (isExternal) {
           try {
             data = await getDataResolver(location);

--- a/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
@@ -298,7 +298,7 @@ describe('Workspace-client helpers', () => {
         optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({ inline: editor });
         const store = new FakeStoreBuilder().build();
 
-        let errorText: string | undefined = undefined;
+        let errorText: string | undefined;
 
         try {
           await getCustomEditor(
@@ -394,7 +394,7 @@ describe('Workspace-client helpers', () => {
             })
             .build();
 
-          let errorText: string | undefined = undefined;
+          let errorText: string | undefined;
           try {
             await getCustomEditor(
               pluginRegistryUrl,
@@ -490,7 +490,7 @@ describe('Workspace-client helpers', () => {
             })
             .build();
 
-          let errorText: string | undefined = undefined;
+          let errorText: string | undefined;
           try {
             await getCustomEditor(
               pluginRegistryUrl,

--- a/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
@@ -128,7 +128,7 @@ export async function getCustomEditor(
   dispatch: ThunkDispatch<AppState, unknown, KnownAction>,
   getState: () => AppState,
 ): Promise<string | undefined> {
-  let editorsDevfile: devfileApi.Devfile | undefined = undefined;
+  let editorsDevfile: devfileApi.Devfile | undefined;
 
   // do we have a custom editor specified in the repository ?
   const cheEditorYaml = optionalFilesContent[CHE_EDITOR_YAML_PATH]
@@ -139,8 +139,8 @@ export async function getCustomEditor(
     // check the content of cheEditor file
     console.debug('Using the repository .che/che-editor.yaml file', cheEditorYaml);
 
-    let repositoryEditorYaml: devfileApi.Devfile | undefined = undefined;
-    let repositoryEditorYamlUrl: string | undefined = undefined;
+    let repositoryEditorYaml: devfileApi.Devfile | undefined;
+    let repositoryEditorYamlUrl: string | undefined;
     // it's an inlined editor, use the inline content
     if (cheEditorYaml.inline) {
       console.debug('Using the inline content of the repository editor');

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
@@ -38,7 +38,7 @@ describe('Get Devfile by URL', () => {
   it('Should throw the "plugin registry URL is required" error message', async () => {
     const store = new FakeStoreBuilder().build();
 
-    let errorText: string | undefined = undefined;
+    let errorText: string | undefined;
     try {
       await getEditor('che-incubator/che-idea/next', store.dispatch, store.getState);
     } catch (e) {
@@ -51,7 +51,7 @@ describe('Get Devfile by URL', () => {
   it('Should throw the "failed to fetch editor yaml" error message', async () => {
     const store = new FakeStoreBuilder().build();
 
-    let errorText: string | undefined = undefined;
+    let errorText: string | undefined;
     try {
       await getEditor(
         'che-incubator/che-idea/next',

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
@@ -21,6 +21,7 @@ import { selectAsyncIsAuthorized, selectSanityCheckError } from '@/store/SanityC
 import { AUTHORIZED, SanityCheckAction } from '@/store/sanityCheckMiddleware';
 
 import { AppThunk } from '..';
+import { selectDefaultNamespace } from "@/store/InfrastructureNamespaces/selectors";
 
 export const DEFAULT_REGISTRY = '/dashboard/devfile-registry/';
 
@@ -156,7 +157,8 @@ export const actionCreators: ActionCreators = {
             const error = selectSanityCheckError(getState());
             throw new Error(error);
           }
-          const metadata: che.DevfileMetaData[] = await fetchRegistryMetadata(url, isExternal);
+          const namespace = selectDefaultNamespace(getState()).name;
+          const metadata: che.DevfileMetaData[] = await fetchRegistryMetadata(url, isExternal, namespace);
           if (!Array.isArray(metadata) || metadata.length === 0) {
             return;
           }

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
@@ -17,7 +17,6 @@ import devfileApi from '@/services/devfileApi';
 import { fetchDevfile, fetchRegistryMetadata } from '@/services/registry/devfiles';
 import { fetchResources, loadResourcesContent } from '@/services/registry/resources';
 import { createObject } from '@/store/helpers';
-import { selectDefaultNamespace } from '@/store/InfrastructureNamespaces/selectors';
 import { selectAsyncIsAuthorized, selectSanityCheckError } from '@/store/SanityCheck/selectors';
 import { AUTHORIZED, SanityCheckAction } from '@/store/sanityCheckMiddleware';
 
@@ -157,12 +156,7 @@ export const actionCreators: ActionCreators = {
             const error = selectSanityCheckError(getState());
             throw new Error(error);
           }
-          const namespace = selectDefaultNamespace(getState()).name;
-          const metadata: che.DevfileMetaData[] = await fetchRegistryMetadata(
-            url,
-            isExternal,
-            namespace,
-          );
+          const metadata: che.DevfileMetaData[] = await fetchRegistryMetadata(url, isExternal);
           if (!Array.isArray(metadata) || metadata.length === 0) {
             return;
           }

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
@@ -17,11 +17,11 @@ import devfileApi from '@/services/devfileApi';
 import { fetchDevfile, fetchRegistryMetadata } from '@/services/registry/devfiles';
 import { fetchResources, loadResourcesContent } from '@/services/registry/resources';
 import { createObject } from '@/store/helpers';
+import { selectDefaultNamespace } from '@/store/InfrastructureNamespaces/selectors';
 import { selectAsyncIsAuthorized, selectSanityCheckError } from '@/store/SanityCheck/selectors';
 import { AUTHORIZED, SanityCheckAction } from '@/store/sanityCheckMiddleware';
 
 import { AppThunk } from '..';
-import { selectDefaultNamespace } from "@/store/InfrastructureNamespaces/selectors";
 
 export const DEFAULT_REGISTRY = '/dashboard/devfile-registry/';
 
@@ -158,7 +158,11 @@ export const actionCreators: ActionCreators = {
             throw new Error(error);
           }
           const namespace = selectDefaultNamespace(getState()).name;
-          const metadata: che.DevfileMetaData[] = await fetchRegistryMetadata(url, isExternal, namespace);
+          const metadata: che.DevfileMetaData[] = await fetchRegistryMetadata(
+            url,
+            isExternal,
+            namespace,
+          );
           if (!Array.isArray(metadata) || metadata.length === 0) {
             return;
           }

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -397,7 +397,7 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).toBeCalledWith('user-che', location);
+      expect(getYamlResolverSpy).toBeCalledWith(location);
       expect(getFactoryResolverSpy).not.toBeCalledWith(location, {
         error_code: undefined,
       });
@@ -410,7 +410,7 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).toBeCalledWith('user-che', location);
+      expect(getYamlResolverSpy).toBeCalledWith(location);
       expect(getFactoryResolverSpy).not.toBeCalledWith(location, {
         error_code: undefined,
       });
@@ -423,7 +423,7 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).toBeCalledWith('user-che', location);
+      expect(getYamlResolverSpy).toBeCalledWith(location);
       expect(getFactoryResolverSpy).not.toBeCalledWith(location, {
         error_code: undefined,
       });
@@ -436,7 +436,7 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).not.toBeCalledWith('user-che', location);
+      expect(getYamlResolverSpy).not.toBeCalledWith(location);
       expect(getFactoryResolverSpy).toBeCalledWith(location, {
         error_code: undefined,
       });

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -172,7 +172,7 @@ export const actionCreators: ActionCreators = {
         }
         let data: FactoryResolver;
         if (isDevfileRegistryLocation(location)) {
-          data = await getYamlResolver(namespace, location);
+          data = await getYamlResolver(location);
         } else {
           data = await getFactoryResolver(location, overrideParams);
           const cheEditor = await grabLink(data.links, CHE_EDITOR_YAML_PATH);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixed reading metadata from `registry.devfile.io` deployed on the cluster.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22705
