### PR TITLE
fix: update editor image method

### DIFF
--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template-with-custom-image.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-devworkspace-template-with-custom-image.yaml
@@ -9,10 +9,10 @@ spec:
     - attributes:
         controller.devfile.io/container-contribution: true
       container:
-        image: test-images/che-code:tag
+        image: quay.io/devfile/universal-developer-image:next
       name: che-code-runtime-description
     - name: checode
       volume: {}
     - container:
-        image: quay.io/che-incubator/che-code:next
+        image: test-images/che-code:tag
       name: che-code-injector

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-editor-devfile-with-custom-image.yaml
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/fixtures/test-editor-devfile-with-custom-image.yaml
@@ -4,11 +4,11 @@ metadata:
 components:
   - name: che-code-runtime-description
     container:
-      image: test-images/che-code:tag
+      image: quay.io/devfile/universal-developer-image:next
     attributes:
       controller.devfile.io/container-contribution: true
   - name: checode
     volume: {}
   - name: che-code-injector
     container:
-      image: quay.io/che-incubator/che-code:next
+      image: test-images/che-code:tag

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
@@ -92,7 +92,7 @@ function updateComponents(
   let isUpdated = false;
   for (let i = 0; i < components.length; i++) {
     if (
-      components[i].attributes?.['controller.devfile.io/container-contribution'] &&
+      components[i].attributes?.['controller.devfile.io/container-contribution'] === undefined &&
       components[i].container?.image
     ) {
       components[i].container!.image = editorImage;

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
@@ -91,10 +91,7 @@ function updateComponents(
   }
   let isUpdated = false;
   for (let i = 0; i < components.length; i++) {
-    if (
-      components[i].attributes?.['controller.devfile.io/container-contribution'] === undefined &&
-      components[i].container?.image
-    ) {
+    if (components[i].name.endsWith('-injector') && components[i].container?.image) {
       components[i].container!.image = editorImage;
       isUpdated = true;
       break;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
fix: update editor image method

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22733

### Is it tested? How?
1. Deploy Eclipse-Che with the image from this PR.
2. Create a new workspace with the next link:
```bash
{CHE-server}#https://github.com/eclipse-che/che-dashboard?che-editor=che-incubator/che-idea/latest&editor-image=quay.io/che-incubator/che-pycharm:next
```
3. Open Swagger in the new tab.
```{CHE-server}/dashboard/api/swagger```

4. Request the list of templates.

![Знімок екрана 2024-02-16 о 15 49 36](https://github.com/eclipse-che/che-dashboard/assets/6310786/dc1cd001-f201-4da6-bbaa-02e1394fb31b)

5. The target devWorkspaceTemplate should have a container with  the name ```che-idea-injector``` and the  image ```quay.io/che-incubator/che-pycharm:next```:

```yaml
components:
- container:
    command:
    - "/projector/entrypoint-init-container.sh"
    cpuLimit: 500m
    cpuRequest: 30m
    image: quay.io/che-incubator/che-pycharm:next
    memoryLimit: 128Mi
    memoryRequest: 32Mi
    sourceMapping: "/projects"
    volumeMounts:
    - name: projector-volume
      path: "/projector-volume"
  name: che-idea-injector
``` 
