### PR TITLE
fix: codecov job

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,3 +43,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ./packages/dashboard-frontend/coverage/lcov.info,./packages/dashboard-backend/coverage/lcov.info,./packages/common/coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+


### PR DESCRIPTION


### What does this PR do?

Fix the codecov job so now it uses the `CODECOV_TOKEN` and can upload coverage reports.
