### PR TITLE
Add meaningful Dashboard warnings during the failures on namespace provisioning

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -118,12 +118,27 @@ export interface IServerConfig {
     runTimeout: number;
     startTimeout: number;
   };
+  networking?: {
+    auth?: {
+      advancedAuthorization: IAdvancedAuthorization;
+    };
+  };
+  defaultNamespace: {
+    autoProvision: boolean;
+  };
   cheNamespace: string;
   pluginRegistryURL: string;
   pluginRegistryInternalURL: string;
   devfileRegistryURL: string;
   devfileRegistryInternalURL: string;
   dashboardLogo?: { base64data: string; mediatype: string };
+}
+
+export interface IAdvancedAuthorization {
+  allowUsers?: string[];
+  allowGroups?: string[];
+  denyUsers?: string[];
+  denyGroups?: string[];
 }
 
 export interface IPluginRegistry {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/serverConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/serverConfigApi.spec.ts
@@ -82,7 +82,7 @@ describe('Server Config API Service', () => {
 
   test('getting openVSXURL from the CR', () => {
     const openVSXURL = 'https://open-vsx.org';
-    const res = serverConfigService.getPluginRegistry(buildCustomResource(openVSXURL));
+    const res = serverConfigService.getPluginRegistry(buildCustomResource({ openVSXURL }));
     expect(res).toEqual({ openVSXURL: 'https://open-vsx.org' });
   });
 
@@ -150,6 +150,16 @@ describe('Server Config API Service', () => {
     const res = serverConfigService.getDefaultDevfileRegistryUrl(buildCustomResource());
     expect(res).toEqual('http://devfile-registry.eclipse-che.svc/devfile-registry/');
   });
+
+  test('getting autoProvision value', () => {
+    const res = serverConfigService.getAutoProvision(buildCustomResource());
+    expect(res).toBeTruthy();
+  });
+
+  test('getting advanced authorization object', () => {
+    const res = serverConfigService.getAdvancedAuthorization(buildCustomResource());
+    expect(res).toEqual({ allowUsers: ['user1', 'user2'] });
+  });
 });
 
 function buildCustomResourceList(): { body: CustomResourceDefinitionList } {
@@ -162,7 +172,7 @@ function buildCustomResourceList(): { body: CustomResourceDefinitionList } {
   };
 }
 
-function buildCustomResource(openVSXURL?: string): CheClusterCustomResource {
+function buildCustomResource(options?: { openVSXURL?: string }): CheClusterCustomResource {
   return {
     apiVersion: 'org.eclipse.che/v2',
     kind: 'CheCluster',
@@ -179,7 +189,7 @@ function buildCustomResource(openVSXURL?: string): CheClusterCustomResource {
           },
         },
         devWorkspace: {},
-        pluginRegistry: openVSXURL ? { openVSXURL } : {},
+        pluginRegistry: options?.openVSXURL ? { openVSXURL: options.openVSXURL } : {},
         devfileRegistry: {
           externalDevfileRegistries: [
             {
@@ -201,10 +211,20 @@ function buildCustomResource(openVSXURL?: string): CheClusterCustomResource {
             name: 'component-name',
           },
         ],
+        defaultNamespace: {
+          autoProvision: true,
+        },
         defaultEditor: 'eclipse/che-theia/latest',
         secondsOfInactivityBeforeIdling: 1800,
         secondsOfRunBeforeIdling: -1,
         storage: { pvcStrategy: 'per-user' },
+      },
+      networking: {
+        auth: {
+          advancedAuthorization: {
+            allowUsers: ['user1', 'user2'],
+          },
+        },
       },
     },
     status: {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -222,4 +222,14 @@ export class ServerConfigApiService implements IServerConfigApi {
   ): { base64data: string; mediatype: string } | undefined {
     return cheCustomResource.spec.components?.dashboard?.branding?.logo;
   }
+
+  getAdvancedAuthorization(
+    cheCustomResource: CheClusterCustomResource,
+  ): api.IAdvancedAuthorization | undefined {
+    return cheCustomResource.spec.networking?.auth?.advancedAuthorization;
+  }
+
+  getAutoProvision(cheCustomResource: CheClusterCustomResource): boolean {
+    return cheCustomResource.spec.devEnvironments?.defaultNamespace?.autoProvision || false;
+  }
 }

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -119,6 +119,11 @@ export type CheClusterCustomResource = k8s.V1CustomResourceDefinition & {
   spec: {
     devEnvironments?: CheClusterCustomResourceSpecDevEnvironments;
     components?: CheClusterCustomResourceSpecComponents;
+    networking?: {
+      auth?: {
+        advancedAuthorization?: api.IAdvancedAuthorization;
+      };
+    };
   };
   status: {
     devfileRegistryURL: string;
@@ -145,6 +150,10 @@ export type CheClusterCustomResourceSpecDevEnvironments = {
     openShiftSecurityContextConstraint?: string;
   };
   defaultComponents?: V222DevfileComponents[];
+  defaultNamespace?: {
+    autoProvision?: boolean;
+    template?: string;
+  };
   defaultEditor?: string;
   defaultPlugins?: api.IWorkspacesDefaultPlugins[];
   disableContainerBuildCapabilities?: boolean;
@@ -325,6 +334,18 @@ export interface IServerConfigApi {
   getDashboardLogo(
     cheCustomResource: CheClusterCustomResource,
   ): { base64data: string; mediatype: string } | undefined;
+
+  /**
+   * Returns the advancedAuthorization value
+   */
+  getAdvancedAuthorization(
+    cheCustomResource: CheClusterCustomResource,
+  ): api.IAdvancedAuthorization | undefined;
+
+  /**
+   * Returns the autoProvision value
+   */
+  getAutoProvision(cheCustomResource: CheClusterCustomResource): boolean;
 }
 
 export interface IKubeConfigApi {

--- a/packages/dashboard-backend/src/routes/api/__tests__/serverConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/serverConfig.spec.ts
@@ -49,6 +49,11 @@ describe('Server Config Route', () => {
       timeouts: { inactivityTimeout: 0, runTimeout: 0, startTimeout: 0 },
       devfileRegistryInternalURL: 'http://devfile-registry.internal',
       devfileRegistryURL: 'http://devfile-registry.eclipse-che.svc',
+      networking: {
+        auth: {
+          advancedAuthorization: {},
+        },
+      },
       pluginRegistryInternalURL: 'http://plugin-registry.internal',
       pluginRegistryURL: 'http://plugin-registry.eclipse-che.svc/v3',
       devfileRegistry: {
@@ -58,6 +63,9 @@ describe('Server Config Route', () => {
             url: 'https://devfile.registry.test.org/',
           },
         ],
+      },
+      defaultNamespace: {
+        autoProvision: true,
       },
       dashboardLogo: {
         base64data: 'base64-encoded-data',

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -125,6 +125,10 @@ export const stubSshKeysList: api.SshKey[] = [
   },
 ];
 
+export const stubAutoProvision = true;
+
+export const stubAdvancedAuthorization = {};
+
 export function getDevWorkspaceClient(
   ..._args: Parameters<typeof helper>
 ): ReturnType<typeof helper> {
@@ -148,6 +152,8 @@ export function getDevWorkspaceClient(
       getExternalDevfileRegistries: _cheCustomResource => externalDevfileRegistries,
       getInternalRegistryDisableStatus: _cheCustomResource => internalRegistryDisableStatus,
       getDashboardLogo: _cheCustomResource => dashboardLogo,
+      getAutoProvision: _cheCustomResource => stubAutoProvision,
+      getAdvancedAuthorization: _cheCustomResource => stubAdvancedAuthorization,
     } as IServerConfigApi,
     devworkspaceApi: {
       create: (_devworkspace, _namespace) =>

--- a/packages/dashboard-backend/src/routes/api/serverConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/serverConfig.ts
@@ -48,6 +48,8 @@ export function registerServerConfigRoute(instance: FastifyInstance) {
       const disableInternalRegistry =
         serverConfigApi.getInternalRegistryDisableStatus(cheCustomResource);
       const dashboardLogo = serverConfigApi.getDashboardLogo(cheCustomResource);
+      const advancedAuthorization = serverConfigApi.getAdvancedAuthorization(cheCustomResource);
+      const autoProvision = serverConfigApi.getAutoProvision(cheCustomResource);
 
       const serverConfig: api.IServerConfig = {
         containerBuild,
@@ -66,6 +68,9 @@ export function registerServerConfigRoute(instance: FastifyInstance) {
           disableInternalRegistry,
           externalDevfileRegistries,
         },
+        defaultNamespace: {
+          autoProvision,
+        },
         pluginRegistry,
         cheNamespace,
         pluginRegistryURL,
@@ -74,10 +79,17 @@ export function registerServerConfigRoute(instance: FastifyInstance) {
         devfileRegistryInternalURL,
       };
 
-      if (dashboardLogo) {
+      if (dashboardLogo !== undefined) {
         serverConfig.dashboardLogo = dashboardLogo;
       }
 
+      if (advancedAuthorization !== undefined) {
+        serverConfig.networking = {
+          auth: {
+            advancedAuthorization,
+          },
+        };
+      }
       return serverConfig;
     });
   });

--- a/packages/dashboard-frontend/src/Layout/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/Layout/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Layout component snapshot 1`] = `
+exports[`Layout component snapshot of the default page 1`] = `
 <div
   className="pf-c-page"
 >
@@ -51,6 +51,101 @@ exports[`Layout component snapshot 1`] = `
         Test
       </div>
     </div>
+  </main>
+</div>
+`;
+
+exports[`Layout component snapshot of the namespace provisioning error page 1`] = `
+<div
+  className="pf-c-page"
+>
+  <main
+    className="pf-c-page__main"
+    tabIndex={-1}
+  >
+    <section
+      className="pf-c-page__main-section pf-m-no-padding pf-m-fill backdropBackground"
+    >
+      <div
+        className="pf-l-stack"
+      >
+        <div
+          className="pf-l-stack__item pf-m-fill"
+        />
+        <div
+          className="pf-l-stack__item errorMessageContainer"
+        >
+          <div
+            className="pf-l-bullseye"
+          >
+            <div
+              className="pf-c-content messageContainer"
+            >
+              <h1
+                className=""
+                data-ouia-component-id="OUIA-Generated-Text-1"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe={true}
+                data-pf-content={true}
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  className="warningIcon"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 1088 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M1057.10141,663.5 L845.101405,215.4 C787.101405,71.8 665.401405,0 542.901405,0 C420.201405,0 296.701405,71.9 235.001405,215.6 L31.7014051,648.5 C10.4014051,700 -0.0985948775,752.3 0.000697596367,800.8 C0.301405123,924.8 70.2014051,1024 209.101405,1024 L868.401405,1024 C1005.80141,1024 1087.70141,918.6 1088.00215,795.5 C1088.10141,752.4 1078.20141,707.2 1057.10141,663.5 Z M959.401405,800.3 C958.701405,822.9 952.901405,843.5 942.601405,859.7 C926.801405,884.6 902.601405,896.7 868.301405,896.7 L209.101405,896.7 C191.201405,896.7 176.601405,893.8 165.401405,888.2 C157.301405,884 150.801405,878.4 145.401405,870.3 C135.101405,855 129.101405,832 128.401405,805.6 C127.601405,772.8 134.901405,736.5 149.401405,700.5 L353.001405,266.7 C363.201405,242.9 376.101405,221.5 391.101405,203.2 C404.801405,186.6 420.301405,172.4 437.401405,161.1 C469.201405,139.9 505.701405,128.8 542.901405,128.8 C579.701405,128.8 615.401405,139.8 646.001405,160.5 C662.401405,171.6 677.101405,185.4 690.101405,201.6 C704.501405,219.6 716.401405,240.6 725.901405,264 L940.901405,718.9 L941.101405,719.3 L941.301405,719.7 C953.901405,746 960.201405,773.9 959.401405,800.3 Z M586.601405,832 L501.301405,832 C489.501405,831.8 480.201405,821.5 480.001405,808.7 L480.001405,727.3 C480.201405,714.5 489.601405,704.3 501.301405,704 L586.601405,704 C598.401405,704.2 607.701405,714.5 607.901405,727.3 L607.901405,808.7 L608.001405,808.7 C607.701405,821.5 598.301405,831.8 586.601405,832 M639.901405,290.7 L613.201405,610.4 C611.801405,626.9 598.001405,640 581.301405,640 L506.601405,640 C490.001405,640 476.101405,627.2 474.701405,610.7 L448.101405,291 C446.501405,272.3 461.301405,256.3 480.001405,256.3 L608.001405,256 C626.701405,256 641.401405,272 639.901405,290.7"
+                  />
+                </svg>
+                Error
+              </h1>
+              <pre
+                className="errorMessage"
+                data-ouia-component-id="OUIA-Generated-Text-2"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe={true}
+                data-pf-content={true}
+              >
+                Namespace provisioning error
+              </pre>
+              <p
+                className=""
+                data-ouia-component-id="OUIA-Generated-Text-3"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe={true}
+                data-pf-content={true}
+              >
+                Please try 
+                <kbd
+                  className="keybinding"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  className="keybinding"
+                >
+                  Refresh
+                </kbd>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pf-l-stack__item pf-m-fill"
+        />
+      </div>
+    </section>
   </main>
 </div>
 `;

--- a/packages/dashboard-frontend/src/Layout/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/__tests__/index.spec.tsx
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import React from 'react';
@@ -114,9 +115,9 @@ describe('Layout component', () => {
 
     renderComponent(store);
 
-    const errorMessageContainer = await screen.findByText(errorMessage);
+    const errorMessageContainer = await waitFor(() => screen.queryByText(errorMessage));
 
-    expect(errorMessageContainer).toBeDefined();
+    expect(errorMessageContainer).not.toBeNull();
   });
 });
 

--- a/packages/dashboard-frontend/src/Layout/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/__tests__/index.spec.tsx
@@ -16,11 +16,15 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
 
+import { container } from '@/inversify.config';
 import Layout from '@/Layout';
 import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
 import { BrandingData } from '@/services/bootstrap/branding.constant';
+import { IssuesReporterService } from '@/services/bootstrap/issuesReporter';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 import * as SanityCheckStore from '@/store/SanityCheck';
+
+const issuesReporterService = container.get(IssuesReporterService);
 
 jest.mock('@/Layout/ErrorBoundary');
 jest.mock('@/Layout/Header');
@@ -56,10 +60,20 @@ describe('Layout component', () => {
   });
 
   afterEach(() => {
+    issuesReporterService.clearIssues();
     jest.clearAllMocks();
   });
 
-  test('snapshot', () => {
+  test('snapshot of the namespace provisioning error page', () => {
+    issuesReporterService.registerIssue(
+      'namespaceProvisioningError',
+      new Error('Namespace provisioning error'),
+    );
+    const snapshot = createSnapshot(store);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  test('snapshot of the default page', () => {
     const snapshot = createSnapshot(store);
     expect(snapshot).toMatchSnapshot();
   });
@@ -92,6 +106,17 @@ describe('Layout component', () => {
     userEvent.click(btn);
 
     expect(mockTestBackends).toHaveBeenCalled();
+  });
+
+  test('onNamespaceProvisioningError', async () => {
+    const errorMessage = 'Namespace provisioning error';
+    issuesReporterService.registerIssue('namespaceProvisioningError', new Error(errorMessage));
+
+    renderComponent(store);
+
+    const errorMessageContainer = await screen.findByText(errorMessage);
+
+    expect(errorMessageContainer).toBeDefined();
   });
 });
 

--- a/packages/dashboard-frontend/src/Layout/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/index.tsx
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { Brand, Page } from '@patternfly/react-core';
+import { AlertVariant, Brand, Page } from '@patternfly/react-core';
 import { History } from 'history';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
@@ -26,7 +26,9 @@ import Header from '@/Layout/Header';
 import Sidebar from '@/Layout/Sidebar';
 import StoreErrorsAlert from '@/Layout/StoreErrorsAlert';
 import { ROUTE } from '@/Routes/routes';
+import { AppAlerts } from '@/services/alerts/appAlerts';
 import { IssuesReporterService } from '@/services/bootstrap/issuesReporter';
+import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
 import { signOut } from '@/services/helpers/login';
 import { AppState } from '@/store';
 import { selectBranding } from '@/store/Branding/selectors';
@@ -48,6 +50,12 @@ type State = {
 export class Layout extends React.PureComponent<Props, State> {
   @lazyInject(IssuesReporterService)
   private readonly issuesReporterService: IssuesReporterService;
+
+  @lazyInject(WarningsReporterService)
+  private readonly warningsReporterService: WarningsReporterService;
+
+  @lazyInject(AppAlerts)
+  private readonly appAlerts: AppAlerts;
 
   constructor(props: Props) {
     super(props);
@@ -88,6 +96,19 @@ export class Layout extends React.PureComponent<Props, State> {
     if (matchFactoryLoaderPath !== null || matchIdeLoaderPath !== null) {
       this.hideAllBars();
     }
+    this.showWarnings();
+  }
+
+  private showWarnings(): void {
+    const warnings = this.warningsReporterService.reportAllWarnings();
+    warnings.forEach(warning => {
+      this.appAlerts.showAlert({
+        key: warning.key,
+        title: warning.title,
+        variant: AlertVariant.warning,
+        timeout: 9999999,
+      });
+    });
   }
   private async testBackends(error?: string): Promise<void> {
     try {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
@@ -76,6 +76,9 @@ const serverConfig: api.IServerConfig = {
     runTimeout: -1,
     startTimeout,
   },
+  defaultNamespace: {
+    autoProvision: true,
+  },
   cheNamespace: '',
   devfileRegistry: {
     disableInternalRegistry: false,

--- a/packages/dashboard-frontend/src/inversify.config.ts
+++ b/packages/dashboard-frontend/src/inversify.config.ts
@@ -18,6 +18,7 @@ import getDecorators from 'inversify-inject-decorators';
 import { AppAlerts } from '@/services/alerts/appAlerts';
 import { WebsocketClient } from '@/services/backend-client/websocketClient';
 import { IssuesReporterService } from '@/services/bootstrap/issuesReporter';
+import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
 import { WorkspaceStoppedDetector } from '@/services/bootstrap/workspaceStoppedDetector';
 import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
 import { DevWorkspaceDefaultPluginsHandler } from '@/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler';
@@ -31,5 +32,6 @@ container.bind(DevWorkspaceClient).toSelf().inSingletonScope();
 container.bind(AppAlerts).toSelf().inSingletonScope();
 container.bind(DevWorkspaceDefaultPluginsHandler).toSelf().inSingletonScope();
 container.bind(WorkspaceStoppedDetector).toSelf().inSingletonScope();
+container.bind(WarningsReporterService).toSelf().inSingletonScope();
 
 export { container, lazyInject };

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/issuesReporter.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/issuesReporter.spec.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '@/inversify.config';
+import { IssuesReporterService } from '@/services/bootstrap/issuesReporter';
+
+const issuesReporterService = container.get(IssuesReporterService);
+
+describe('Issues Reporter', () => {
+  afterEach(() => {
+    issuesReporterService.clearIssues();
+  });
+
+  test('report issues', () => {
+    const error_1 = new Error('Error message 1');
+    const error_2 = new Error('Error message 2');
+
+    issuesReporterService.registerIssue('workspaceStoppedError', error_1);
+    issuesReporterService.registerIssue('workspaceRunTimeout', error_2, {
+      ideLoaderPath: 'MockIdeLoaderPath',
+      workspaceDetailsPath: 'MockWorkspaceDetailsPath',
+    });
+
+    expect(issuesReporterService.hasIssue).toBeTruthy();
+    expect(issuesReporterService.reportIssue()).toEqual({
+      data: {
+        ideLoaderPath: 'MockIdeLoaderPath',
+        workspaceDetailsPath: 'MockWorkspaceDetailsPath',
+      },
+      error: error_2,
+      type: 'workspaceRunTimeout',
+    });
+    expect(issuesReporterService.reportAllIssues()).toEqual([
+      {
+        data: undefined,
+        error: error_1,
+        type: 'workspaceStoppedError',
+      },
+      {
+        data: {
+          ideLoaderPath: 'MockIdeLoaderPath',
+          workspaceDetailsPath: 'MockWorkspaceDetailsPath',
+        },
+        error: error_2,
+        type: 'workspaceRunTimeout',
+      },
+    ]);
+
+    issuesReporterService.clearIssues();
+
+    expect(issuesReporterService.hasIssue).toBeFalsy();
+    expect(issuesReporterService.reportIssue()).toBeUndefined();
+    expect(issuesReporterService.reportAllIssues()).toEqual([]);
+  });
+});

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
@@ -209,7 +209,8 @@ describe('Check namespace provision warnings', () => {
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'advancedAuthorizationUsersWarning',
-        title: 'Access for test-user is forbidden. Please contact the administrator.',
+        title:
+          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
       },
     ]);
   });
@@ -273,11 +274,6 @@ describe('Check namespace provision warnings', () => {
         key: 'autoProvisionWarning',
         title:
           'Automatic namespace provisioning is disabled. Namespace for test-user might not have been configured yet. Please, contact the administrator.',
-      },
-      {
-        key: 'advancedAuthorizationGroupsWarning',
-        title:
-          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
       },
       {
         key: 'advancedAuthorizationUsersWarning',

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
@@ -20,16 +20,23 @@ import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 const warningsReporterService = container.get(WarningsReporterService);
 
 describe('Check namespace provision warnings', () => {
-  const testUser = {
-    name: 'test-user',
+  const testNamespace = {
+    name: 'test-namespace',
     attributes: { default: true },
+  };
+  const testUser = {
+    username: 'test-user',
+    email: 'test-user@che',
   };
 
   const mockGet = mockAxios.get as jest.Mock;
 
   beforeEach(() => {
     mockGet.mockResolvedValueOnce({
-      data: [testUser],
+      data: [testNamespace],
+    });
+    mockGet.mockResolvedValueOnce({
+      data: testUser,
     });
   });
 
@@ -73,7 +80,11 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(mockGet.mock.calls).toEqual([
+      ['/api/kubernetes/namespace', undefined],
+      ['/dashboard/api/userprofile/test-namespace', undefined],
+    ]);
+    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
@@ -99,7 +110,11 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(mockGet.mock.calls).toEqual([
+      ['/api/kubernetes/namespace', undefined],
+      ['/dashboard/api/userprofile/test-namespace', undefined],
+    ]);
+    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
@@ -125,7 +140,11 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(mockGet.mock.calls).toEqual([
+      ['/api/kubernetes/namespace', undefined],
+      ['/dashboard/api/userprofile/test-namespace', undefined],
+    ]);
+    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
@@ -151,7 +170,11 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(mockGet.mock.calls).toEqual([
+      ['/api/kubernetes/namespace', undefined],
+      ['/dashboard/api/userprofile/test-namespace', undefined],
+    ]);
+    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
@@ -177,7 +200,11 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(mockGet.mock.calls).toEqual([
+      ['/api/kubernetes/namespace', undefined],
+      ['/dashboard/api/userprofile/test-namespace', undefined],
+    ]);
+    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
@@ -202,7 +229,11 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(mockGet.mock.calls).toEqual([
+      ['/api/kubernetes/namespace', undefined],
+      ['/dashboard/api/userprofile/test-namespace', undefined],
+    ]);
+    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
@@ -231,8 +262,11 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
-    expect(mockGet).toBeCalledTimes(1);
+    expect(mockGet.mock.calls).toEqual([
+      ['/api/kubernetes/namespace', undefined],
+      ['/dashboard/api/userprofile/test-namespace', undefined],
+    ]);
+    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import mockAxios from 'axios';
+
+import { container } from '@/inversify.config';
+import { checkNamespaceProvisionWarnings } from '@/services/bootstrap/namespaceProvisionWarnings';
+import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
+import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
+
+const warningsReporterService = container.get(WarningsReporterService);
+
+describe('Check namespace provision warnings', () => {
+  const testUser = {
+    name: 'test-user',
+    attributes: { default: true },
+  };
+
+  const mockGet = mockAxios.get as jest.Mock;
+
+  beforeEach(() => {
+    mockGet.mockResolvedValueOnce({
+      data: [testUser],
+    });
+  });
+
+  afterEach(() => {
+    warningsReporterService.clearWarnings();
+    jest.clearAllMocks();
+  });
+
+  it('should not register any warning', async () => {
+    let store = new FakeStoreBuilder().build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).not.toBeCalled();
+    expect(warningsReporterService.hasWarning).toBeFalsy();
+
+    store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        networking: {
+          auth: {
+            advancedAuthorization: {},
+          },
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).not.toBeCalled();
+    expect(warningsReporterService.hasWarning).toBeFalsy();
+  });
+
+  it('should register the autoProvision warning', async () => {
+    const store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        defaultNamespace: {
+          autoProvision: false,
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'autoProvisionWarning',
+        title:
+          'Automatic namespace provisioning is disabled. Namespace for test-user might not have been configured yet. Please, contact the administrator.',
+      },
+    ]);
+  });
+
+  it('should register the advanced authorization warning for allowGroups', async () => {
+    const store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        networking: {
+          auth: {
+            advancedAuthorization: {
+              allowGroups: ['test-group'],
+            },
+          },
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'advancedAuthorizationGroupsWarning',
+        title:
+          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+      },
+    ]);
+  });
+
+  it('should register the advanced authorization warning for denyGroups', async () => {
+    const store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        networking: {
+          auth: {
+            advancedAuthorization: {
+              denyGroups: ['test-group'],
+            },
+          },
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'advancedAuthorizationGroupsWarning',
+        title:
+          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+      },
+    ]);
+  });
+
+  it('should register the advanced authorization warning for allowGroups', async () => {
+    const store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        networking: {
+          auth: {
+            advancedAuthorization: {
+              allowGroups: ['test-group'],
+            },
+          },
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'advancedAuthorizationGroupsWarning',
+        title:
+          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+      },
+    ]);
+  });
+
+  it('should register the advanced authorization warning for allowUsers', async () => {
+    const store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        networking: {
+          auth: {
+            advancedAuthorization: {
+              allowUsers: ['user0'],
+            },
+          },
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'advancedAuthorizationUsersWarning',
+        title: 'Access for test-user is forbidden. Please contact the administrator.',
+      },
+    ]);
+  });
+
+  it('should register the advanced authorization warning for denyUsers', async () => {
+    const store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        networking: {
+          auth: {
+            advancedAuthorization: {
+              denyUsers: ['test-user'],
+            },
+          },
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'advancedAuthorizationUsersWarning',
+        title: 'Access for test-user is forbidden. Please contact the administrator.',
+      },
+    ]);
+  });
+
+  it('should register all possible warnings', async () => {
+    const store = new FakeStoreBuilder()
+      .withDwServerConfig({
+        defaultNamespace: {
+          autoProvision: false,
+        },
+        networking: {
+          auth: {
+            advancedAuthorization: {
+              denyUsers: ['test-user'],
+              denyGroups: ['test-group'],
+            },
+          },
+        },
+      })
+      .build();
+
+    await checkNamespaceProvisionWarnings(store.getState);
+
+    expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+    expect(mockGet).toBeCalledTimes(1);
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'autoProvisionWarning',
+        title:
+          'Automatic namespace provisioning is disabled. Namespace for test-user might not have been configured yet. Please, contact the administrator.',
+      },
+      {
+        key: 'advancedAuthorizationGroupsWarning',
+        title:
+          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+      },
+      {
+        key: 'advancedAuthorizationUsersWarning',
+        title: 'Access for test-user is forbidden. Please contact the administrator.',
+      },
+    ]);
+  });
+});

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
@@ -65,7 +65,7 @@ describe('Check namespace provision warnings', () => {
 
     await checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).not.toBeCalled();
+    expect(mockGet).not.toHaveBeenCalled();
     expect(warningsReporterService.hasWarning).toBeFalsy();
   });
 

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
@@ -10,8 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import mockAxios from 'axios';
-
 import { container } from '@/inversify.config';
 import { checkNamespaceProvisionWarnings } from '@/services/bootstrap/namespaceProvisionWarnings';
 import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
@@ -20,37 +18,16 @@ import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 const warningsReporterService = container.get(WarningsReporterService);
 
 describe('Check namespace provision warnings', () => {
-  const testNamespace = {
-    name: 'test-namespace',
-    attributes: { default: true },
-  };
-  const testUser = {
-    username: 'test-user',
-    email: 'test-user@che',
-  };
-
-  const mockGet = mockAxios.get as jest.Mock;
-
-  beforeEach(() => {
-    mockGet.mockResolvedValueOnce({
-      data: [testNamespace],
-    });
-    mockGet.mockResolvedValueOnce({
-      data: testUser,
-    });
-  });
-
   afterEach(() => {
     warningsReporterService.clearWarnings();
     jest.clearAllMocks();
   });
 
-  it('should not register any warning', async () => {
+  it('should not register any warning', () => {
     let store = new FakeStoreBuilder().build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).not.toBeCalled();
     expect(warningsReporterService.hasWarning).toBeFalsy();
 
     store = new FakeStoreBuilder()
@@ -63,13 +40,12 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet).not.toHaveBeenCalled();
     expect(warningsReporterService.hasWarning).toBeFalsy();
   });
 
-  it('should register the autoProvision warning', async () => {
+  it('should register the autoProvision warning', () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig({
         defaultNamespace: {
@@ -78,24 +54,19 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet.mock.calls).toEqual([
-      ['/api/kubernetes/namespace', undefined],
-      ['/dashboard/api/userprofile/test-namespace', undefined],
-    ]);
-    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'autoProvisionWarning',
         title:
-          'Automatic namespace provisioning is disabled. Namespace for test-user might not have been configured yet. Please, contact the administrator.',
+          'Automatic namespace provisioning is disabled. Namespace might not have been configured yet. Please, contact the administrator.',
       },
     ]);
   });
 
-  it('should register the advanced authorization warning for allowGroups', async () => {
+  it('should register the advanced authorization warning for allowGroups', () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig({
         networking: {
@@ -108,24 +79,19 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet.mock.calls).toEqual([
-      ['/api/kubernetes/namespace', undefined],
-      ['/dashboard/api/userprofile/test-namespace', undefined],
-    ]);
-    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'advancedAuthorizationGroupsWarning',
         title:
-          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+          'Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.',
       },
     ]);
   });
 
-  it('should register the advanced authorization warning for denyGroups', async () => {
+  it('should register the advanced authorization warning for denyGroups', () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig({
         networking: {
@@ -138,24 +104,19 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet.mock.calls).toEqual([
-      ['/api/kubernetes/namespace', undefined],
-      ['/dashboard/api/userprofile/test-namespace', undefined],
-    ]);
-    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'advancedAuthorizationGroupsWarning',
         title:
-          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+          'Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.',
       },
     ]);
   });
 
-  it('should register the advanced authorization warning for allowGroups', async () => {
+  it('should register the advanced authorization warning for allowGroups', () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig({
         networking: {
@@ -168,24 +129,19 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet.mock.calls).toEqual([
-      ['/api/kubernetes/namespace', undefined],
-      ['/dashboard/api/userprofile/test-namespace', undefined],
-    ]);
-    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'advancedAuthorizationGroupsWarning',
         title:
-          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+          'Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.',
       },
     ]);
   });
 
-  it('should register the advanced authorization warning for allowUsers', async () => {
+  it('should register the advanced authorization warning for allowUsers', () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig({
         networking: {
@@ -198,24 +154,19 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet.mock.calls).toEqual([
-      ['/api/kubernetes/namespace', undefined],
-      ['/dashboard/api/userprofile/test-namespace', undefined],
-    ]);
-    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'advancedAuthorizationUsersWarning',
         title:
-          'Advanced authorization is enabled. User test-user might not be allowed. Please, contact the administrator.',
+          'Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.',
       },
     ]);
   });
 
-  it('should register the advanced authorization warning for denyUsers', async () => {
+  it('should register the advanced authorization warning for denyUsers', () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig({
         networking: {
@@ -228,23 +179,19 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet.mock.calls).toEqual([
-      ['/api/kubernetes/namespace', undefined],
-      ['/dashboard/api/userprofile/test-namespace', undefined],
-    ]);
-    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'advancedAuthorizationUsersWarning',
-        title: 'Access for test-user is forbidden. Please contact the administrator.',
+        title:
+          'Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.',
       },
     ]);
   });
 
-  it('should register all possible warnings', async () => {
+  it('should register all possible warnings', () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig({
         defaultNamespace: {
@@ -261,23 +208,24 @@ describe('Check namespace provision warnings', () => {
       })
       .build();
 
-    await checkNamespaceProvisionWarnings(store.getState);
+    checkNamespaceProvisionWarnings(store.getState);
 
-    expect(mockGet.mock.calls).toEqual([
-      ['/api/kubernetes/namespace', undefined],
-      ['/dashboard/api/userprofile/test-namespace', undefined],
-    ]);
-    expect(mockGet).toBeCalledTimes(2);
     expect(warningsReporterService.hasWarning).toBeTruthy();
     expect(warningsReporterService.reportAllWarnings()).toEqual([
       {
         key: 'autoProvisionWarning',
         title:
-          'Automatic namespace provisioning is disabled. Namespace for test-user might not have been configured yet. Please, contact the administrator.',
+          'Automatic namespace provisioning is disabled. Namespace might not have been configured yet. Please, contact the administrator.',
+      },
+      {
+        key: 'advancedAuthorizationGroupsWarning',
+        title:
+          'Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.',
       },
       {
         key: 'advancedAuthorizationUsersWarning',
-        title: 'Access for test-user is forbidden. Please contact the administrator.',
+        title:
+          'Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.',
       },
     ]);
   });

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/warningsReporter.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/warningsReporter.spec.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '@/inversify.config';
+import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
+
+const warningsReporterService = container.get(WarningsReporterService);
+
+describe('Warnings Reporter', () => {
+  afterEach(() => {
+    warningsReporterService.clearWarnings();
+  });
+
+  test('report warnings', () => {
+    const warningMessage_1 = 'Mock warning message 1';
+    const warningMessage_2 = 'Mock warning message 2';
+
+    warningsReporterService.registerWarning('key_1', warningMessage_1);
+    warningsReporterService.registerWarning('key_2', warningMessage_2);
+
+    expect(warningsReporterService.hasWarning).toBeTruthy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([
+      {
+        key: 'key_1',
+        title: warningMessage_1,
+      },
+      {
+        key: 'key_2',
+        title: warningMessage_2,
+      },
+    ]);
+
+    warningsReporterService.clearWarnings();
+
+    expect(warningsReporterService.hasWarning).toBeFalsy();
+    expect(warningsReporterService.reportAllWarnings()).toEqual([]);
+  });
+});

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -135,7 +135,7 @@ export default class Bootstrap {
     try {
       await testBackends()(this.store.dispatch, this.store.getState, undefined);
     } catch (e) {
-      await checkNamespaceProvisionWarnings(this.store.getState);
+      checkNamespaceProvisionWarnings(this.store.getState);
       const errorMessage = common.helpers.errors.getMessage(e);
       this.issuesReporterService.registerIssue(
         'namespaceProvisioningError',

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -21,6 +21,7 @@ import {
   IssueType,
   WorkspaceData,
 } from '@/services/bootstrap/issuesReporter';
+import { checkNamespaceProvisionWarnings } from '@/services/bootstrap/namespaceProvisionWarnings';
 import {
   WorkspaceRunningError,
   WorkspaceStoppedDetector,
@@ -85,14 +86,12 @@ export default class Bootstrap {
   }
 
   async init(): Promise<void> {
-    await this.doBackendsSanityCheck();
-
+    await this.fetchServerConfig().then(() => this.doBackendsSanityCheck());
     this.prefetchResources();
 
     await Promise.all([
       this.fetchBranding(),
       this.fetchInfrastructureNamespaces(),
-      this.fetchServerConfig(),
       this.fetchClusterInfo(),
     ]);
 
@@ -136,8 +135,12 @@ export default class Bootstrap {
     try {
       await testBackends()(this.store.dispatch, this.store.getState, undefined);
     } catch (e) {
+      await checkNamespaceProvisionWarnings(this.store.getState);
       const errorMessage = common.helpers.errors.getMessage(e);
-      this.issuesReporterService.registerIssue('sessionExpired', new Error(errorMessage));
+      this.issuesReporterService.registerIssue(
+        'namespaceProvisioningError',
+        new Error(errorMessage),
+      );
       throw e;
     }
   }

--- a/packages/dashboard-frontend/src/services/bootstrap/issuesReporter.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/issuesReporter.ts
@@ -12,7 +12,13 @@
 
 import { injectable } from 'inversify';
 
+export type Warning = {
+  key: string;
+  title: string;
+};
+
 export type IssueType =
+  | 'namespaceProvisioningError'
   | 'sessionExpired'
   | 'sso'
   | 'workspaceInactive'
@@ -45,10 +51,17 @@ export class IssuesReporterService {
   }
 
   public reportIssue(): Issue | undefined {
-    return this.issues[0];
+    if (!this.hasIssue) {
+      return undefined;
+    }
+    return this.issues[this.issues.length - 1];
   }
 
   public reportAllIssues(): Issue[] {
     return this.issues;
+  }
+
+  public clearIssues(): void {
+    this.issues = [];
   }
 }

--- a/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { container } from '@/inversify.config';
+import { getKubernetesNamespace } from '@/services/backend-client/kubernetesNamespaceApi';
+import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
+import { AppState } from '@/store';
+import { selectAdvancedAuthorization, selectAutoProvision } from '@/store/ServerConfig/selectors';
+
+const warningsReporterService = container.get(WarningsReporterService);
+
+export async function checkNamespaceProvisionWarnings(getState: () => AppState): Promise<void> {
+  let username: string | undefined = undefined;
+  const state = getState();
+  const autoProvision = selectAutoProvision(state);
+  if (autoProvision === false) {
+    if (username === undefined) {
+      username = await getUsername();
+    }
+    warningsReporterService.registerWarning(
+      'autoProvisionWarning',
+      `Automatic namespace provisioning is disabled. Namespace for ${username} might not have been configured yet. Please, contact the administrator.`,
+    );
+  }
+
+  const advancedAuthorization = selectAdvancedAuthorization(state);
+  if (advancedAuthorization === undefined || Object.keys(advancedAuthorization).length === 0) {
+    return;
+  }
+  if (advancedAuthorization.allowGroups || advancedAuthorization.denyGroups) {
+    if (username === undefined) {
+      username = await getUsername();
+    }
+    warningsReporterService.registerWarning(
+      'advancedAuthorizationGroupsWarning',
+      `Advanced authorization is enabled. User ${username} might not be allowed. Please, contact the administrator.`,
+    );
+  }
+  if (advancedAuthorization.allowUsers || advancedAuthorization.denyUsers) {
+    if (username === undefined) {
+      username = await getUsername();
+    }
+    warningsReporterService.registerWarning(
+      'advancedAuthorizationUsersWarning',
+      `Access for ${username} is forbidden. Please contact the administrator.`,
+    );
+  }
+}
+
+async function getUsername(): Promise<string> {
+  let username = 'unknown';
+  try {
+    const namespaces = await getKubernetesNamespace();
+    const targetNamespace =
+      namespaces.find(namespace => namespace.attributes.default === 'true') || namespaces[0];
+    if (targetNamespace !== undefined) {
+      username = targetNamespace.name;
+    }
+  } catch (e) {
+    // noop
+  }
+
+  return username;
+}

--- a/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
@@ -12,6 +12,7 @@
 
 import { container } from '@/inversify.config';
 import { getKubernetesNamespace } from '@/services/backend-client/kubernetesNamespaceApi';
+import { fetchUserProfile } from '@/services/backend-client/userProfileApi';
 import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
 import { AppState } from '@/store';
 import { selectAdvancedAuthorization, selectAutoProvision } from '@/store/ServerConfig/selectors';
@@ -63,7 +64,8 @@ async function getUsername(): Promise<string> {
     const targetNamespace =
       namespaces.find(namespace => namespace.attributes.default === 'true') || namespaces[0];
     if (targetNamespace !== undefined) {
-      username = targetNamespace.name;
+      const userProfile = await fetchUserProfile(targetNamespace.name);
+      username = userProfile.username;
     }
   } catch (e) {
     // noop

--- a/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
@@ -37,6 +37,18 @@ export async function checkNamespaceProvisionWarnings(getState: () => AppState):
   if (advancedAuthorization === undefined || Object.keys(advancedAuthorization).length === 0) {
     return;
   }
+  if (advancedAuthorization.denyUsers) {
+    if (username === undefined) {
+      username = await getUsername();
+    }
+    if (advancedAuthorization.denyUsers.includes(username)) {
+      warningsReporterService.registerWarning(
+        'advancedAuthorizationUsersWarning',
+        `Access for ${username} is forbidden. Please contact the administrator.`,
+      );
+      return;
+    }
+  }
   if (advancedAuthorization.allowGroups || advancedAuthorization.denyGroups) {
     if (username === undefined) {
       username = await getUsername();
@@ -52,7 +64,7 @@ export async function checkNamespaceProvisionWarnings(getState: () => AppState):
     }
     warningsReporterService.registerWarning(
       'advancedAuthorizationUsersWarning',
-      `Access for ${username} is forbidden. Please contact the administrator.`,
+      `Advanced authorization is enabled. User ${username} might not be allowed. Please, contact the administrator.`,
     );
   }
 }

--- a/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
@@ -11,25 +11,19 @@
  */
 
 import { container } from '@/inversify.config';
-import { getKubernetesNamespace } from '@/services/backend-client/kubernetesNamespaceApi';
-import { fetchUserProfile } from '@/services/backend-client/userProfileApi';
 import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
 import { AppState } from '@/store';
 import { selectAdvancedAuthorization, selectAutoProvision } from '@/store/ServerConfig/selectors';
 
 const warningsReporterService = container.get(WarningsReporterService);
 
-export async function checkNamespaceProvisionWarnings(getState: () => AppState): Promise<void> {
-  let username: string | undefined = undefined;
+export function checkNamespaceProvisionWarnings(getState: () => AppState): void {
   const state = getState();
   const autoProvision = selectAutoProvision(state);
   if (autoProvision === false) {
-    if (username === undefined) {
-      username = await getUsername();
-    }
     warningsReporterService.registerWarning(
       'autoProvisionWarning',
-      `Automatic namespace provisioning is disabled. Namespace for ${username} might not have been configured yet. Please, contact the administrator.`,
+      `Automatic namespace provisioning is disabled. Namespace might not have been configured yet. Please, contact the administrator.`,
     );
   }
 
@@ -37,51 +31,16 @@ export async function checkNamespaceProvisionWarnings(getState: () => AppState):
   if (advancedAuthorization === undefined || Object.keys(advancedAuthorization).length === 0) {
     return;
   }
-  if (advancedAuthorization.denyUsers) {
-    if (username === undefined) {
-      username = await getUsername();
-    }
-    if (advancedAuthorization.denyUsers.includes(username)) {
-      warningsReporterService.registerWarning(
-        'advancedAuthorizationUsersWarning',
-        `Access for ${username} is forbidden. Please contact the administrator.`,
-      );
-      return;
-    }
-  }
   if (advancedAuthorization.allowGroups || advancedAuthorization.denyGroups) {
-    if (username === undefined) {
-      username = await getUsername();
-    }
     warningsReporterService.registerWarning(
       'advancedAuthorizationGroupsWarning',
-      `Advanced authorization is enabled. User ${username} might not be allowed. Please, contact the administrator.`,
+      `Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.`,
     );
   }
   if (advancedAuthorization.allowUsers || advancedAuthorization.denyUsers) {
-    if (username === undefined) {
-      username = await getUsername();
-    }
     warningsReporterService.registerWarning(
       'advancedAuthorizationUsersWarning',
-      `Advanced authorization is enabled. User ${username} might not be allowed. Please, contact the administrator.`,
+      `Advanced authorization is enabled. User might not be allowed. Please, contact the administrator.`,
     );
   }
-}
-
-async function getUsername(): Promise<string> {
-  let username = 'unknown';
-  try {
-    const namespaces = await getKubernetesNamespace();
-    const targetNamespace =
-      namespaces.find(namespace => namespace.attributes.default === 'true') || namespaces[0];
-    if (targetNamespace !== undefined) {
-      const userProfile = await fetchUserProfile(targetNamespace.name);
-      username = userProfile.username;
-    }
-  } catch (e) {
-    // noop
-  }
-
-  return username;
 }

--- a/packages/dashboard-frontend/src/services/bootstrap/warningsReporter.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/warningsReporter.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { injectable } from 'inversify';
+
+export type Warning = {
+  key: string;
+  title: string;
+};
+
+@injectable()
+export class WarningsReporterService {
+  private warnings: Warning[] = [];
+
+  public get hasWarning(): boolean {
+    return this.warnings.length !== 0;
+  }
+
+  public registerWarning(key: string, title: string): void {
+    this.warnings.push({ key, title });
+  }
+
+  public reportAllWarnings(): Warning[] {
+    return this.warnings;
+  }
+
+  public clearWarnings(): void {
+    this.warnings = [];
+  }
+}

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/index.spec.ts
@@ -16,7 +16,6 @@ import { ThunkDispatch } from 'redux-thunk';
 
 import { AppState } from '@/store';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
-import { AUTHORIZED } from '@/store/sanityCheckMiddleware';
 import * as dwServerConfigStore from '@/store/ServerConfig';
 import { serverConfig } from '@/store/ServerConfig/__tests__/stubs';
 
@@ -46,7 +45,6 @@ describe('dwPlugins store', () => {
       const expectedActions: dwServerConfigStore.KnownAction[] = [
         {
           type: 'REQUEST_DW_SERVER_CONFIG',
-          check: AUTHORIZED,
         },
         {
           type: 'RECEIVE_DW_SERVER_CONFIG',
@@ -76,7 +74,6 @@ describe('dwPlugins store', () => {
     const expectedActions: dwServerConfigStore.KnownAction[] = [
       {
         type: 'REQUEST_DW_SERVER_CONFIG',
-        check: AUTHORIZED,
       },
       {
         type: 'RECEIVE_DW_SERVER_CONFIG_ERROR',

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { api } from '@eclipse-che/common';
 import { AnyAction } from 'redux';
 import { MockStoreEnhanced } from 'redux-mock-store';
 import { ThunkDispatch } from 'redux-thunk';
@@ -18,6 +19,8 @@ import { AppState } from '@/store';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 import { serverConfig } from '@/store/ServerConfig/__tests__/stubs';
 import {
+  selectAdvancedAuthorization,
+  selectAutoProvision,
   selectDashboardLogo,
   selectDefaultComponents,
   selectDefaultEditor,
@@ -203,6 +206,68 @@ describe('serverConfig selectors', () => {
 
       const selectedDashboardLogo = selectDashboardLogo(state);
       expect(selectedDashboardLogo).toBeUndefined();
+    });
+  });
+
+  describe('selectAdvancedAuthorization', () => {
+    it('should return provided value', () => {
+      const fakeStore = new FakeStoreBuilder()
+        .withDwServerConfig(
+          Object.assign({}, serverConfig, {
+            networking: {
+              auth: {
+                advancedAuthorization: {
+                  allowUsers: ['user0'],
+                },
+              },
+            },
+          } as api.IServerConfig),
+        )
+        .build() as MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, AnyAction>>;
+      const state = fakeStore.getState();
+
+      const selectedAdvancedAuthorization = selectAdvancedAuthorization(state);
+      expect(selectedAdvancedAuthorization).toEqual({ allowUsers: ['user0'] });
+    });
+
+    it('should return default value', () => {
+      const fakeStore = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, AnyAction>
+      >;
+      const state = fakeStore.getState();
+
+      const selectedAdvancedAuthorization = selectAdvancedAuthorization(state);
+      expect(selectedAdvancedAuthorization).toBeUndefined();
+    });
+  });
+
+  describe('selectAutoProvision', () => {
+    it('should return provided value', () => {
+      const fakeStore = new FakeStoreBuilder()
+        .withDwServerConfig(
+          Object.assign({}, serverConfig, {
+            defaultNamespace: {
+              autoProvision: false,
+            },
+          } as api.IServerConfig),
+        )
+        .build() as MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, AnyAction>>;
+      const state = fakeStore.getState();
+
+      const selectedDashboardLogo = selectAutoProvision(state);
+      expect(selectedDashboardLogo).toBeFalsy();
+    });
+
+    it('should return default value', () => {
+      const fakeStore = new FakeStoreBuilder().build() as MockStoreEnhanced<
+        AppState,
+        ThunkDispatch<AppState, undefined, AnyAction>
+      >;
+      const state = fakeStore.getState();
+
+      const selectedDashboardLogo = selectAutoProvision(state);
+      expect(selectedDashboardLogo).toBeTruthy();
     });
   });
 });

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/stubs.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/stubs.ts
@@ -45,6 +45,9 @@ export const serverConfig: api.IServerConfig = {
     runTimeout: -1,
     startTimeout: 300,
   },
+  defaultNamespace: {
+    autoProvision: true,
+  },
   cheNamespace: 'eclipse-che',
   devfileRegistry: {
     disableInternalRegistry: false,

--- a/packages/dashboard-frontend/src/store/ServerConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/index.ts
@@ -16,7 +16,6 @@ import { Action, Reducer } from 'redux';
 import * as ServerConfigApi from '@/services/backend-client/serverConfigApi';
 import { AppThunk } from '@/store';
 import { createObject } from '@/store/helpers';
-import { AUTHORIZED, SanityCheckAction } from '@/store/sanityCheckMiddleware';
 
 export interface State {
   isLoading: boolean;
@@ -24,7 +23,7 @@ export interface State {
   error?: string;
 }
 
-export interface RequestDwServerConfigAction extends Action, SanityCheckAction {
+export interface RequestDwServerConfigAction {
   type: 'REQUEST_DW_SERVER_CONFIG';
 }
 
@@ -50,10 +49,7 @@ export const actionCreators: ActionCreators = {
   requestServerConfig:
     (): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch): Promise<void> => {
-      await dispatch({
-        type: 'REQUEST_DW_SERVER_CONFIG',
-        check: AUTHORIZED,
-      });
+      dispatch({ type: 'REQUEST_DW_SERVER_CONFIG' });
       try {
         const config = await ServerConfigApi.fetchServerConfig();
         dispatch({
@@ -92,6 +88,9 @@ const unloadedState: State = {
       inactivityTimeout: -1,
       runTimeout: -1,
       startTimeout: 300,
+    },
+    defaultNamespace: {
+      autoProvision: true,
     },
     cheNamespace: '',
     devfileRegistryURL: '',

--- a/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
@@ -61,4 +61,14 @@ export const selectStartTimeout = createSelector(
 
 export const selectDashboardLogo = createSelector(selectState, state => state.config.dashboardLogo);
 
+export const selectAdvancedAuthorization = createSelector(
+  selectState,
+  state => state.config.networking?.auth?.advancedAuthorization,
+);
+
+export const selectAutoProvision = createSelector(
+  selectState,
+  state => state.config.defaultNamespace.autoProvision,
+);
+
 export const selectServerConfigError = createSelector(selectState, state => state.error);

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -23,7 +23,6 @@ import { container } from '@/inversify.config';
 import { fetchServerConfig } from '@/services/backend-client/serverConfigApi';
 import { WebsocketClient } from '@/services/backend-client/websocketClient';
 import devfileApi from '@/services/devfileApi';
-import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
 import { FactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
 import { AppState } from '@/store';
@@ -360,7 +359,6 @@ describe('DevWorkspace store, actions', () => {
           check: AUTHORIZED,
         },
         {
-          check: AUTHORIZED,
           type: 'REQUEST_DW_SERVER_CONFIG',
         },
         {

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -76,6 +76,9 @@ export class FakeStoreBuilder {
           runTimeout: -1,
           startTimeout: 300,
         },
+        defaultNamespace: {
+          autoProvision: true,
+        },
         cheNamespace: '',
         devfileRegistry: {
           disableInternalRegistry: false,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add meaningful Dashboard warnings during the failures on namespace provisioning.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22714

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Eclipse Che and the dashboard image from this PR:
  ```sh
  kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {containers: [{image: "quay.io/eclipse/che-dashboard:pr-1023", name: che-dashboard}]}}]"
  ```
2. Turn off auto-provision for namespaces:
```sh
kubectl patch -n eclipse-che checluster/eclipse-che  --type=json -p="[{\"op\": \"replace\", \"path\": \"/spec/devEnvironments/defaultNamespace/autoProvision\", \"value\": false}]"
```
3. Delete the existing namespace:
```sh
kubectl delete namespace admin-che
```
4. Relogin the Dashboard page and the next error page should appear:

![Знімок екрана 2024-01-04 о 02 09 01](https://github.com/eclipse-che/che-dashboard/assets/6310786/e0bb382e-f525-42a5-95c4-56ffcee4c30d)

5. Activate the advanced authorization and allow just some users:
```sh
kubectl patch -n eclipse-che checluster/eclipse-che  --type=json -p="[{\"op\": \"add\", \"path\": \"/spec/networking/auth/advancedAuthorization\", \"value\": {allowUsers: [user0]}}]"
```

6. Refresh the Dashboard page and the next error page should appear:

![Знімок екрана 2024-01-04 о 02 09 55](https://github.com/eclipse-che/che-dashboard/assets/6310786/aa970c06-925c-471c-a670-07f04fa72010)


