### PR TITLE
Fix workspaces creation in the local development flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 
 run/.che-dashboard-pod
 run/.custom-resources
+run/public-certs

--- a/run/local-run.sh
+++ b/run/local-run.sh
@@ -59,6 +59,7 @@ CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
 # guide backend to use the current cluster from kubeconfig
 export LOCAL_RUN="true"
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+export CHE_SELF_SIGNED_MOUNT_PATH="${CHE_SELF_SIGNED_MOUNT_PATH:-$PWD/run/public-certs}"
 
 DASHBOARD_COMMON=packages/common
 DASHBOARD_FRONTEND=packages/dashboard-frontend


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR restores the ability to create workspaces when the dashboard is running in the local development flow.
