### PR TITLE
fix: apply attribute to the default configuration devfile

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -200,6 +200,14 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
           devfile.metadata.generateName = project.name;
         }
       }
+    } else if (factoryResolver?.source === 'repo') {
+      if (FactoryLocationAdapter.isSshLocation(factoryParams.sourceUrl)) {
+        if (!devfile.attributes) {
+          devfile.attributes = {};
+        }
+
+        devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
+      }
     }
 
     if (remotes) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fix for https://github.com/eclipse-che/che-dashboard/pull/1016

Apply the attribute `controller.devfile.io/bootstrap-devworkspace: true` also when devfile resolution succeded but no devfile found.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/22697


### Is it tested? How?

1. Deploy Eclipse Che and the dashboard image from this PR:
  ```sh
  kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {containers: [{image: "quay.io/eclipse/che-dashboard:pr-1029", name: che-dashboard}]}}]"
  ```
2. Add your SSH keys to the Dashboard, and make sure the public one is uploaded to your Git provider.
3. Copy the git+SSH URL of your git repository, and create a new workspace using this URL.
4. The workspace should start successfully with the project cloned and the Devfile applied.
