### PR TITLE
Fix the blank page if DevWorkspace is missing controller.devfile.io/creator label

### DIFF
--- a/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devWorkspace/metadata.ts
@@ -23,6 +23,6 @@ type DevWorkspaceMetadataAnnotation = {
 };
 
 export type DevWorkspaceMetadata = V1alpha2DevWorkspaceMetadata &
-  Required<Pick<V1alpha2DevWorkspaceMetadata, 'labels' | 'name' | 'namespace' | 'uid'>> & {
+  Required<Pick<V1alpha2DevWorkspaceMetadata, 'name' | 'namespace' | 'uid'>> & {
     annotations?: DevWorkspaceMetadataAnnotation;
   };

--- a/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/typeguards.ts
@@ -48,7 +48,6 @@ export function isDevWorkspaceMetadata(
 ): metadata is devfileApi.DevWorkspaceMetadata {
   return (
     metadata !== undefined &&
-    (metadata as devfileApi.DevWorkspaceMetadata).labels !== undefined &&
     (metadata as devfileApi.DevWorkspaceMetadata).name !== undefined &&
     (metadata as devfileApi.DevWorkspaceMetadata).namespace !== undefined &&
     (metadata as devfileApi.DevWorkspaceMetadata).uid !== undefined


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

With this fix the dashboard can correctly process DevWorkspaces without `metadata.label`.


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/22899

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

See "Steps to reproduce" [in the issue](https://github.com/eclipse/che/issues/22899).

