### PR TITLE
Restore the authorisation opt-out functionality

### DIFF
--- a/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
+++ b/packages/dashboard-backend/src/routes/factoryAcceptanceRedirect.ts
@@ -23,13 +23,11 @@ export function registerFactoryAcceptanceRedirect(instance: FastifyInstance): vo
           .replace(path, '')
           .replace(/^\?/, '')
           .replace(`${FACTORY_LINK_ATTR}%3D`, `${FACTORY_LINK_ATTR}=`);
-        if (!factoryLinkStr.includes('=')) {
-          factoryLinkStr = decodeURIComponent(factoryLinkStr);
-        }
+        factoryLinkStr = decodeURIComponent(factoryLinkStr);
         const query = querystring.parse(factoryLinkStr);
         if (query[FACTORY_LINK_ATTR] !== undefined) {
           // restore the factory link from the query string as base64 encoded string
-          const factoryLinkBase64 = decodeURIComponent(query[FACTORY_LINK_ATTR] as string);
+          const factoryLinkBase64 = query[FACTORY_LINK_ATTR] as string;
           // decode from base64
           factoryLinkStr = Buffer.from(factoryLinkBase64, 'base64').toString('utf-8');
         }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
@@ -43,6 +43,7 @@ describe('GitServicesList', () => {
       ],
       isDisabled: false,
       onRevokeServices: jest.fn(),
+      onClearService: jest.fn(),
       providersWithToken: ['github', 'gitlab'],
       skipOauthProviders: [],
     };
@@ -248,6 +249,7 @@ function getComponent(props: Props): React.ReactElement<Props> {
       gitOauth={props.gitOauth}
       isDisabled={props.isDisabled}
       onRevokeServices={props.onRevokeServices}
+      onClearService={props.onClearService}
       providersWithToken={props.providersWithToken}
       skipOauthProviders={props.skipOauthProviders}
     />

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
@@ -179,6 +179,58 @@ describe('GitServicesList', () => {
     ]);
   });
 
+  test('can clear opt-out (github)', () => {
+    props = {
+      gitOauth: [
+        {
+          name: 'github',
+          endpointUrl: 'https://github.com',
+        },
+      ],
+      isDisabled: false,
+      onRevokeServices: jest.fn(),
+      onClearService: jest.fn(),
+      providersWithToken: [],
+      skipOauthProviders: ['github'],
+    };
+    renderComponent(props);
+
+    const rows = screen.getAllByRole('row');
+
+    // get the github row
+    const githubRow = rows[1];
+    expect(githubRow).toHaveTextContent('github');
+
+    const githubCheckbox = within(githubRow).getByRole('checkbox');
+    const githubKebab = within(githubRow).getByRole('button', { name: 'Actions' });
+
+    // the checkbox is disabled and unchecked
+    expect(githubCheckbox).toBeDisabled();
+    expect(githubCheckbox).not.toBeChecked();
+
+    // the kebab button is enabled
+    expect(githubKebab).toBeEnabled();
+
+    // Clear button is not present
+    {
+      const clearButton = within(githubRow).queryByRole('menuitem', { name: 'Clear' });
+      expect(clearButton).toBeNull();
+    }
+
+    // open kebab menu
+    userEvent.click(githubKebab);
+
+    // the Clear button is present
+    const clearButton = within(githubRow).queryByRole('menuitem', { name: 'Clear' });
+    expect(clearButton).not.toBeNull();
+
+    // click the Clear button
+    userEvent.click(clearButton!);
+
+    expect(props.onClearService).toHaveBeenCalledTimes(1);
+    expect(props.onClearService).toHaveBeenCalledWith('github');
+  });
+
   test('toolbar', () => {
     renderComponent(props);
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/index.tsx
@@ -131,6 +131,10 @@ export class GitServices extends React.PureComponent<Props, State> {
     });
   }
 
+  private handleClearServices(selectedService: api.GitOauthProvider): void {
+    this.props.deleteSkipOauth(selectedService);
+  }
+
   render(): React.ReactNode {
     const { gitOauth, isLoading, providersWithToken, skipOauthProviders } = this.props;
     const { isModalOpen, selectedServices } = this.state;
@@ -155,6 +159,7 @@ export class GitServices extends React.PureComponent<Props, State> {
               providersWithToken={providersWithToken}
               skipOauthProviders={skipOauthProviders}
               onRevokeServices={services => this.handleRevokeServices(services)}
+              onClearService={service => this.handleClearServices(service)}
             />
           )}
         </PageSection>

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/index.ts
@@ -235,11 +235,18 @@ export const actionCreators: ActionCreators = {
         });
       } catch (e) {
         const errorMessage = common.helpers.errors.getMessage(e);
-        dispatch({
-          type: Type.RECEIVE_GIT_OAUTH_ERROR,
-          error: errorMessage,
-        });
-        throw e;
+        if (new RegExp('^OAuth token for user .* was not found$').test(errorMessage)) {
+          dispatch({
+            type: Type.DELETE_GIT_OAUTH_TOKEN,
+            provider: oauthProvider,
+          });
+        } else {
+          dispatch({
+            type: Type.RECEIVE_GIT_OAUTH_ERROR,
+            error: errorMessage,
+          });
+          throw e;
+        }
       }
     },
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Always decode url on factory url accept.
* Restore the skip oauth functionality.
see: https://github.com/eclipse-che/che-dashboard/pull/972
### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6245

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Configure [GitHub oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/)
2. Start a workspace from a GitHub repository with devfile.
3. When the authorisation page appears, click the `Cancel` button.
4. Go back to Dashboard -> User Preferences ->  Git Services tab
5. See: a yellow warning sign is present in the GitHub item, click the kebab icon and then the `Clear` menu button.
6. See: the yellow sign is disappeared.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
