### PR TITLE
Do not throw an error on get workspace preferences request

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspacePreferencesApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspacePreferencesApi.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import * as mockClient from '@kubernetes/client-node';
+import { CustomObjectsApi } from '@kubernetes/client-node';
+
+import { DevWorkspacePreferencesApiService } from '@/devworkspaceClient/services/devWorkspacePreferencesApi';
+
+describe('DevWorkspace Preferences API Service', () => {
+  let devWorkspacePreferencesApiService: DevWorkspacePreferencesApiService;
+
+  const setup = (stubCustomObjectsApi: CustomObjectsApi) => {
+    const { KubeConfig } = mockClient;
+    const kubeConfig = new KubeConfig();
+
+    kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => stubCustomObjectsApi);
+
+    devWorkspacePreferencesApiService = new DevWorkspacePreferencesApiService(kubeConfig);
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('get skip-authorisation workspace preferences from empty configmap', async () => {
+    const stubCustomObjectsApi = {
+      readNamespacedConfigMap: () => {
+        return Promise.resolve({ body: {} });
+      },
+    } as unknown as CustomObjectsApi;
+    setup(stubCustomObjectsApi);
+    const res =
+      await devWorkspacePreferencesApiService.getWorkspacePreferences('skip-authorisation');
+    expect(res['skip-authorisation']).toEqual([]);
+  });
+
+  test('get skip-authorisation workspace preferences from configmap with empty skip-authorisation', async () => {
+    const stubCustomObjectsApi = {
+      readNamespacedConfigMap: () => {
+        return Promise.resolve({ body: { body: { data: { 'skip-authorisation': '[]' } } } });
+      },
+    } as unknown as CustomObjectsApi;
+    setup(stubCustomObjectsApi);
+    const res =
+      await devWorkspacePreferencesApiService.getWorkspacePreferences('skip-authorisation');
+    expect(res['skip-authorisation']).toEqual([]);
+  });
+
+  test('get skip-authorisation workspace preferences from configmap with skip-authorisation values', async () => {
+    const stubCustomObjectsApi = {
+      readNamespacedConfigMap: () => {
+        return Promise.resolve({
+          body: { data: { 'skip-authorisation': '[github, gitlab, bitbucket]' } },
+        });
+      },
+    } as unknown as CustomObjectsApi;
+    setup(stubCustomObjectsApi);
+    const res =
+      await devWorkspacePreferencesApiService.getWorkspacePreferences('skip-authorisation');
+    expect(res['skip-authorisation']).toEqual(['github', 'gitlab', 'bitbucket']);
+  });
+});

--- a/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspacePreferencesApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspacePreferencesApi.ts
@@ -39,14 +39,15 @@ export class DevWorkspacePreferencesApiService implements IDevWorkspacePreferenc
         namespace,
       );
       const data = response.body.data;
+      let skipAuthorization: string[];
       if (data === undefined) {
-        throw new Error('Data is empty');
+        skipAuthorization = [];
+      } else {
+        skipAuthorization =
+          data[SKIP_AUTHORIZATION_KEY] && data[SKIP_AUTHORIZATION_KEY] !== '[]'
+            ? data[SKIP_AUTHORIZATION_KEY].replace(/^\[/, '').replace(/\]$/, '').split(', ')
+            : [];
       }
-
-      const skipAuthorization =
-        data[SKIP_AUTHORIZATION_KEY] && data[SKIP_AUTHORIZATION_KEY] !== '[]'
-          ? data[SKIP_AUTHORIZATION_KEY].replace(/^\[/, '').replace(/\]$/, '').split(', ')
-          : [];
 
       return Object.assign({}, data, {
         [SKIP_AUTHORIZATION_KEY]: skipAuthorization,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Return an empty result instead of throwing an error, if an empty data is received from the `get workspace preferences` request.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22721

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Setup GitHub oauth config.
2. Start a workspace from the GitHub repository.
3. Open browser console.
4. Go to dashboard user preferences page -> Git Services.

See: no error is present in the browser console.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
