### PR TITLE
Add a length limitation for auto-generated workspace names

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -264,6 +264,7 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
         this.updateCurrentDevfile(_devfile);
       } else {
         try {
+          console.log('>>>>>>>>>> STEP 1 >>>>>>>>>> devfile', devfile);
           await this.createWorkspaceFromDevfile(devfile);
         } catch (e) {
           const errorMessage = common.helpers.errors.getMessage(e);

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/getName.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/getName.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { generateWorkspaceName, WORKSPACE_NAME_MAX_LENGTH } from '@/services/helpers/generateName';
+
+describe('Get a new workspace name', () => {
+  it('returns a workspace name which start from the generateName', () => {
+    const generateName = 'project-demo';
+
+    const workspaceName = generateWorkspaceName(generateName);
+
+    expect(workspaceName.startsWith(generateName)).toBeTruthy();
+  });
+
+  it('returns a workspace name with 5 char suffix', () => {
+    const generateName = 'project-demo';
+
+    const workspaceName = generateWorkspaceName(generateName);
+
+    expect(workspaceName.length).toBe(generateName.length + 5);
+  });
+
+  it('returns a workspace name less then WORKSPACE_NAME_MAX_LENGTH symbols', () => {
+    const generateName = 'a'.repeat(WORKSPACE_NAME_MAX_LENGTH + 100);
+
+    const workspaceName = generateWorkspaceName(generateName);
+
+    expect(workspaceName.length).toBeLessThan(WORKSPACE_NAME_MAX_LENGTH);
+  });
+});

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/getProjectName.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/getProjectName.spec.ts
@@ -10,16 +10,16 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { getProjectName } from '@/services/helpers/getProjectName';
+import { getProjectName, PROJECT_NAME_MAX_LENGTH } from '@/services/helpers/getProjectName';
 
 describe('Get a project name based on location', () => {
-  it('should return a valid name less then 63 symbols', () => {
+  it('should return a valid name less then PROJECT_NAME_MAX_LENGTH symbols', () => {
     let cloneUrl = 'http://dummy/test.com/project-demo';
 
     cloneUrl += 'a'.repeat(100);
     const projectName = getProjectName(cloneUrl);
 
-    expect(projectName).toEqual('project-demo' + 'a'.repeat(50));
+    expect(projectName.length).toBeLessThan(PROJECT_NAME_MAX_LENGTH);
   });
 
   it('should return a valid name which has the first char [a-z0-9]', () => {

--- a/packages/dashboard-frontend/src/services/helpers/generateName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/generateName.ts
@@ -12,8 +12,15 @@
 
 import getRandomString from '@/services/helpers/random';
 
+export const WORKSPACE_NAME_MAX_LENGTH = 63;
+
 export function generateWorkspaceName(generateName: string): string {
-  return generateName + generateSuffix();
+  const suffix = generateSuffix();
+
+  if (generateName.length + suffix.length > WORKSPACE_NAME_MAX_LENGTH) {
+    generateName = generateName.substring(0, WORKSPACE_NAME_MAX_LENGTH - suffix.length - 1);
+  }
+  return generateName + suffix;
 }
 
 export function generateSuffix(): string {

--- a/packages/dashboard-frontend/src/services/helpers/getProjectName.ts
+++ b/packages/dashboard-frontend/src/services/helpers/getProjectName.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-const PROJECT_NAME_MAX_LENGTH = 63;
+export const PROJECT_NAME_MAX_LENGTH = 63;
 
 export function getProjectName(cloneUrl: string): string {
   let name = cloneUrl
@@ -22,7 +22,7 @@ export function getProjectName(cloneUrl: string): string {
   name = name.replace(/(^[-]+)/, '');
   name = name.replace(/([-]+$)/, '');
   if (name.length > PROJECT_NAME_MAX_LENGTH) {
-    name = name.substr(0, PROJECT_NAME_MAX_LENGTH - 1);
+    name = name.substring(0, PROJECT_NAME_MAX_LENGTH - 1);
   }
 
   return name;

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/editorImage.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/editorImage.spec.ts
@@ -104,7 +104,7 @@ describe('Update editor image', () => {
       }
 
       expect(errorMessage).toEqual(
-        'Failed to update editor image. Editor components is not defined.',
+        'Failed to update editor image. Editor components are not defined.',
       );
     });
 
@@ -146,7 +146,7 @@ describe('Update editor image', () => {
       }
 
       expect(errorMessage).toEqual(
-        'Failed to update editor image. Editor components is not defined.',
+        'Failed to update editor image. Editor components are not defined.',
       );
     });
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
@@ -87,7 +87,7 @@ function updateComponents(
   editorImage: string,
 ): boolean {
   if (!components) {
-    throw new Error('Editor components is not defined.');
+    throw new Error('Editor components are not defined.');
   }
   let isUpdated = false;
   for (let i = 0; i < components.length; i++) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR added a length limitation for auto-generated workspace names.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22758

### Is it tested? How?
1. Deploy Eclipse-Che with the image from this PR.
2. Create a new workspace with the custom editor from the next link:
```bash
{CHE-server}#https://github.com/olexii4/che-editor-theiahkhjkhkjhkjhjhghjhgfghfhgfhgjfghfghjfghjfhgfghfghjfhgfghfhgjfhgjfhg
```
3. A warning message will appear:
![Знімок екрана 2024-01-22 о 16 18 02](https://github.com/eclipse-che/che-dashboard/assets/6310786/8ad32b62-7eca-45ff-9b8c-16729672b95b)
4. Press **Continue with default devfile**.
5. A new workspace should be created.
