### PR TITLE
Align the git services skip-oauth flag with oauth-1 providers

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
@@ -66,7 +66,10 @@ export class ProviderIcon extends React.PureComponent<Props, State> {
   }
 
   private isSkipOauth(providerName: api.GitOauthProvider): boolean {
-    return this.props.skipOauthProviders.includes(providerName);
+    // Use includes filter to handle the bitbucket-server oauth 2 provider.
+    // The bitbucket server oauth2 provider name is 'bitbucket',
+    // but the corresponding 'skip oauth' item is 'bitbucket-server'.
+    return this.props.skipOauthProviders.some(s => s.includes(providerName));
   }
 
   private hasOauthToken(providerName: api.GitOauthProvider): boolean {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
@@ -73,7 +73,10 @@ export class ProviderIcon extends React.PureComponent<Props, State> {
   }
 
   private hasOauthToken(providerName: api.GitOauthProvider): boolean {
-    return this.props.providersWithToken.includes(providerName);
+    // Use includes filter to handle the bitbucket-server oauth 2 provider.
+    // The bitbucket server oauth2 provider name is 'bitbucket',
+    // but the corresponding 'provider with token' item is 'bitbucket-server'.
+    return this.props.providersWithToken.some(p => p.includes(providerName));
   }
 
   public render(): React.ReactElement {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
   >
     <div
       className="pf-c-toolbar pf-m-page-insets"
-      data-ouia-component-id="OUIA-Generated-Toolbar-2"
+      data-ouia-component-id="OUIA-Generated-Toolbar-1"
       data-ouia-component-type="PF4/Toolbar"
       data-ouia-safe={true}
       id="git-services-list-toolbar"
@@ -30,7 +30,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
               aria-disabled={true}
               aria-label={null}
               className="pf-c-button pf-m-danger pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-Button-danger-2"
+              data-ouia-component-id="OUIA-Generated-Button-danger-1"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe={true}
               data-testid="bulk-revoke-button"
@@ -46,7 +46,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </div>
         <div
           className="pf-c-toolbar__expandable-content"
-          id="git-services-list-toolbar-expandable-content-1"
+          id="git-services-list-toolbar-expandable-content-0"
         >
           <div
             className="pf-c-toolbar__group"
@@ -65,7 +65,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
     <table
       aria-label="Git services"
       className="pf-c-table pf-m-grid-md pf-m-compact"
-      data-ouia-component-id="OUIA-Generated-Table-4"
+      data-ouia-component-id="OUIA-Generated-Table-2"
       data-ouia-component-type="PF4/Table"
       data-ouia-safe={true}
       role="grid"
@@ -75,7 +75,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
       >
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-6"
+          data-ouia-component-id="OUIA-Generated-TableRow-1"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -133,7 +133,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
       >
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-7"
+          data-ouia-component-id="OUIA-Generated-TableRow-2"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -221,7 +221,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-5"
+              data-ouia-component-id="OUIA-Generated-Dropdown-1"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -231,7 +231,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={false}
-                id="pf-dropdown-toggle-id-4"
+                id="pf-dropdown-toggle-id-0"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"
@@ -260,7 +260,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </tr>
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-8"
+          data-ouia-component-id="OUIA-Generated-TableRow-3"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -349,7 +349,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-6"
+              data-ouia-component-id="OUIA-Generated-Dropdown-2"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -359,7 +359,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={true}
-                id="pf-dropdown-toggle-id-5"
+                id="pf-dropdown-toggle-id-1"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"
@@ -388,7 +388,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </tr>
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-9"
+          data-ouia-component-id="OUIA-Generated-TableRow-4"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -418,7 +418,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
             data-label="Name"
             onMouseEnter={[Function]}
           >
-            Bitbucket Server (OAuth 1.0)
+            Bitbucket
           </td>
           <td
             className=""
@@ -477,7 +477,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-7"
+              data-ouia-component-id="OUIA-Generated-Dropdown-3"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -487,7 +487,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={true}
-                id="pf-dropdown-toggle-id-6"
+                id="pf-dropdown-toggle-id-2"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"
@@ -516,7 +516,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </tr>
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-10"
+          data-ouia-component-id="OUIA-Generated-TableRow-5"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -535,6 +535,134 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 checked={false}
                 disabled={true}
                 name="checkrow3"
+                onChange={[Function]}
+                type="checkbox"
+              />
+            </label>
+          </td>
+          <td
+            className=""
+            data-key={1}
+            data-label="Name"
+            onMouseEnter={[Function]}
+          >
+            Bitbucket (OAuth 1.0)
+          </td>
+          <td
+            className=""
+            data-key={2}
+            data-label="Server"
+            onMouseEnter={[Function]}
+          >
+            <a
+              href="https://bitbucket-server.dummy.endpoint.org"
+              rel="noreferrer"
+              target="_blank"
+            >
+              https://bitbucket-server.dummy.endpoint.org
+            </a>
+          </td>
+          <td
+            className=""
+            data-key={3}
+            data-label="Authorization"
+            onMouseEnter={[Function]}
+          >
+            <div>
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="var(--pf-global--disabled-color--100)"
+                height="1em"
+                role="img"
+                style={
+                  {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.7,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 L512,896 Z M512.1,0 C229.7,0 0,229.8 0,512 C0,794.3 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0 L512.1,0 Z"
+                />
+              </svg>
+              <span>
+                Unauthorized
+              </span>
+            </div>
+          </td>
+          <td
+            className="pf-c-table__action"
+            data-key={4}
+            data-label={null}
+            onMouseEnter={[Function]}
+            style={
+              {
+                "paddingRight": 0,
+              }
+            }
+          >
+            <div
+              className="pf-c-dropdown pf-m-align-right"
+              data-ouia-component-id="OUIA-Generated-Dropdown-4"
+              data-ouia-component-type="PF4/Dropdown"
+              data-ouia-safe={true}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="Actions"
+                className="pf-c-dropdown__toggle pf-m-plain"
+                disabled={true}
+                id="pf-dropdown-toggle-id-3"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr
+          className=""
+          data-ouia-component-id="OUIA-Generated-TableRow-6"
+          data-ouia-component-type="PF4/TableRow"
+          data-ouia-safe={true}
+          hidden={false}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          <td
+            className="pf-c-table__check"
+            data-key={0}
+            data-label={null}
+            onMouseEnter={[Function]}
+          >
+            <label>
+              <input
+                aria-label="Select row 4"
+                checked={false}
+                disabled={true}
+                name="checkrow4"
                 onChange={[Function]}
                 type="checkbox"
               />
@@ -605,7 +733,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-8"
+              data-ouia-component-id="OUIA-Generated-Dropdown-5"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -615,7 +743,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={true}
-                id="pf-dropdown-toggle-id-7"
+                id="pf-dropdown-toggle-id-4"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__snapshots__/index.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
   >
     <div
       className="pf-c-toolbar pf-m-page-insets"
-      data-ouia-component-id="OUIA-Generated-Toolbar-1"
+      data-ouia-component-id="OUIA-Generated-Toolbar-2"
       data-ouia-component-type="PF4/Toolbar"
       data-ouia-safe={true}
       id="git-services-list-toolbar"
@@ -30,7 +30,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
               aria-disabled={true}
               aria-label={null}
               className="pf-c-button pf-m-danger pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-Button-danger-1"
+              data-ouia-component-id="OUIA-Generated-Button-danger-2"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe={true}
               data-testid="bulk-revoke-button"
@@ -46,7 +46,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </div>
         <div
           className="pf-c-toolbar__expandable-content"
-          id="git-services-list-toolbar-expandable-content-0"
+          id="git-services-list-toolbar-expandable-content-1"
         >
           <div
             className="pf-c-toolbar__group"
@@ -65,7 +65,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
     <table
       aria-label="Git services"
       className="pf-c-table pf-m-grid-md pf-m-compact"
-      data-ouia-component-id="OUIA-Generated-Table-2"
+      data-ouia-component-id="OUIA-Generated-Table-4"
       data-ouia-component-type="PF4/Table"
       data-ouia-safe={true}
       role="grid"
@@ -75,7 +75,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
       >
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-1"
+          data-ouia-component-id="OUIA-Generated-TableRow-7"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -133,7 +133,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
       >
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-2"
+          data-ouia-component-id="OUIA-Generated-TableRow-8"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -221,7 +221,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-1"
+              data-ouia-component-id="OUIA-Generated-Dropdown-6"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -231,7 +231,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={false}
-                id="pf-dropdown-toggle-id-0"
+                id="pf-dropdown-toggle-id-5"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"
@@ -260,7 +260,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </tr>
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-3"
+          data-ouia-component-id="OUIA-Generated-TableRow-9"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -349,7 +349,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-2"
+              data-ouia-component-id="OUIA-Generated-Dropdown-7"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -359,7 +359,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={true}
-                id="pf-dropdown-toggle-id-1"
+                id="pf-dropdown-toggle-id-6"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"
@@ -388,7 +388,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </tr>
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-4"
+          data-ouia-component-id="OUIA-Generated-TableRow-10"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -477,7 +477,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-3"
+              data-ouia-component-id="OUIA-Generated-Dropdown-8"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -487,7 +487,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={true}
-                id="pf-dropdown-toggle-id-2"
+                id="pf-dropdown-toggle-id-7"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"
@@ -516,7 +516,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </tr>
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-5"
+          data-ouia-component-id="OUIA-Generated-TableRow-11"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -605,7 +605,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-4"
+              data-ouia-component-id="OUIA-Generated-Dropdown-9"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -615,7 +615,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={true}
-                id="pf-dropdown-toggle-id-3"
+                id="pf-dropdown-toggle-id-8"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"
@@ -644,7 +644,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
         </tr>
         <tr
           className=""
-          data-ouia-component-id="OUIA-Generated-TableRow-6"
+          data-ouia-component-id="OUIA-Generated-TableRow-12"
           data-ouia-component-type="PF4/TableRow"
           data-ouia-safe={true}
           hidden={false}
@@ -733,7 +733,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
           >
             <div
               className="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-5"
+              data-ouia-component-id="OUIA-Generated-Dropdown-10"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe={true}
             >
@@ -743,7 +743,7 @@ exports[`GitServices with 4 git services snapshot 1`] = `
                 aria-label="Actions"
                 className="pf-c-dropdown__toggle pf-m-plain"
                 disabled={true}
-                id="pf-dropdown-toggle-id-4"
+                id="pf-dropdown-toggle-id-9"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 type="button"

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/index.spec.tsx
@@ -106,6 +106,10 @@ describe('GitServices', () => {
               .withEndpointUrl('https://bitbucket.dummy.endpoint.org')
               .build(),
             new FakeGitOauthBuilder()
+              .withName('bitbucket-server')
+              .withEndpointUrl('https://bitbucket-server.dummy.endpoint.org')
+              .build(),
+            new FakeGitOauthBuilder()
               .withName('azure-devops')
               .withEndpointUrl('https://azure.dummy.endpoint.com/')
               .build(),
@@ -124,11 +128,12 @@ describe('GitServices', () => {
 
       const actions = screen.queryAllByRole('button', { name: /actions/i });
 
-      expect(actions.length).toEqual(4);
+      expect(actions.length).toEqual(5);
       expect(actions[0]).not.toBeDisabled();
       expect(actions[1]).toBeDisabled();
       expect(actions[2]).toBeDisabled();
       expect(actions[3]).toBeDisabled();
+      expect(actions[4]).toBeDisabled();
     });
 
     test('snapshot', () => {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
@@ -116,7 +116,10 @@ export class GitServices extends React.PureComponent<Props, State> {
   }
 
   private isSkipOauth(providerName: api.GitOauthProvider): boolean {
-    return this.props.skipOauthProviders.includes(providerName);
+    // Use includes filter to handle the bitbucket-server oauth 2 provider.
+    // The bitbucket server oauth2 provider name is 'bitbucket',
+    // but the corresponding 'skip oauth' item is 'bitbucket-server'.
+    return this.props.skipOauthProviders.some(s => s.includes(providerName));
   }
 
   private hasOauthToken(providerName: api.GitOauthProvider): boolean {
@@ -149,7 +152,12 @@ export class GitServices extends React.PureComponent<Props, State> {
             title: 'Clear',
             onClick: (event, rowIndex) => {
               event.stopPropagation();
-              this.props.deleteSkipOauth(gitOauth[rowIndex].name);
+              // Use includes filter to handle the bitbucket-server oauth 2 provider.
+              // The bitbucket server oauth2 provider name is 'bitbucket',
+              // but the corresponding 'skip oauth' item is 'bitbucket-server'.
+              const itemName = gitOauth[rowIndex].name;
+              const providerName = this.props.skipOauthProviders.find(s => s.includes(itemName));
+              this.props.deleteSkipOauth(providerName !== undefined ? providerName : itemName);
             },
           },
         ];

--- a/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
@@ -16,10 +16,10 @@ export const GIT_OAUTH_PROVIDERS: Record<api.GitOauthProvider, string> = {
   'azure-devops': 'Microsoft Azure DevOps',
   // Either Bitbucket Cloud or Bitbucket Server
   // https://github.com/eclipse-che/che-server/blob/main/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
-  'bitbucket-server': 'Bitbucket',
+  'bitbucket-server': 'Bitbucket (OAuth 1.0)',
   // Bitbucket Server only
   // https://github.com/eclipse-che/che-server/blob/main/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/BitbucketServerOAuthAuthenticator.java
-  bitbucket: 'Bitbucket Server (OAuth 1.0)',
+  bitbucket: 'Bitbucket',
   github: 'GitHub',
   github_2: 'GitHub (The second provider)',
   gitlab: 'GitLab',

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
@@ -32,6 +32,10 @@ const gitOauth = [
     name: 'azure-devops',
     endpointUrl: 'https://dev.azure.com',
   },
+  {
+    name: 'bitbucket-server',
+    endpointUrl: 'https://bitbucket-server.com',
+  },
 ] as IGitOauth[];
 
 const mockGetOAuthProviders = jest.fn().mockResolvedValue(gitOauth);
@@ -46,7 +50,17 @@ const mockFetchTokens = jest.fn().mockResolvedValue([
   {
     tokenName: 'github-personal-access-token',
     gitProvider: 'oauth2-token',
+    gitProviderEndpoint: 'https://github.com/',
+  },
+  {
+    tokenName: 'azure-devops-personal-access-token',
+    gitProvider: 'oauth2-token',
     gitProviderEndpoint: 'https://dev.azure.com/',
+  },
+  {
+    tokenName: 'bitbucket-server-personal-access-token',
+    gitProvider: 'che-token-<user.id>-<bitbucket-server>',
+    gitProviderEndpoint: 'https://bitbucket-server.com/',
   },
 ] as any[]);
 
@@ -65,6 +79,13 @@ jest.mock('../../../services/backend-client/personalAccessTokenApi', () => {
 
 // mute the outputs
 console.error = jest.fn();
+
+window = Object.create(window);
+Object.defineProperty(window, 'location', {
+  value: {
+    hostname: 'bitbucket-server',
+  },
+});
 
 describe('GitOauthConfig store, actions', () => {
   let store: MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, TestStore.KnownAction>>;
@@ -86,7 +107,7 @@ describe('GitOauthConfig store, actions', () => {
 
     const expectedAction: TestStore.KnownAction = {
       supportedGitOauth: gitOauth,
-      providersWithToken: ['github', 'azure-devops'],
+      providersWithToken: ['github', 'azure-devops', 'bitbucket-server'],
       type: TestStore.Type.RECEIVE_GIT_OAUTH_PROVIDERS,
     };
 

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
@@ -167,8 +167,13 @@ export const actionCreators: ActionCreators = {
                     : token.gitProviderEndpoint;
 
                   // compare Git OAuth Endpoint url ONLY with OAuth tokens
+                  const gitProvider = token.gitProvider;
                   if (
-                    token.gitProvider.startsWith('oauth2') &&
+                    (gitProvider.startsWith('oauth2') ||
+                      // The git provider value format of a bitbucket-server token is 'che-token-<user id>-<che hostname>'
+                      new RegExp(`^che-token-<.*>-<${window.location.hostname}>$`).test(
+                        gitProvider,
+                      )) &&
                     normalizedGitOauthEndpoint === normalizedTokenGitProviderEndpoint
                   ) {
                     providersWithToken.push(gitOauth.name);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Use includes filter to handle the bitbucket-server oauth 2 provider. The bitbucket server oauth2 provider name is 'bitbucket', but the corresponding 'skip oauth' item is 'bitbucket-server'.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22723

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy che from the che-server PR image: `quay.io/eclipse/che-server:pr-624`
2. Register Bitbucket Server oauth2 provider.
3. Start a workspace from the Bitbucket-Server repo
4. Reject the Bitbucket-Server authorisation page.
5. Go to `User Preferences` -> `Git Services` tab, see: the authorisation flag is set to `skip authorisation` warning.
6. Click the `three dot` icon of the Bitbucket item and clear the `skip authorisation` flag.
7. Delete the workspace and start the workspace from the Bitbucket-Server again, accept the authorisation page, see: the `skip authorisation` flag is set to `authorised` icon.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
