### PR TITLE
fix: add retries to server-config request

### DIFF
--- a/packages/dashboard-frontend/src/services/backend-client/serverConfigApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/serverConfigApi.ts
@@ -11,8 +11,8 @@
  */
 
 import { api } from '@eclipse-che/common';
-import axios from 'axios';
 
+import { AxiosWrapper } from '@/services/axios-wrapper/axiosWrapper';
 import { dashboardBackendPrefix } from '@/services/backend-client/const';
 
 /**
@@ -24,6 +24,6 @@ import { dashboardBackendPrefix } from '@/services/backend-client/const';
  */
 export async function fetchServerConfig(): Promise<api.IServerConfig> {
   const url = `${dashboardBackendPrefix}/server-config`;
-  const response = await axios.get(url);
+  const response = await AxiosWrapper.createToRetryAnyErrors().get(url);
   return response.data ? response.data : [];
 }

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
@@ -84,7 +84,7 @@ describe('Dashboard bootstrap', () => {
     expect(mockGet).toHaveBeenCalledWith('https://prefetch-che-cdn.test', {
       headers: { 'Cache-Control': 'no-cache', Expires: '0' },
     });
-    expect(mockGet).toHaveBeenCalledWith('/dashboard/api/server-config');
+    expect(mockGet).toHaveBeenCalledWith('/dashboard/api/server-config', undefined);
     expect(mockGet).toHaveBeenCalledWith('/dashboard/api/cluster-info');
     expect(mockGet).toHaveBeenCalledWith('/dashboard/api/userprofile/test-che', undefined);
     expect(mockGet).toHaveBeenCalledWith('/plugin-registry/v3/plugins/index.json');

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/index.spec.ts
@@ -56,7 +56,7 @@ describe('dwPlugins store', () => {
   });
 
   it('should create RECEIVE_DW_SERVER_CONFIG_ERROR when fetching server and got an error', async () => {
-    (mockAxios.get as jest.Mock).mockRejectedValueOnce('Test error');
+    (mockAxios.get as jest.Mock).mockRejectedValue('Test error');
 
     const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
       AppState,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds axios retry functionality to `/server-config` requests.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22641

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
This issue can be difficult to test in a real situation, but to quickly test the issue, you can:

1. Apply this patch:

<details><summary>Patch</summary>

```
diff --git a/packages/dashboard-backend/src/routes/api/serverConfig.ts b/packages/dashboard-backend/src/routes/api/serverConfig.ts
index b952336f..0a229cea 100644
--- a/packages/dashboard-backend/src/routes/api/serverConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/serverConfig.ts
@@ -16,7 +16,7 @@ import { FastifyInstance } from 'fastify';
 import { baseApiPath } from '@/constants/config';
 import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
 import { getServiceAccountToken } from '@/routes/api/helpers/getServiceAccountToken';
-import { getSchema } from '@/services/helpers';
+import { createFastifyError, getSchema } from '@/services/helpers';
 
 const tags = ['Server Config'];
 
@@ -28,6 +28,10 @@ export function registerServerConfigRoute(instance: FastifyInstance) {
 
   instance.register(async server => {
     server.get(`${baseApiPath}/server-config`, getSchema({ tags }), async function () {
+      if (Math.random() < 0.4) {
+        throw createFastifyError('ERROR', 'Bearer Token Authorization is required', 500);
+      }
+
       const token = getServiceAccountToken();
       const { serverConfigApi } = getDevWorkspaceClient(token);
       const cheCustomResource = await serverConfigApi.fetchCheCustomResource();

```

</details>

2. Build the dashboard image with the patch (I built it here: `quay.io/dkwon17/che-dashboard:server-config`) and apply it to an eclipse che installation.

3. Create a workspace within the Che dashboard.

About 40% of the time, you should see the retries in action in the web console:

<img width="964" alt="image" src="https://github.com/eclipse-che/che-dashboard/assets/83611742/4f534d5e-e1ac-4e4c-8ee3-2f087696e10b">


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
