### PR TITLE
Fix cors issue when fetching editor devfile

### DIFF
--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/yamlResolverApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/yamlResolverApi.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { getYamlResolver } from '@/services/backend-client/yamlResolverApi';
+
+// mock fetchData
+const mockFetchData = jest.fn();
+jest.mock('@/services/registry/fetchData', () => ({
+  fetchData: (...args: unknown[]) => mockFetchData(...args),
+}));
+
+describe('yamlResolverApi', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should resolve yaml', async () => {
+    mockFetchData.mockResolvedValue('schemaVersion: 2.2.2\nmetadata:\n  name: test');
+
+    const yamlResolver = await getYamlResolver('location');
+    expect(yamlResolver).toEqual({
+      v: 'yaml-resolver',
+      devfile: {
+        schemaVersion: '2.2.2',
+        metadata: {
+          name: 'test',
+        },
+      },
+      links: [],
+      location: 'location',
+    });
+  });
+
+  it('should throw error when failed to resolve yaml', async () => {
+    mockFetchData.mockRejectedValue(new Error('error message'));
+
+    await expect(getYamlResolver('location')).rejects.toThrow(
+      'Failed to resolve yaml. error message',
+    );
+  });
+});

--- a/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
@@ -11,27 +11,20 @@
  */
 
 import { helpers } from '@eclipse-che/common';
-import axios from 'axios';
 import * as yaml from 'js-yaml';
 
-import { dashboardBackendPrefix } from '@/services/backend-client/const';
 import devfileApi from '@/services/devfileApi';
 import { FactoryResolver } from '@/services/helpers/types';
+import { fetchData } from '@/services/registry/fetchData';
 
 export async function getYamlResolver(location: string): Promise<FactoryResolver> {
   try {
-    const url = new URL(location);
-    const response =
-      url.origin === window.location.origin
-        ? await axios.get(url.href)
-        : await axios.post(`${dashboardBackendPrefix}/data/resolver`, {
-            url: url.href,
-          });
+    const data = await fetchData<string>(location);
 
     return {
       v: 'yaml-resolver',
-      devfile: yaml.load(response.data) as devfileApi.Devfile,
-      location: url.href,
+      devfile: yaml.load(data) as devfileApi.Devfile,
+      location,
       links: [],
     };
   } catch (e) {

--- a/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
@@ -28,6 +28,6 @@ export async function getYamlResolver(location: string): Promise<FactoryResolver
       links: [],
     };
   } catch (e) {
-    throw new Error(`Failed to resolve yaml'. ${helpers.errors.getMessage(e)}`);
+    throw new Error(`Failed to resolve yaml. ${helpers.errors.getMessage(e)}`);
   }
 }

--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
@@ -93,8 +93,10 @@ describe('Dashboard bootstrap', () => {
     expect(mockGet).toHaveBeenCalledWith('/dashboard/api/server-config', undefined);
     expect(mockGet).toHaveBeenCalledWith('/dashboard/api/cluster-info');
     expect(mockGet).toHaveBeenCalledWith('/dashboard/api/userprofile/test-che', undefined);
-    expect(mockGet).toHaveBeenCalledWith('/plugin-registry/v3/plugins/index.json');
-    expect(mockGet).toHaveBeenCalledWith('/plugin-registry/v3/plugins/default-editor/devfile.yaml');
+    expect(mockGet).toHaveBeenCalledWith('http://localhost/plugin-registry/v3/plugins/index.json');
+    expect(mockGet).toHaveBeenCalledWith(
+      'http://localhost/plugin-registry/v3/plugins/default-editor/devfile.yaml',
+    );
     expect(mockGet).toHaveBeenCalledWith(
       'http://localhost/dashboard/devfile-registry/devfiles/index.json',
     );
@@ -146,7 +148,7 @@ function getStore(namespace: che.KubernetesNamespace): Store {
       defaults: {
         editor: 'default-editor',
       },
-      pluginRegistryURL: '/plugin-registry/v3',
+      pluginRegistryURL: 'http://localhost/plugin-registry/v3',
     } as api.IServerConfig)
     .build();
 }

