### PR TITLE
chore: change years in license headers

### DIFF
--- a/.ci/oci-dashboard-happy-path.sh
+++ b/.ci/oci-dashboard-happy-path.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019-2022 Red Hat, Inc.
+# Copyright (c) 2019-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.ci/oci-dashboard-puppeteer.sh
+++ b/.ci/oci-dashboard-puppeteer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019-2022 Red Hat, Inc.
+# Copyright (c) 2019-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2022 Red Hat, Inc.
+# Copyright (c) 2012-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.config/copyright.js
+++ b/.config/copyright.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023 Red Hat, Inc.
+# Copyright (c) 2020-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023 Red Hat, Inc.
+# Copyright (c) 2020-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023 Red Hat, Inc.
+# Copyright (c) 2020-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Red Hat, Inc.
+# Copyright (c) 2020-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/brew.Dockerfile
+++ b/build/dockerfiles/brew.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/rhel.entrypoint.sh
+++ b/build/dockerfiles/rhel.entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/skaffold.Dockerfile
+++ b/build/dockerfiles/skaffold.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/make-release.sh
+++ b/make-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020-2023 Red Hat, Inc.
+# Copyright (c) 2020-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/jest.config.js
+++ b/packages/common/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/__tests__/index.spec.ts
+++ b/packages/common/src/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/dto/api/__tests__/webSocket.spec.ts
+++ b/packages/common/src/dto/api/__tests__/webSocket.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/dto/api/webSocket.ts
+++ b/packages/common/src/dto/api/webSocket.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/dto/cluster-config.ts
+++ b/packages/common/src/dto/cluster-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/dto/cluster-info.ts
+++ b/packages/common/src/dto/cluster-info.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/helpers/__tests__/errors.spec.ts
+++ b/packages/common/src/helpers/__tests__/errors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/helpers/__tests__/index.spec.ts
+++ b/packages/common/src/helpers/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/helpers/__tests__/sanitize.spec.ts
+++ b/packages/common/src/helpers/__tests__/sanitize.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/helpers/errors.ts
+++ b/packages/common/src/helpers/errors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/helpers/index.ts
+++ b/packages/common/src/helpers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/helpers/sanitize.ts
+++ b/packages/common/src/helpers/sanitize.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/.eslintrc.js
+++ b/packages/dashboard-backend/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/jest.config.js
+++ b/packages/dashboard-backend/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/jest.setup.js
+++ b/packages/dashboard-backend/jest.setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/__mocks__/args.ts
+++ b/packages/dashboard-backend/src/__mocks__/args.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/__tests__/app.spec.ts
+++ b/packages/dashboard-backend/src/__tests__/app.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/app.ts
+++ b/packages/dashboard-backend/src/app.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/constants/config.ts
+++ b/packages/dashboard-backend/src/constants/config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/constants/examples.ts
+++ b/packages/dashboard-backend/src/constants/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/constants/server-config.ts
+++ b/packages/dashboard-backend/src/constants/server-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/__mocks__/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/__mocks__/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspacePreferencesApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspacePreferencesApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceTemplateApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/devWorkspaceTemplateApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/dockerConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/dockerConfigApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/eventApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/eventApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/gettingStartedSamplesApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/gettingStartedSamplesApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/serverConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/serverConfigApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/userProfileApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/userProfileApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspaceApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspaceApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspacePreferencesApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspacePreferencesApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspaceTemplateApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/devWorkspaceTemplateApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/dockerConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/dockerConfigApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/eventApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/eventApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/gettingStartedSamplesApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/gettingStartedSamplesApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/__mocks__/prepareCustomObjectWatch.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/__mocks__/prepareCustomObjectWatch.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/__mocks__/retryableExec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/__mocks__/retryableExec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/__tests__/retryableExec.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/__tests__/retryableExec.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/createError.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/createError.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/exec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/exec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/getSampleIcon.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/getSampleIcon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCoreV1API.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCoreV1API.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCustomObjectAPI.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCustomObjectAPI.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCustomObjectWatch.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCustomObjectWatch.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/retryableExec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/retryableExec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/__tests__/logsApi.retry1.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/__tests__/logsApi.retry1.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/__tests__/logsApi.retry2.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/__tests__/logsApi.retry2.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/__tests__/logsApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/__tests__/logsApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/const.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/const.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/logsApi/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/helpers.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/helpers.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/podApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/__tests__/helpers.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/__tests__/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/helpers.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/sshKeysApi/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/services/userProfileApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/userProfileApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/helpers/__mocks__/getUserName.ts
+++ b/packages/dashboard-backend/src/helpers/__mocks__/getUserName.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/helpers/__tests__/getUserName.spec.ts
+++ b/packages/dashboard-backend/src/helpers/__tests__/getUserName.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/helpers/findApi.ts
+++ b/packages/dashboard-backend/src/helpers/findApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/helpers/getUserName.ts
+++ b/packages/dashboard-backend/src/helpers/getUserName.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/helpers/parseArgs.ts
+++ b/packages/dashboard-backend/src/helpers/parseArgs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/helpers/typeguards.ts
+++ b/packages/dashboard-backend/src/helpers/typeguards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/hooks/authenticateApiRequests.ts
+++ b/packages/dashboard-backend/src/localRun/hooks/authenticateApiRequests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/hooks/authorizationHooks.ts
+++ b/packages/dashboard-backend/src/localRun/hooks/authorizationHooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/hooks/stubCheServerOptionsRequests.ts
+++ b/packages/dashboard-backend/src/localRun/hooks/stubCheServerOptionsRequests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/index.ts
+++ b/packages/dashboard-backend/src/localRun/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/plugins/oauth2.ts
+++ b/packages/dashboard-backend/src/localRun/plugins/oauth2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/proxies/cheServerApi.ts
+++ b/packages/dashboard-backend/src/localRun/proxies/cheServerApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/proxies/dexProxies.ts
+++ b/packages/dashboard-backend/src/localRun/proxies/dexProxies.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/routes/dexCallback.ts
+++ b/packages/dashboard-backend/src/localRun/routes/dexCallback.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/localRun/routes/signOut.ts
+++ b/packages/dashboard-backend/src/localRun/routes/signOut.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/models/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/models/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/models/__tests__/restParams.spec.ts
+++ b/packages/dashboard-backend/src/models/__tests__/restParams.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/models/index.ts
+++ b/packages/dashboard-backend/src/models/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/models/restParams.ts
+++ b/packages/dashboard-backend/src/models/restParams.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/plugins/cors.ts
+++ b/packages/dashboard-backend/src/plugins/cors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/plugins/staticServer.ts
+++ b/packages/dashboard-backend/src/plugins/staticServer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/plugins/swagger.ts
+++ b/packages/dashboard-backend/src/plugins/swagger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/plugins/webSocket.ts
+++ b/packages/dashboard-backend/src/plugins/webSocket.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
+++ b/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/devworkspaceTemplates.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/devworkspaceTemplates.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/devworkspaces.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/devworkspaces.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/dockerConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dockerConfig.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/events.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/events.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/gitConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/gitConfig.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/kubeConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/kubeConfig.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/personalAccessToken.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/personalAccessToken.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/pods.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/pods.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/serverConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/serverConfig.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/sshKeys.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/sshKeys.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/__tests__/userProfile.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/userProfile.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/clusterConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/clusterInfo.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterInfo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/devworkspaces.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/dockerConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/dockerConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/events.ts
+++ b/packages/dashboard-backend/src/routes/api/events.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/gettingStartedSample.ts
+++ b/packages/dashboard-backend/src/routes/api/gettingStartedSample.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/gitConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/gitConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getServiceAccountToken.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getServiceAccountToken.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getToken.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getToken.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/helpers/getCertificateAuthority.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getCertificateAuthority.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/helpers/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getDevWorkspaceClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/helpers/getServiceAccountToken.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getServiceAccountToken.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getToken.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/kubeConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/kubeConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/personalAccessToken.ts
+++ b/packages/dashboard-backend/src/routes/api/personalAccessToken.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/podmanLogin.ts
+++ b/packages/dashboard-backend/src/routes/api/podmanLogin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/pods.ts
+++ b/packages/dashboard-backend/src/routes/api/pods.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/serverConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/serverConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/sshKeys.ts
+++ b/packages/dashboard-backend/src/routes/api/sshKeys.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/userProfile.ts
+++ b/packages/dashboard-backend/src/routes/api/userProfile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/websocket.ts
+++ b/packages/dashboard-backend/src/routes/api/websocket.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/api/workspacePreferences.ts
+++ b/packages/dashboard-backend/src/routes/api/workspacePreferences.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/routes/workspaceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/workspaceRedirect.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/server.ts
+++ b/packages/dashboard-backend/src/server.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/ObjectsWatcher.ts
+++ b/packages/dashboard-backend/src/services/ObjectsWatcher.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/SubscriptionManager.ts
+++ b/packages/dashboard-backend/src/services/SubscriptionManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/__tests__/ObjectsWatcher.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/ObjectsWatcher.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/__tests__/SubscriptionManager.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/SubscriptionManager.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/__tests__/helpers.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/helpers.ts
+++ b/packages/dashboard-backend/src/services/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/kubeclient/__mocks__/kubeConfigProvider.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/__mocks__/kubeConfigProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/kubeclient/__tests__/dwClientProvider.spec.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/__tests__/dwClientProvider.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/kubeclient/__tests__/kubeConfigProvider.spec.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/__tests__/kubeConfigProvider.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/kubeclient/dwClientProvider.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/dwClientProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/kubeclient/helpers/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/helpers/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/kubeclient/helpers/index.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/helpers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/kubeclient/kubeConfigProvider.ts
+++ b/packages/dashboard-backend/src/services/kubeclient/kubeConfigProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/logWatcher/__mocks__/index.ts
+++ b/packages/dashboard-backend/src/services/logWatcher/__mocks__/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/logWatcher/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/services/logWatcher/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/logWatcher/index.ts
+++ b/packages/dashboard-backend/src/services/logWatcher/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/types/Observer.ts
+++ b/packages/dashboard-backend/src/services/types/Observer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/services/types/__tests__/Observer.spec.ts
+++ b/packages/dashboard-backend/src/services/types/__tests__/Observer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/typings/multi-ini.d.ts
+++ b/packages/dashboard-backend/src/typings/multi-ini.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/utils/__mocks__/logger.ts
+++ b/packages/dashboard-backend/src/utils/__mocks__/logger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/utils/appBuilder.ts
+++ b/packages/dashboard-backend/src/utils/appBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/src/utils/logger.ts
+++ b/packages/dashboard-backend/src/utils/logger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/webpack.config.common.js
+++ b/packages/dashboard-backend/webpack.config.common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/webpack.config.dev.js
+++ b/packages/dashboard-backend/webpack.config.dev.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-backend/webpack.config.prod.js
+++ b/packages/dashboard-backend/webpack.config.prod.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/.eslintrc.js
+++ b/packages/dashboard-frontend/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/.stylelintrc.js
+++ b/packages/dashboard-frontend/.stylelintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/__mocks__/fileMock.js
+++ b/packages/dashboard-frontend/__mocks__/fileMock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/index.html
+++ b/packages/dashboard-frontend/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2018 Red Hat, Inc.
+    Copyright (c) 2015-2024 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/jest.config.check.js
+++ b/packages/dashboard-frontend/jest.config.check.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/jest.config.js
+++ b/packages/dashboard-frontend/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/jest.setup.tsx
+++ b/packages/dashboard-frontend/jest.setup.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/App.tsx
+++ b/packages/dashboard-frontend/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorBoundary/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/ErrorBoundary/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorBoundary/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/ErrorBoundary/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorBoundary/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/ErrorBoundary/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.module.css
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/index.module.css
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/Modal.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/Modal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/__tests__/Modal.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/__tests__/Modal.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/AboutMenu/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/ApplicationsMenu/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/ApplicationsMenu/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/ApplicationsMenu/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/ApplicationsMenu/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/UserMenu/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/UserMenu/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/UserMenu/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/UserMenu/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/Tools/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Header/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/MainItem.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/MainItem.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/MainList.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/MainList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentItem.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentItem.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentItemWorkspaceActions.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentItemWorkspaceActions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/MainItem.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/MainItem.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/MainList.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/MainList.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentItem.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentItem.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentList.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/RecentList.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/__tests__/isActive.spec.ts
+++ b/packages/dashboard-frontend/src/Layout/Navigation/__tests__/isActive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/index.module.css
+++ b/packages/dashboard-frontend/src/Layout/Navigation/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Navigation/isActive.ts
+++ b/packages/dashboard-frontend/src/Layout/Navigation/isActive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Sidebar/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Sidebar/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Sidebar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Sidebar/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/Sidebar/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Sidebar/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/StoreErrorsAlert/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/StoreErrorsAlert/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/StoreErrorsAlert/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/StoreErrorsAlert/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/StoreErrorsAlert/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/StoreErrorsAlert/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Layout/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Routes/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Routes/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Routes/index.tsx
+++ b/packages/dashboard-frontend/src/Routes/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/Routes/routes.ts
+++ b/packages/dashboard-frontend/src/Routes/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/__tests__/const.ts
+++ b/packages/dashboard-frontend/src/__tests__/const.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
+++ b/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/app.css
+++ b/packages/dashboard-frontend/src/app.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/AppAlertGroup/__tests__/AppAlertGroup.spec.tsx
+++ b/packages/dashboard-frontend/src/components/AppAlertGroup/__tests__/AppAlertGroup.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/AppAlertGroup/index.tsx
+++ b/packages/dashboard-frontend/src/components/AppAlertGroup/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/Branding/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Branding/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/Branding/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Branding/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/Branding/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Branding/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/Custom/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Custom/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/Custom/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Custom/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/Custom/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/Custom/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/isSupportedBrowser.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/NotSupportedBrowser/isSupportedBrowser.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/WebSocket/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/WebSocket/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/WebSocket/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/WebSocket/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/WebSocket/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/WebSocket/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/BannerAlert/index.tsx
+++ b/packages/dashboard-frontend/src/components/BannerAlert/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/CheTooltip/__tests__/CheTooltip.spec.tsx
+++ b/packages/dashboard-frontend/src/components/CheTooltip/__tests__/CheTooltip.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/CheTooltip/index.module.css
+++ b/packages/dashboard-frontend/src/components/CheTooltip/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/CheTooltip/index.tsx
+++ b/packages/dashboard-frontend/src/components/CheTooltip/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/DevfileViewer/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/DevfileViewer/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/DevfileViewer/index.module.css
+++ b/packages/dashboard-frontend/src/components/DevfileViewer/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/DevfileViewer/index.tsx
+++ b/packages/dashboard-frontend/src/components/DevfileViewer/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/EditorTools/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorTools/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/EditorTools/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/EditorTools/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/EditorTools/index.module.css
+++ b/packages/dashboard-frontend/src/components/EditorTools/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/EditorTools/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorTools/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/index.module.css
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Fallback/__tests__/Fallback.spec.tsx
+++ b/packages/dashboard-frontend/src/components/Fallback/__tests__/Fallback.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Fallback/index.tsx
+++ b/packages/dashboard-frontend/src/components/Fallback/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Head/__tests__/Head.spec.tsx
+++ b/packages/dashboard-frontend/src/components/Head/__tests__/Head.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Head/index.tsx
+++ b/packages/dashboard-frontend/src/components/Head/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Header/__tests__/Header.spec.tsx
+++ b/packages/dashboard-frontend/src/components/Header/__tests__/Header.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Header/index.tsx
+++ b/packages/dashboard-frontend/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/InputGroupExtended/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/InputGroupExtended/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/InputGroupExtended/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/InputGroupExtended/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/InputGroupExtended/index.module.css
+++ b/packages/dashboard-frontend/src/components/InputGroupExtended/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/InputGroupExtended/index.tsx
+++ b/packages/dashboard-frontend/src/components/InputGroupExtended/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Progress/__tests__/Progress.spec.tsx
+++ b/packages/dashboard-frontend/src/components/Progress/__tests__/Progress.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Progress/index.tsx
+++ b/packages/dashboard-frontend/src/components/Progress/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/ResourceIcon/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/ResourceIcon/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/ResourceIcon/index.module.css
+++ b/packages/dashboard-frontend/src/components/ResourceIcon/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/ResourceIcon/index.tsx
+++ b/packages/dashboard-frontend/src/components/ResourceIcon/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TagLabel/__tests__/TagLabel.spec.tsx
+++ b/packages/dashboard-frontend/src/components/TagLabel/__tests__/TagLabel.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TagLabel/index.module.css
+++ b/packages/dashboard-frontend/src/components/TagLabel/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TagLabel/index.tsx
+++ b/packages/dashboard-frontend/src/components/TagLabel/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TextFileUpload/Preview/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/Preview/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TextFileUpload/Preview/index.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/Preview/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TextFileUpload/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/TextFileUpload/index.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/UnsavedChangesModal/__tests__/UnsavedChangesModal.spec.tsx
+++ b/packages/dashboard-frontend/src/components/UnsavedChangesModal/__tests__/UnsavedChangesModal.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/UnsavedChangesModal/index.tsx
+++ b/packages/dashboard-frontend/src/components/UnsavedChangesModal/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/Indicator.spec.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/Indicator.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Label/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Label/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Label/index.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Label/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Workspace/Status/StoppedIcon.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/StoppedIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/Workspace/Status/getStatusIcon.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/getStatusIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/compareEventTime.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/compareEventTime.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/compareEventTime.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/compareEventTime.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ContainerSelector/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ContainerSelector/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ContainerSelector/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ContainerSelector/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ContainerSelector/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ContainerSelector/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ToolsPanel/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ToolsPanel/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ToolsPanel/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ToolsPanel/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/Viewer/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/Viewer/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/Viewer/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/Viewer/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/Viewer/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/Viewer/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ViewerTools/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ViewerTools/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ViewerTools/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ViewerTools/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/ViewerTools/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/ViewerTools/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceLogs/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceLogs/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/getGitRemotes.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/getGitRemotes.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/getProjectFromLocation.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/getProjectFromLocation.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/prepareDevfile.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/prepareDevfile.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getProjectFromLocation.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getProjectFromLocation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/prepareResources.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/prepareResources.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/buildStepName.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/buildStepName.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/buildStepName.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/buildStepName.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/ProgressStep.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/ProgressStep.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/prepareRestart.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/prepareRestart.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/prepareRestart.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/prepareRestart.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/fixtures.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/fixtures.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/utils.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/Icon/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/TimeLimit/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/TimeLimit/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/TimeLimit/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/TimeLimit/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/TimeLimit/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/TimeLimit/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__mocks__/ProgressStep.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__mocks__/ProgressStep.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/const.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/const.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/utils.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/workspaceStatusIs.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/workspaceStatusIs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/containers/Loader/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/containers/Loader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspaceDetails/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspacesList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/containers/__tests__/WorkspacesList.spec.tsx
+++ b/packages/dashboard-frontend/src/containers/__tests__/WorkspacesList.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/contexts/ToggleBars/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/ToggleBars/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/contexts/ToggleBars/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/ToggleBars/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/index.tsx
+++ b/packages/dashboard-frontend/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/inversify.config.ts
+++ b/packages/dashboard-frontend/src/inversify.config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/DropdownEditors/index.module.css
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/DropdownEditors/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/DropdownEditors/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/DropdownEditors/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/GitRepoLocationInput.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/GitRepoLocationInput.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/ImportFromGit/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SampleCard/index.module.css
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SampleCard/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SampleCard/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SampleCard/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListGallery.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListHeader.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListToolbar.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/SamplesListToolbar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/TemporaryStorageSwitch.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/TemporaryStorageSwitch.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/DropdownEditors.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/DropdownEditors.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/GetStartedTab.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/GetStartedTab.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SampleCard.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SampleCard.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListToolbar.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListToolbar.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/TemporaryStorageSwitch.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/TemporaryStorageSwitch.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/__tests__/GetStarted.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/Loader/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/Loader/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/Loader/index.module.css
+++ b/packages/dashboard-frontend/src/pages/Loader/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/Loader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/EmptyState/NoRegistries.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/EmptyState/NoRegistries.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/EmptyState/__tests__/NoRegistries.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/EmptyState/__tests__/NoRegistries.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/DeleteRegistriesModal.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/DeleteRegistriesModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/EditRegistryModal.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/EditRegistryModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/__tests__/DeleteRegistriesModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/__tests__/DeleteRegistriesModal.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/__tests__/EditRegistryModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/__tests__/EditRegistryModal.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryPassword/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryPassword/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryPassword/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryPassword/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUsername/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUsername/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUsername/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUsername/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__tests__/__mocks__/registryRowBuilder.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__tests__/__mocks__/registryRowBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/EmptyState/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/EmptyState/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/EmptyState/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/EmptyState/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Email/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Email/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Email/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Email/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Email/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Email/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Name/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Name/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Name/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Name/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Name/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/Name/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/SectionUser/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/EmptyState/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/EmptyState/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/EmptyState/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/EmptyState/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/GitServicesToolbar/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/GitServicesToolbar/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/Modals/RevokeGitServicesModal.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/Modals/RevokeGitServicesModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/Modals/__tests__/RevokeRegistriesModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/Modals/__tests__/RevokeRegistriesModal.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/__tests__/ProviderIcon.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/__tests__/ProviderIcon.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderIcon/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderWarning/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderWarning/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderWarning/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/ProviderWarning/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__mocks__/gitOauthRowBuilder.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/__mocks__/gitOauthRowBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__tests__/stub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/EmptyState/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/EmptyState/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/EmptyState/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/EmptyState/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/Toolbar/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/Toolbar/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/Toolbar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/Toolbar/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/Toolbar/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/Toolbar/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__tests__/stub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/types.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/types.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/DeleteModal/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/DeleteModal/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/DeleteModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/DeleteModal/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/DeleteModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/DeleteModal/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/EmptyState/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/EmptyState/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/EmptyState/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/EmptyState/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/Entry/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/Entry/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/Entry/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/Entry/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/Entry/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/Entry/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/List/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/__tests__/stub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/ConversionButton/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Button.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Button.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/Dropdown/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Projects/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Projects/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Projects/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Projects/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Projects/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Projects/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.module.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018-2023 Red Hat, Inc.
+* Copyright (c) 2018-2024 Red Hat, Inc.
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
 * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/__mocks__/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/EmptyState/NoWorkspaces.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/EmptyState/NoWorkspaces.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/EmptyState/NothingFound.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/EmptyState/NothingFound.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Rows.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/Toolbar/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/preload/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/preload/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
