### PR TITLE
fix: make PR license check step working again

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "${PWD}/run/local-run.sh $@",
     "start:prepare": "${PWD}/run/prepare-local-run.sh",
     "start:cleanup": "${PWD}/run/revert-local-run.sh",
-    "license:check": "${PWD}/scripts/container_tool.sh run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses@sha256:72290f67f297a31b7b9b343d19f42cc0ecc90e1d36cc9f18473c586a70e4b7eb --check",
+    "license:check": "${PWD}/scripts/container_tool.sh run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses:next --check",
     "license:generate": "${PWD}/scripts/container_tool.sh run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses:next",
     "test": "lerna run test --stream -- --no-cache $@",
     "test:check": "yarn pretest && yarn --cwd packages/dashboard-frontend test --config=jest.config.check.js",

--- a/scripts/container_tool.sh
+++ b/scripts/container_tool.sh
@@ -39,6 +39,7 @@ container_tool() {
 # Main script
 case "$1" in
 build | run | push)
+    set -e
     container_tool "$@"
     ;;
 *)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Make dash-licenses step in pr.yaml workflow working again:
- use next tag instead of non-existent SHA
- add `set -e` to throw error during execution

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22674

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
