### PR TITLE
Add gitlab to the list of allowed to revoke providers

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/__snapshots__/index.spec.tsx.snap
@@ -343,7 +343,6 @@ exports[`GitServicesList snapshot 1`] = `
             <input
               aria-label="Select row 2"
               checked={false}
-              disabled={true}
               name="checkrow2"
               onChange={[Function]}
               type="checkbox"
@@ -362,7 +361,7 @@ exports[`GitServicesList snapshot 1`] = `
           >
             <span>
               isVisible: 
-              true
+              false
             </span>
           </span>
         </td>
@@ -418,7 +417,7 @@ exports[`GitServicesList snapshot 1`] = `
               aria-haspopup={true}
               aria-label="Actions"
               className="pf-c-dropdown__toggle pf-m-plain"
-              disabled={true}
+              disabled={false}
               id="pf-dropdown-toggle-id-2"
               onClick={[Function]}
               onKeyDown={[Function]}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
@@ -100,15 +100,15 @@ describe('GitServicesList', () => {
       expect(gitlabRow).toHaveTextContent('https://gitlab.com');
 
       const checkbox = within(gitlabRow).getByRole('checkbox');
-      expect(checkbox).toBeDisabled();
+      expect(checkbox).toBeEnabled();
       expect(checkbox).not.toBeChecked();
 
       const kebab = within(gitlabRow).getByRole('button', { name: 'Actions' });
-      expect(kebab).toBeDisabled();
+      expect(kebab).toBeEnabled();
     }
   });
 
-  test('service not revokable (gitlab)', () => {
+  test('service revocable (gitlab)', () => {
     renderComponent(props);
 
     const rows = screen.getAllByRole('row');
@@ -120,15 +120,13 @@ describe('GitServicesList', () => {
     const gitlabCheckbox = within(gitlabRow).getByRole('checkbox');
     const gitlabKebab = within(gitlabRow).getByRole('button', { name: 'Actions' });
 
-    // the checkbox is disabled and unchecked
-    expect(gitlabCheckbox).toBeDisabled();
+    expect(gitlabCheckbox).toBeEnabled();
     expect(gitlabCheckbox).not.toBeChecked();
 
-    // the kebab button is disabled
-    expect(gitlabKebab).toBeDisabled();
+    expect(gitlabKebab).toBeEnabled();
   });
 
-  test('service revokable (github)', () => {
+  test('service revocable (github)', () => {
     renderComponent(props);
 
     const rows = screen.getAllByRole('row');

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
@@ -34,6 +34,7 @@ import { IGitOauth } from '@/store/GitOauthConfig/types';
 export const CAN_REVOKE_FROM_DASHBOARD: ReadonlyArray<api.GitOauthProvider> = [
   'github',
   'github_2',
+  'gitlab',
 ];
 
 export type Props = {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add gitlab to the list of allowed to revoke oauth providers

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/22832


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Configure [Gitlab oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-gitlab/).
2. Start a workspace from a Gitlab repository with a devfile, consent the authorisation agreement.
3. Go to User Preferences -> Git Services tab.
4. Revoke the Gitlab authorisation either by clicking the three dot button or selecting the provider icon and then clicking the `Revoke` red button.

See: the Gitlab authorisation is successfully revoked.
#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
