### PR TITLE
Update yarn.lock to fix devspaces-dashboard build.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -353,7 +353,7 @@
     request "^2.81.0"
     rewire "^3.0.2"
 
-"@devfile/api@^2.2.1-alpha-1667236163", "@devfile/api@latest":
+"@devfile/api@2.2.1-alpha-1667236163", "@devfile/api@^2.2.1-alpha-1667236163":
   version "2.2.1-alpha-1667236163"
   resolved "https://registry.yarnpkg.com/@devfile/api/-/api-2.2.1-alpha-1667236163.tgz#33cf448dae960c071037b32c6c68f96ba26f1990"
   integrity sha512-tspoTrbyMbPIVwTD2qr6ljvQAJLE1lCN6uBFIGcYXKw89JGt0s0+WLQ/qIh2+RP5pDpDWbDp/yNFKCmzaOLupg==
@@ -374,17 +374,18 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.76.0.tgz#4e51015b566df5a9843d32d4de040875da78e368"
   integrity sha512-V7egXY0x5Ce9DJGLrjXEeBkA/0854C9oz+KhxzCT/mXYbVVj4+YbNFjiuufNRnuGOBOOVCOLhhe69ebODjCiQQ==
 
-"@eclipse-che/che-devworkspace-generator@next":
-  version "7.77.0-next-363e98c"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-7.77.0-next-363e98c.tgz#f7bca5e7dcc9762b802d7aaebd7d6a16f4f06051"
-  integrity sha512-fpPopblHrUYC8d6qhn9GP2bUBmCKNaq8n3PFK/mY0Yf7ERT1Cj9x+4JCCGRGya1/4aOKk4HC1KD61LROLGaYqw==
+"@eclipse-che/che-devworkspace-generator@7.78.0":
+  version "7.78.0"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-7.78.0.tgz#75817ba92f0f68293e10fa5389266af8495701d8"
+  integrity sha512-A8eYJAHZqupSLt3yaNgCfGXfDOswatQBiDXFhKghIfscDYE0+ExQW5KxwtRgT5kszPqeupvsRqLWmmuqgsOe2Q==
   dependencies:
-    "@devfile/api" latest
-    axios "0.21.2"
+    "@devfile/api" "2.2.1-alpha-1667236163"
+    axios "1.6.0"
     fs-extra "^10.0.0"
     inversify "^5.0.1"
     js-yaml "^4.0.0"
     jsonc-parser "^3.0.0"
+    jsonschema "^1.4.1"
     reflect-metadata "^0.1.13"
 
 "@eclipse-che/devfile-converter@0.0.1-ff55f9a":
@@ -2702,7 +2703,7 @@ axios-mock-adapter@^1.21.5:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@*, axios@^1.0.0, axios@^1.4.0:
+axios@*, axios@1.6.0, axios@^1.0.0, axios@^1.4.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.0.tgz#f1e5292f26b2fd5c2e66876adc5b06cdbd7d2102"
   integrity sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==
@@ -2710,13 +2711,6 @@ axios@*, axios@^1.0.0, axios@^1.4.0:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
-
-axios@0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
-  dependencies:
-    follow-redirects "^1.14.0"
 
 axios@^0.21.4:
   version "0.21.4"
@@ -7281,6 +7275,11 @@ jsonpath-plus@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz#7ad94e147b3ed42f7939c315d2b9ce490c5a3899"
   integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
+
+jsonschema@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
+  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
 jsprim@^1.2.2:
   version "1.4.2"


### PR DESCRIPTION
### What does this PR do?
regenerated the yarn.lock file

### What issues does this PR fix or reference?
Failing downstream 3.11 build of devspaces dashboard.


