### PR TITLE
feat: podman login into external docker registries on workspace start

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V1alpha2DevWorkspace, V221DevfileComponents } from '@devfile/api';
+import { V1alpha2DevWorkspace, V222DevfileComponents } from '@devfile/api';
 import { CoreV1EventList, V1PodList } from '@kubernetes/client-node';
 import * as webSocket from './webSocket';
 

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V1alpha2DevWorkspace, V222DevfileComponents } from '@devfile/api';
+import { V1alpha2DevWorkspace, V221DevfileComponents } from '@devfile/api';
 import { CoreV1EventList, V1PodList } from '@kubernetes/client-node';
 import * as webSocket from './webSocket';
 

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
@@ -71,9 +71,13 @@ describe('podman Config API Service', () => {
         'sh',
         '-c',
         '\n' +
-          '            podman login registry1 -u user1 -p password1 || true\npodman login registry2 -u user2 -p password2 || true\n' +
+          '            command -v podman >/dev/null 2>&1 || { echo "podman is absent in the container"; exit 1; }\n' +
           '\n' +
-          '            command -v oc >/dev/null 2>&1 && command -v podman >/dev/null 2>&1 && [[ -n "$HOME" ]] || { echo "oc, podman, or HOME is not set"; exit 1; }\n' +
+          '            # Login to external docker registries configured by user on the dashboard\n' +
+          '            podman login registry1 -u user1 -p password1 >/dev/null 2>&1 || true\npodman login registry2 -u user2 -p password2 >/dev/null 2>&1 || true\n' +
+          '\n' +
+          '            command -v oc >/dev/null 2>&1 || { echo "oc is absent in the container"; exit 1; }\n' +
+          '            [[ -n "$HOME" ]] || { echo "HOME is not set"; exit 1; }\n' +
           '            export CERTS_SRC="/var/run/secrets/kubernetes.io/serviceaccount"\n' +
           '            export CERTS_DEST="$HOME/.config/containers/certs.d/image-registry.openshift-image-registry.svc:5000"\n' +
           '            mkdir -p "$CERTS_DEST"\n' +
@@ -81,6 +85,8 @@ describe('podman Config API Service', () => {
           '            ln -s "$CERTS_SRC/ca.crt" "$CERTS_DEST/ca.crt"\n' +
           '            export OC_USER=$(oc whoami)\n' +
           '            [[ "$OC_USER" == "kube:admin" ]] && export OC_USER="kubeadmin"\n' +
+          '\n' +
+          '            # Login to internal OpenShift registry\n' +
           '            podman login -u "$OC_USER" -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000\n' +
           '            ',
       ],

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import * as mockClient from '@kubernetes/client-node';
+import { CoreV1Api, V1PodList, V1Secret } from '@kubernetes/client-node';
+
+import * as helper from '@/devworkspaceClient/services/helpers/exec';
+import { PodmanApiService } from '@/devworkspaceClient/services/podmanApi';
+
+jest.mock('@/helpers/getUserName.ts');
+
+const userNamespace = 'user-che';
+const workspaceName = 'workspace-1';
+const containerName = 'container-1';
+const workspaceId = 'workspace-id-1';
+
+const spyExec = jest
+  .spyOn(helper, 'exec')
+  .mockImplementation((..._args: Parameters<typeof helper.exec>) => {
+    return Promise.resolve({
+      stdOut: '',
+      stdError: '',
+    });
+  });
+
+describe('podman Config API Service', () => {
+  let podmanApiService: PodmanApiService;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    const { KubeConfig } = mockClient;
+    const kubeConfig = new KubeConfig();
+
+    kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => {
+      return {
+        listNamespacedPod: () => {
+          return Promise.resolve(buildListNamespacedPod());
+        },
+        readNamespacedSecret: () => {
+          return Promise.resolve(buildSecret());
+        },
+      } as unknown as CoreV1Api;
+    });
+
+    podmanApiService = new PodmanApiService(kubeConfig);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('podman login', async () => {
+    await podmanApiService.podmanLogin(userNamespace, workspaceId);
+    expect(spyExec).toHaveBeenCalledWith(
+      workspaceName,
+      userNamespace,
+      containerName,
+      [
+        'sh',
+        '-c',
+        '\n' +
+          '            command -v oc >/dev/null 2>&1 && command -v podman >/dev/null 2>&1 && [[ -n "$HOME" ]] || { echo "oc, podman, or HOME is not set"; exit 1; }\n' +
+          '            export CERTS_SRC="/var/run/secrets/kubernetes.io/serviceaccount"\n' +
+          '            export CERTS_DEST="$HOME/.config/containers/certs.d/image-registry.openshift-image-registry.svc:5000"\n' +
+          '            mkdir -p "$CERTS_DEST"\n' +
+          '            ln -s "$CERTS_SRC/service-ca.crt" "$CERTS_DEST/service-ca.crt"\n' +
+          '            ln -s "$CERTS_SRC/ca.crt" "$CERTS_DEST/ca.crt"\n' +
+          '            export OC_USER=$(oc whoami)\n' +
+          '            [[ "$OC_USER" == "kube:admin" ]] && export OC_USER="kubeadmin"\n' +
+          '            podman login -u "$OC_USER" -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000\n' +
+          '            podman login registry1 -u user1 -p password1\npodman login registry2 -u user2 -p password2\n',
+      ],
+      expect.anything(),
+    );
+  });
+
+  function buildSecret(): { body: V1Secret } {
+    return {
+      body: {
+        apiVersion: 'v1',
+        data: {
+          '.dockerconfigjson': Buffer.from(
+            '{"auths":' +
+              '{' +
+              '"registry1":{"username":"user1","password":"password1"},' +
+              '"registry2":{"auth":"' +
+              Buffer.from('user2:password2', 'binary').toString('base64') +
+              '"}}' +
+              '}',
+            'binary',
+          ).toString('base64'),
+        },
+        kind: 'Secret',
+      },
+    };
+  }
+
+  function buildListNamespacedPod(): { body: V1PodList } {
+    return {
+      body: {
+        apiVersion: 'v1',
+        items: [
+          {
+            metadata: {
+              name: workspaceName,
+              namespace: userNamespace,
+            },
+            spec: {
+              containers: [{ name: containerName }],
+            },
+          },
+        ],
+        kind: 'PodList',
+      },
+    };
+  }
+});

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
@@ -71,6 +71,8 @@ describe('podman Config API Service', () => {
         'sh',
         '-c',
         '\n' +
+          '            podman login registry1 -u user1 -p password1 || true\npodman login registry2 -u user2 -p password2 || true\n' +
+          '\n' +
           '            command -v oc >/dev/null 2>&1 && command -v podman >/dev/null 2>&1 && [[ -n "$HOME" ]] || { echo "oc, podman, or HOME is not set"; exit 1; }\n' +
           '            export CERTS_SRC="/var/run/secrets/kubernetes.io/serviceaccount"\n' +
           '            export CERTS_DEST="$HOME/.config/containers/certs.d/image-registry.openshift-image-registry.svc:5000"\n' +
@@ -80,7 +82,7 @@ describe('podman Config API Service', () => {
           '            export OC_USER=$(oc whoami)\n' +
           '            [[ "$OC_USER" == "kube:admin" ]] && export OC_USER="kubeadmin"\n' +
           '            podman login -u "$OC_USER" -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000\n' +
-          '            podman login registry1 -u user1 -p password1\npodman login registry2 -u user2 -p password2\n',
+          '            ',
       ],
       expect.anything(),
     );

--- a/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
@@ -79,6 +79,7 @@ export class PodmanApiService implements IPodmanApi {
             'sh',
             '-c',
             `
+            ${externalDockerRegistriesPodmanLoginCommand}
             command -v oc >/dev/null 2>&1 && command -v podman >/dev/null 2>&1 && [[ -n "$HOME" ]] || { echo "oc, podman, or HOME is not set"; exit 1; }
             export CERTS_SRC="/var/run/secrets/kubernetes.io/serviceaccount"
             export CERTS_DEST="$HOME/.config/containers/certs.d/image-registry.openshift-image-registry.svc:5000"
@@ -88,7 +89,7 @@ export class PodmanApiService implements IPodmanApi {
             export OC_USER=$(oc whoami)
             [[ "$OC_USER" == "kube:admin" ]] && export OC_USER="kubeadmin"
             podman login -u "$OC_USER" -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
-            ${externalDockerRegistriesPodmanLoginCommand}`,
+            `,
           ],
           this.getServerConfig(),
         );
@@ -167,7 +168,7 @@ export class PodmanApiService implements IPodmanApi {
         }
 
         if (username && password) {
-          externalDockerRegistriesPodmanLoginCommand += `podman login ${registry} -u ${username} -p ${password}\n`;
+          externalDockerRegistriesPodmanLoginCommand += `podman login ${registry} -u ${username} -p ${password} || true\n`;
         }
       }
     }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
@@ -88,8 +88,7 @@ export class PodmanApiService implements IPodmanApi {
             export OC_USER=$(oc whoami)
             [[ "$OC_USER" == "kube:admin" ]] && export OC_USER="kubeadmin"
             podman login -u "$OC_USER" -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
-            ${externalDockerRegistriesPodmanLoginCommand}
-            `,
+            ${externalDockerRegistriesPodmanLoginCommand}`,
           ],
           this.getServerConfig(),
         );

--- a/run/prepare-local-run.sh
+++ b/run/prepare-local-run.sh
@@ -86,7 +86,7 @@ if [ "$GATEWAY" == "true" ]; then
   fi
 
   echo 'Looking for redirect_url for local start'
-  if kubectl get configMaps che-gateway-config-oauth-proxy -o jsonpath="{.data}" -n "$CHE_NAMESPACE" | yq -r ".[\"oauth-proxy.cfg\"]" - | grep $CHE_HOST/oauth/callback; then
+  if kubectl get configMaps che-gateway-config-oauth-proxy -o jsonpath="{.data}" -n "$CHE_NAMESPACE" | yq e ".[\"oauth-proxy.cfg\"]" - | grep $CHE_HOST/oauth/callback; then
     echo 'Found the redirect_url for localStart'
   else
     if kubectl get deployment/che-operator -n "$CHE_NAMESPACE" -o jsonpath="{.spec.replicas}" | grep 1; then
@@ -98,7 +98,7 @@ if [ "$GATEWAY" == "true" ]; then
     fi
 
     echo 'Patching che-gateway-config-oauth-proxy config map...'
-    CONFIG_YAML=$(kubectl get configMaps che-gateway-config-oauth-proxy -o jsonpath="{.data}" -n "$CHE_NAMESPACE" | yq -r ".[\"oauth-proxy.cfg\"]" - | sed "s/${CHE_HOST_ORIGIN//\//\\/}\/oauth\/callback/${CHE_HOST//\//\\/}\/oauth\/callback/g")
+    CONFIG_YAML=$(kubectl get configMaps che-gateway-config-oauth-proxy -o jsonpath="{.data}" -n "$CHE_NAMESPACE" | yq e ".[\"oauth-proxy.cfg\"]" - | sed "s/${CHE_HOST_ORIGIN//\//\\/}\/oauth\/callback/${CHE_HOST//\//\\/}\/oauth\/callback/g")
     dq_mid=\\\"
     yaml_esc="${CONFIG_YAML//\"/$dq_mid}"
     kubectl get configMaps che-gateway-config-oauth-proxy -n "$CHE_NAMESPACE" -o json | jq ".data[\"oauth-proxy.cfg\"] |= \"${yaml_esc}\"" | kubectl replace -f -

--- a/run/prepare-local-run.sh
+++ b/run/prepare-local-run.sh
@@ -40,9 +40,8 @@ CHECLUSTER_CR_NAME=$(grep -o 'CHECLUSTER_CR_NAME:.*' run/.che-dashboard-pod | gr
 
 kubectl get checluster -n "$CHE_NAMESPACE" "$CHECLUSTER_CR_NAME" -o=json > run/.custom-resources
 
-if [ ! -d "$CHE_SELF_SIGNED_MOUNT_PATH" ]; then
-  mkdir -p "$CHE_SELF_SIGNED_MOUNT_PATH"
-fi
+rm -rf "$CHE_SELF_SIGNED_MOUNT_PATH"
+mkdir -p "$CHE_SELF_SIGNED_MOUNT_PATH"
 
 # copy certificate from the dashboard pod
 kubectl cp $CHE_NAMESPACE/$DASHBOARD_POD_NAME:/public-certs/che-self-signed/..data/ca.crt "$CHE_SELF_SIGNED_MOUNT_PATH/ca.crt"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
feat: podman login into external docker registries on workspace start

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/22863

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che on OpenShift
2. Configure valid credentials for a registry, for instance docker.io
3. Configure invalid credentials for another registry, for instance for quay.io
4. Start a workspace
5. Check in the terminal the output
```bash
$ podman login docker.io
Authenticating with existing credentials for docker.io
Existing credentials are valid. Already logged in to docker.io
$ podman login quay.io
Username: ^Cprojects $ 
$ podman login image-registry.openshift-image-registry.svc:5000
Authenticating with existing credentials for image-registry.openshift-image-registry.svc:5000
Existing credentials are valid. Already logged in to image-registry.openshift-image-registry.svc:5000 
```

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A