--- a/packages/dashboard-frontend/src/services/registry/__tests__/fetchData.spec.ts
+++ b/packages/dashboard-frontend/src/services/registry/__tests__/fetchData.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import axios from 'axios';
+
+import { fetchData } from '@/services/registry/fetchData';
+
+const mockAxiosGet = jest.fn();
+const mockAxiosPost = jest.fn();
+axios.get = mockAxiosGet;
+axios.post = mockAxiosPost;
+
+describe('fetchData', () => {
+  beforeEach(() => {
+    mockAxiosGet.mockResolvedValue({ data: 'GET data' });
+    mockAxiosPost.mockResolvedValue({ data: 'POST data' });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should GET data when location is the same origin', async () => {
+    await fetchData('http://localhost');
+
+    expect(mockAxiosGet).toHaveBeenCalledWith('http://localhost/');
+    expect(mockAxiosGet).toHaveBeenCalledTimes(1);
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it('should POST data when location is not the same origin', async () => {
+    await fetchData('http://example.com');
+
+    expect(mockAxiosPost).toHaveBeenCalledWith('/dashboard/api/data/resolver', {
+      url: 'http://example.com/',
+    });
+  });
+
+  it('should throw error when failed to fetch data', async () => {
+    const errorMessage = 'Test error message';
+    mockAxiosGet.mockRejectedValueOnce(new Error(errorMessage));
+
+    await expect(fetchData('http://localhost')).rejects.toThrow(errorMessage);
+  });
+});

--- a/packages/dashboard-frontend/src/services/registry/fetchData.ts
+++ b/packages/dashboard-frontend/src/services/registry/fetchData.ts
@@ -10,14 +10,22 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import common from '@eclipse-che/common';
+import { helpers } from '@eclipse-che/common';
 import axios from 'axios';
 
-export async function fetchData<T>(url: string): Promise<T> {
+import { dashboardBackendPrefix } from '@/services/backend-client/const';
+
+export async function fetchData<T>(location: string): Promise<T> {
   try {
-    const response = await axios.get<T>(url);
-    return response?.data;
+    const url = new URL(location);
+    const response =
+      url.origin === window.location.origin
+        ? await axios.get(url.href)
+        : await axios.post(`${dashboardBackendPrefix}/data/resolver`, {
+            url: url.href,
+          });
+    return response?.data as T;
   } catch (e) {
-    throw new Error(common.helpers.errors.getMessage(e));
+    throw new Error(helpers.errors.getMessage(e));
   }
 }

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
@@ -11,24 +11,23 @@
  */
 
 import common from '@eclipse-che/common';
-import mockAxios from 'axios';
 import { dump } from 'js-yaml';
 
 import devfileApi from '@/services/devfileApi';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 import { getEditor } from '@/store/DevfileRegistries/getEditor';
 
+const mockFetchData = jest.fn();
+jest.mock('@/services/registry/fetchData', () => ({
+  fetchData: (...args: unknown[]) => mockFetchData(...args),
+}));
+
 describe('Get Devfile by URL', () => {
   let editor: devfileApi.Devfile;
-  let mockFetch: jest.Mock;
 
   beforeEach(() => {
     editor = buildEditor();
-
-    mockFetch = mockAxios.get as jest.Mock;
-    mockFetch.mockResolvedValueOnce({
-      data: dump(editor),
-    });
+    mockFetchData.mockResolvedValueOnce(dump(editor));
   });
 
   afterEach(() => {
@@ -82,11 +81,10 @@ describe('Get Devfile by URL', () => {
       // no-op
     }
 
-    expect(mockFetch.mock.calls).toEqual([
-      [
-        'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',
-      ],
-    ]);
+    expect(mockFetchData).toHaveBeenCalledTimes(1);
+    expect(mockFetchData).toHaveBeenCalledWith(
+      'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',
+    );
   });
 
   it('Should request a devfile content by editor path', async () => {
@@ -102,11 +100,10 @@ describe('Get Devfile by URL', () => {
       // no-op
     }
 
-    expect(mockFetch.mock.calls).toEqual([
-      [
-        'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',
-      ],
-    ]);
+    expect(mockFetchData).toHaveBeenCalledTimes(1);
+    expect(mockFetchData).toHaveBeenCalledWith(
+      'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',
+    );
   });
 
   it('Should return an existing devfile content by editor id', async () => {
@@ -128,7 +125,7 @@ describe('Get Devfile by URL', () => {
       'https://dummy/che-plugin-registry/main/v3',
     );
 
-    expect(mockFetch.mock.calls).toEqual([]);
+    expect(mockFetchData).toHaveBeenCalledTimes(0);
     expect(customEditor.content).toEqual(dump(editor));
     expect(customEditor.editorYamlUrl).toEqual(
       'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',
@@ -153,7 +150,7 @@ describe('Get Devfile by URL', () => {
       store.getState,
     );
 
-    expect(mockFetch.mock.calls).toEqual([]);
+    expect(mockFetchData).toHaveBeenCalledTimes(0);
     expect(customEditor.content).toEqual(dump(editor));
     expect(customEditor.editorYamlUrl).toEqual(
       'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/index.ts
@@ -157,10 +157,12 @@ export const actionCreators: ActionCreators = {
             const error = selectSanityCheckError(getState());
             throw new Error(error);
           }
+
           const metadata: che.DevfileMetaData[] = await fetchRegistryMetadata(url, isExternal);
           if (!Array.isArray(metadata) || metadata.length === 0) {
             return;
           }
+
           dispatch({
             type: Type.RECEIVE_REGISTRY_METADATA,
             url,
@@ -193,7 +195,9 @@ export const actionCreators: ActionCreators = {
           const error = selectSanityCheckError(getState());
           throw new Error(error);
         }
+
         const devfile = await fetchDevfile(url);
+
         dispatch({ type: Type.RECEIVE_DEVFILE, devfile, url });
         return devfile;
       } catch (e) {

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
@@ -26,6 +26,17 @@ import * as dwPluginsStore from '..';
 // mute the outputs
 console.error = jest.fn();
 
+const mockFetchDevfile = jest.fn();
+jest.mock('@/services/registry/devfiles', () => ({
+  fetchDevfile: (...args: unknown[]) => mockFetchDevfile(...args),
+}));
+
+// mock fetchData
+const mockFetchData = jest.fn();
+jest.mock('@/services/registry/fetchData', () => ({
+  fetchData: (...args: unknown[]) => mockFetchData(...args),
+}));
+
 const plugin = {
   schemaVersion: '2.1.0',
   metadata: {
@@ -40,9 +51,7 @@ describe('dwPlugins store', () => {
 
   describe('actions', () => {
     it('should create REQUEST_DW_PLUGIN and RECEIVE_DW_PLUGIN when fetching a plugin', async () => {
-      (mockAxios.get as jest.Mock).mockResolvedValueOnce({
-        data: JSON.stringify(plugin),
-      });
+      mockFetchDevfile.mockResolvedValueOnce(JSON.stringify(plugin));
 
       const store = new FakeStoreBuilder().build() as MockStoreEnhanced<
         AppState,
@@ -71,7 +80,7 @@ describe('dwPlugins store', () => {
     });
 
     it('should create REQUEST_DW_PLUGIN and RECEIVE_DW_PLUGIN_ERROR when failed to fetch a plugin', async () => {
-      (mockAxios.get as jest.Mock).mockRejectedValueOnce({
+      mockFetchDevfile.mockRejectedValueOnce({
         isAxiosError: true,
         code: '500',
         message: 'Something unexpected happened.',
@@ -107,9 +116,7 @@ describe('dwPlugins store', () => {
     });
 
     it('should create REQUEST_DW_EDITOR and RECEIVE_DW_EDITOR when fetching the default editor', async () => {
-      (mockAxios.get as jest.Mock).mockResolvedValueOnce({
-        data: JSON.stringify(plugin),
-      });
+      mockFetchData.mockResolvedValueOnce(JSON.stringify(plugin));
 
       const store = new FakeStoreBuilder()
         .withDwServerConfig({
@@ -157,9 +164,7 @@ describe('dwPlugins store', () => {
     });
 
     it('should create REQUEST_DW_EDITOR and RECEIVE_DW_EDITOR when fetching http editor', async () => {
-      (mockAxios.get as jest.Mock).mockResolvedValueOnce({
-        data: JSON.stringify(plugin),
-      });
+      mockFetchData.mockResolvedValueOnce(JSON.stringify(plugin));
 
       const store = new FakeStoreBuilder()
         .withDwServerConfig({
@@ -193,12 +198,11 @@ describe('dwPlugins store', () => {
       ];
       expect(actions).toEqual(expectedActions);
 
-      // check that we fetched the editor on axios
-      expect(mockAxios.get).toHaveBeenCalledWith(editorLink);
+      expect(mockFetchData).toHaveBeenCalledWith(editorLink);
     });
 
     it('should create REQUEST_DW_EDITOR and RECEIVE_DW_EDITOR_ERROR when failed to fetch an editor', async () => {
-      (mockAxios.get as jest.Mock).mockRejectedValueOnce({
+      mockFetchData.mockRejectedValueOnce({
         isAxiosError: true,
         code: '500',
         message: 'Something unexpected happened.',

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/__tests__/index.spec.ts
@@ -31,7 +31,6 @@ jest.mock('@/services/registry/devfiles', () => ({
   fetchDevfile: (...args: unknown[]) => mockFetchDevfile(...args),
 }));
 
-// mock fetchData
 const mockFetchData = jest.fn();
 jest.mock('@/services/registry/fetchData', () => ({
   fetchData: (...args: unknown[]) => mockFetchData(...args),

--- a/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/devWorkspacePlugins/index.ts
@@ -157,7 +157,7 @@ export const actionCreators: ActionCreators = {
   requestDwEditor:
     (editorName: string): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
-      let editorUrl;
+      let editorUrl: string;
       // check if the editor is an id or a path to a given editor
       if (editorName.startsWith('https://')) {
         editorUrl = editorName;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes the CORS issue that prevents creating a new workspace with an editor devfile published on an external resource.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/22875

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Eclipse Che, and patch `CheCluster` using the following command:
    ```sh
    kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {containers: [{image: "quay.io/eclipse/che-dashboard:pr-1078", name: che-dashboard}]}}]"    ```
2. Open the User Dashboard
3. Create a new workspace from this link: https://github.com/redhat-developer-demos/ansible-devspaces-demo?che-editor=https://pr-check-1899-che-plugin-registry.surge.sh/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
