### PR TITLE
Fix workspace startup

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
@@ -398,22 +398,8 @@ describe('Starting steps, starting a workspace', () => {
 
     await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-    // should report the error
-    const expectAlertItem = expect.objectContaining({
-      title: 'Failed to open the workspace',
-      children: 'The workspace status changed unexpectedly to "Stopping".',
-      actionCallbacks: [
-        expect.objectContaining({
-          title: 'Restart',
-          callback: expect.any(Function),
-        }),
-        expect.objectContaining({
-          title: 'Restart with default devfile',
-          callback: expect.any(Function),
-        }),
-      ],
-    });
-    await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
+    // should not report any error
+    expect(mockOnError).not.toHaveBeenCalled();
 
     // should not start the workspace
     expect(mockStartWorkspace).not.toHaveBeenCalled();
@@ -518,22 +504,8 @@ describe('Starting steps, starting a workspace', () => {
 
     await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-    // should report the error
-    const expectAlertItem = expect.objectContaining({
-      title: 'Failed to open the workspace',
-      children: 'The workspace status changed unexpectedly to "Failing".',
-      actionCallbacks: [
-        expect.objectContaining({
-          title: 'Restart',
-          callback: expect.any(Function),
-        }),
-        expect.objectContaining({
-          title: 'Restart with default devfile',
-          callback: expect.any(Function),
-        }),
-      ],
-    });
-    await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
+    // should not report any error
+    expect(mockOnError).not.toHaveBeenCalled();
 
     expect(mockStartWorkspace).not.toHaveBeenCalled();
     expect(mockOnNextStep).not.toHaveBeenCalled();
@@ -617,22 +589,8 @@ describe('Starting steps, starting a workspace', () => {
 
     await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-    // should report the error
-    const expectAlertItem = expect.objectContaining({
-      title: 'Failed to open the workspace',
-      children: 'The workspace status changed unexpectedly to "Failing".',
-      actionCallbacks: [
-        expect.objectContaining({
-          title: 'Restart',
-          callback: expect.any(Function),
-        }),
-        expect.objectContaining({
-          title: 'Restart with default devfile',
-          callback: expect.any(Function),
-        }),
-      ],
-    });
-    await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
+    // should not report any error
+    expect(mockOnError).not.toHaveBeenCalled();
 
     expect(mockOnNextStep).not.toHaveBeenCalled();
     expect(mockOnRestart).not.toHaveBeenCalled();
@@ -655,22 +613,8 @@ describe('Starting steps, starting a workspace', () => {
 
     await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-    // should report the error
-    const expectAlertItem = expect.objectContaining({
-      title: 'Failed to open the workspace',
-      children: 'The workspace status changed unexpectedly to "Stopping".',
-      actionCallbacks: [
-        expect.objectContaining({
-          title: 'Restart',
-          callback: expect.any(Function),
-        }),
-        expect.objectContaining({
-          title: 'Restart with default devfile',
-          callback: expect.any(Function),
-        }),
-      ],
-    });
-    await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
+    // should not report any error
+    expect(mockOnError).not.toHaveBeenCalled();
 
     expect(mockOnNextStep).not.toHaveBeenCalled();
     expect(mockOnRestart).not.toHaveBeenCalled();

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
@@ -176,12 +176,7 @@ class StartingStepStartWorkspace extends ProgressStep<Props, State> {
     }
 
     if (
-      workspaceStatusIs(
-        workspace,
-        DevWorkspaceStatus.TERMINATING,
-        DevWorkspaceStatus.STOPPING,
-        DevWorkspaceStatus.FAILING,
-      ) ||
+      workspaceStatusIs(workspace, DevWorkspaceStatus.TERMINATING) ||
       (this.state.shouldStart === false &&
         workspaceStatusIs(workspace, DevWorkspaceStatus.STOPPED, DevWorkspaceStatus.FAILED))
     ) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The dashboard will ignore workspace status changes (except `failed` and `terminating`) on workspace startup.


### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-6287
https://issues.redhat.com/browse/CRW-6281

### How to test

1. Install Dev Spaces 3.13.0
2. Patch the CheCluster CR to use this dashboard image: **quay.io/eclipse/che-dashboard:pr-1109**
3. Go to User Dashboard > Create workspace page
4. Click on the "Empty Workspace" tile to start the empty workspace
