### PR TITLE
Set che-editor annotation to devworkspace when using default editor

### DIFF
--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -29,12 +29,12 @@ import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/dev
 import { AppState } from '@/store';
 import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
+import * as getEditorModule from '@/store/DevfileRegistries/getEditor';
 import { AUTHORIZED } from '@/store/sanityCheckMiddleware';
 import * as ServerConfigStore from '@/store/ServerConfig';
 import { checkRunningWorkspacesLimit } from '@/store/Workspaces/devWorkspaces/checkRunningWorkspacesLimit';
 
 import * as testStore from '..';
-import * as getEditorModule from '@/store/DevfileRegistries/getEditor';
 
 jest.mock('../../../../services/backend-client/serverConfigApi');
 jest.mock('../../../../services/helpers/delay', () => ({

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -819,7 +819,7 @@ export const actionCreators: ActionCreators = {
       let editorContent: string | undefined;
       let editorYamlUrl: string | undefined;
       // do we have an optional editor parameter ?
-      const editor = attributes.cheEditor;
+      let editor = attributes.cheEditor;
       if (editor) {
         const response = await getEditor(editor, dispatch, getState, pluginRegistryUrl);
         if (response.content) {
@@ -855,6 +855,7 @@ export const actionCreators: ActionCreators = {
           } else {
             throw new Error(response.error);
           }
+          editor = defaultsEditor;
           console.debug(`Using default editor ${defaultsEditor}`);
         }
       }

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -540,6 +540,7 @@ export const actionCreators: ActionCreators = {
       const openVSXUrl = selectOpenVSXUrl(state);
       const pluginRegistryUrl = selectPluginRegistryUrl(state);
       const pluginRegistryInternalUrl = selectPluginRegistryInternalUrl(state);
+      const cheEditor = editorId ? editorId : selectDefaultEditor(state);
       const defaultNamespace = defaultKubernetesNamespace.name;
 
       try {
@@ -552,7 +553,7 @@ export const actionCreators: ActionCreators = {
         const createResp = await getDevWorkspaceClient().createDevWorkspace(
           defaultNamespace,
           devWorkspaceResource,
-          editorId,
+          cheEditor,
         );
 
         if (createResp.headers.warning) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds the `che.eclipse.org/che-editor` annotation on workspaces that use the default editor.
This annotation is required for defaultPlugin support.

Fixes https://github.com/eclipse/che/issues/22017

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22017


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Create a workspace by clicking the dashboard samples (use default editor)
2. After the workspace is created, run:
```
oc get dw <workspacename> -n <usernamespace> -o jsonpath='{.metadata.annotations.che\.eclipse\.org/che-editor}'
```
3. Verify that the command from step 2 returns: 
```
che-incubator/che-code/latest
```
4. Create a workspace using factory url: `<CHE-HOST>/#https://github.com/che-incubator/quarkus-api-example`
5. Repeat steps 2 and 3 with the new workspace.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