+++ b/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/preload/index.html
+++ b/packages/dashboard-frontend/src/preload/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2018 Red Hat, Inc.
+    Copyright (c) 2015-2024 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/preload/index.ts
+++ b/packages/dashboard-frontend/src/preload/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/preload/main.ts
+++ b/packages/dashboard-frontend/src/preload/main.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/service-worker.ts
+++ b/packages/dashboard-frontend/src/service-worker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/__mocks__/axios.ts
+++ b/packages/dashboard-frontend/src/services/__mocks__/axios.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/__mocks__/getComponentRenderer.tsx
+++ b/packages/dashboard-frontend/src/services/__mocks__/getComponentRenderer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/__mocks__/router.ts
+++ b/packages/dashboard-frontend/src/services/__mocks__/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/alerts/appAlerts.ts
+++ b/packages/dashboard-frontend/src/services/alerts/appAlerts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/assets/branding.ts
+++ b/packages/dashboard-frontend/src/services/assets/branding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/axios-wrapper/__tests__/axiosWrapper.spec.ts
+++ b/packages/dashboard-frontend/src/services/axios-wrapper/__tests__/axiosWrapper.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/axios-wrapper/axiosWrapper.ts
+++ b/packages/dashboard-frontend/src/services/axios-wrapper/axiosWrapper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/axios-wrapper/getAxiosInstance.ts
+++ b/packages/dashboard-frontend/src/services/axios-wrapper/getAxiosInstance.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/factoryApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/factoryApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/oAuthApi.spec.tsx
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/oAuthApi.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/clusterConfigApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/clusterConfigApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/clusterInfoApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/clusterInfoApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/const.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/const.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/dataResolverApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/devWorkspaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devWorkspaceApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/devworkspaceResourcesApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devworkspaceResourcesApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/eventsApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/eventsApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/factoryApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/factoryApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/gitConfigApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/gitConfigApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/kubernetesNamespaceApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/oAuthApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/oAuthApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/personalAccessTokenApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/personalAccessTokenApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/podsApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/podsApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/serverConfigApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/serverConfigApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/sshKeysApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/sshKeysApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/userProfileApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/userProfileApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/messageHandler.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/messageHandler.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/subscriptionsManager.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/subscriptionsManager.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/websocketClient/index.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/websocketClient/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/websocketClient/messageHandler.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/websocketClient/messageHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/websocketClient/subscriptionsManager.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/websocketClient/subscriptionsManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/issuesReporter.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/issuesReporter.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/namespaceProvisionWarnings.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/warningsReporter.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/warningsReporter.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/workspaceStoppedDetector.spec.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/workspaceStoppedDetector.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/issuesReporter.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/issuesReporter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/namespaceProvisionWarnings.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/warningsReporter.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/warningsReporter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/bootstrap/workspaceStoppedDetector.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/workspaceStoppedDetector.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/che-user-id/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/che-user-id/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/che-user-id/index.ts
+++ b/packages/dashboard-frontend/src/services/che-user-id/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfile/__tests__/devfileAdapter.spec.ts
+++ b/packages/dashboard-frontend/src/services/devfile/__tests__/devfileAdapter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfile/adapter.ts
+++ b/packages/dashboard-frontend/src/services/devfile/adapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfile/converters.ts
+++ b/packages/dashboard-frontend/src/services/devfile/converters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/__mocks__/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/__mocks__/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/spec/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/spec/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/spec/template.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/spec/template.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/__tests__/metadata.spec.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/__tests__/metadata.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspaceTemplate/metadata.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/__tests__/metadata.spec.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/__tests__/metadata.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/metadata.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/devfileApi.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfileApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/api-ping.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/api-ping.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/dates.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/dates.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/filter.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/getProjectName.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/getProjectName.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/sanitizeName.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/types.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/types.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/api-ping.ts
+++ b/packages/dashboard-frontend/src/services/helpers/api-ping.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/dates.ts
+++ b/packages/dashboard-frontend/src/services/helpers/dates.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/debounce.ts
+++ b/packages/dashboard-frontend/src/services/helpers/debounce.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/deferred.ts
+++ b/packages/dashboard-frontend/src/services/helpers/deferred.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/delay.ts
+++ b/packages/dashboard-frontend/src/services/helpers/delay.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/devworkspace.ts
+++ b/packages/dashboard-frontend/src/services/helpers/devworkspace.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/disposable.ts
+++ b/packages/dashboard-frontend/src/services/helpers/disposable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/document.ts
+++ b/packages/dashboard-frontend/src/services/helpers/document.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/editor.ts
+++ b/packages/dashboard-frontend/src/services/helpers/editor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/getLoaderMode.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/getLoaderMode.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/findTargetWorkspace.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/findTargetWorkspace.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/getLoaderMode.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/getLoaderMode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/filter.ts
+++ b/packages/dashboard-frontend/src/services/helpers/filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/generateName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/generateName.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/getProjectName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/getProjectName.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/login.ts
+++ b/packages/dashboard-frontend/src/services/helpers/login.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/random.ts
+++ b/packages/dashboard-frontend/src/services/helpers/random.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/resourceVersion.ts
+++ b/packages/dashboard-frontend/src/services/helpers/resourceVersion.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/sanitizeName.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/tools.ts
+++ b/packages/dashboard-frontend/src/services/helpers/tools.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/oauth/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/oauth/index.ts
+++ b/packages/dashboard-frontend/src/services/oauth/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
+++ b/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/registry/__tests__/types.spec.ts
+++ b/packages/dashboard-frontend/src/services/registry/__tests__/types.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/registry/fetchData.ts
+++ b/packages/dashboard-frontend/src/services/registry/fetchData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/registry/resources.ts
+++ b/packages/dashboard-frontend/src/services/registry/resources.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/registry/types.ts
+++ b/packages/dashboard-frontend/src/services/registry/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/resource-fetcher/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/resource-fetcher/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/resource-fetcher/appendLink.ts
+++ b/packages/dashboard-frontend/src/services/resource-fetcher/appendLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/resource-fetcher/index.ts
+++ b/packages/dashboard-frontend/src/services/resource-fetcher/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/session-storage/index.ts
+++ b/packages/dashboard-frontend/src/services/session-storage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/storageTypes.ts
+++ b/packages/dashboard-frontend/src/services/storageTypes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.debugMode.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.debugMode.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.managePvcStrategy.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.managePvcStrategy.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.onStart.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/converter.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/converter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/BannerAlert/index.ts
+++ b/packages/dashboard-frontend/src/store/BannerAlert/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/BannerAlert/selectors.ts
+++ b/packages/dashboard-frontend/src/store/BannerAlert/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Branding/index.ts
+++ b/packages/dashboard-frontend/src/store/Branding/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Branding/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Branding/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterInfo/index.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ClusterInfo/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ClusterInfo/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/getEditor.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/getEditor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/selectors.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DockerConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/DockerConfig/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DockerConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/DockerConfig/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DockerConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/DockerConfig/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DockerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/DockerConfig/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/DockerConfig/types.ts
+++ b/packages/dashboard-frontend/src/store/DockerConfig/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Events/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Events/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Events/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/Events/__tests__/reducers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Events/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/Events/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Events/__tests__/stubs.ts
+++ b/packages/dashboard-frontend/src/store/Events/__tests__/stubs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Events/index.ts
+++ b/packages/dashboard-frontend/src/store/Events/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Events/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Events/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/normalizeDevfileV2.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/normalizeDevfileV2.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV1.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/normalizeDevfileV2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/FactoryResolver/selectors.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitConfig/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitConfig/__tests__/reducer.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitConfig/__tests__/reducer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitConfig/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitConfig/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitConfig/reducer.ts
+++ b/packages/dashboard-frontend/src/store/GitConfig/reducer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/GitConfig/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitConfig/types.ts
+++ b/packages/dashboard-frontend/src/store/GitConfig/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/types.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/InfrastructureNamespaces/index.ts
+++ b/packages/dashboard-frontend/src/store/InfrastructureNamespaces/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/InfrastructureNamespaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/InfrastructureNamespaces/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/reducers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessToken/__tests__/stub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/PersonalAccessToken/index.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessToken/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/PersonalAccessToken/selectors.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessToken/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/PersonalAccessToken/state.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessToken/state.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Plugins/chePlugins/index.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/chePlugins/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Plugins/chePlugins/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/chePlugins/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/reducers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/Logs/index.ts
+++ b/packages/dashboard-frontend/src/store/Pods/Logs/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/Logs/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Pods/Logs/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/__tests__/isSamePod.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/__tests__/isSamePod.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/__tests__/reducers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/store/Pods/__tests__/stub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/index.ts
+++ b/packages/dashboard-frontend/src/store/Pods/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/isSamePod.ts
+++ b/packages/dashboard-frontend/src/store/Pods/isSamePod.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Pods/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Pods/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SanityCheck/index.ts
+++ b/packages/dashboard-frontend/src/store/SanityCheck/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SanityCheck/selectors.ts
+++ b/packages/dashboard-frontend/src/store/SanityCheck/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/stubs.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/stubs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ServerConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SshKeys/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/SshKeys/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SshKeys/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/SshKeys/__tests__/reducers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SshKeys/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/SshKeys/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SshKeys/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/store/SshKeys/__tests__/stub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SshKeys/index.ts
+++ b/packages/dashboard-frontend/src/store/SshKeys/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SshKeys/selectors.ts
+++ b/packages/dashboard-frontend/src/store/SshKeys/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/SshKeys/state.ts
+++ b/packages/dashboard-frontend/src/store/SshKeys/state.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Id/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/User/Id/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Id/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/User/Id/__tests__/reducers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Id/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/User/Id/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Id/index.ts
+++ b/packages/dashboard-frontend/src/store/User/Id/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Id/selectors.ts
+++ b/packages/dashboard-frontend/src/store/User/Id/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Profile/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/User/Profile/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Profile/index.ts
+++ b/packages/dashboard-frontend/src/store/User/Profile/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/User/Profile/selectors.ts
+++ b/packages/dashboard-frontend/src/store/User/Profile/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/reducers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/checkRunningWorkspacesLimit.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/checkRunningWorkspacesLimit.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Workspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/selectors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/__mocks__/devfile.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devfile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/__mocks__/factoryResolverBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/factoryResolverBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/__mocks__/thunk.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/thunk.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/store/__tests__/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/configureStore.ts
+++ b/packages/dashboard-frontend/src/store/configureStore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/helpers.ts
+++ b/packages/dashboard-frontend/src/store/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/index.ts
+++ b/packages/dashboard-frontend/src/store/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/store/sanityCheckMiddleware.ts
+++ b/packages/dashboard-frontend/src/store/sanityCheckMiddleware.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/typings/api.che.d.ts
+++ b/packages/dashboard-frontend/src/typings/api.che.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/typings/che.d.ts
+++ b/packages/dashboard-frontend/src/typings/che.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/typings/css.module.d.ts
+++ b/packages/dashboard-frontend/src/typings/css.module.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/static/loader.html
+++ b/packages/dashboard-frontend/static/loader.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2018 Red Hat, Inc.
+    Copyright (c) 2015-2024 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/webpack.config.common.js
+++ b/packages/dashboard-frontend/webpack.config.common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/webpack.config.dev.js
+++ b/packages/dashboard-frontend/webpack.config.dev.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/webpack.config.prod.js
+++ b/packages/dashboard-frontend/webpack.config.prod.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Bump year in all the license headers.

```diff
-Copyright (c) 2019-2023 Red Hat, Inc.
+Copyright (c) 2019-2024 Red Hat, Inc.
```