### PR TITLE
Catch delete token error if namespace is not provisioned

### DIFF
--- a/packages/common/src/helpers/__tests__/errors.spec.ts
+++ b/packages/common/src/helpers/__tests__/errors.spec.ts
@@ -14,7 +14,12 @@ import axios, { AxiosError, AxiosResponse } from 'axios';
 import { HttpError } from '@kubernetes/client-node';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import * as http from 'http';
-import { getMessage, isAxiosError, isError } from '../errors';
+import {
+  getMessage,
+  isAxiosError,
+  isError,
+  isTokenNotFoundError,
+} from '../errors';
 
 const mockAxios = new AxiosMockAdapter(axios);
 
@@ -40,6 +45,30 @@ describe('Errors helper', () => {
       const error = new Error(message) as AxiosError;
       error.isAxiosError = true;
       expect(isAxiosError(error)).toEqual(true);
+    });
+
+    it('should check if token not found error', () => {
+      const expectedError = {
+        name: '',
+        config: {},
+        request: {},
+        response: {
+          data: {
+            message:
+              'OAuth token for user xxxxx-xxxxx-xxxxx-xxxxx was not found',
+          },
+          status: 401,
+          statusText: '',
+          headers: {},
+          config: {},
+          request: {},
+        },
+        message: '',
+      };
+
+      const unexpectedError = new Error('Unsupported OAuth provider xxxxx');
+      expect(isTokenNotFoundError(expectedError)).toEqual(true);
+      expect(isTokenNotFoundError(unexpectedError)).toEqual(false);
     });
   });
 

--- a/packages/common/src/helpers/errors.ts
+++ b/packages/common/src/helpers/errors.ts
@@ -123,3 +123,13 @@ export function isKubeClientError(error: unknown): error is HttpError {
     'body' in (error as HttpError)
   );
 }
+export function isTokenNotFoundError(
+  error: unknown,
+): error is ObjectWithAxiosResponse {
+  return (
+    includesAxiosResponse(error) &&
+    /^OAuth token for user .* was not found$/.test(
+      (error as ObjectWithAxiosResponse).response.data.message,
+    )
+  );
+}

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
@@ -225,11 +225,18 @@ export const actionCreators: ActionCreators = {
         });
       } catch (e) {
         const errorMessage = common.helpers.errors.getMessage(e);
-        dispatch({
-          type: Type.RECEIVE_GIT_OAUTH_ERROR,
-          error: errorMessage,
-        });
-        throw e;
+        if (new RegExp('^OAuth token for user .* was not found$').test(errorMessage)) {
+          dispatch({
+            type: Type.DELETE_GIT_OAUTH_TOKEN,
+            provider: oauthProvider,
+          });
+        } else {
+          dispatch({
+            type: Type.RECEIVE_GIT_OAUTH_ERROR,
+            error: errorMessage,
+          });
+          throw e;
+        }
       }
     },
 

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
@@ -219,18 +219,9 @@ export const actionCreators: ActionCreators = {
 
       try {
         await deleteOAuthToken(oauthProvider);
-        dispatch({
-          type: Type.DELETE_GIT_OAUTH_TOKEN,
-          provider: oauthProvider,
-        });
       } catch (e) {
-        const errorMessage = common.helpers.errors.getMessage(e);
-        if (new RegExp('^OAuth token for user .* was not found$').test(errorMessage)) {
-          dispatch({
-            type: Type.DELETE_GIT_OAUTH_TOKEN,
-            provider: oauthProvider,
-          });
-        } else {
+        if (!common.helpers.errors.isTokenNotFoundError(e)) {
+          const errorMessage = common.helpers.errors.getMessage(e);
           dispatch({
             type: Type.RECEIVE_GIT_OAUTH_ERROR,
             error: errorMessage,
@@ -238,6 +229,10 @@ export const actionCreators: ActionCreators = {
           throw e;
         }
       }
+      dispatch({
+        type: Type.DELETE_GIT_OAUTH_TOKEN,
+        provider: oauthProvider,
+      });
     },
 
   deleteSkipOauth:


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Do not throw an error on Git Service revoke if the related oauth access token is not deleted.
Currently dashboard has a timer that controls che-server's namespace provision API request: If the namespace provision is executed another provision request will be ignored for 15 seconds:
https://github.com/eclipse-che/che-dashboard/blob/4b58763693995368bbc54384fa18002394e728c7/packages/dashboard-frontend/src/store/SanityCheck/index.ts#L83-L88
This timer causes a side effect that activates the revoke a Git service button after an actual revoke is performed. With this PR we intercept the delete token error on such case and deactivating the revoke button.
### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22776

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Setup GitHub oauth: https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github
2. Start a workspace from a GitHub repository, accept the GitHub token agreement.
3. Go to the dashboard `Git Services` tab and revoke the GitHub authorisation.
4. Quickly go to the `Personal Access Tokens` tab and then quickly switch back to the `Git Services` tab.
5. See: the GitHub still has an authorised state as the provision request was ignored and the related oauth token was not deleted.
6. Revoke the GitHub authorisation.
7. See: a notification about successful revoke appears and the authorisation status is changed to unauthorised.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
