### PR TITLE
Set the editor content as an editor ID for custom editors

### DIFF
--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -184,6 +184,7 @@ export type ActionCreators = {
   createWorkspaceFromResources: (
     devWorkspace: devfileApi.DevWorkspace,
     devWorkspaceTemplate: devfileApi.DevWorkspaceTemplate,
+    // it could be editorId or editorContent
     editor?: string,
   ) => AppThunk<KnownAction, Promise<void>>;
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -184,7 +184,7 @@ export type ActionCreators = {
   createWorkspaceFromResources: (
     devWorkspace: devfileApi.DevWorkspace,
     devWorkspaceTemplate: devfileApi.DevWorkspaceTemplate,
-    editorId?: string,
+    editor?: string,
   ) => AppThunk<KnownAction, Promise<void>>;
 
   handleWebSocketMessage: (
@@ -532,7 +532,7 @@ export const actionCreators: ActionCreators = {
     (
       devWorkspaceResource: devfileApi.DevWorkspace,
       devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate,
-      editorId?: string,
+      editor?: string,
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       const state = getState();
@@ -540,7 +540,7 @@ export const actionCreators: ActionCreators = {
       const openVSXUrl = selectOpenVSXUrl(state);
       const pluginRegistryUrl = selectPluginRegistryUrl(state);
       const pluginRegistryInternalUrl = selectPluginRegistryInternalUrl(state);
-      const cheEditor = editorId ? editorId : selectDefaultEditor(state);
+      const cheEditor = editor ? editor : selectDefaultEditor(state);
       const defaultNamespace = defaultKubernetesNamespace.name;
 
       try {
@@ -912,7 +912,7 @@ export const actionCreators: ActionCreators = {
         actionCreators.createWorkspaceFromResources(
           devWorkspaceResource,
           devWorkspaceTemplateResource,
-          editor,
+          editor ? editor : editorContent,
         ),
       );
     },


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixed the problem with the wrong editor annotation for custom editors. It happens when we try to create a new workspace from the git repository with the custom editor in the ```.che``` directory.

For example:
Create a new workspace with the custom editor from the next link
```bash
{CHE-server}#https://github.com/olexii4/web-java-spring-boot.git
```
Check created devworkspace attributes with **swagger**
```bash
 {CHE-server}/dashboard/api/swagger
 ```

![Знімок екрана 2024-01-16 о 17 31 20](https://github.com/eclipse-che/che-dashboard/assets/6310786/a474d60c-7729-4106-8eaf-d45518f3f0d0)


We can see the wrong annotation ```"che.eclipse.org/che-editor": "che-incubator/che-code/latest"``` for **che-idea**.


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Eclipse-Che with the image from this PR:
<details>
<summary>kubectl patch command</summary>

```bash
kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {containers: [{image: "quay.io/eclipse/che-dashboard:pr-1038", name: che-dashboard}]}}]"
```
</details>

2. Create a new workspace with the custom editor from the next link
```bash
{CHE-server}#https://github.com/olexii4/web-java-spring-boot.git
```
3. Check created devworkspace attributes with **swagger**
```bash
 {CHE-server}/dashboard/api/swagger
 ```
![Знімок екрана 2024-01-16 о 17 51 51](https://github.com/eclipse-che/che-dashboard/assets/6310786/a1d99c18-3107-4ecc-810c-f3fdf948a3c0)

 We can see the custom editor content as ```che.eclipse.org/che-editor``` annotation.
 