### PR TITLE
Fix workspace start from Bitbucket server repository with OAuth2

### DIFF
--- a/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
+++ b/packages/dashboard-backend/src/routes/__tests__/factoryAcceptanceRedirect.spec.ts
@@ -25,7 +25,7 @@ describe('Factory Acceptance Redirect', () => {
     teardown(app);
   });
 
-  it('should redirect "/f?url=factoryUrl"', async () => {
+  it('should redirect to "/load-factory?url=factoryUrl" (no `factoryLink` param)', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
       url: `/f?url=${factoryUrl}`,
@@ -34,20 +34,24 @@ describe('Factory Acceptance Redirect', () => {
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
-  it('should redirect "/f?factoryLink=url%3DfactoryUrl"', async () => {
+  it('should redirect to "/load-factory?url=factoryUrl"', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
-      url: `/f?factoryLink=${encodeURIComponent('url=' + factoryUrl)}`,
+      url: `/f?factoryLink=${encodeURIComponent(btoa('url=' + factoryUrl))}`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
-  it('should redirect "/f?factoryLink=che-editor=che-incubator/.che-code/insiders&override.devfileFilename=my.devfile.yaml&url=factoryUr"', async () => {
+  it('should redirect to "/load-factory?che-editor=che-incubator%2F.che-code%2Finsiders&override.devfileFilename=my.devfile.yaml&url=factoryUrl"', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
       url: `/f?${encodeURIComponent(
-        'factoryLink=che-editor=che-incubator/.che-code/insiders&override.devfileFilename=my.devfile.yaml&url=factoryUrl',
+        `factoryLink=${encodeURIComponent(
+          btoa(
+            'che-editor=che-incubator/.che-code/insiders&override.devfileFilename=my.devfile.yaml&url=factoryUrl',
+          ),
+        )}`,
       )}`,
     });
     expect(res.statusCode).toEqual(302);
@@ -56,28 +60,21 @@ describe('Factory Acceptance Redirect', () => {
     );
   });
 
-  it('should redirect "/f?url=factoryUrl"', async () => {
+  it('should redirect to "/load-factory?url=factoryUrl" (with extra encoding)', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
-      url: `/f?url=${factoryUrl}`,
+      url: `/f?factoryLink%3D${encodeURIComponent(btoa('url=' + factoryUrl))}`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
   });
 
-  it('should redirect "/f?factoryLink%3Durl%3DfactoryUrl"', async () => {
+  it('should redirect to "/load-factory?url=factoryUrl&error_code=access_denied" (with extra encoding)', async () => {
     const factoryUrl = 'factoryUrl';
     const res = await app.inject({
-      url: `/f?factoryLink%3Durl%3D${factoryUrl}`,
-    });
-    expect(res.statusCode).toEqual(302);
-    expect(res.headers.location).toEqual(`/dashboard/#/load-factory?url=${factoryUrl}`);
-  });
-
-  it('should redirect "/f?factoryLink%3Durl%3DfactoryUrl%26error_code%3Daccess_denied"', async () => {
-    const factoryUrl = 'factoryUrl';
-    const res = await app.inject({
-      url: `/f?factoryLink%3Durl%3D${factoryUrl}%26error_code%3Daccess_denied`,
+      url: `/f?factoryLink%3D${encodeURIComponent(
+        btoa('url=' + factoryUrl + '&error_code=access_denied'),
+      )}`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(
@@ -85,9 +82,11 @@ describe('Factory Acceptance Redirect', () => {
     );
   });
 
-  it('should redirect "/f?factoryLink=url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git"', async () => {
+  it('should redirect to "/load-factory?url=https%3A%2F%2Fgithub.com%2Folexii4%2Fhelloworld.git"', async () => {
     const res = await app.inject({
-      url: `/f?factoryLink=url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git`,
+      url: `/f?factoryLink=${encodeURIComponent(
+        btoa('url=https%3A%2F%2Fgithub.com%2Folexii4%2Fhelloworld.git'),
+      )}`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(
@@ -95,9 +94,13 @@ describe('Factory Acceptance Redirect', () => {
     );
   });
 
-  it('should redirect "/f?factoryLink=override.devfileFilename%3Ddevfile2.yaml%26url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git"', async () => {
+  it('should redirect to "/load-factory?override.devfileFilename=devfile2.yaml&url=https%3A%2F%2Fgithub.com%2Folexii4%2Fhelloworld.git"', async () => {
     const res = await app.inject({
-      url: `/f?factoryLink=override.devfileFilename%3Ddevfile2.yaml%26url%3Dhttps%253A%252F%252Fgithub.com%252Folexii4%252Fhelloworld.git`,
+      url: `/f?factoryLink=${encodeURIComponent(
+        btoa(
+          'override.devfileFilename=devfile2.yaml&url=https%3A%2F%2Fgithub.com%2Folexii4%2Fhelloworld.git',
+        ),
+      )}`,
     });
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(

--- a/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
@@ -28,8 +28,10 @@ export function registerFactoryAcceptanceRedirect(instance: FastifyInstance): vo
         }
         const query = querystring.parse(factoryLinkStr);
         if (query[FACTORY_LINK_ATTR] !== undefined) {
-          // restore the factory link from the query string
-          factoryLinkStr = decodeURIComponent(query[FACTORY_LINK_ATTR] as string);
+          // restore the factory link from the query string as base64 encoded string
+          const factoryLinkBase64 = decodeURIComponent(query[FACTORY_LINK_ATTR] as string);
+          // decode from base64
+          factoryLinkStr = Buffer.from(factoryLinkBase64, 'base64').toString('utf-8');
         }
 
         const params = new URLSearchParams(factoryLinkStr);

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -582,7 +582,7 @@ describe('Creating steps, fetching a devfile', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       const expectedRedirectUrl = `${protocol}${host}/f?${FACTORY_LINK_ATTR}=${encodeURIComponent(
-        'url=' + encodeURIComponent(factoryUrl),
+        btoa('url=' + encodeURIComponent(factoryUrl)),
       )}`;
 
       await waitFor(() =>
@@ -601,7 +601,7 @@ describe('Creating steps, fetching a devfile', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       const expectedRedirectUrl = `${protocol}${host}/f?${FACTORY_LINK_ATTR}=${encodeURIComponent(
-        'url=' + encodeURIComponent(factoryUrl),
+        btoa('url=' + encodeURIComponent(factoryUrl)),
       )}`;
 
       await waitFor(() =>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -268,7 +268,8 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
         const redirectUrl = new URL('/f', window.location.origin);
         redirectUrl.searchParams.set(
           FACTORY_LINK_ATTR,
-          this.props.history.location.search.replace(/^\?/, ''),
+          // encode to base64
+          btoa(this.props.history.location.search.replace(/^\?/, '')),
         );
 
         OAuthService.openOAuthPage(e.attributes.oauth_authentication_url, redirectUrl.toString());


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes a bug when some query parameters of the factory link were dropped after the authorization redirect so the dashboard could not find the repository URL to proceed with creating the workspace.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/22871

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Setup [oauth2 for BitBucket Server](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-a-bitbucket-server/).
2. Start a repository from a private BitBucket Server repository with a valid devfile.
3. Consent for the BitBucket Server authorization request.
