### PR TITLE
fix: getGitRepoOptionsFromLocation method

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -13,4 +13,5 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `cookie-signature@1.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cookie-signature/1.2.1) |
 | `fast-uri@2.3.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.3.0) |
 | `fastify@4.26.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/4.26.2) |
+| `jsbn@0.1.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsbn/0.1.1) |
 | `real-require@0.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/real-require/0.2.0) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,9 +5,9 @@
 | [`@babel/runtime@7.23.2`](https://github.com/babel/babel.git) | MIT | #10718 |
 | [`@devfile/api@2.2.2-1700686170`](https://github.com/GIT_USER_ID/GIT_REPO_ID.git) | Apache-2.0 | clearlydefined |
 | [`@eclipse-che/che-devworkspace-generator@7.79.0-next-1427c19`](git+https://github.com/eclipse-che/che-devfile-registry.git) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/common@7.85.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-backend@7.85.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-frontend@7.85.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/common@7.86.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-backend@7.86.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-frontend@7.86.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
 | [`@fastify/accept-negotiator@1.1.0`](git+https://github.com/fastify/accept-negotiator.git) | MIT | clearlydefined |
 | [`@fastify/ajv-compiler@3.5.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | clearlydefined |
 | [`@fastify/busboy@2.0.0`](https://github.com/fastify/busboy.git) | MIT | clearlydefined |
@@ -108,7 +108,7 @@
 | [`create-hmac@1.1.7`](https://github.com/crypto-browserify/createHmac.git) | MIT | clearlydefined |
 | [`crypto-browserify@3.12.0`](git://github.com/crypto-browserify/crypto-browserify.git) | MIT | #1033 |
 | [`csstype@3.1.2`](https://github.com/frenic/csstype) | MIT | #11847 |
-| [`dashdash@1.14.1`](git://github.com/trentm/node-dashdash.git) | MIT | clearlydefined |
+| [`dashdash@1.14.1`](git://github.com/trentm/node-dashdash.git) | MIT | #14596 |
 | [`date-fns@2.30.0`](https://github.com/date-fns/date-fns) | MIT | clearlydefined |
 | [`dateformat@4.6.3`](https://github.com/felixge/node-dateformat.git) | MIT | clearlydefined |
 | [`debug@4.3.4`](git://github.com/debug-js/debug.git) | MIT | clearlydefined |
@@ -200,7 +200,7 @@
 | [`joycon@3.1.1`](https://github.com/egoist/joycon.git) | MIT | clearlydefined |
 | [`js-tokens@4.0.0`](https://github.com/lydell/js-tokens.git) | MIT | #2401 |
 | [`js-yaml@4.1.0`](https://github.com/nodeca/js-yaml.git) | MIT | clearlydefined |
-| [`jsbn@0.1.1`](https://github.com/andyperlitch/jsbn.git) | MIT | clearlydefined |
+| [`jsbn@0.1.1`](https://github.com/andyperlitch/jsbn.git) | MIT |  |
 | [`json-schema-ref-resolver@1.0.1`](git+https://github.com/fastify/json-schema-ref-resolver.git) | MIT | clearlydefined |
 | [`json-schema-resolver@2.0.0`](git+https://github.com/Eomm/json-schema-resolver.git) | MIT | clearlydefined |
 | [`json-schema-traverse@1.0.0`](git+https://github.com/epoberezkin/json-schema-traverse.git) | MIT | clearlydefined |

--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
@@ -237,7 +237,7 @@ describe('helpers', () => {
           const options = helpers.getGitRepoOptionsFromLocation(location);
           expect(options).toEqual({
             location:
-              'https://github.com/eclipse-che/che-dashboard/tree/main?remotes=%7B%7Btest-1%2Chttp%3A%2F%2Ftest-1.git%7D%7D&override.devfileFilename=devfile2.yaml',
+              'https://github.com/eclipse-che/che-dashboard/tree/main?remotes=%7B%7Btest-1%2Chttp%3A%2F%2Ftest-1.git%7D%7D&devfilePath=devfile2.yaml',
             hasSupportedGitService: true,
             gitBranch: 'main',
             remotes: [{ name: 'test-1', url: 'http://test-1.git' }],
@@ -263,7 +263,7 @@ describe('helpers', () => {
           const options = helpers.getGitRepoOptionsFromLocation(location);
           expect(options).toEqual({
             location:
-              'git@github.com:eclipse-che/che-dashboard.git?remotes=%7B%7Btest-1%2Chttp%3A%2F%2Ftest-1.git%7D%7D&override.devfileFilename=devfile2.yaml',
+              'git@github.com:eclipse-che/che-dashboard.git?remotes=%7B%7Btest-1%2Chttp%3A%2F%2Ftest-1.git%7D%7D&devfilePath=devfile2.yaml',
             hasSupportedGitService: false,
             gitBranch: undefined,
             remotes: [{ name: 'test-1', url: 'http://test-1.git' }],
@@ -279,7 +279,7 @@ describe('helpers', () => {
         const options = helpers.getGitRepoOptionsFromLocation(location);
         expect(options).toEqual({
           location:
-            'https://not-supported.com?remotes=%7B%7Btest-1%2Chttp%3A%2F%2Ftest-1.git%7D%7D&override.devfileFilename=devfile2.yaml',
+            'https://not-supported.com?remotes=%7B%7Btest-1%2Chttp%3A%2F%2Ftest-1.git%7D%7D&devfilePath=devfile2.yaml',
           hasSupportedGitService: false,
           gitBranch: undefined,
           remotes: [{ name: 'test-1', url: 'http://test-1.git' }],

--- a/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
@@ -129,11 +129,8 @@ export function getGitRepoOptionsFromLocation(location: string): {
   const params = decodeURIComponent(factoryLoaderPath.split('?')[1] || '');
   const searchParams = new URLSearchParams(params);
   searchParams.delete('url');
-  let devfilePath = searchParams.get('override.devfileFilename') || undefined;
-  if (devfilePath === 'true') {
-    searchParams.delete('override.devfileFilename');
-    devfilePath = undefined;
-  } else if (devfilePath) {
+  const devfilePath = searchParams.get('override.devfileFilename') || undefined;
+  if (devfilePath !== 'true' && devfilePath) {
     searchParams.set('devfilePath', devfilePath);
   }
   if (searchParams.has('override.devfileFilename')) {

--- a/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
@@ -133,6 +133,11 @@ export function getGitRepoOptionsFromLocation(location: string): {
   if (devfilePath === 'true') {
     searchParams.delete('override.devfileFilename');
     devfilePath = undefined;
+  } else if (devfilePath) {
+    searchParams.set('devfilePath', devfilePath);
+  }
+  if (searchParams.has('override.devfileFilename')) {
+    searchParams.delete('override.devfileFilename');
   }
   let remotes: GitRemote[] | undefined;
   const _remotes = searchParams.get('remotes') || undefined;

--- a/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
@@ -102,7 +102,7 @@ class ImportFromGit extends React.PureComponent<Props, State> {
 
   private handleCreate(): void {
     const { editorDefinition, editorImage } = this.props;
-    const { location } = this.state;
+    const location = decodeURIComponent(this.state.location);
 
     const factory = new FactoryLocationAdapter(location);
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixed the getGitRepoOptionsFromLocation method.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/22949

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Open **Create Workspace** page on the dashboard.
3. Put `https://github.com/che-incubator/quarkus-api-example?df=smoke-test.devfile.yaml` factory into **Git repo URL**.
4. Click **Create & Open**.
5. The workspace should start without problems.
