### PR TITLE
Fix data resolver API

### DIFF
--- a/packages/dashboard-backend/src/localRun/hooks/stubCheServerOptionsRequests.ts
+++ b/packages/dashboard-backend/src/localRun/hooks/stubCheServerOptionsRequests.ts
@@ -16,7 +16,7 @@ export function stubCheServerOptionsRequests(server: FastifyInstance) {
   // stub OPTIONS requests to '/api/' since they fail when running the backend locally.
   server.addHook('onRequest', (request, reply, done) => {
     if ((request.url === '/api' || request.url === '/api/') && request.method === 'OPTIONS') {
-      return reply.send({
+      reply.send({
         implementationVersion: 'Local Run',
       });
     }

--- a/packages/dashboard-backend/src/localRun/routes/dexCallback.ts
+++ b/packages/dashboard-backend/src/localRun/routes/dexCallback.ts
@@ -17,10 +17,10 @@ export function registerDexCallback(server: FastifyInstance) {
     try {
       const { token } = await server.localStart.getAccessTokenFromAuthorizationCodeFlow(request);
       process.env.CLUSTER_ACCESS_TOKEN = token.access_token;
-      return reply.redirect('/dashboard/');
+      reply.redirect('/dashboard/');
     } catch (e) {
       // handle an error that usually occurs during the authorization flow from an abandoned tab with outdated state
-      return reply.redirect('/oauth/sign_in');
+      reply.redirect('/oauth/sign_in');
     }
   });
 }

--- a/packages/dashboard-backend/src/localRun/routes/signOut.ts
+++ b/packages/dashboard-backend/src/localRun/routes/signOut.ts
@@ -15,6 +15,6 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 export function registerSignOut(server: FastifyInstance) {
   server.get('/oauth/sign_out', async function (request: FastifyRequest, reply: FastifyReply) {
     process.env.CLUSTER_ACCESS_TOKEN = '';
-    return reply.redirect('/oauth/sign_in');
+    reply.redirect('/oauth/sign_in');
   });
 }

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -13,7 +13,7 @@
 import { FastifyInstance } from 'fastify';
 
 import { baseApiPath } from '@/constants/config';
-import { axiosInstance, defaultAxiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
+import { axiosInstance, axiosInstanceNoCert } from '@/routes/api/helpers/getCertificateAuthority';
 import { createFastifyError } from '@/services/helpers';
 import { setup, teardown } from '@/utils/appBuilder';
 
@@ -21,7 +21,7 @@ jest.mock('@/routes/api/helpers/getCertificateAuthority');
 const axiosInstanceMock = jest.fn();
 (axiosInstance.get as jest.Mock).mockImplementation(axiosInstanceMock);
 const defaultAxiosInstanceMock = jest.fn();
-(defaultAxiosInstance.get as jest.Mock).mockImplementation(defaultAxiosInstanceMock);
+(axiosInstanceNoCert.get as jest.Mock).mockImplementation(defaultAxiosInstanceMock);
 
 describe('Data Resolver Route', () => {
   let app: FastifyInstance;

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -13,15 +13,15 @@
 import { FastifyInstance } from 'fastify';
 
 import { baseApiPath } from '@/constants/config';
-import { axiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
+import { axiosInstance, defaultAxiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
+import { createFastifyError } from '@/services/helpers';
 import { setup, teardown } from '@/utils/appBuilder';
 
-jest.mock('@/routes/api/helpers/getDevWorkspaceClient.ts');
-jest.mock('@/routes/api/helpers/getToken.ts');
-
 jest.mock('@/routes/api/helpers/getCertificateAuthority');
-const getAxiosInstanceMock = jest.fn();
-(axiosInstance.get as jest.Mock).mockImplementation(getAxiosInstanceMock);
+const axiosInstanceMock = jest.fn();
+(axiosInstance.get as jest.Mock).mockImplementation(axiosInstanceMock);
+const defaultAxiosInstanceMock = jest.fn();
+(defaultAxiosInstance.get as jest.Mock).mockImplementation(defaultAxiosInstanceMock);
 
 describe('Data Resolver Route', () => {
   let app: FastifyInstance;
@@ -34,37 +34,111 @@ describe('Data Resolver Route', () => {
     teardown(app);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('POST ${baseApiPath}/data/resolver', () => {
-    test('file exists', async () => {
-      const devfileContent = 'devfile content';
-      getAxiosInstanceMock.mockResolvedValue({
-        status: 200,
-        data: devfileContent,
+    describe('with certificate authority', () => {
+      beforeEach(() => {
+        defaultAxiosInstanceMock.mockRejectedValueOnce({
+          response: {
+            headers: {},
+            status: 500,
+            config: {},
+            statusText: '500 Internal Server Error',
+            data: createFastifyError(
+              'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+              'Internal Server Error',
+              500,
+            ),
+          },
+        });
       });
 
-      const res = await app
-        .inject()
-        .post(`${baseApiPath}/data/resolver`)
-        .payload({ url: 'https://devfile.yaml' });
+      test('file exists', async () => {
+        axiosInstanceMock.mockResolvedValueOnce({
+          status: 200,
+          data: 'test content',
+        });
 
-      expect(res.statusCode).toEqual(200);
-      expect(res.body).toEqual(devfileContent);
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'https://devfile.yaml' });
+
+        expect(defaultAxiosInstanceMock).toHaveBeenCalledTimes(1);
+        expect(axiosInstanceMock).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toEqual('test content');
+      });
+
+      test('file not found', async () => {
+        axiosInstanceMock.mockRejectedValueOnce({
+          response: {
+            headers: {},
+            status: 404,
+            config: {},
+            statusText: '404 Not Found',
+            data: createFastifyError('ERR_BAD_REQUEST', 'Not Found', 404),
+          },
+        });
+
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'https://devfile.yaml' });
+
+        expect(defaultAxiosInstanceMock).toHaveBeenCalledTimes(1);
+        expect(axiosInstanceMock).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toEqual(404);
+        expect(res.body).toEqual(
+          '{"statusCode":404,"code":"ERR_BAD_REQUEST","error":"Not Found","message":"Not Found"}',
+        );
+      });
     });
+    describe('without certificate authority', () => {
+      test('file exists', async () => {
+        defaultAxiosInstanceMock.mockResolvedValueOnce({
+          status: 200,
+          data: 'test content',
+        });
 
-    test('file not found', async () => {
-      const responseText = 'not found';
-      getAxiosInstanceMock.mockResolvedValue({
-        status: 404,
-        data: responseText,
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'https://devfile.yaml' });
+
+        expect(defaultAxiosInstanceMock).toHaveBeenCalledTimes(1);
+        expect(axiosInstanceMock).toHaveBeenCalledTimes(0);
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toEqual('test content');
       });
 
-      const res = await app
-        .inject()
-        .post(`${baseApiPath}/data/resolver`)
-        .payload({ url: 'https://devfile.yaml' });
+      test('file not found', async () => {
+        const fastifyError = createFastifyError('ERR_BAD_REQUEST', 'Not Found', 404);
+        defaultAxiosInstanceMock.mockRejectedValueOnce({
+          response: {
+            headers: {},
+            status: 404,
+            config: {},
+            statusText: '404 Not Found',
+            data: fastifyError,
+          },
+        });
 
-      expect(res.statusCode).toEqual(404);
-      expect(res.body).toEqual(responseText);
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'https://devfile.yaml' });
+
+        expect(defaultAxiosInstanceMock).toHaveBeenCalledTimes(1);
+        expect(axiosInstanceMock).toHaveBeenCalledTimes(0);
+        expect(res.statusCode).toEqual(404);
+        expect(res.body).toEqual(
+          '{"statusCode":404,"code":"ERR_BAD_REQUEST","error":"Not Found","message":"Not Found"}',
+        );
+      });
     });
   });
 });

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -17,7 +17,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { baseApiPath } from '@/constants/config';
 import { dataResolverSchema } from '@/constants/schemas';
 import { restParams } from '@/models';
-import { axiosInstance, defaultAxiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
+import { axiosInstance, axiosInstanceNoCert } from '@/routes/api/helpers/getCertificateAuthority';
 import { getSchema } from '@/services/helpers';
 
 const tags = ['Data Resolver'];
@@ -37,7 +37,7 @@ export function registerDataResolverRoute(instance: FastifyInstance) {
         try {
           let response: AxiosResponse;
           try {
-            response = await defaultAxiosInstance.get(url, config);
+            response = await axiosInstanceNoCert.get(url, config);
           } catch (error) {
             if (helpers.errors.includesAxiosResponse(error) && error.response.status === 404) {
               throw error;

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { helpers } from '@eclipse-che/common';
 import axios, { AxiosResponse } from 'axios';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
@@ -33,15 +34,23 @@ export function registerDataResolverRoute(instance: FastifyInstance) {
       async function (request: FastifyRequest, reply: FastifyReply): Promise<string | void> {
         const { url } = request.body as restParams.IYamlResolverParams;
 
-        let response: AxiosResponse;
         try {
-          response = await axios.get(url, config);
-        } catch (e) {
-          response = await axiosInstance.get(url, config);
+          let response: AxiosResponse;
+          try {
+            response = await axios.get(url, config);
+          } catch (error) {
+            if (helpers.errors.includesAxiosResponse(error) && error.response.status === 404) {
+              throw error;
+            }
+            response = await axiosInstance.get(url, config);
+          }
+          return response.data;
+        } catch (error) {
+          if (!helpers.errors.includesAxiosResponse(error)) {
+            throw error;
+          }
+          reply.code(error.response.status).send(error.response.data);
         }
-        reply.code(response.status);
-        reply.send(response.data);
-        return reply;
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -11,13 +11,13 @@
  */
 
 import { helpers } from '@eclipse-che/common';
-import axios, { AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import { baseApiPath } from '@/constants/config';
 import { dataResolverSchema } from '@/constants/schemas';
 import { restParams } from '@/models';
-import { axiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
+import { axiosInstance, defaultAxiosInstance } from '@/routes/api/helpers/getCertificateAuthority';
 import { getSchema } from '@/services/helpers';
 
 const tags = ['Data Resolver'];
@@ -37,7 +37,7 @@ export function registerDataResolverRoute(instance: FastifyInstance) {
         try {
           let response: AxiosResponse;
           try {
-            response = await axios.get(url, config);
+            response = await defaultAxiosInstance.get(url, config);
           } catch (error) {
             if (helpers.errors.includesAxiosResponse(error) && error.response.status === 404) {
               throw error;

--- a/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
@@ -107,9 +107,10 @@ export function registerDevWorkspaceTemplates(instance: FastifyInstance) {
             request.params as restParams.INamespacedTemplateParams;
           const token = getToken(request);
           const { devWorkspaceTemplateApi: templateApi } = getDevWorkspaceClient(token);
+
           await templateApi.delete(namespace, templateName);
-          reply.code(204);
-          return reply.send();
+
+          reply.code(204).send();
         },
       );
     }

--- a/packages/dashboard-backend/src/routes/api/devworkspaces.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaces.ts
@@ -57,8 +57,7 @@ export function registerDevworkspacesRoutes(instance: FastifyInstance) {
         const { devworkspaceApi } = getDevWorkspaceClient(token);
         const { headers, devWorkspace } = await devworkspaceApi.create(devworkspace, namespace);
 
-        reply.headers(headers);
-        reply.send(devWorkspace);
+        reply.headers(headers).send(devWorkspace);
       },
     );
 
@@ -89,8 +88,7 @@ export function registerDevworkspacesRoutes(instance: FastifyInstance) {
           patch,
         );
 
-        reply.headers(headers);
-        reply.send(devWorkspace);
+        reply.headers(headers).send(devWorkspace);
       },
     );
 
@@ -111,9 +109,10 @@ export function registerDevworkspacesRoutes(instance: FastifyInstance) {
           request.params as restParams.INamespacedWorkspaceParams;
         const token = getToken(request);
         const { devworkspaceApi } = getDevWorkspaceClient(token);
+
         await devworkspaceApi.delete(namespace, workspaceName);
-        reply.code(204);
-        return reply.send();
+
+        reply.code(204).send();
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/api/helpers/getCertificateAuthority.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getCertificateAuthority.ts
@@ -22,7 +22,7 @@ const certificateAuthority = getCertificateAuthority(
   CHE_SELF_SIGNED_MOUNT_PATH ? CHE_SELF_SIGNED_MOUNT_PATH : DEFAULT_CHE_SELF_SIGNED_MOUNT_PATH,
 );
 
-export const defaultAxiosInstance = axios.create();
+export const axiosInstanceNoCert = axios.create();
 export const axiosInstance =
   certificateAuthority !== undefined
     ? axios.create({

--- a/packages/dashboard-backend/src/routes/api/helpers/getCertificateAuthority.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getCertificateAuthority.ts
@@ -22,11 +22,15 @@ const certificateAuthority = getCertificateAuthority(
   CHE_SELF_SIGNED_MOUNT_PATH ? CHE_SELF_SIGNED_MOUNT_PATH : DEFAULT_CHE_SELF_SIGNED_MOUNT_PATH,
 );
 
-export const axiosInstance = axios.create({
-  httpsAgent: new https.Agent({
-    ca: certificateAuthority,
-  }),
-});
+export const defaultAxiosInstance = axios.create();
+export const axiosInstance =
+  certificateAuthority !== undefined
+    ? axios.create({
+        httpsAgent: new https.Agent({
+          ca: certificateAuthority,
+        }),
+      })
+    : axios.create();
 
 function searchCertificate(
   certPath: string,

--- a/packages/dashboard-backend/src/routes/api/kubeConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/kubeConfig.ts
@@ -40,8 +40,8 @@ export function registerKubeConfigRoute(instance: FastifyInstance) {
         const { kubeConfigApi } = getDevWorkspaceClient(token);
         const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParams;
         await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
-        reply.code(204);
-        return reply.send();
+
+        reply.code(204).send();
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/api/personalAccessToken.ts
+++ b/packages/dashboard-backend/src/routes/api/personalAccessToken.ts
@@ -77,7 +77,8 @@ export function registerPersonalAccessTokenRoutes(instance: FastifyInstance) {
         const { personalAccessTokenApi } = getDevWorkspaceClient(token);
 
         await personalAccessTokenApi.delete(namespace, tokenName);
-        return reply.code(204).send();
+
+        reply.code(204).send();
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/api/podmanLogin.ts
+++ b/packages/dashboard-backend/src/routes/api/podmanLogin.ts
@@ -41,8 +41,7 @@ export function registerPodmanLoginRoute(instance: FastifyInstance) {
         const { podmanApi } = getDevWorkspaceClient(token);
         const { namespace, devworkspaceId } = request.params as restParams.INamespacedPodParams;
         await podmanApi.podmanLogin(namespace, devworkspaceId);
-        reply.code(204);
-        return reply.send();
+        reply.code(204).send();
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/api/sshKeys.ts
+++ b/packages/dashboard-backend/src/routes/api/sshKeys.ts
@@ -59,7 +59,8 @@ export function registerSShKeysRoutes(instance: FastifyInstance) {
         const { sshKeysApi } = getDevWorkspaceClient(token);
 
         await sshKeysApi.delete(namespace, name);
-        return reply.code(204).send();
+
+        reply.code(204).send();
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/api/workspacePreferences.ts
+++ b/packages/dashboard-backend/src/routes/api/workspacePreferences.ts
@@ -50,12 +50,13 @@ export function registerWorkspacePreferencesRoute(instance: FastifyInstance) {
         const { namespace, provider } = request.params as restParams.IWorkspacePreferencesParams;
         const token = getToken(request);
         const { devWorkspacePreferencesApi } = getDevWorkspaceClient(token);
+
         await devWorkspacePreferencesApi.removeProviderFromSkipAuthorizationList(
           namespace,
           provider,
         );
-        reply.code(204);
-        return reply.send();
+
+        reply.code(204).send();
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
@@ -39,7 +39,7 @@ export function registerFactoryAcceptanceRedirect(instance: FastifyInstance): vo
 
         const sanitizedQueryParams = helpers.sanitizeSearchParams(params);
 
-        return reply.redirect('/dashboard/#/load-factory?' + sanitizedQueryParams.toString());
+        reply.redirect('/dashboard/#/load-factory?' + sanitizedQueryParams.toString());
       });
     });
   }

--- a/packages/dashboard-backend/src/routes/workspaceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/workspaceRedirect.ts
@@ -21,7 +21,7 @@ export function registerWorkspaceRedirect(instance: FastifyInstance): void {
         const params = searchParams.get('params');
         if (params) {
           const parse: { namespace: string; workspace: string } = JSON.parse(params);
-          return reply.redirect(`/dashboard/#/ide/${parse.namespace}/${parse.workspace}`);
+          reply.redirect(`/dashboard/#/ide/${parse.namespace}/${parse.workspace}`);
         }
       });
     });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix the error for data resolver API 'POST ${baseApiPath}/data/resolver'.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22814

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Open Swagger in the new tab.
```{CHE-server}/dashboard/api/swagger```

3. Request data resolver with the next payload:
```json
{
  "url": "{CHE-server}/dashboard/devfile-registry/devfiles/index.json"
}
```
![Знімок екрана 2024-02-14 о 14 07 44](https://github.com/eclipse-che/che-dashboard/assets/6310786/bd2e3f57-1788-45b6-ad9b-4158b772e71d)

The status code should be `200`.

4. Request data resolver with non-existence payload:
```json
{
  "url": "{CHE-server}/dashboard/devfile-registry/devfiles/index111.json"
}
```

![Знімок екрана 2024-02-14 о 14 01 33](https://github.com/eclipse-che/che-dashboard/assets/6310786/d14b51a1-fd18-475a-b80a-690236786adf)

The status code should be `404`.