### PR TITLE
Add a new workspace creation URL parameter

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -3,6 +3,7 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | Packages | Resolved CQs |
 | --- | --- |
 | `@fastify/cors@8.4.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@fastify/cors/8.4.1) |
+| `@fastify/reply-from@^9.6.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@fastify/reply-from/9.6.0) |
 | `@patternfly/react-core@4.278.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-core/4.278.0) |
 | `@patternfly/react-table@4.113.6` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-table/4.113.6) |
 | `@patternfly/react-icons@4.93.7` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-icons/4.93.7) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -808,7 +808,7 @@
 | [`safe-regex-test@1.0.0`](git+https://github.com/ljharb/safe-regex-test.git) | MIT | clearlydefined |
 | [`saxes@6.0.0`](https://github.com/lddubeau/saxes.git) | ISC | clearlydefined |
 | [`schema-utils@4.2.0`](https://github.com/webpack/schema-utils.git) | MIT | #8986 |
-| [`serialize-javascript@6.0.1`](git+https://github.com/yahoo/serialize-javascript.git) | BSD-3-Clause | clearlydefined |
+| [`serialize-javascript@6.0.1`](git+https://github.com/yahoo/serialize-javascript.git) | BSD-3-Clause | #12680 |
 | [`set-blocking@2.0.0`](git+https://github.com/yargs/set-blocking.git) | ISC | #5899 |
 | [`set-function-name@2.0.1`](git+https://github.com/ljharb/set-function-name.git) | MIT | #10590 |
 | [`shallow-clone@3.0.1`](https://github.com/jonschlinkert/shallow-clone.git) | MIT | clearlydefined |
@@ -852,7 +852,7 @@
 | [`strip-final-newline@2.0.0`](https://github.com/sindresorhus/strip-final-newline.git) | MIT | clearlydefined |
 | [`strip-indent@3.0.0`](https://github.com/sindresorhus/strip-indent.git) | MIT | clearlydefined |
 | [`strong-log-transformer@2.1.0`](git://github.com/strongloop/strong-log-transformer) | Apache-2.0 | #1138 |
-| [`style-loader@3.3.3`](https://github.com/webpack-contrib/style-loader.git) | MIT | clearlydefined |
+| [`style-loader@3.3.3`](https://github.com/webpack-contrib/style-loader.git) | MIT | #12669 |
 | [`style-search@0.1.0`](git+https://github.com/davidtheclark/style-search.git) | ISC | clearlydefined |
 | [`stylehacks@6.0.0`](https://github.com/cssnano/cssnano.git) | MIT | clearlydefined |
 | [`stylelint-config-clean-order@5.2.0`](https://github.com/kutsan/stylelint-config-clean-order.git) | MIT | clearlydefined |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -6,9 +6,9 @@
 | [`@devfile/api@2.2.0-alpha-1637255314`](https://github.com/devfile/api.git) | EPL-2.0 | clearlydefined |
 | `@eclipse-che/api@7.76.0` | EPL-2.0 | ecd.che |
 | [`@eclipse-che/che-devworkspace-generator@7.79.0-next-1427c19`](git+https://github.com/eclipse-che/che-devfile-registry.git) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/common@7.79.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-backend@7.79.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-frontend@7.79.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/common@7.81.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-backend@7.81.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-frontend@7.81.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/devfile-converter@0.0.1-0751ad2`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | ecd.che |
 | [`@fastify/accept-negotiator@1.1.0`](git+https://github.com/fastify/accept-negotiator.git) | MIT | clearlydefined |
 | [`@fastify/ajv-compiler@3.5.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
@@ -20,7 +20,7 @@
 | [`@fastify/fast-json-stringify-compiler@4.3.0`](git+https://github.com/fastify/fast-json-stringify-compiler.git) | MIT | clearlydefined |
 | [`@fastify/http-proxy@9.3.0`](git+https://github.com/fastify/fastify-http-proxy.git) | MIT | clearlydefined |
 | [`@fastify/oauth2@7.5.0`](git+https://github.com/fastify/fastify-oauth2.git) | MIT | clearlydefined |
-| [`@fastify/reply-from@9.4.0`](git+https://github.com/fastify/fastify-reply-from.git) | MIT | clearlydefined |
+| [`@fastify/reply-from@9.6.0`](git+https://github.com/fastify/fastify-reply-from.git) | MIT | clearlydefined |
 | [`@fastify/send@2.1.0`](git+https://github.com/fastify/send.git) | MIT | clearlydefined |
 | [`@fastify/static@6.12.0`](https://github.com/fastify/fastify-static.git) | MIT | clearlydefined |
 | [`@fastify/swagger-ui@1.9.2`](git+https://github.com/fastify/fastify-swagger-ui.git) | MIT | clearlydefined |
@@ -170,7 +170,7 @@
 | [`file-selector@0.1.19`](https://github.com/react-dropzone/file-selector.git) | MIT | [CQ22350](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22350) |
 | [`find-my-way@7.7.0`](git+https://github.com/delvedor/find-my-way.git) | MIT | clearlydefined |
 | [`focus-trap@6.9.2`](git+https://github.com/focus-trap/focus-trap.git) | MIT | clearlydefined |
-| [`follow-redirects@1.15.3`](git@github.com:follow-redirects/follow-redirects.git) | MIT | #10782 |
+| [`follow-redirects@1.15.4`](git@github.com:follow-redirects/follow-redirects.git) | MIT | #10782 |
 | [`forever-agent@0.6.1`](https://github.com/mikeal/forever-agent) | Apache-2.0 | clearlydefined |
 | [`form-data@4.0.0`](git://github.com/form-data/form-data.git) | MIT | clearlydefined |
 | [`forwarded@0.2.0`](https://github.com/jshttp/forwarded.git) | MIT | clearlydefined |

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
@@ -226,7 +226,7 @@ class CreatingStepApplyResources extends ProgressStep<Props, State> {
       return false;
     }
 
-    await this.props.createWorkspaceFromResources(...resources, cheEditor);
+    await this.props.createWorkspaceFromResources(...resources, factoryParams, cheEditor);
 
     // wait for the workspace creation to complete
     return false;

--- a/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
+++ b/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
@@ -32,6 +32,15 @@ describe('test buildFactoryLoaderPath()', () => {
       );
     });
 
+    test('editor-image parameter', () => {
+      const result = buildFactoryLoaderPath(
+        'git@github.com:eclipse-che/che-dashboard.git?editor-image=quay.io/mloriedo/che-code:copilot-builtin',
+      );
+      expect(result).toEqual(
+        '/f?editor-image=quay.io%2Fmloriedo%2Fche-code%3Acopilot-builtin&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+      );
+    });
+
     test('devfilePath parameter', () => {
       const result = buildFactoryLoaderPath(
         'git@github.com:eclipse-che/che-dashboard.git?devfilePath=devfilev2.yaml',

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -18,6 +18,7 @@ export const POLICIES_CREATE_ATTR = 'policies.create';
 export const STORAGE_TYPE_ATTR = 'storageType';
 export const REMOTES_ATTR = 'remotes';
 export const IMAGE_ATTR = 'image';
+export const EDITOR_IMAGE_ATTR = 'editor-image';
 export const USE_DEFAULT_DEVFILE = 'useDefaultDevfile';
 export const DEBUG_WORKSPACE_START = 'debugWorkspaceStart';
 export const PROPAGATE_FACTORY_ATTRS = [
@@ -30,6 +31,7 @@ export const PROPAGATE_FACTORY_ATTRS = [
   STORAGE_TYPE_ATTR,
   REMOTES_ATTR,
   IMAGE_ATTR,
+  EDITOR_IMAGE_ATTR,
 ];
 export const OVERRIDE_ATTR_PREFIX = 'override.';
 export const DEFAULT_POLICIES_CREATE = 'peruser';
@@ -44,6 +46,7 @@ export type FactoryParams = {
   errorCode: ErrorCode | undefined;
   storageType: che.WorkspaceStorageType | undefined;
   cheEditor: string | undefined;
+  editorImage: string | undefined;
   remotes: string | undefined;
   image: string | undefined;
   useDefaultDevfile: boolean;
@@ -57,6 +60,7 @@ export type ErrorCode = 'invalid_request' | 'access_denied';
 export function buildFactoryParams(searchParams: URLSearchParams): FactoryParams {
   return {
     cheEditor: getEditorId(searchParams),
+    editorImage: getEditorImage(searchParams),
     errorCode: getErrorCode(searchParams),
     factoryId: buildFactoryId(searchParams),
     factoryUrl: getFactoryUrl(searchParams),
@@ -104,6 +108,10 @@ function getStorageType(searchParams: URLSearchParams): che.WorkspaceStorageType
 
 function getEditorId(searchParams: URLSearchParams): string | undefined {
   return searchParams.get(EDITOR_ATTR) || undefined;
+}
+
+function getEditorImage(searchParams: URLSearchParams): string | undefined {
+  return searchParams.get(EDITOR_IMAGE_ATTR) || undefined;
 }
 
 function getErrorCode(searchParams: URLSearchParams): ErrorCode | undefined {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -803,7 +803,11 @@ describe('DevWorkspace store, actions', () => {
       mockOnStart.mockResolvedValueOnce(undefined);
 
       await store.dispatch(
-        testStore.actionCreators.createWorkspaceFromResources(devWorkspace, devWorkspaceTemplate),
+        testStore.actionCreators.createWorkspaceFromResources(
+          devWorkspace,
+          devWorkspaceTemplate,
+          {},
+        ),
       );
 
       const actions = store.getActions();
@@ -843,7 +847,11 @@ describe('DevWorkspace store, actions', () => {
 
       try {
         await store.dispatch(
-          testStore.actionCreators.createWorkspaceFromResources(devWorkspace, devWorkspaceTemplate),
+          testStore.actionCreators.createWorkspaceFromResources(
+            devWorkspace,
+            devWorkspaceTemplate,
+            {},
+          ),
         );
       } catch (e) {
         // no-op
@@ -891,7 +899,11 @@ describe('DevWorkspace store, actions', () => {
 
       it('should provide default editor id when creating a new workspace from resources', async () => {
         await store.dispatch(
-          testStore.actionCreators.createWorkspaceFromResources(devWorkspace, devWorkspaceTemplate),
+          testStore.actionCreators.createWorkspaceFromResources(
+            devWorkspace,
+            devWorkspaceTemplate,
+            {},
+          ),
         );
 
         expect(mockCreateDevWorkspace).toHaveBeenCalledWith(
@@ -906,6 +918,7 @@ describe('DevWorkspace store, actions', () => {
           testStore.actionCreators.createWorkspaceFromResources(
             devWorkspace,
             devWorkspaceTemplate,
+            {},
             'editorid',
           ),
         );

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/editorImage.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/editorImage.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import fs from 'fs';
+import { dump, load } from 'js-yaml';
+
+import devfileApi from '@/services/devfileApi';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+import {
+  getEditorImage,
+  updateDevWorkspaceTemplate,
+  updateEditorDevfile,
+} from '@/store/Workspaces/devWorkspaces/editorImage';
+
+describe('Update editor image', () => {
+  it('should return the editor image param', () => {
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withTemplateAttributes({
+        'dw.metadata.annotations': {
+          'che.eclipse.org/devfile-source': dump({
+            factory: {
+              params:
+                'editor-image=test-images/che-code:tag&url=https://github.com/eclipse-che/che-dashboard',
+            },
+          }),
+        },
+      })
+      .build();
+
+    const editorImageParam = getEditorImage(devWorkspace);
+
+    expect(editorImageParam).toStrictEqual('test-images/che-code:tag');
+  });
+
+  it('should update the target image(editor devfile)', () => {
+    const customEditorImage = 'test-images/che-code:tag';
+
+    const editorContent = fs.readFileSync(
+      __dirname + '/fixtures/test-editor-devfile.yaml',
+      'utf-8',
+    );
+
+    const customEditorContent = updateEditorDevfile(editorContent, customEditorImage);
+
+    const output = fs.readFileSync(
+      __dirname + '/fixtures/test-editor-devfile-with-custom-image.yaml',
+      'utf-8',
+    );
+
+    expect(customEditorContent).toStrictEqual(output);
+  });
+
+  it('should update the target image(devWorkspace template)', () => {
+    const customEditorImage = 'test-images/che-code:tag';
+
+    const devWorkspaceTemplate = load(
+      fs.readFileSync(__dirname + '/fixtures/test-devworkspace-template.yaml', 'utf-8'),
+    ) as devfileApi.DevWorkspaceTemplate;
+
+    const customEditorContent = updateDevWorkspaceTemplate(devWorkspaceTemplate, customEditorImage);
+
+    const output = load(
+      fs.readFileSync(
+        __dirname + '/fixtures/test-devworkspace-template-with-custom-image.yaml',
+        'utf-8',
+      ),
+    );
+
+    expect(customEditorContent).toStrictEqual(output);
+  });
+});

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/editorImage.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/editorImage.spec.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import common from '@eclipse-che/common';
 import fs from 'fs';
 import { dump, load } from 'js-yaml';
 
@@ -22,59 +23,153 @@ import {
 } from '@/store/Workspaces/devWorkspaces/editorImage';
 
 describe('Update editor image', () => {
-  it('should return the editor image param', () => {
-    const devWorkspace = new DevWorkspaceBuilder()
-      .withTemplateAttributes({
-        'dw.metadata.annotations': {
-          'che.eclipse.org/devfile-source': dump({
-            factory: {
-              params:
-                'editor-image=test-images/che-code:tag&url=https://github.com/eclipse-che/che-dashboard',
-            },
-          }),
-        },
-      })
-      .build();
+  describe('devfile source annotation', () => {
+    it('should return undefined without devfile-source', () => {
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withTemplateAttributes({
+          'dw.metadata.annotations': {},
+        })
+        .build();
 
-    const editorImageParam = getEditorImage(devWorkspace);
+      const editorImageParam = getEditorImage(devWorkspace);
 
-    expect(editorImageParam).toStrictEqual('test-images/che-code:tag');
+      expect(editorImageParam).toBeUndefined();
+    });
+
+    it('should return undefined without factory params', () => {
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withTemplateAttributes({
+          'dw.metadata.annotations': {
+            'che.eclipse.org/devfile-source': dump({
+              factory: {},
+            }),
+          },
+        })
+        .build();
+
+      const editorImageParam = getEditorImage(devWorkspace);
+
+      expect(editorImageParam).toBeUndefined();
+    });
+
+    it('should return the editor image param', () => {
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withTemplateAttributes({
+          'dw.metadata.annotations': {
+            'che.eclipse.org/devfile-source': dump({
+              factory: {
+                params:
+                  'editor-image=test-images/che-code:tag&url=https://github.com/eclipse-che/che-dashboard',
+              },
+            }),
+          },
+        })
+        .build();
+
+      const editorImageParam = getEditorImage(devWorkspace);
+
+      expect(editorImageParam).toStrictEqual('test-images/che-code:tag');
+    });
   });
 
-  it('should update the target image(editor devfile)', () => {
-    const customEditorImage = 'test-images/che-code:tag';
+  describe('editor devfile', () => {
+    it('should throw an error if editorContent is not defined', () => {
+      const customEditorImage = 'test-images/che-code:tag';
 
-    const editorContent = fs.readFileSync(
-      __dirname + '/fixtures/test-editor-devfile.yaml',
-      'utf-8',
-    );
+      const editorContent = '';
 
-    const customEditorContent = updateEditorDevfile(editorContent, customEditorImage);
+      let errorMessage: string | undefined;
+      try {
+        updateEditorDevfile(editorContent, customEditorImage);
+      } catch (err) {
+        errorMessage = common.helpers.errors.getMessage(err);
+      }
 
-    const output = fs.readFileSync(
-      __dirname + '/fixtures/test-editor-devfile-with-custom-image.yaml',
-      'utf-8',
-    );
+      expect(errorMessage).toEqual('Editor content is empty.');
+    });
 
-    expect(customEditorContent).toStrictEqual(output);
-  });
+    it('should throw an error if editor components are not defined', () => {
+      const customEditorImage = 'test-images/che-code:tag';
 
-  it('should update the target image(devWorkspace template)', () => {
-    const customEditorImage = 'test-images/che-code:tag';
-
-    const devWorkspaceTemplate = load(
-      fs.readFileSync(__dirname + '/fixtures/test-devworkspace-template.yaml', 'utf-8'),
-    ) as devfileApi.DevWorkspaceTemplate;
-
-    const customEditorContent = updateDevWorkspaceTemplate(devWorkspaceTemplate, customEditorImage);
-
-    const output = load(
-      fs.readFileSync(
-        __dirname + '/fixtures/test-devworkspace-template-with-custom-image.yaml',
+      const editorContent = fs.readFileSync(
+        __dirname + '/fixtures/test-devfile-without-components.yaml',
         'utf-8',
-      ),
-    );
+      );
 
-    expect(customEditorContent).toStrictEqual(output);
+      let errorMessage: string | undefined;
+      try {
+        updateEditorDevfile(editorContent, customEditorImage);
+      } catch (err) {
+        errorMessage = common.helpers.errors.getMessage(err);
+      }
+
+      expect(errorMessage).toEqual(
+        'Failed to update editor image. Editor components is not defined.',
+      );
+    });
+
+    it('should update the target image', () => {
+      const customEditorImage = 'test-images/che-code:tag';
+
+      const editorContent = fs.readFileSync(
+        __dirname + '/fixtures/test-editor-devfile.yaml',
+        'utf-8',
+      );
+
+      const customEditorContent = updateEditorDevfile(editorContent, customEditorImage);
+
+      const output = fs.readFileSync(
+        __dirname + '/fixtures/test-editor-devfile-with-custom-image.yaml',
+        'utf-8',
+      );
+
+      expect(customEditorContent).toStrictEqual(output);
+    });
+  });
+
+  describe('devWorkspace template', () => {
+    it('should throw an error if editor components are not defined', () => {
+      const customEditorImage = 'test-images/che-code:tag';
+
+      const devWorkspaceTemplate = load(
+        fs.readFileSync(
+          __dirname + '/fixtures/test-devworkspace-template-without-components.yaml',
+          'utf-8',
+        ),
+      ) as devfileApi.DevWorkspaceTemplate;
+
+      let errorMessage: string | undefined;
+      try {
+        updateDevWorkspaceTemplate(devWorkspaceTemplate, customEditorImage);
+      } catch (err) {
+        errorMessage = common.helpers.errors.getMessage(err);
+      }
+
+      expect(errorMessage).toEqual(
+        'Failed to update editor image. Editor components is not defined.',
+      );
+    });
+
+    it('should update the target image', () => {
+      const customEditorImage = 'test-images/che-code:tag';
+
+      const devWorkspaceTemplate = load(
+        fs.readFileSync(__dirname + '/fixtures/test-devworkspace-template.yaml', 'utf-8'),
+      ) as devfileApi.DevWorkspaceTemplate;
+
+      const customEditorContent = updateDevWorkspaceTemplate(
+        devWorkspaceTemplate,
+        customEditorImage,
+      );
+
+      const output = load(
+        fs.readFileSync(
+          __dirname + '/fixtures/test-devworkspace-template-with-custom-image.yaml',
+          'utf-8',
+        ),
+      );
+
+      expect(customEditorContent).toStrictEqual(output);
+    });
   });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devfile-without-components.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devfile-without-components.yaml
@@ -1,0 +1,5 @@
+schemaVersion: 2.2.0
+metadata:
+  name: che-test
+
+

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devfile-without-components.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devfile-without-components.yaml
@@ -1,5 +1,3 @@
 schemaVersion: 2.2.0
 metadata:
   name: che-test
-
-

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template-with-custom-image.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template-with-custom-image.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  annotations:
+    che.eclipse.org/components-update-policy: manual
+  name: che-code
+spec:
+  components:
+    - attributes:
+        controller.devfile.io/container-contribution: true
+      container:
+        image: test-images/che-code:tag
+      name: che-code-runtime-description
+    - name: checode
+      volume: {}
+    - container:
+        image: quay.io/che-incubator/che-code:next
+      name: che-code-injector

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template-without-components.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template-without-components.yaml
@@ -1,0 +1,7 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  annotations:
+    che.eclipse.org/components-update-policy: managed
+  name: che-code
+spec: {}

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  annotations:
+    che.eclipse.org/components-update-policy: managed
+  name: che-code
+spec:
+  components:
+    - attributes:
+        controller.devfile.io/container-contribution: true
+      container:
+        image: quay.io/devfile/universal-developer-image:next
+      name: che-code-runtime-description
+    - name: checode
+      volume: {}
+    - container:
+        image: quay.io/che-incubator/che-code:next
+      name: che-code-injector

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-editor-devfile-with-custom-image.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-editor-devfile-with-custom-image.yaml
@@ -1,0 +1,14 @@
+schemaVersion: 2.2.0
+metadata:
+  name: che-code
+components:
+  - name: che-code-runtime-description
+    container:
+      image: test-images/che-code:tag
+    attributes:
+      controller.devfile.io/container-contribution: true
+  - name: checode
+    volume: {}
+  - name: che-code-injector
+    container:
+      image: quay.io/che-incubator/che-code:next

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-editor-devfile.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-editor-devfile.yaml
@@ -1,0 +1,14 @@
+schemaVersion: 2.2.0
+metadata:
+  name: che-code
+components:
+  - name: che-code-runtime-description
+    container:
+      image: quay.io/devfile/universal-developer-image:next
+    attributes:
+      controller.devfile.io/container-contribution: true
+  - name: checode
+    volume: {}
+  - name: che-code-injector
+    container:
+      image: quay.io/che-incubator/che-code:next

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { V222DevfileComponents } from '@devfile/api';
+import common from '@eclipse-che/common';
+import { dump, load } from 'js-yaml';
+import cloneDeep from 'lodash/cloneDeep';
+
+import devfileApi from '@/services/devfileApi';
+import { buildFactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
+import { COMPONENT_UPDATE_POLICY } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+
+export function updateEditorDevfile(editorContent: string, editorImage: string): string {
+  if (!editorContent) {
+    throw new Error('Editor content is empty');
+  }
+  try {
+    const editorObj = load(editorContent) as devfileApi.Devfile;
+    updateComponents(editorObj.components, editorImage);
+    return dump(editorObj);
+  } catch (err) {
+    throw new Error(`Failed to update editor image. ${common.helpers.errors.getMessage(err)}`);
+  }
+}
+
+export function updateDevWorkspaceTemplate(
+  devWorkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+  editorImage: string,
+): devfileApi.DevWorkspaceTemplate {
+  if (!editorImage) {
+    throw new Error('Failed to update editor image. Editor image is empty.');
+  }
+  const _devWorkspaceTemplate = cloneDeep(devWorkspaceTemplate);
+  try {
+    const isUpdated = updateComponents(_devWorkspaceTemplate.spec?.components, editorImage);
+    if (
+      isUpdated &&
+      _devWorkspaceTemplate.metadata?.annotations?.[COMPONENT_UPDATE_POLICY] === 'managed'
+    ) {
+      _devWorkspaceTemplate.metadata.annotations[COMPONENT_UPDATE_POLICY] = 'manual';
+    }
+    return _devWorkspaceTemplate;
+  } catch (err) {
+    throw new Error(`Failed to update editor image. ${common.helpers.errors.getMessage(err)}`);
+  }
+}
+
+export function getEditorImage(workspace: devfileApi.DevWorkspace): string | undefined {
+  const devfileSourceYaml =
+    workspace.spec.template.attributes?.['dw.metadata.annotations']?.[
+      'che.eclipse.org/devfile-source'
+    ];
+  if (!devfileSourceYaml) {
+    return undefined;
+  }
+  const factorySearchParams = (
+    load(devfileSourceYaml) as {
+      factory?: {
+        params?: string;
+      };
+    }
+  )?.factory?.params;
+  if (!factorySearchParams) {
+    return undefined;
+  }
+  const factoryParams = buildFactoryParams(new URLSearchParams(factorySearchParams));
+
+  return factoryParams.editorImage;
+}
+
+function updateComponents(
+  components: V222DevfileComponents[] | undefined,
+  editorImage: string,
+): boolean {
+  if (!editorImage) {
+    throw new Error('Editor image is empty.');
+  }
+  if (!components) {
+    throw new Error('Editor components are empty');
+  }
+  let isUpdated = false;
+  for (let i = 0; i < components.length; i++) {
+    if (
+      components[i].attributes?.['controller.devfile.io/container-contribution'] &&
+      components[i].container?.image
+    ) {
+      components[i].container!.image = editorImage;
+      isUpdated = true;
+      break;
+    }
+  }
+  return isUpdated;
+}

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -181,7 +181,7 @@ export type ActionCreators = {
   ) => AppThunk<KnownAction, Promise<void>>;
   createWorkspaceFromDevfile: (
     devfile: devfileApi.Devfile,
-    attributes: Partial<FactoryParams>,
+    params: Partial<FactoryParams>,
     optionalFilesContent: {
       [fileName: string]: string;
     },
@@ -189,7 +189,7 @@ export type ActionCreators = {
   createWorkspaceFromResources: (
     devWorkspace: devfileApi.DevWorkspace,
     devWorkspaceTemplate: devfileApi.DevWorkspaceTemplate,
-    attributes: Partial<FactoryParams>,
+    params: Partial<FactoryParams>,
     // it could be editorId or editorContent
     editor?: string,
   ) => AppThunk<KnownAction, Promise<void>>;
@@ -537,9 +537,9 @@ export const actionCreators: ActionCreators = {
 
   createWorkspaceFromResources:
     (
-      devWorkspaceResource: devfileApi.DevWorkspace,
-      devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate,
-      attributes: Partial<FactoryParams>,
+      devWorkspace: devfileApi.DevWorkspace,
+      devWorkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+      params: Partial<FactoryParams>,
       editor?: string,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
@@ -560,7 +560,7 @@ export const actionCreators: ActionCreators = {
         /* create a new DevWorkspace */
         const createResp = await getDevWorkspaceClient().createDevWorkspace(
           defaultNamespace,
-          devWorkspaceResource,
+          devWorkspace,
           cheEditor,
         );
 
@@ -579,17 +579,12 @@ export const actionCreators: ActionCreators = {
           app => app.id === ApplicationId.CLUSTER_CONSOLE,
         );
 
-        if (attributes.editorImage) {
-          devWorkspaceTemplateResource = updateDevWorkspaceTemplate(
-            devWorkspaceTemplateResource,
-            attributes.editorImage,
-          );
-        }
+        devWorkspaceTemplate = updateDevWorkspaceTemplate(devWorkspaceTemplate, params.editorImage);
         /* create a new DevWorkspaceTemplate */
         await getDevWorkspaceClient().createDevWorkspaceTemplate(
           defaultNamespace,
           createResp.devWorkspace,
-          devWorkspaceTemplateResource,
+          devWorkspaceTemplate,
           pluginRegistryUrl,
           pluginRegistryInternalUrl,
           openVSXUrl,
@@ -826,7 +821,7 @@ export const actionCreators: ActionCreators = {
   createWorkspaceFromDevfile:
     (
       devfile: devfileApi.Devfile,
-      attributes: Partial<FactoryParams>,
+      params: Partial<FactoryParams>,
       optionalFilesContent: {
         [fileName: string]: string;
       },
@@ -839,7 +834,7 @@ export const actionCreators: ActionCreators = {
       let editorContent: string | undefined;
       let editorYamlUrl: string | undefined;
       // do we have an optional editor parameter ?
-      let editor = attributes.cheEditor;
+      let editor = params.cheEditor;
       if (editor) {
         const response = await getEditor(editor, dispatch, getState, pluginRegistryUrl);
         if (response.content) {
@@ -886,9 +881,7 @@ export const actionCreators: ActionCreators = {
           const error = selectSanityCheckError(getState());
           throw new Error(error);
         }
-        if (attributes.editorImage) {
-          editorContent = updateEditorDevfile(editorContent, attributes.editorImage);
-        }
+        editorContent = updateEditorDevfile(editorContent, params.editorImage);
         const resourcesContent = await fetchResources({
           pluginRegistryUrl,
           devfileContent: dump(devfile),
@@ -934,7 +927,7 @@ export const actionCreators: ActionCreators = {
         actionCreators.createWorkspaceFromResources(
           devWorkspaceResource,
           devWorkspaceTemplateResource,
-          attributes,
+          params,
           editor ? editor : editorContent,
         ),
       );

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -14,6 +14,7 @@ import { V1alpha2DevWorkspaceStatus, V1alpha2DevWorkspaceStatusConditions } from
 
 import devfileApi from '@/services/devfileApi';
 import { DevWorkspacePlugin } from '@/services/devfileApi/devWorkspace';
+import { DevWorkspaceSpecTemplateAttribute } from '@/services/devfileApi/devWorkspace/spec/template';
 import getRandomString from '@/services/helpers/random';
 import { DevWorkspaceStatus } from '@/services/helpers/types';
 
@@ -132,8 +133,7 @@ export class DevWorkspaceBuilder {
     this.workspace.spec.template.projects = projects;
     return this;
   }
-
-  withTemplateAttributes(attributes: any): DevWorkspaceBuilder {
+  withTemplateAttributes(attributes: DevWorkspaceSpecTemplateAttribute): DevWorkspaceBuilder {
     this.workspace.spec.template.attributes = attributes;
     return this;
   }

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -133,6 +133,11 @@ export class DevWorkspaceBuilder {
     return this;
   }
 
+  withTemplateAttributes(attributes: any): DevWorkspaceBuilder {
+    this.workspace.spec.template.attributes = attributes;
+    return this;
+  }
+
   build(): devfileApi.DevWorkspace {
     return this.workspace;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,12 +505,13 @@
     simple-oauth2 "^5.0.0"
 
 "@fastify/reply-from@^9.0.0":
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/@fastify/reply-from/-/reply-from-9.4.0.tgz#7d648cd5221e1aa9a0ec2cd5451f32078c431dd3"
-  integrity sha512-A0rT2o2Y8Xe9+CpS/VCfpWMLyptwI7peljdtdsW3nlLwwMbDr3kxDry5aiIb43SCfI1nr3B5mMH48kerJAZ8YQ==
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@fastify/reply-from/-/reply-from-9.6.0.tgz#63d45f4cd63f95a012549cc56fcb73ea6432d660"
+  integrity sha512-c1AqCq5+Wsc9iGpeRE5UpkzNJFn1HW1tCBgQw9h/EcaohqhYp2zoeXFM/MVFZvVKPph9eFkbWzLoQqMH4degfg==
   dependencies:
     "@fastify/error" "^3.0.0"
     end-of-stream "^1.4.4"
+    fast-content-type-parse "^1.1.0"
     fast-querystring "^1.0.0"
     fastify-plugin "^4.0.0"
     pump "^3.0.0"
@@ -5179,9 +5180,9 @@ focus-trap@6.9.2:
     tabbable "^5.3.2"
 
 follow-redirects@^1.15.0:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add a new workspace creation URL parameter named ```editor-image```

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22733

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR:
<details>
<summary>kubectl patch command</summary>

```bash
kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {containers: [{image: "quay.io/eclipse/che-dashboard:pr-1037", name: che-dashboard}]}}]"
```
</details>

2. Create a new workspace with the custom editor image from the next link
```bash
{CHE-server}#https://github.com/eclipse-che/che-dashboard&editor-image=quay.io/mloriedo/che-code:copilot-builtin
```

3. The new workspace should be created with the custom editor image ```quay.io/mloriedo/che-code:copilot-builtin```.
It  could be checked with **swagger**
```bash
 {CHE-server}/dashboard/api/swagger
 ```
![Знімок екрана 2024-01-16 о 16 52 26](https://github.com/eclipse-che/che-dashboard/assets/6310786/61b14c97-f63b-477d-87e4-798fae2ace38)

4. Create a new workspace with the custom che-editor and editor image from the next link
```bash
{CHE-server}#https://github.com/che-samples/bash&che-editor=che-incubator/che-idea/next&editor-image=quay.io/mloriedo/che-rider:2023:2
```
5. The new workspace should be created with the custom editor ```che-incubator/che-idea/next``` and the custom editor image ```quay.io/mloriedo/che-rider:2023:2```.
It  could be checked with **swagger**
```bash
 {CHE-server}/dashboard/api/swagger
 ```

![Знімок екрана 2024-01-16 о 17 24 50](https://github.com/eclipse-che/che-dashboard/assets/6310786/0da07a40-ed1b-47d4-ac79-d212bc827e18)

