### PR TITLE
Add attribute controller.devfile.io/bootstrap-devworkspace: true when Devfile resolution via API fails or is not supported

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
@@ -22,6 +22,9 @@ import { Action, Store } from 'redux';
 
 import ExpandableWarning from '@/components/ExpandableWarning';
 import { MIN_STEP_DURATION_MS } from '@/components/WorkspaceProgress/const';
+import CreatingStepApplyDevfile, {
+  State,
+} from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile';
 import { prepareDevfile } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile';
 import { ROUTE } from '@/Routes/routes';
 import getComponentRenderer from '@/services/__mocks__/getComponentRenderer';
@@ -38,13 +41,11 @@ import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 import { ActionCreators } from '@/store/Workspaces';
 
-import CreatingStepApplyDevfile, { State } from '..';
-
-jest.mock('../../../../TimeLimit');
-jest.mock('../prepareDevfile.ts');
+jest.mock('@/components/WorkspaceProgress/TimeLimit');
+jest.mock('@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile.ts');
 
 let mockCreateWorkspaceFromDevfile;
-jest.mock('../../../../../../store/Workspaces/index', () => {
+jest.mock('@/store/Workspaces/index', () => {
   return {
     actionCreators: {
       createWorkspaceFromDevfile:
@@ -228,6 +229,82 @@ describe('Creating steps, applying a devfile', () => {
           expect.objectContaining({
             attributes: {
               defaultDevfile: true,
+            },
+          }),
+          factoryId,
+          undefined,
+          false,
+        ),
+      );
+      await waitFor(() => expect(mockCreateWorkspaceFromDevfile).toHaveBeenCalled());
+    });
+
+    test('git+SHH URL', async () => {
+      const factoryUrl = 'git@github.com:user/repository-name.git';
+      const factoryId = `${FACTORY_URL_ATTR}=${factoryUrl}`;
+      const searchParams = new URLSearchParams({
+        [FACTORY_URL_ATTR]: factoryUrl,
+      });
+
+      const registryUrl = 'https://registry-url';
+      const sampleResourceUrl = 'https://resources-url';
+      const registryMetadata = {
+        displayName: 'Empty Workspace',
+        description: 'Start an empty remote development environment',
+        tags: ['Empty'],
+        icon: '/images/empty.svg',
+        links: {
+          v2: sampleResourceUrl,
+        },
+      } as che.DevfileMetaData;
+      const sampleContent = dump({
+        schemaVersion: '2.1.0',
+        metadata: {
+          generateName: 'empty',
+        },
+        attributes: {
+          defaultDevfile: true, // this is the default devfile
+        },
+      } as devfileApi.Devfile);
+      const defaultComponents = [
+        {
+          name: 'universal-developer-image',
+          container: {
+            image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+          },
+        },
+      ];
+
+      const store = getStoreBuilder()
+        .withFactoryResolver({ resolver: undefined, converted: undefined })
+        .withDevfileRegistries({
+          registries: {
+            [registryUrl]: {
+              metadata: [registryMetadata],
+            },
+          },
+          devfiles: {
+            [sampleResourceUrl]: {
+              content: sampleContent,
+            },
+          },
+        })
+        .withDwServerConfig({
+          defaults: {
+            components: defaultComponents,
+          },
+        } as api.IServerConfig)
+        .build();
+
+      renderComponent(store, searchParams);
+      jest.runAllTimers();
+
+      await waitFor(() =>
+        expect(prepareDevfile).toHaveBeenCalledWith(
+          expect.objectContaining({
+            attributes: {
+              defaultDevfile: true,
+              'controller.devfile.io/bootstrap-devworkspace': true,
             },
           }),
           factoryId,

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -30,6 +30,7 @@ import {
 import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
 import devfileApi from '@/services/devfileApi';
+import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 import {
   buildFactoryParams,
   FactoryParams,
@@ -178,6 +179,14 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
 
     // when using the default devfile instead of a user devfile
     if (factoryResolver === undefined && isEqual(devfile, defaultDevfile)) {
+      if (FactoryLocationAdapter.isSshLocation(factoryParams.sourceUrl)) {
+        if (!devfile.attributes) {
+          devfile.attributes = {};
+        }
+
+        devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
+      }
+
       if (devfile.projects === undefined) {
         devfile.projects = [];
       }
@@ -244,9 +253,6 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
           throw new Error('Failed to resolve the default devfile.');
         }
         const _devfile = cloneDeep(defaultDevfile);
-        if (!_devfile.attributes) {
-          _devfile.attributes = {};
-        }
         this.updateCurrentDevfile(_devfile);
       } else {
         try {
@@ -419,8 +425,8 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
     const { name, lastError, warning } = this.state;
 
     const isActive = distance === 0;
-    const isError = lastError !== undefined;
-    const isWarning = warning !== undefined;
+    const isError = false;
+    const isWarning = warning !== undefined || lastError !== undefined;
 
     return (
       <React.Fragment>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds the attribute `controller.devfile.io/bootstrap-devworkspace: true` when Devfile resolution via API fails or is not supported. 

### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/22697

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Eclipse Che and the dashboard image from this PR:
  ```sh
  kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {containers: [{image: "quay.io/eclipse/che-dashboard:pr-1016", name: che-dashboard}]}}]"
  ```
2. Add your SSH keys to the Dashboard, and make sure the public one is uploaded to your Git provider.
3. Copy the git+SSH URL of your git repository, and create a new workspace using this URL.
4. The workspace should start successfully with the project cloned and the Devfile applied.
