### PR TITLE
Fix yarn lock release

### DIFF
--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -502,7 +502,7 @@
 | [`inquirer@8.2.6`](https://github.com/SBoudrias/Inquirer.js.git) | MIT | transitive dependency |
 | [`internal-slot@1.0.6`](git+https://github.com/ljharb/internal-slot.git) | MIT | #7118 |
 | [`interpret@3.1.1`](https://github.com/gulpjs/interpret.git) | MIT | clearlydefined |
-| [`ip@2.0.0`](http://github.com/indutny/node-ip.git) | MIT | clearlydefined |
+| [`ip@2.0.0`](http://github.com/indutny/node-ip.git) | MIT | #13289 |
 | [`is-array-buffer@3.0.2`](git+https://github.com/inspect-js/is-array-buffer.git) | MIT | #6248 |
 | [`is-arrayish@0.2.1`](https://github.com/qix-/node-is-arrayish.git) | MIT | clearlydefined |
 | [`is-async-function@2.0.0`](git://github.com/inspect-js/is-async-function.git) | MIT | clearlydefined |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,10 +5,10 @@
 | [`@babel/runtime@7.23.2`](https://github.com/babel/babel.git) | MIT | #10718 |
 | [`@devfile/api@2.2.0-alpha-1637255314`](https://github.com/devfile/api.git) | EPL-2.0 | clearlydefined |
 | `@eclipse-che/api@7.76.0` | EPL-2.0 | ecd.che |
-| [`@eclipse-che/che-devworkspace-generator@7.79.0-next-1427c19`](git+https://github.com/eclipse-che/che-devfile-registry.git) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/common@7.82.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-backend@7.82.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-frontend@7.82.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/che-devworkspace-generator@7.82.0`](git+https://github.com/eclipse-che/che-devfile-registry.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/common@7.82.1-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-backend@7.82.1-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-frontend@7.82.1-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
 | [`@eclipse-che/devfile-converter@0.0.1-0751ad2`](git+https://github.com/che-incubator/devfile-converter.git) | EPL-2.0 | ecd.che |
 | [`@fastify/accept-negotiator@1.1.0`](git+https://github.com/fastify/accept-negotiator.git) | MIT | clearlydefined |
 | [`@fastify/ajv-compiler@3.5.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.80.0.tgz#3e62755ebe6598391fd0b77436ef0092fd9e7e20"
   integrity sha512-+steYN8zsI/KH6sv1/avrpg+JV+NhplavyD92B334eGMBTevrzDFSOsWXB0a3z/u6BZ4wCPbxAwQr5gPMbVk+g==
 
-"@eclipse-che/che-devworkspace-generator@7.79.0-next-1427c19":
-  version "7.79.0-next-1427c19"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-7.79.0-next-1427c19.tgz#2530b87d3e551b2c71ebb84e3e2e15c8229c0a19"
-  integrity sha512-eIu2bW165I4UzYFdpFQ1c2JXU1qGd7RRO4ITWE4To372+Cq1DTKNMjhVdj40DDeU2Pw1UjYh3Rr0flS7KBAUbg==
+"@eclipse-che/che-devworkspace-generator@7.82.0":
+  version "7.82.0"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-7.82.0.tgz#974b6d064cadef61e5ede82943c8f7bb6ab0f663"
+  integrity sha512-/eHSaN8ILT3ObJDSV1FOF13z6g3N8K3XN5c0i/lO+n71NmNh6Gq5gRUmPnogeDBbRZGvRHX1/owADWZSu1Jsgw==
   dependencies:
     "@devfile/api" "2.2.2-1700686170"
     axios "1.6.0"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix missing new version of devworkspace-generator in yarn lock, which is needed for downstream dependency resolution

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
