### PR TITLE
Fix editor update flow

### DIFF
--- a/packages/common/src/helpers/__tests__/errors.spec.ts
+++ b/packages/common/src/helpers/__tests__/errors.spec.ts
@@ -66,7 +66,7 @@ describe('Errors helper', () => {
     expect(getMessage(notError)).toEqual(expectedMessage);
 
     const expectedOutput = ['Unexpected error:', { alert: 'Beware of bugs!' }];
-    expect(console.error).toBeCalledWith(...expectedOutput);
+    expect(console.error).toHaveBeenCalledWith(...expectedOutput);
   });
 
   describe('Frontend errors', () => {

--- a/packages/dashboard-backend/src/routes/api/__tests__/devworkspaceTemplates.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/devworkspaceTemplates.spec.ts
@@ -63,6 +63,16 @@ describe('DevWorkspaceTemplates Routes', () => {
       expect(res.json()).toEqual(stubDevWorkspaceTemplate);
     });
 
+    test('GET ${baseApiPath}/namespace/:namespace/devworkspacetemplates/:templateName', async () => {
+      const templateName = 'tmpl';
+      const res = await app
+        .inject()
+        .get(`${baseApiPath}/namespace/${namespace}/devworkspacetemplates/${templateName}`);
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.json()).toEqual(stubDevWorkspaceTemplate);
+    });
+
     test('PATCH ${baseApiPath}/namespace/:namespace/devworkspacetemplates/:templateName', async () => {
       const templateName = 'tmpl';
       const patches: api.IPatch[] = [

--- a/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
@@ -43,6 +43,20 @@ export function registerDevWorkspaceTemplates(instance: FastifyInstance) {
       },
     );
 
+    server.get(
+      `${baseApiPath}/namespace/:namespace/devworkspacetemplates/:templateName`,
+      getSchema({
+        tags,
+        params: namespacedTemplateSchema,
+      }),
+      async function (request: FastifyRequest) {
+        const { namespace, templateName } = request.params as restParams.INamespacedTemplateParams;
+        const token = getToken(request);
+        const { devWorkspaceTemplateApi: templateApi } = getDevWorkspaceClient(token);
+        return templateApi.getByName(namespace, templateName);
+      },
+    );
+
     server.post(
       `${baseApiPath}/namespace/:namespace/devworkspacetemplates`,
       getSchema({

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -174,6 +174,7 @@ export function getDevWorkspaceClient(
     devWorkspaceTemplateApi: {
       create: _template => Promise.resolve(stubDevWorkspaceTemplate),
       listInNamespace: _namespace => Promise.resolve(stubDevWorkspaceTemplatesList),
+      getByName: (_namespace, _name) => Promise.resolve(stubDevWorkspaceTemplate),
       patch: (_namespace, _name, _patches) => Promise.resolve(stubDevWorkspaceTemplate),
       delete: (_namespace, _name) => Promise.resolve(undefined),
     } as IDevWorkspaceTemplateApi,

--- a/packages/dashboard-backend/src/services/logWatcher/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/services/logWatcher/__tests__/index.spec.ts
@@ -73,7 +73,7 @@ describe('watchLogLevel', () => {
 
     await watchLogLevel(server);
 
-    expect(mockWatch).toBeCalledWith(
+    expect(mockWatch).toHaveBeenCalledWith(
       `/apis/org.eclipse.che/v2/namespaces/${namespace}/checlusters`,
       { watch: true },
       expect.any(Function),
@@ -90,6 +90,6 @@ describe('watchLogLevel', () => {
       },
     } as CheClusterCustomResource);
 
-    expect(mockUpdateLogLevel).toBeCalledWith('DEBUG', server);
+    expect(mockUpdateLogLevel).toHaveBeenCalledWith('DEBUG', server);
   });
 });

--- a/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
+++ b/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
@@ -186,7 +186,7 @@ describe('Workspace creation time', () => {
             },
             pluginRegistryURL: 'http://localhost/plugin-registry/v3',
           } as api.IServerConfig)
-          .withDwPlugins(plugins)
+          .withDwPlugins(plugins, {}, false)
           .withDevfileRegistries({
             devfiles: {
               ['http://localhost/plugin-registry/v3/plugins/che-incubator/che-code/insiders/devfile.yaml']:

--- a/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/GetStartedTab/__tests__/SamplesListGallery.spec.tsx
@@ -96,7 +96,7 @@ describe('Samples List Gallery', () => {
     const cardHeader = screen.getByText('Java with Spring Boot and MongoDB');
     fireEvent.click(cardHeader);
     jest.runOnlyPendingTimers();
-    expect(windowSpy).toBeCalledWith(
+    expect(windowSpy).toHaveBeenCalledWith(
       'http://localhost/#/load-factory?url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-guestbook%2Ftree%2Fdevfilev2',
       '_blank',
     );

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/__tests__/EditRegistryModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/Modals/__tests__/EditRegistryModal.spec.tsx
@@ -91,7 +91,9 @@ describe('Edit Registry Modal', () => {
     expect(editButton).toBeEnabled();
 
     userEvent.click(editButton);
-    expect(mockOnChange).toBeCalledWith(Object.assign({}, registry, { url: 'http://test.com' }));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      Object.assign({}, registry, { url: 'http://test.com' }),
+    );
   });
 
   it('should fire onCancel event', () => {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/__tests__/index.spec.tsx
@@ -97,7 +97,7 @@ describe('ContainerRegistries', () => {
     expect(editButton).toBeEnabled();
 
     userEvent.click(editButton);
-    expect(mockUpdateCredentials).toBeCalledWith([
+    expect(mockUpdateCredentials).toHaveBeenCalledWith([
       {
         url: 'http://tst',
         username: '',
@@ -133,6 +133,6 @@ describe('ContainerRegistries', () => {
     expect(deleteButton).toBeEnabled();
 
     userEvent.click(deleteButton);
-    expect(mockUpdateCredentials).toBeCalledWith([]);
+    expect(mockUpdateCredentials).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/Header/Actions/__tests__/index.spec.tsx
@@ -116,7 +116,10 @@ describe('Workspace WorkspaceAction widget', () => {
     targetAction.click();
 
     await waitFor(() =>
-      expect(window.open).toBeCalledWith(`#/ide/${namespace}/test-workspace-name`, workspaceUID),
+      expect(window.open).toHaveBeenCalledWith(
+        `#/ide/${namespace}/test-workspace-name`,
+        workspaceUID,
+      ),
     );
   });
 
@@ -136,7 +139,10 @@ describe('Workspace WorkspaceAction widget', () => {
     targetAction.click();
 
     await waitFor(() =>
-      expect(window.open).toBeCalledWith(`#/ide/${namespace}/test-workspace-name`, workspaceUID),
+      expect(window.open).toHaveBeenCalledWith(
+        `#/ide/${namespace}/test-workspace-name`,
+        workspaceUID,
+      ),
     );
   });
 

--- a/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
+++ b/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
@@ -158,7 +158,7 @@ describe('test storePathnameIfNeeded()', () => {
 
   test('regular path', () => {
     storePathIfNeeded('/test');
-    expect(mockUpdate).toBeCalledWith(SessionStorageKey.ORIGINAL_LOCATION_PATH, '/test');
+    expect(mockUpdate).toHaveBeenCalledWith(SessionStorageKey.ORIGINAL_LOCATION_PATH, '/test');
   });
 
   test('empty path', () => {

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/dataResolverApi.spec.ts
@@ -44,7 +44,7 @@ describe('Data Resolver API', () => {
       });
       const data = await getDataResolver(registryLocation);
 
-      expect(mockPost).toBeCalledWith('/dashboard/api/data/resolver', {
+      expect(mockPost).toHaveBeenCalledWith('/dashboard/api/data/resolver', {
         url: 'http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json',
       });
       expect(data).toEqual(metaData);

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/devWorkspaceTemplateApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/devWorkspaceTemplateApi.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import mockAxios from 'axios';
+
+import {
+  createTemplate,
+  getTemplateByName,
+  getTemplates,
+  patchTemplate,
+} from '@/services/backend-client/devWorkspaceTemplateApi';
+import devfileApi from '@/services/devfileApi';
+
+describe('DevWorkspaceTemplate API', () => {
+  const mockGet = mockAxios.get as jest.Mock;
+  const mockPost = mockAxios.post as jest.Mock;
+  const mockPatch = mockAxios.patch as jest.Mock;
+
+  const namespace = 'test-name';
+  const devWorkspaceTemplateName = 'che-code';
+  const devWorkspaceTemplate: devfileApi.DevWorkspaceTemplate = {
+    apiVersion: 'workspace.devfile.io/v1alpha2',
+    kind: 'DevWorkspaceTemplate',
+    metadata: {
+      name: devWorkspaceTemplateName,
+      namespace,
+      annotations: {},
+    },
+    spec: {},
+  };
+  const devWorkspaceTemplatePatch: api.IPatch[] = [
+    {
+      op: 'replace',
+      path: '/spec',
+      value: devWorkspaceTemplate.spec,
+    },
+  ];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetch DevWorkspaceTemplates', () => {
+    it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates"', async () => {
+      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      await getTemplates(namespace);
+
+      expect(mockGet).toBeCalledWith(
+        '/dashboard/api/namespace/test-name/devworkspacetemplates',
+        undefined,
+      );
+    });
+
+    it('should return a list of devWorkspaceTemplates', async () => {
+      mockGet.mockResolvedValueOnce(
+        new Promise(resolve => resolve({ data: [devWorkspaceTemplate] })),
+      );
+
+      const res = await getTemplates(namespace);
+
+      expect(res).toEqual([devWorkspaceTemplate]);
+    });
+  });
+
+  describe('fetch a DevWorkspaceTemplate by name', () => {
+    it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates/che-code"', async () => {
+      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      await getTemplateByName(namespace, devWorkspaceTemplateName);
+
+      expect(mockGet).toBeCalledWith(
+        '/dashboard/api/namespace/test-name/devworkspacetemplates/che-code',
+        undefined,
+      );
+    });
+
+    it('should return a devWorkspaceTemplate', async () => {
+      mockGet.mockResolvedValueOnce(
+        new Promise(resolve => resolve({ data: devWorkspaceTemplate })),
+      );
+
+      const res = await getTemplateByName(namespace, devWorkspaceTemplateName);
+
+      expect(res).toEqual(devWorkspaceTemplate);
+    });
+  });
+
+  describe('create a DevWorkspaceTemplate', () => {
+    it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates"', async () => {
+      mockPost.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      await createTemplate(devWorkspaceTemplate);
+
+      expect(mockPost).toBeCalledWith(
+        '/dashboard/api/namespace/test-name/devworkspacetemplates',
+        { template: devWorkspaceTemplate },
+        undefined,
+      );
+    });
+
+    it('should return a devWorkspaceTemplate', async () => {
+      mockPost.mockResolvedValueOnce(
+        new Promise(resolve => resolve({ data: devWorkspaceTemplate })),
+      );
+
+      const res = await createTemplate(devWorkspaceTemplate);
+
+      expect(res).toEqual(devWorkspaceTemplate);
+    });
+  });
+
+  describe('patch a DevWorkspaceTemplate', () => {
+    it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates/che-code"', async () => {
+      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      await patchTemplate(namespace, devWorkspaceTemplateName, devWorkspaceTemplatePatch);
+
+      expect(mockPatch).toBeCalledWith(
+        '/dashboard/api/namespace/test-name/devworkspacetemplates/che-code',
+        [{ op: 'replace', path: '/spec', value: {} }],
+        undefined,
+      );
+    });
+
+    it('should return a devWorkspaceTemplate', async () => {
+      mockPatch.mockResolvedValueOnce(
+        new Promise(resolve => resolve({ data: devWorkspaceTemplate })),
+      );
+
+      const res = await patchTemplate(
+        namespace,
+        devWorkspaceTemplateName,
+        devWorkspaceTemplatePatch,
+      );
+
+      expect(res).toEqual(devWorkspaceTemplate);
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/devWorkspaceTemplateApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/devWorkspaceTemplateApi.spec.ts
@@ -52,10 +52,10 @@ describe('DevWorkspaceTemplate API', () => {
 
   describe('fetch DevWorkspaceTemplates', () => {
     it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates"', async () => {
-      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: {} })));
       await getTemplates(namespace);
 
-      expect(mockGet).toBeCalledWith(
+      expect(mockGet).toHaveBeenCalledWith(
         '/dashboard/api/namespace/test-name/devworkspacetemplates',
         undefined,
       );
@@ -74,10 +74,10 @@ describe('DevWorkspaceTemplate API', () => {
 
   describe('fetch a DevWorkspaceTemplate by name', () => {
     it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates/che-code"', async () => {
-      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: {} })));
       await getTemplateByName(namespace, devWorkspaceTemplateName);
 
-      expect(mockGet).toBeCalledWith(
+      expect(mockGet).toHaveBeenCalledWith(
         '/dashboard/api/namespace/test-name/devworkspacetemplates/che-code',
         undefined,
       );
@@ -96,10 +96,10 @@ describe('DevWorkspaceTemplate API', () => {
 
   describe('create a DevWorkspaceTemplate', () => {
     it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates"', async () => {
-      mockPost.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      mockPost.mockResolvedValueOnce(new Promise(resolve => resolve({ data: {} })));
       await createTemplate(devWorkspaceTemplate);
 
-      expect(mockPost).toBeCalledWith(
+      expect(mockPost).toHaveBeenCalledWith(
         '/dashboard/api/namespace/test-name/devworkspacetemplates',
         { template: devWorkspaceTemplate },
         undefined,
@@ -119,10 +119,10 @@ describe('DevWorkspaceTemplate API', () => {
 
   describe('patch a DevWorkspaceTemplate', () => {
     it('should call "/dashboard/api/namespace/test-name/devworkspacetemplates/che-code"', async () => {
-      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: {} })));
       await patchTemplate(namespace, devWorkspaceTemplateName, devWorkspaceTemplatePatch);
 
-      expect(mockPatch).toBeCalledWith(
+      expect(mockPatch).toHaveBeenCalledWith(
         '/dashboard/api/namespace/test-name/devworkspacetemplates/che-code',
         [{ op: 'replace', path: '/spec', value: {} }],
         undefined,

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/factoryApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/factoryApi.spec.ts
@@ -48,7 +48,7 @@ describe('Factory API', () => {
       });
       await getFactoryResolver(location, {});
 
-      expect(mockPost).toBeCalledWith('/api/factory/resolver', {
+      expect(mockPost).toHaveBeenCalledWith('/api/factory/resolver', {
         url: 'https://github.com/eclipse-che/che-dashboard.git',
       });
     });
@@ -72,7 +72,7 @@ describe('Factory API', () => {
 
       await refreshFactoryOauthToken(location);
 
-      expect(mockPost).toBeCalledWith(
+      expect(mockPost).toHaveBeenCalledWith(
         '/api/factory/token/refresh?url=https://github.com/eclipse-che/che-dashboard.git',
       );
     });

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/kubernetesNamespaceApi.spec.ts
@@ -30,10 +30,10 @@ describe('Kubernetes namespace API', () => {
 
   describe('fetch namespace', () => {
     it('should call "/api/kubernetes/namespace"', async () => {
-      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: expect.anything() })));
+      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: {} })));
       await getKubernetesNamespace();
 
-      expect(mockGet).toBeCalledWith('/api/kubernetes/namespace', undefined);
+      expect(mockGet).toHaveBeenCalledWith('/api/kubernetes/namespace', undefined);
       expect(mockPost).not.toBeCalled();
     });
 
@@ -54,7 +54,11 @@ describe('Kubernetes namespace API', () => {
       await provisionKubernetesNamespace();
 
       expect(mockGet).not.toBeCalled();
-      expect(mockPost).toBeCalledWith('/api/kubernetes/namespace/provision', undefined, undefined);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/kubernetes/namespace/provision',
+        undefined,
+        undefined,
+      );
     });
 
     it('should return a list of namespaces', async () => {

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/oAuthApi.spec.tsx
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/oAuthApi.spec.tsx
@@ -38,7 +38,7 @@ describe('Open Authorization API', () => {
       await getOAuthProviders();
 
       expect(mockDelete).not.toBeCalled();
-      expect(mockGet).toBeCalledWith('/api/oauth');
+      expect(mockGet).toHaveBeenCalledWith('/api/oauth');
     });
 
     it('should return a list of providers', async () => {
@@ -61,7 +61,7 @@ describe('Open Authorization API', () => {
       await getOAuthToken(oAuthProvider.name);
 
       expect(mockDelete).not.toBeCalled();
-      expect(mockGet).toBeCalledWith('/api/oauth/token?oauth_provider=github');
+      expect(mockGet).toHaveBeenCalledWith('/api/oauth/token?oauth_provider=github');
     });
 
     it('should return the OAuth token', async () => {
@@ -83,7 +83,7 @@ describe('Open Authorization API', () => {
       await deleteOAuthToken(oAuthProvider.name);
 
       expect(mockGet).not.toBeCalled();
-      expect(mockDelete).toBeCalledWith('/api/oauth/token?oauth_provider=github');
+      expect(mockDelete).toHaveBeenCalledWith('/api/oauth/token?oauth_provider=github');
     });
 
     it('should return undefined', async () => {

--- a/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
@@ -54,7 +54,7 @@ export async function getTemplateByName(
     return response.data;
   } catch (e) {
     throw new Error(
-      `Failed to fetch devWorkspaceTemplate by name. ${common.helpers.errors.getMessage(e)}`,
+      `Failed to fetch DevWorkspaceTemplate by name. ${common.helpers.errors.getMessage(e)}`,
     );
   }
 }

--- a/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
@@ -44,11 +44,26 @@ export async function getTemplates(namespace: string): Promise<devfileApi.DevWor
   }
 }
 
+export async function getTemplateByName(
+  namespace: string,
+  name: string,
+): Promise<devfileApi.DevWorkspaceTemplate> {
+  const url = `${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${name}`;
+  try {
+    const response = await AxiosWrapper.createToRetryMissedBearerTokenError().get(url);
+    return response.data;
+  } catch (e) {
+    throw new Error(
+      `Failed to fetch devWorkspaceTemplate by name. ${common.helpers.errors.getMessage(e)}`,
+    );
+  }
+}
+
 export async function patchTemplate(
   namespace: string,
   templateName: string,
   patch: api.IPatch[],
-): Promise<devfileApi.DevWorkspace> {
+): Promise<devfileApi.DevWorkspaceTemplate> {
   const url = `${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${templateName}`;
   try {
     const response = await AxiosWrapper.createToRetryMissedBearerTokenError().patch(url, patch);

--- a/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/messageHandler.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/websocketClient/__tests__/messageHandler.spec.ts
@@ -94,7 +94,7 @@ describe('messageHandler', () => {
 
     const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
     messageHandler.notifyListeners(messageEvent);
-    expect(consoleWarn).toBeCalledWith(
+    expect(consoleWarn).toHaveBeenCalledWith(
       "[WARN] Can't parse the WS message payload:",
       'not a valid JSON',
     );
@@ -112,7 +112,7 @@ describe('messageHandler', () => {
 
     const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
     messageHandler.notifyListeners(messageEvent);
-    expect(consoleWarn).toBeCalledWith(
+    expect(consoleWarn).toHaveBeenCalledWith(
       '[WARN] Unexpected WS message payload:',
       '{"channel":"event","message":{}}',
     );

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
@@ -68,7 +68,7 @@ describe('Dashboard bootstrap', () => {
 
   test('requests which should be sent', async () => {
     prepareMocks(mockPost, 1, namespace); // provisionNamespace
-    prepareMocks(mockGet, 16, []); // branding, namespace, prefetch, server-config, cluster-info, userprofile, plugin-registry, default-editor, devfile-registry, getting-started-sample, devworkspacetemplates, devworkspaces, events, pods, cluster-config, ssh-key
+    prepareMocks(mockGet, 16, []); // branding, namespace, prefetch, server-config, cluster-info, userprofile, plugin-registry, default-editor, devfile-registry, getting-started-sample, devworkspaces, events, pods, cluster-config, ssh-key
 
     await preloadData.init();
 
@@ -80,7 +80,7 @@ describe('Dashboard bootstrap', () => {
       undefined,
     );
     // wait for all GET requests to be sent
-    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(16));
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(15));
 
     await waitFor(() =>
       expect(mockGet).toHaveBeenCalledWith('/dashboard/api/namespace/test-che/ssh-key', undefined),
@@ -99,10 +99,6 @@ describe('Dashboard bootstrap', () => {
       'http://localhost/dashboard/devfile-registry/devfiles/index.json',
     );
     expect(mockGet).toHaveBeenCalledWith('http://localhost/dashboard/api/getting-started-sample');
-    expect(mockGet).toHaveBeenCalledWith(
-      '/dashboard/api/namespace/test-che/devworkspacetemplates',
-      undefined,
-    );
     expect(mockGet).toHaveBeenCalledWith(
       '/dashboard/api/namespace/test-che/devworkspaces',
       undefined,

--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/index.ts
@@ -22,7 +22,7 @@ export type DevWorkspacePlugin = {
   uri?: string;
   kubernetes?: {
     name: string;
-    namespace: string;
+    namespace?: string;
   };
 };
 export const devWorkspaceKind: DevWorkspaceKind = 'DevWorkspace';

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/api-ping.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/api-ping.spec.ts
@@ -107,9 +107,9 @@ describe('test API endpoints', () => {
 
     const isAvailable = await isAvailableEndpoint(endpoint);
 
-    expect(delayMock).toBeCalledWith(2500);
+    expect(delayMock).toHaveBeenCalledWith(2500);
     expect(delayMock).toHaveBeenCalledTimes(11);
-    expect(console.error).toBeCalledWith(
+    expect(console.error).toHaveBeenCalledWith(
       `Endpoint 'https://example.com/developer-image/3100/' is not available. Error: 503 Service Unavailable.`,
     );
     expect(isAvailable).toBeFalsy();
@@ -128,9 +128,9 @@ describe('test API endpoints', () => {
 
     const isAvailable = await isAvailableEndpoint(endpoint);
 
-    expect(delayMock).toBeCalledWith(2500);
+    expect(delayMock).toHaveBeenCalledWith(2500);
     expect(delayMock).toHaveBeenCalledTimes(11);
-    expect(console.error).toBeCalledWith(
+    expect(console.error).toHaveBeenCalledWith(
       `Endpoint 'https://example.com/developer-image/3100/' is not available. Error: 404 Page Not Found.`,
     );
     expect(isAvailable).toBeFalsy();

--- a/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
+++ b/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
@@ -71,7 +71,7 @@ describe('fetch registry metadata', () => {
 
       expect(mockSessionStorageServiceGet).not.toHaveBeenCalled();
       expect(mockFetchData).toHaveBeenCalledTimes(1);
-      expect(mockFetchData).toBeCalledWith('http://this.is.my.base.url/devfiles/index.json');
+      expect(mockFetchData).toHaveBeenCalledWith('http://this.is.my.base.url/devfiles/index.json');
       expect(mockSessionStorageServiceUpdate).not.toHaveBeenCalled();
       expect(resolved).toEqual([metadata]);
     });
@@ -89,7 +89,7 @@ describe('fetch registry metadata', () => {
 
       await fetchRegistryMetadata(baseUrl, true);
 
-      expect(mockFetchData).toBeCalledWith(
+      expect(mockFetchData).toHaveBeenCalledWith(
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(mockFetchRemoteData.mock.calls).toEqual([
@@ -116,7 +116,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith(
+      expect(mockFetchRemoteData).toHaveBeenCalledWith(
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
@@ -150,7 +150,9 @@ describe('fetch registry metadata', () => {
 
         expect(mockSessionStorageServiceGet).not.toHaveBeenCalled();
         expect(mockFetchData).toHaveBeenCalledTimes(1);
-        expect(mockFetchData).toBeCalledWith(`${baseUrl}/dashboard/api/getting-started-sample`);
+        expect(mockFetchData).toHaveBeenCalledWith(
+          `${baseUrl}/dashboard/api/getting-started-sample`,
+        );
         expect(mockSessionStorageServiceUpdate).not.toHaveBeenCalled();
         expect(resolved).toEqual([metadata]);
       });
@@ -179,7 +181,7 @@ describe('fetch registry metadata', () => {
       expect(errorMessage).toEqual(
         'Failed to fetch devfiles metadata from registry URL: https://eclipse-che.github.io/che-devfile-registry/7.71.0/, reason: Returned value is not array.',
       );
-      expect(console.error).toBeCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         'Failed to fetch devfiles metadata from registry URL: https://eclipse-che.github.io/che-devfile-registry/7.71.0/, reason: Returned value is not array.',
       );
     });
@@ -211,7 +213,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith(
+      expect(mockFetchRemoteData).toHaveBeenCalledWith(
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(console.warn).toBeCalledTimes(2);
@@ -286,7 +288,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith(
+      expect(mockFetchRemoteData).toHaveBeenCalledWith(
         'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
       );
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
@@ -323,7 +325,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
@@ -351,12 +353,12 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
       expect(mockSessionStorageServiceUpdate).not.toHaveBeenCalled();
       expect(errorMessage).toEqual(
         'Failed to fetch devfiles metadata from registry URL: https://registry.devfile.io/, reason: Returned value is not array.',
       );
-      expect(console.error).toBeCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         'Failed to fetch devfiles metadata from registry URL: https://registry.devfile.io/, reason: Returned value is not array.',
       );
     });
@@ -388,7 +390,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
       expect(console.warn).toBeCalledTimes(2);
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
@@ -461,7 +463,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toBeCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
@@ -10,8 +10,10 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
-  ({
+import devfileApi from '@/services/devfileApi';
+
+const getDevWorkspaceTemplate = (cpuLimit = '1500m'): devfileApi.DevWorkspaceTemplate => {
+  return {
     apiVersion: 'workspace.devfile.io/v1alpha2',
     kind: 'DevWorkspaceTemplate',
     metadata: {
@@ -20,7 +22,7 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
         'che.eclipse.org/plugin-registry-url':
           'https://192.168.64.24.nip.io/plugin-registry/v3/plugins/eclipse/che-theia/next/devfile.yaml',
       },
-      creationTimestamp: '2021-11-24T17:11:37Z',
+      creationTimestamp: new Date('2021-11-24T17:11:37Z'),
       generation: 1,
       name: 'theia-ide-workspacee2ade80d625b4f3e',
       namespace: 'admin-che',
@@ -149,6 +151,7 @@ const getDevWorkspaceTemplate = (cpuLimit = '1500m') =>
         preStart: ['init-container-command'],
       },
     },
-  }) as any;
+  };
+};
 
 export default getDevWorkspaceTemplate;

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.changeWorkspaceStatus.spec.ts
@@ -55,7 +55,7 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
 
     await client.changeWorkspaceStatus(testWorkspace, true);
 
-    expect(spyPatchWorkspace).toBeCalledWith(
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.arrayContaining([
@@ -90,7 +90,7 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
 
     await client.changeWorkspaceStatus(testWorkspace, true);
 
-    expect(spyPatchWorkspace).toBeCalledWith(
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.arrayContaining([
@@ -120,7 +120,7 @@ describe('DevWorkspace client, changeWorkspaceStatus', () => {
 
     await client.changeWorkspaceStatus(testWorkspace, false);
 
-    expect(spyPatchWorkspace).toBeCalledWith(
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.not.arrayContaining([

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.create.spec.ts
@@ -109,7 +109,7 @@ describe('DevWorkspace client, create', () => {
         openVSXUrl,
       );
 
-      expect(spyCreateWorkspaceTemplate).toBeCalledWith(
+      expect(spyCreateWorkspaceTemplate).toHaveBeenCalledWith(
         expect.objectContaining({
           spec: expect.objectContaining({
             components: expect.arrayContaining([
@@ -155,7 +155,7 @@ describe('DevWorkspace client, create', () => {
         clusterConsole,
       );
 
-      expect(spyCreateWorkspaceTemplate).toBeCalledWith(
+      expect(spyCreateWorkspaceTemplate).toHaveBeenCalledWith(
         expect.objectContaining({
           spec: expect.objectContaining({
             components: expect.arrayContaining([
@@ -193,7 +193,7 @@ describe('DevWorkspace client, create', () => {
         openVSXUrl,
       );
 
-      expect(spyCreateWorkspaceTemplate).toBeCalledWith(
+      expect(spyCreateWorkspaceTemplate).toHaveBeenCalledWith(
         expect.objectContaining({
           metadata: expect.objectContaining({
             ownerReferences: expect.arrayContaining([
@@ -217,7 +217,7 @@ describe('DevWorkspace client, create', () => {
 
       await client.createDevWorkspace(namespace, testDevWorkspace, undefined);
 
-      expect(spyCreateWorkspace).toBeCalledWith(
+      expect(spyCreateWorkspace).toHaveBeenCalledWith(
         expect.objectContaining({
           spec: expect.objectContaining({
             routingClass: routingClass,

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -33,7 +33,7 @@ describe('DevWorkspace client editor update', () => {
     it('should return patch for an editor if it has been updated', async () => {
       const template = getDevWorkspaceTemplate('1000m');
       const mockPatch = mockAxios.get as jest.Mock;
-      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: [template] })));
+      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
 
       // if cpuLimit changed from '1000m' to '2000m'
       const newTemplate = getDevWorkspaceTemplate('2000m');
@@ -42,7 +42,10 @@ describe('DevWorkspace client editor update', () => {
         'che.eclipse.org/plugin-registry-url'
       ] as string;
 
+      const editorName = newTemplate?.metadata?.name as string;
+
       const patch = await client.checkForTemplatesUpdate(
+        editorName,
         namespace,
         {
           [url]: newTemplate.spec as devfileApi.Devfile,
@@ -53,33 +56,34 @@ describe('DevWorkspace client editor update', () => {
       );
 
       expect(mockPatch.mock.calls).toEqual([
-        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates`],
+        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${editorName}`],
       ]);
 
-      expect(patch).toEqual({
-        [newTemplate?.metadata?.name]: [
-          {
-            op: 'replace',
-            path: '/spec',
-            value: newTemplate.spec,
-          },
-        ],
-      });
+      expect(patch).toEqual([
+        {
+          op: 'replace',
+          path: '/spec',
+          value: newTemplate.spec,
+        },
+      ]);
     });
 
     it(`should return an empty object if it hasn't been updated`, async () => {
-      const template = getDevWorkspaceTemplate();
+      const template = getDevWorkspaceTemplate('1000m');
       const mockPatch = mockAxios.get as jest.Mock;
-      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: [template] })));
+      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
 
       // if nothing changed
-      const newTemplate = getDevWorkspaceTemplate();
+      const newTemplate = getDevWorkspaceTemplate('1000m');
 
       const url = newTemplate?.metadata?.annotations?.[
         'che.eclipse.org/plugin-registry-url'
       ] as string;
 
+      const editorName = newTemplate?.metadata?.name as string;
+
       const patch = await client.checkForTemplatesUpdate(
+        editorName,
         namespace,
         {
           [url]: newTemplate.spec as devfileApi.Devfile,
@@ -90,10 +94,10 @@ describe('DevWorkspace client editor update', () => {
       );
 
       expect(mockPatch.mock.calls).toEqual([
-        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates`],
+        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${editorName}`],
       ]);
 
-      expect(patch).toEqual({});
+      expect(patch).toEqual([]);
     });
   });
 
@@ -101,7 +105,7 @@ describe('DevWorkspace client editor update', () => {
     it('should return patch for an editor if it has been updated', async () => {
       const template = getDevWorkspaceTemplate('1000m');
       const mockPatch = mockAxios.get as jest.Mock;
-      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: [template] })));
+      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
 
       // if cpuLimit changed from '1000m' to '2000m'
       const newTemplate = getDevWorkspaceTemplate('2000m');
@@ -113,7 +117,10 @@ describe('DevWorkspace client editor update', () => {
         'che.eclipse.org/plugin-registry-url'
       ] as string;
 
+      const editorName = newTemplate?.metadata?.name as string;
+
       const patch = await client.checkForTemplatesUpdate(
+        editorName,
         namespace,
         {},
         pluginRegistryUrl,
@@ -122,28 +129,26 @@ describe('DevWorkspace client editor update', () => {
       );
 
       expect(mockPatch.mock.calls).toEqual([
-        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates`],
+        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${editorName}`],
         [url],
       ]);
 
-      expect(patch).toEqual({
-        [newTemplate?.metadata?.name]: [
-          {
-            op: 'replace',
-            path: '/spec',
-            value: newTemplate.spec,
-          },
-        ],
-      });
+      expect(patch).toEqual([
+        {
+          op: 'replace',
+          path: '/spec',
+          value: newTemplate.spec,
+        },
+      ]);
     });
 
     it(`should return an empty object if it hasn't been updated`, async () => {
-      const template = getDevWorkspaceTemplate();
+      const template = getDevWorkspaceTemplate('1000m');
       const mockPatch = mockAxios.get as jest.Mock;
-      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: [template] })));
+      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
 
       // if nothing changed
-      const newTemplate = getDevWorkspaceTemplate();
+      const newTemplate = getDevWorkspaceTemplate('1000m');
       mockPatch.mockResolvedValueOnce(
         new Promise(resolve => resolve({ data: JSON.stringify(newTemplate.spec) })),
       );
@@ -152,7 +157,10 @@ describe('DevWorkspace client editor update', () => {
         'che.eclipse.org/plugin-registry-url'
       ] as string;
 
+      const editorName = newTemplate?.metadata?.name as string;
+
       const patch = await client.checkForTemplatesUpdate(
+        editorName,
         namespace,
         {},
         pluginRegistryUrl,
@@ -161,30 +169,29 @@ describe('DevWorkspace client editor update', () => {
       );
 
       expect(mockPatch.mock.calls).toEqual([
-        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates`],
+        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${editorName}`],
         [url],
       ]);
 
-      expect(patch).toEqual({});
+      expect(patch).toEqual([]);
     });
   });
 
   it('should patch target template', async () => {
-    const template = getDevWorkspaceTemplate();
+    const template = getDevWorkspaceTemplate('1000m');
+
+    const editorName = template?.metadata?.name as string;
 
     const spyPatchWorkspace = jest.spyOn(DwtApi, 'patchTemplate').mockResolvedValue(template);
 
-    await client.updateTemplates(namespace, {
-      [template?.metadata?.name]: [
-        {
-          op: 'replace',
-          path: '/spec',
-          value: template.spec,
-        },
-      ],
-    });
-
-    expect(spyPatchWorkspace).toBeCalledWith(namespace, template?.metadata?.name, [
+    await DwtApi.patchTemplate(namespace, editorName, [
+      {
+        op: 'replace',
+        path: '/spec',
+        value: template.spec,
+      },
+    ]);
+    expect(spyPatchWorkspace).toBeCalledWith(namespace, editorName, [
       {
         op: 'replace',
         path: '/spec',

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -38,11 +38,9 @@ describe('DevWorkspace client editor update', () => {
       // if cpuLimit changed from '1000m' to '2000m'
       const newTemplate = getDevWorkspaceTemplate('2000m');
 
-      const url = newTemplate?.metadata?.annotations?.[
-        'che.eclipse.org/plugin-registry-url'
-      ] as string;
+      const url = newTemplate.metadata.annotations?.['che.eclipse.org/plugin-registry-url'];
 
-      const editorName = newTemplate?.metadata?.name as string;
+      const editorName = newTemplate.metadata.name;
 
       const patch = await client.checkForTemplatesUpdate(
         editorName,
@@ -76,11 +74,9 @@ describe('DevWorkspace client editor update', () => {
       // if nothing changed
       const newTemplate = getDevWorkspaceTemplate('1000m');
 
-      const url = newTemplate?.metadata?.annotations?.[
-        'che.eclipse.org/plugin-registry-url'
-      ] as string;
+      const url = newTemplate.metadata.annotations?.['che.eclipse.org/plugin-registry-url'];
 
-      const editorName = newTemplate?.metadata?.name as string;
+      const editorName = newTemplate.metadata.name;
 
       const patch = await client.checkForTemplatesUpdate(
         editorName,
@@ -113,11 +109,9 @@ describe('DevWorkspace client editor update', () => {
         new Promise(resolve => resolve({ data: JSON.stringify(newTemplate.spec) })),
       );
 
-      const url = newTemplate?.metadata?.annotations?.[
-        'che.eclipse.org/plugin-registry-url'
-      ] as string;
+      const url = newTemplate.metadata.annotations?.['che.eclipse.org/plugin-registry-url'];
 
-      const editorName = newTemplate?.metadata?.name as string;
+      const editorName = newTemplate.metadata.name;
 
       const patch = await client.checkForTemplatesUpdate(
         editorName,
@@ -153,11 +147,9 @@ describe('DevWorkspace client editor update', () => {
         new Promise(resolve => resolve({ data: JSON.stringify(newTemplate.spec) })),
       );
 
-      const url = newTemplate?.metadata?.annotations?.[
-        'che.eclipse.org/plugin-registry-url'
-      ] as string;
+      const url = newTemplate.metadata.annotations?.['che.eclipse.org/plugin-registry-url'];
 
-      const editorName = newTemplate?.metadata?.name as string;
+      const editorName = newTemplate.metadata.name;
 
       const patch = await client.checkForTemplatesUpdate(
         editorName,
@@ -180,7 +172,7 @@ describe('DevWorkspace client editor update', () => {
   it('should patch target template', async () => {
     const template = getDevWorkspaceTemplate('1000m');
 
-    const editorName = template?.metadata?.name as string;
+    const editorName = template.metadata.name;
 
     const spyPatchWorkspace = jest.spyOn(DwtApi, 'patchTemplate').mockResolvedValue(template);
 

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -191,7 +191,7 @@ describe('DevWorkspace client editor update', () => {
         value: template.spec,
       },
     ]);
-    expect(spyPatchWorkspace).toBeCalledWith(namespace, editorName, [
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, editorName, [
       {
         op: 'replace',
         path: '/spec',

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.update.spec.ts
@@ -54,7 +54,7 @@ describe('DevWorkspace client, update', () => {
 
     await client.update(testWorkspace);
 
-    expect(spyPatchWorkspace).toBeCalledWith(
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.arrayContaining([
@@ -88,7 +88,7 @@ describe('DevWorkspace client, update', () => {
 
     await client.update(testWorkspace);
 
-    expect(spyPatchWorkspace).toBeCalledWith(
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.arrayContaining([

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/converter.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/converters/__tests__/converter.spec.ts
@@ -60,7 +60,7 @@ describe('testing sample conversions', () => {
         ),
       );
       const devfile = devWorkspaceToDevfile(input);
-      expect(console.debug).toBeCalledWith(
+      expect(console.debug).toHaveBeenCalledWith(
         'Failed to parse the origin devfile. The target object is not devfile V2.',
       );
       expect(devfile.schemaVersion).toEqual(devfileSchemaVersion);

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/index.spec.ts
@@ -391,8 +391,8 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).toBeCalledWith(location);
-      expect(getFactoryResolverSpy).not.toBeCalledWith(location, {
+      expect(getYamlResolverSpy).toHaveBeenCalledWith(location);
+      expect(getFactoryResolverSpy).not.toHaveBeenCalledWith(location, {
         error_code: undefined,
       });
     });
@@ -404,8 +404,8 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).toBeCalledWith(location);
-      expect(getFactoryResolverSpy).not.toBeCalledWith(location, {
+      expect(getYamlResolverSpy).toHaveBeenCalledWith(location);
+      expect(getFactoryResolverSpy).not.toHaveBeenCalledWith(location, {
         error_code: undefined,
       });
     });
@@ -417,8 +417,8 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).toBeCalledWith(location);
-      expect(getFactoryResolverSpy).not.toBeCalledWith(location, {
+      expect(getYamlResolverSpy).toHaveBeenCalledWith(location);
+      expect(getFactoryResolverSpy).not.toHaveBeenCalledWith(location, {
         error_code: undefined,
       });
     });
@@ -430,8 +430,8 @@ describe('FactoryResolver store', () => {
         factoryResolverStore.actionCreators.requestFactoryResolver(location, {}),
       );
 
-      expect(getYamlResolverSpy).not.toBeCalledWith(location);
-      expect(getFactoryResolverSpy).toBeCalledWith(location, {
+      expect(getYamlResolverSpy).not.toHaveBeenCalledWith(location);
+      expect(getFactoryResolverSpy).toHaveBeenCalledWith(location, {
         error_code: undefined,
       });
     });

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
@@ -194,7 +194,7 @@ describe('dwPlugins store', () => {
       expect(actions).toEqual(expectedActions);
 
       // check that we fetched the editor on axios
-      expect(mockAxios.get).toBeCalledWith(editorLink);
+      expect(mockAxios.get).toHaveBeenCalledWith(editorLink);
     });
 
     it('should create REQUEST_DW_EDITOR and RECEIVE_DW_EDITOR_ERROR when failed to fetch an editor', async () => {

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/selectors.spec.ts
@@ -54,7 +54,7 @@ describe('dwPlugins selectors', () => {
 
   it('should return all plugins and errors', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withDwPlugins(plugins, false, 'default editor fetching error')
+      .withDwPlugins(plugins, {}, false, 'default editor fetching error')
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
@@ -68,7 +68,7 @@ describe('dwPlugins selectors', () => {
 
   it('should return array of plugins', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withDwPlugins(plugins, false, 'default editor fetching error')
+      .withDwPlugins(plugins, {}, false, 'default editor fetching error')
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>
@@ -95,7 +95,7 @@ describe('dwPlugins selectors', () => {
 
   it('should return an error related to default editor fetching', () => {
     const fakeStore = new FakeStoreBuilder()
-      .withDwPlugins(plugins, false, 'default editor fetching error')
+      .withDwPlugins(plugins, {}, false, 'default editor fetching error')
       .build() as MockStoreEnhanced<
       AppState,
       ThunkDispatch<AppState, undefined, store.KnownAction>

--- a/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Pods/Logs/__tests__/actions.spec.ts
@@ -99,11 +99,13 @@ describe('Pod logs store, actions', () => {
       await appStore.dispatch(testStore.actionCreators.watchPodLogs(pod));
 
       expect(websocketClient.connect).toBeCalled();
-      expect(websocketClient.addChannelMessageListener).toBeCalledWith(
+      expect(websocketClient.addChannelMessageListener).toHaveBeenCalledWith(
         api.webSocket.Channel.LOGS,
         expect.any(Function),
       );
-      expect(websocketClient.unsubscribeFromChannel).toBeCalledWith(api.webSocket.Channel.LOGS);
+      expect(websocketClient.unsubscribeFromChannel).toHaveBeenCalledWith(
+        api.webSocket.Channel.LOGS,
+      );
       expect(websocketClient.subscribeToChannel).toHaveBeenCalledWith(
         api.webSocket.Channel.LOGS,
         namespace,
@@ -126,7 +128,9 @@ describe('Pod logs store, actions', () => {
 
       await appStore.dispatch(testStore.actionCreators.stopWatchingPodLogs(pod));
 
-      expect(websocketClient.unsubscribeFromChannel).toBeCalledWith(api.webSocket.Channel.LOGS);
+      expect(websocketClient.unsubscribeFromChannel).toHaveBeenCalledWith(
+        api.webSocket.Channel.LOGS,
+      );
     });
   });
 
@@ -282,7 +286,7 @@ describe('Pod logs store, actions', () => {
       const expectedActions: testStore.KnownAction[] = [];
 
       expect(actions).toStrictEqual(expectedActions);
-      expect(console.warn).toBeCalledWith('WebSocket: unexpected message:', message);
+      expect(console.warn).toHaveBeenCalledWith('WebSocket: unexpected message:', message);
     });
   });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -341,7 +341,12 @@ describe('DevWorkspace store, actions', () => {
   });
 
   describe('startWorkspace', () => {
-    const prepareDevWorkspaceMocks = (devWorkspace: devfileApi.DevWorkspace) => {
+    let devWorkspace: devfileApi.DevWorkspace;
+
+    beforeEach(() => {
+      (fetchServerConfig as jest.Mock).mockResolvedValueOnce({});
+
+      devWorkspace = new DevWorkspaceBuilder().build();
       mockChangeWorkspaceStatus.mockResolvedValueOnce(devWorkspace);
       mockManageContainerBuildAttribute.mockResolvedValueOnce(devWorkspace);
       mockManageDebugMode.mockResolvedValueOnce(devWorkspace);
@@ -350,18 +355,10 @@ describe('DevWorkspace store, actions', () => {
       mockUpdate.mockResolvedValueOnce(devWorkspace);
       mockOnStart.mockResolvedValueOnce(devWorkspace);
       mockCheckForDevWorkspaceError.mockReturnValueOnce(devWorkspace);
-    };
-
-    beforeEach(() => {
-      (fetchServerConfig as jest.Mock).mockResolvedValueOnce({});
     });
 
     describe('updateEditor', () => {
       it('should check for update if the target devWorkspase has an editor name and the lifeTime > 30s', async () => {
-        const devWorkspace = new DevWorkspaceBuilder().build();
-
-        prepareDevWorkspaceMocks(devWorkspace);
-
         mockGetEditorName.mockReturnValueOnce('che-code');
         mockGetLifeTimeMs.mockReturnValueOnce(60000);
 
@@ -375,10 +372,6 @@ describe('DevWorkspace store, actions', () => {
       });
 
       it('should not check for update if the lifeTime less then 30s', async () => {
-        const devWorkspace = new DevWorkspaceBuilder().build();
-
-        prepareDevWorkspaceMocks(devWorkspace);
-
         mockGetEditorName.mockReturnValueOnce('che-code');
         mockGetLifeTimeMs.mockReturnValueOnce(1000);
 
@@ -392,10 +385,6 @@ describe('DevWorkspace store, actions', () => {
       });
 
       it('should not check for update without editor name', async () => {
-        const devWorkspace = new DevWorkspaceBuilder().build();
-
-        prepareDevWorkspaceMocks(devWorkspace);
-
         mockGetEditorName.mockReturnValueOnce(undefined);
         mockGetLifeTimeMs.mockReturnValueOnce(60000);
 
@@ -409,11 +398,7 @@ describe('DevWorkspace store, actions', () => {
       });
     });
     it('should create REQUEST_DEVWORKSPACE and UPDATE_DEVWORKSPACE when starting DevWorkspace', async () => {
-      const devWorkspace = new DevWorkspaceBuilder().build();
-
       (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
-
-      prepareDevWorkspaceMocks(devWorkspace);
 
       const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
 
@@ -443,13 +428,9 @@ describe('DevWorkspace store, actions', () => {
     });
 
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when failed to start a DevWorkspace', async () => {
-      const devWorkspace = new DevWorkspaceBuilder().build();
-
       (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => {
         throw new Error('Limit reached.');
       });
-
-      prepareDevWorkspaceMocks(devWorkspace);
 
       const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -358,21 +358,7 @@ describe('DevWorkspace store, actions', () => {
 
     describe('updateEditor', () => {
       it('should check for update if the target devWorkspase has an editor name and the lifeTime > 30s', async () => {
-        const devWorkspace = new DevWorkspaceBuilder()
-          .withMetadata({
-            creationTimestamp: new Date(Date.now() - 60 * 1000),
-          })
-          .withContributions([
-            {
-              name: 'editor',
-              kubernetes: {
-                name: 'che-code',
-              },
-            },
-          ])
-          .build();
-
-        (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
+        const devWorkspace = new DevWorkspaceBuilder().build();
 
         prepareDevWorkspaceMocks(devWorkspace);
 
@@ -385,27 +371,16 @@ describe('DevWorkspace store, actions', () => {
 
         await store.dispatch(testStore.actionCreators.startWorkspace(devWorkspace));
 
-        expect(mockCheckForEditorUpdate).toHaveBeenCalled();
+        expect(mockCheckForEditorUpdate).toHaveBeenCalledWith('che-code', store.getState);
       });
 
       it('should not check for update if the lifeTime less then 30s', async () => {
-        const devWorkspace = new DevWorkspaceBuilder()
-          .withMetadata({
-            creationTimestamp: new Date(Date.now() - 10 * 1000),
-          })
-          .withContributions([
-            {
-              name: 'editor',
-              kubernetes: {
-                name: 'che-code',
-              },
-            },
-          ])
-          .build();
-
-        (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
+        const devWorkspace = new DevWorkspaceBuilder().build();
 
         prepareDevWorkspaceMocks(devWorkspace);
+
+        mockGetEditorName.mockReturnValueOnce('che-code');
+        mockGetLifeTimeMs.mockReturnValueOnce(1000);
 
         mockCheckForEditorUpdate.mockResolvedValueOnce([]);
 
@@ -417,15 +392,12 @@ describe('DevWorkspace store, actions', () => {
       });
 
       it('should not check for update without editor name', async () => {
-        const devWorkspace = new DevWorkspaceBuilder()
-          .withMetadata({
-            creationTimestamp: new Date(Date.now() - 60 * 1000),
-          })
-          .build();
-
-        (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
+        const devWorkspace = new DevWorkspaceBuilder().build();
 
         prepareDevWorkspaceMocks(devWorkspace);
+
+        mockGetEditorName.mockReturnValueOnce(undefined);
+        mockGetLifeTimeMs.mockReturnValueOnce(60000);
 
         mockCheckForEditorUpdate.mockResolvedValueOnce([]);
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -336,6 +336,21 @@ describe('DevWorkspace store, actions', () => {
   });
 
   describe('startWorkspace', () => {
+    const prepareDevWorkspaceMocks = (devWorkspace: devfileApi.DevWorkspace) => {
+      mockChangeWorkspaceStatus.mockResolvedValueOnce(devWorkspace);
+      mockManageContainerBuildAttribute.mockResolvedValueOnce(devWorkspace);
+      mockManageDebugMode.mockResolvedValueOnce(devWorkspace);
+      mockManagePvcStrategy.mockResolvedValueOnce(devWorkspace);
+      mockOnStart.mockResolvedValueOnce(devWorkspace);
+      mockUpdate.mockResolvedValueOnce(devWorkspace);
+      mockOnStart.mockResolvedValueOnce(devWorkspace);
+      mockCheckForDevWorkspaceError.mockReturnValueOnce(devWorkspace);
+    };
+
+    beforeEach(() => {
+      (fetchServerConfig as jest.Mock).mockResolvedValueOnce({});
+    });
+
     describe('updateEditor', () => {
       it('should check for update if the target devWorkspase has an editor name and the lifeTime > 30s', async () => {
         const devWorkspace = new DevWorkspaceBuilder()
@@ -354,16 +369,8 @@ describe('DevWorkspace store, actions', () => {
 
         (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
 
-        (fetchServerConfig as jest.Mock).mockResolvedValueOnce({});
+        prepareDevWorkspaceMocks(devWorkspace);
 
-        mockChangeWorkspaceStatus.mockResolvedValueOnce(devWorkspace);
-        mockManageContainerBuildAttribute.mockResolvedValueOnce(devWorkspace);
-        mockManageDebugMode.mockResolvedValueOnce(devWorkspace);
-        mockManagePvcStrategy.mockResolvedValueOnce(devWorkspace);
-        mockOnStart.mockResolvedValueOnce(devWorkspace);
-        mockUpdate.mockResolvedValueOnce(devWorkspace);
-        mockOnStart.mockResolvedValueOnce(devWorkspace);
-        mockCheckForDevWorkspaceError.mockReturnValueOnce(devWorkspace);
         mockCheckForEditorUpdate.mockResolvedValueOnce([]);
 
         const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
@@ -390,16 +397,8 @@ describe('DevWorkspace store, actions', () => {
 
         (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
 
-        (fetchServerConfig as jest.Mock).mockResolvedValueOnce({});
+        prepareDevWorkspaceMocks(devWorkspace);
 
-        mockChangeWorkspaceStatus.mockResolvedValueOnce(devWorkspace);
-        mockManageContainerBuildAttribute.mockResolvedValueOnce(devWorkspace);
-        mockManageDebugMode.mockResolvedValueOnce(devWorkspace);
-        mockManagePvcStrategy.mockResolvedValueOnce(devWorkspace);
-        mockOnStart.mockResolvedValueOnce(devWorkspace);
-        mockUpdate.mockResolvedValueOnce(devWorkspace);
-        mockOnStart.mockResolvedValueOnce(devWorkspace);
-        mockCheckForDevWorkspaceError.mockReturnValueOnce(devWorkspace);
         mockCheckForEditorUpdate.mockResolvedValueOnce([]);
 
         const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
@@ -418,16 +417,8 @@ describe('DevWorkspace store, actions', () => {
 
         (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
 
-        (fetchServerConfig as jest.Mock).mockResolvedValueOnce({});
+        prepareDevWorkspaceMocks(devWorkspace);
 
-        mockChangeWorkspaceStatus.mockResolvedValueOnce(devWorkspace);
-        mockManageContainerBuildAttribute.mockResolvedValueOnce(devWorkspace);
-        mockManageDebugMode.mockResolvedValueOnce(devWorkspace);
-        mockManagePvcStrategy.mockResolvedValueOnce(devWorkspace);
-        mockOnStart.mockResolvedValueOnce(devWorkspace);
-        mockUpdate.mockResolvedValueOnce(devWorkspace);
-        mockOnStart.mockResolvedValueOnce(devWorkspace);
-        mockCheckForDevWorkspaceError.mockReturnValueOnce(devWorkspace);
         mockCheckForEditorUpdate.mockResolvedValueOnce([]);
 
         const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
@@ -442,16 +433,7 @@ describe('DevWorkspace store, actions', () => {
 
       (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
 
-      (fetchServerConfig as jest.Mock).mockResolvedValueOnce({});
-
-      mockChangeWorkspaceStatus.mockResolvedValueOnce(devWorkspace);
-      mockManageContainerBuildAttribute.mockResolvedValueOnce(devWorkspace);
-      mockManageDebugMode.mockResolvedValueOnce(devWorkspace);
-      mockManagePvcStrategy.mockResolvedValueOnce(devWorkspace);
-      mockOnStart.mockResolvedValueOnce(devWorkspace);
-      mockUpdate.mockResolvedValueOnce(devWorkspace);
-      mockOnStart.mockResolvedValueOnce(devWorkspace);
-      mockCheckForDevWorkspaceError.mockReturnValueOnce(devWorkspace);
+      prepareDevWorkspaceMocks(devWorkspace);
 
       const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
 
@@ -487,14 +469,7 @@ describe('DevWorkspace store, actions', () => {
         throw new Error('Limit reached.');
       });
 
-      mockChangeWorkspaceStatus.mockResolvedValueOnce(devWorkspace);
-      mockManageContainerBuildAttribute.mockResolvedValueOnce(devWorkspace);
-      mockManageDebugMode.mockResolvedValueOnce(devWorkspace);
-      mockManagePvcStrategy.mockResolvedValueOnce(devWorkspace);
-      mockOnStart.mockResolvedValueOnce(devWorkspace);
-      mockUpdate.mockResolvedValueOnce(devWorkspace);
-      mockOnStart.mockResolvedValueOnce(devWorkspace);
-      mockCheckForDevWorkspaceError.mockReturnValueOnce(devWorkspace);
+      prepareDevWorkspaceMocks(devWorkspace);
 
       const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/updateEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/updateEditor.spec.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { api, ApplicationId } from '@eclipse-che/common';
+import { AnyAction } from 'redux';
+import { MockStoreEnhanced } from 'redux-mock-store';
+import { ThunkDispatch } from 'redux-thunk';
+
+import { container } from '@/inversify.config';
+import devfileApi from '@/services/devfileApi';
+import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+import { AppState } from '@/store';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
+import {
+  getEditorName,
+  getLifeTimeMs,
+  updateEditor,
+} from '@/store/Workspaces/devWorkspaces/updateEditor';
+
+const mockPatchTemplate = jest.fn();
+jest.mock('@/services/backend-client/devWorkspaceTemplateApi', () => ({
+  patchTemplate: (namespace: string, templateName: string, patch: api.IPatch[]) =>
+    mockPatchTemplate(namespace, templateName, patch),
+}));
+
+describe('updateEditor, functions', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  describe('getEditorName', () => {
+    it('should return undefined if the target devworkspace dos not have an editor', async () => {
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withContributions([
+          {
+            name: 'default',
+            uri: 'https://test.com/devfile.yaml',
+            attributes: { 'che.eclipse.org/default-plugin': true },
+          },
+        ])
+        .build();
+
+      const name = getEditorName(devWorkspace);
+
+      expect(name).toBeUndefined();
+    });
+
+    it('should return the editor name', async () => {
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withContributions([
+          {
+            name: 'default',
+            uri: 'https://test.com/devfile.yaml',
+            attributes: { 'che.eclipse.org/default-plugin': true },
+          },
+          {
+            name: 'editor',
+            kubernetes: {
+              name: 'che-code',
+            },
+          },
+        ])
+        .build();
+
+      const editorName = getEditorName(devWorkspace);
+
+      expect(editorName).toBe('che-code');
+    });
+  });
+
+  describe('getLifeTimeMs', () => {
+    it('should return 0 without creationTimestamp', async () => {
+      const devWorkspace = new DevWorkspaceBuilder().build();
+
+      const result = getLifeTimeMs(devWorkspace);
+
+      expect(result).toBe(0);
+    });
+
+    it('should return the devWorkspace lifetime', async () => {
+      const lifetime = 1234;
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withMetadata({
+          creationTimestamp: new Date(Date.now() - lifetime),
+        })
+        .build();
+
+      const result = getLifeTimeMs(devWorkspace);
+
+      expect(result).toBe(1234);
+    });
+  });
+
+  describe('updateEditor', () => {
+    const mockCheckForEditorUpdate = jest.fn();
+    const devWorkspaceClient = container.get(DevWorkspaceClient);
+    devWorkspaceClient.checkForTemplatesUpdate = mockCheckForEditorUpdate;
+
+    const namespace = 'user-che';
+    const pluginRegistryURL = 'https://dummy.registry';
+    const clusterConsole = {
+      id: ApplicationId.CLUSTER_CONSOLE,
+      url: 'https://console-url',
+      icon: 'https://console-icon-url',
+      title: 'Cluster console',
+    };
+    const editorResourceUrl = 'http://editor-url';
+    const editorId = 'che-incubator/che-code/latest';
+    const editors = {
+      [editorId]: {
+        url: editorResourceUrl,
+        plugin: {
+          schemaVersion: '2.2.0',
+          metadata: {
+            name: 'che-code',
+          },
+        } as devfileApi.Devfile,
+      },
+    };
+    let store: MockStoreEnhanced<AppState, ThunkDispatch<AppState, undefined, AnyAction>>;
+    beforeEach(() => {
+      store = new FakeStoreBuilder()
+        .withInfrastructureNamespace([
+          { name: namespace, attributes: { default: 'true', phase: 'Active' } },
+        ])
+        .withClusterInfo({ applications: [clusterConsole] })
+        .withDwServerConfig({
+          pluginRegistry: { openVSXURL: 'https://openvsx.org' },
+          pluginRegistryInternalURL: 'https://internal.registry',
+          pluginRegistryURL,
+        })
+        .withDwPlugins({}, editors, false, undefined, editorId)
+        .build();
+    });
+
+    it('should check for update and do nothing', async () => {
+      mockCheckForEditorUpdate.mockResolvedValueOnce([]);
+
+      await updateEditor('che-code', store.getState);
+
+      expect(mockCheckForEditorUpdate).toHaveBeenCalledWith(
+        'che-code',
+        namespace,
+        { [editorResourceUrl]: editors[editorId].plugin },
+        pluginRegistryURL,
+        'https://internal.registry',
+        'https://openvsx.org',
+        clusterConsole,
+      );
+      expect(mockPatchTemplate).not.toHaveBeenCalled();
+    });
+
+    it('should update the target devWorkspaceTemplate', async () => {
+      mockCheckForEditorUpdate.mockResolvedValueOnce([
+        { op: 'replace', path: '/spec/commands', value: [] },
+      ]);
+
+      await updateEditor('che-code', store.getState);
+
+      expect(mockCheckForEditorUpdate).toHaveBeenCalledWith(
+        'che-code',
+        namespace,
+        { [editorResourceUrl]: editors[editorId].plugin },
+        pluginRegistryURL,
+        'https://internal.registry',
+        'https://openvsx.org',
+        clusterConsole,
+      );
+      expect(mockPatchTemplate).toHaveBeenCalledWith('user-che', 'che-code', [
+        {
+          op: 'replace',
+          path: '/spec/commands',
+          value: [],
+        },
+      ]);
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -65,6 +65,11 @@ import {
   updateEditorDevfile,
 } from '@/store/Workspaces/devWorkspaces/editorImage';
 import { selectDevWorkspacesResourceVersion } from '@/store/Workspaces/devWorkspaces/selectors';
+import {
+  getEditorName,
+  getLifeTime,
+  updateEditor,
+} from '@/store/Workspaces/devWorkspaces/updateEditor';
 
 export const onStatusChangeCallbacks = new Map<string, (status: string) => void>();
 
@@ -337,6 +342,12 @@ export const actionCreators: ActionCreators = {
         workspace = await getDevWorkspaceClient().manageContainerBuildAttribute(workspace, config);
 
         workspace = await getDevWorkspaceClient().manageDebugMode(workspace, debugWorkspace);
+
+        const editorName = getEditorName(workspace);
+        const lifeTime = getLifeTime(workspace);
+        if (editorName && lifeTime > 30) {
+          await updateEditor(editorName, getState);
+        }
 
         const startingWorkspace = await getDevWorkspaceClient().changeWorkspaceStatus(
           workspace,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -749,18 +749,13 @@ export const actionCreators: ActionCreators = {
           openVSXUrl,
           clusterConsole,
         );
-        const templates = await DwtApi.getTemplates(workspace.metadata.namespace);
-        const targetTemplate = templates.find(template => {
-          const ownerReferences = template.metadata?.ownerReferences || [];
-          return (
-            ownerReferences.find(
-              ownerReference => ownerReference.uid === workspace.metadata.uid,
-            ) !== undefined
-          );
-        });
-        const templateName = targetTemplate?.metadata?.name;
-        const templateNamespace = targetTemplate?.metadata?.namespace;
-        if (!templateName || !templateNamespace) {
+        let targetTemplate: devfileApi.DevWorkspaceTemplate | undefined;
+        const templateName = getEditorName(workspace);
+        const templateNamespace = workspace.metadata.namespace;
+        if (templateName && templateNamespace) {
+          targetTemplate = await DwtApi.getTemplateByName(templateNamespace, templateName);
+        }
+        if (!templateName || !templateNamespace || !targetTemplate) {
           throw new Error('Cannot define the target template');
         }
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -67,7 +67,7 @@ import {
 import { selectDevWorkspacesResourceVersion } from '@/store/Workspaces/devWorkspaces/selectors';
 import {
   getEditorName,
-  getLifeTime,
+  getLifeTimeMs,
   updateEditor,
 } from '@/store/Workspaces/devWorkspaces/updateEditor';
 
@@ -344,8 +344,8 @@ export const actionCreators: ActionCreators = {
         workspace = await getDevWorkspaceClient().manageDebugMode(workspace, debugWorkspace);
 
         const editorName = getEditorName(workspace);
-        const lifeTime = getLifeTime(workspace);
-        if (editorName && lifeTime > 30) {
+        const lifeTimeMs = getLifeTimeMs(workspace);
+        if (editorName && lifeTimeMs > 30000) {
           await updateEditor(editorName, getState);
         }
 

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/updateEditor.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/updateEditor.ts
@@ -20,7 +20,11 @@ import { AppState } from '@/store';
 import { selectApplications } from '@/store/ClusterInfo/selectors';
 import { selectDefaultNamespace } from '@/store/InfrastructureNamespaces/selectors';
 import { selectDwEditorsPluginsList } from '@/store/Plugins/devWorkspacePlugins/selectors';
-import { selectOpenVSXUrl, selectPluginRegistryUrl } from '@/store/ServerConfig/selectors';
+import {
+  selectOpenVSXUrl,
+  selectPluginRegistryInternalUrl,
+  selectPluginRegistryUrl,
+} from '@/store/ServerConfig/selectors';
 
 const devWorkspaceClient = container.get(DevWorkspaceClient);
 
@@ -33,7 +37,7 @@ export async function updateEditor(editorName: string, getState: () => AppState)
   });
   const openVSXUrl = selectOpenVSXUrl(state);
   const pluginRegistryUrl = selectPluginRegistryUrl(state);
-  const pluginRegistryInternalUrl = state.dwServerConfig.config.pluginRegistryInternalURL;
+  const pluginRegistryInternalUrl = selectPluginRegistryInternalUrl(state);
   const clusterConsole = selectApplications(state).find(
     app => app.id === ApplicationId.CLUSTER_CONSOLE,
   );
@@ -52,7 +56,7 @@ export async function updateEditor(editorName: string, getState: () => AppState)
       await DwtApi.patchTemplate(namespace, editorName, updates);
     }
   } catch (e) {
-    console.error('Failed to update devWorkspaceTemplate.', e);
+    console.error(e);
   }
 }
 
@@ -73,14 +77,11 @@ export function getEditorName(workspace: devfileApi.DevWorkspace): string | unde
   return editorName;
 }
 
-export function getLifeTime(workspace: devfileApi.DevWorkspace): number {
+export function getLifeTimeMs(workspace: devfileApi.DevWorkspace): number {
   const creationTimestamp = workspace.metadata.creationTimestamp;
-
   if (creationTimestamp === undefined) {
     return 0;
   }
 
-  const lifeTimeInMs = new Date().getTime() - new Date(creationTimestamp).getTime();
-
-  return Math.floor(lifeTimeInMs / 1000);
+  return new Date().getTime() - new Date(creationTimestamp).getTime();
 }

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/updateEditor.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/updateEditor.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { ApplicationId } from '@eclipse-che/common';
+
+import { container } from '@/inversify.config';
+import * as DwtApi from '@/services/backend-client/devWorkspaceTemplateApi';
+import devfileApi from '@/services/devfileApi';
+import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+import { AppState } from '@/store';
+import { selectApplications } from '@/store/ClusterInfo/selectors';
+import { selectDefaultNamespace } from '@/store/InfrastructureNamespaces/selectors';
+import { selectDwEditorsPluginsList } from '@/store/Plugins/devWorkspacePlugins/selectors';
+import { selectOpenVSXUrl, selectPluginRegistryUrl } from '@/store/ServerConfig/selectors';
+
+const devWorkspaceClient = container.get(DevWorkspaceClient);
+
+export async function updateEditor(editorName: string, getState: () => AppState): Promise<void> {
+  const state = getState();
+  const namespace = selectDefaultNamespace(state).name;
+  const pluginsByUrl: { [url: string]: devfileApi.Devfile } = {};
+  selectDwEditorsPluginsList(state.dwPlugins.defaultEditorName)(state).forEach(dwEditor => {
+    pluginsByUrl[dwEditor.url] = dwEditor.devfile;
+  });
+  const openVSXUrl = selectOpenVSXUrl(state);
+  const pluginRegistryUrl = selectPluginRegistryUrl(state);
+  const pluginRegistryInternalUrl = state.dwServerConfig.config.pluginRegistryInternalURL;
+  const clusterConsole = selectApplications(state).find(
+    app => app.id === ApplicationId.CLUSTER_CONSOLE,
+  );
+
+  try {
+    const updates = await devWorkspaceClient.checkForTemplatesUpdate(
+      editorName,
+      namespace,
+      pluginsByUrl,
+      pluginRegistryUrl,
+      pluginRegistryInternalUrl,
+      openVSXUrl,
+      clusterConsole,
+    );
+    if (updates.length > 0) {
+      await DwtApi.patchTemplate(namespace, editorName, updates);
+    }
+  } catch (e) {
+    console.error('Failed to update devWorkspaceTemplate.', e);
+  }
+}
+
+export function getEditorName(workspace: devfileApi.DevWorkspace): string | undefined {
+  const contributions = workspace.spec?.contributions;
+  if (!contributions || contributions.length === 0) {
+    return undefined;
+  }
+  let editorName: string | undefined = undefined;
+
+  for (const contribution of contributions) {
+    if (contribution.name === 'editor' && contribution.kubernetes?.name) {
+      editorName = contribution.kubernetes.name;
+      break;
+    }
+  }
+
+  return editorName;
+}
+
+export function getLifeTime(workspace: devfileApi.DevWorkspace): number {
+  const creationTimestamp = workspace.metadata.creationTimestamp;
+
+  if (creationTimestamp === undefined) {
+    return 0;
+  }
+
+  const lifeTimeInMs = new Date().getTime() - new Date(creationTimestamp).getTime();
+
+  return Math.floor(lifeTimeInMs / 1000);
+}

--- a/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/storeBuilder.ts
@@ -31,6 +31,7 @@ import {
 import { IGitOauth } from '@/store/GitOauthConfig/types';
 import { State as InfrastructureNamespaceState } from '@/store/InfrastructureNamespaces';
 import { State as PluginsState } from '@/store/Plugins/chePlugins';
+import { PluginDefinition } from '@/store/Plugins/devWorkspacePlugins';
 import { State as LogsState } from '@/store/Pods/Logs';
 import { State as UserProfileState } from '@/store/User/Profile';
 import { State as WorkspacesState } from '@/store/Workspaces';
@@ -380,19 +381,15 @@ export class FakeStoreBuilder {
   }
 
   public withDwPlugins(
-    plugins: {
-      [location: string]: {
-        plugin?: devfileApi.Devfile;
-        url: string;
-        error?: string;
-      };
-    },
+    plugins: { [url: string]: PluginDefinition },
+    editors: { [url: string]: PluginDefinition },
     isLoading = false,
     defaultEditorError?: string,
     defaultEditorName?: string,
   ) {
     this.state.dwPlugins.defaultEditorError = defaultEditorError;
     this.state.dwPlugins.plugins = Object.assign({}, plugins);
+    this.state.dwPlugins.editors = Object.assign({}, editors);
     this.state.dwPlugins.isLoading = isLoading;
     this.state.dwPlugins.defaultEditorName = defaultEditorName;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR changed the way to update Editors.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22750

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Create a new workspace from the **Empty Workspace** sample.
3. Return to the Dashboard tab and stop the created workspace.
4. Open the **Chrome Menu** and select **More Tools** > **Developer Tools**.

5. Select **Network** > **XHR and Fetch** and paste ```devworkspacetemplate``` into the filter.
![Знімок екрана 2024-02-08 о 12 28 19](https://github.com/eclipse-che/che-dashboard/assets/6310786/ce23f94f-c0e6-4d6c-a314-425ce1d2cdf4)

6. Refresh the Dashboard page. The request that includes ```devworkspacetemplate``` should not be called.

7. Open Swagger in the new tab.
```{CHE-server}/dashboard/api/swagger```

8. Request the list of templates and copy the target editor's name.
![Знімок екрана 2024-02-06 о 16 05 32](https://github.com/eclipse-che/che-dashboard/assets/6310786/b4f91b42-fc65-4fa3-98e0-e7868ca56fc1)

9. Patch the target editor with empty commands.

```
[
  {
    "op": "replace",
    "path": "/spec/commands",
    "value": []
  }
]
```

![Знімок екрана 2024-02-06 о 16 06 34](https://github.com/eclipse-che/che-dashboard/assets/6310786/8da81790-2dd5-4f82-a32a-cbbc6fce80ae)

10. Return to the Dashboard tab and start the target workspace in the background. Two requests(GET and PATCH) that include ```devworkspacetemplate``` should not be called.
![Знімок екрана 2024-02-06 о 16 06 55](https://github.com/eclipse-che/che-dashboard/assets/6310786/f1fa696f-b718-415c-a69c-6a4b8dec8701)

11. After restarting the target workspace only one GET request that includes ```devworkspacetemplate``` should be called.
![Знімок екрана 2024-02-06 о 16 21 11](https://github.com/eclipse-che/che-dashboard/assets/6310786/7e4139b0-49a5-4b6d-ba61-bb6adacdc026)

