### PR TITLE
Add gitlab to the list of allowed to revoke oauth providers

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServicesTab/index.tsx
@@ -33,7 +33,7 @@ import {
   selectSkipOauthProviders,
 } from '@/store/GitOauthConfig/selectors';
 
-export const enabledProviders: api.GitOauthProvider[] = ['github', 'github_2'];
+export const enabledProviders: api.GitOauthProvider[] = ['github', 'github_2', 'gitlab'];
 
 type Props = MappedProps;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add gitlab to the list of allowed to revoke oauth providers

**Do not merge** before https://github.com/eclipse-che/che-server/pull/667 is merged.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22832

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
see https://github.com/eclipse-che/che-server/pull/667

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
