### PR TITLE
Switch to existing tab with the same workspace

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -13,5 +13,4 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `cookie-signature@1.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cookie-signature/1.2.1) |
 | `fast-uri@2.3.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.3.0) |
 | `fastify@4.26.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/4.26.2) |
-| `jsbn@0.1.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsbn/0.1.1) |
 | `real-require@0.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/real-require/0.2.0) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -89,7 +89,7 @@
 | [`@nodelib/fs.stat@2.0.5`](https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat) | MIT | clearlydefined |
 | [`@nodelib/fs.walk@1.2.8`](https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk) | MIT | clearlydefined |
 | [`@npmcli/arborist@6.2.3`](https://github.com/npm/cli.git) | ISC | clearlydefined |
-| [`@npmcli/fs@3.1.0`](https://github.com/npm/fs.git) | ISC | clearlydefined |
+| [`@npmcli/fs@3.1.0`](https://github.com/npm/fs.git) | ISC | #14656 |
 | [`@npmcli/git@4.1.0`](https://github.com/npm/git.git) | ISC | #8724 |
 | [`@npmcli/installed-package-contents@2.0.2`](https://github.com/npm/installed-package-contents.git) | ISC | clearlydefined |
 | [`@npmcli/map-workspaces@3.0.4`](https://github.com/npm/map-workspaces.git) | ISC | #7603 |
@@ -173,6 +173,8 @@
 | [`@types/parse-json@4.0.1`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/qs@6.9.9`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | #13991 |
 | [`@types/react-copy-to-clipboard@4.3.0`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
+| [`@types/react-router-dom@5.3.3`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
+| [`@types/react-router@5.1.20`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/react-test-renderer@18.0.5`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/redux-mock-store@1.0.5`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/request@2.48.12`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
@@ -260,7 +262,7 @@
 | [`before-after-hook@2.2.3`](https://github.com/gr2m/before-after-hook.git) | Apache-2.0 | clearlydefined |
 | [`big-integer@1.6.51`](git@github.com:peterolson/BigInteger.js.git) | Unlicense | #2439 |
 | [`big.js@5.2.2`](https://github.com/MikeMcl/big.js.git) | MIT | clearlydefined |
-| [`bin-links@4.0.3`](https://github.com/npm/bin-links.git) | ISC | clearlydefined |
+| [`bin-links@4.0.3`](https://github.com/npm/bin-links.git) | ISC | #14651 |
 | [`binary-extensions@2.2.0`](https://github.com/sindresorhus/binary-extensions.git) | MIT | clearlydefined |
 | [`bl@4.1.0`](https://github.com/rvagg/bl.git) | MIT | clearlydefined |
 | [`boolbase@1.0.0`](https://github.com/fb55/boolbase) | ISC | clearlydefined |
@@ -592,7 +594,7 @@
 | [`jsesc@2.5.2`](https://github.com/mathiasbynens/jsesc.git) | MIT | clearlydefined |
 | [`json-buffer@3.0.1`](git://github.com/dominictarr/json-buffer.git) | MIT | clearlydefined |
 | [`json-parse-better-errors@1.0.2`](https://github.com/zkat/json-parse-better-errors) | MIT | clearlydefined |
-| [`json-parse-even-better-errors@3.0.0`](https://github.com/npm/json-parse-even-better-errors.git) | MIT | clearlydefined |
+| [`json-parse-even-better-errors@3.0.0`](https://github.com/npm/json-parse-even-better-errors.git) | MIT | #14658 |
 | [`json-stable-stringify-without-jsonify@1.0.1`](git://github.com/samn/json-stable-stringify.git) | MIT | clearlydefined |
 | [`json-stringify-nice@1.1.4`](https://github.com/isaacs/json-stringify-nice) | ISC | clearlydefined |
 | [`json5@2.2.3`](git+https://github.com/json5/json5.git) | MIT | #2126 |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -200,7 +200,7 @@
 | [`joycon@3.1.1`](https://github.com/egoist/joycon.git) | MIT | clearlydefined |
 | [`js-tokens@4.0.0`](https://github.com/lydell/js-tokens.git) | MIT | #2401 |
 | [`js-yaml@4.1.0`](https://github.com/nodeca/js-yaml.git) | MIT | clearlydefined |
-| [`jsbn@0.1.1`](https://github.com/andyperlitch/jsbn.git) | MIT |  |
+| [`jsbn@0.1.1`](https://github.com/andyperlitch/jsbn.git) | MIT | #14597 |
 | [`json-schema-ref-resolver@1.0.1`](git+https://github.com/fastify/json-schema-ref-resolver.git) | MIT | clearlydefined |
 | [`json-schema-resolver@2.0.0`](git+https://github.com/Eomm/json-schema-resolver.git) | MIT | clearlydefined |
 | [`json-schema-traverse@1.0.0`](git+https://github.com/epoberezkin/json-schema-traverse.git) | MIT | clearlydefined |

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -84,6 +84,7 @@
     "@types/qs": "^6.9.7",
     "@types/react-copy-to-clipboard": "^4.3.0",
     "@types/react-test-renderer": "^18.0.0",
+    "@types/react-router-dom": "^5.3.3",
     "@types/redux-mock-store": "^1.0.2",
     "@types/sanitize-html": "^2.9.0",
     "@types/testing-library__jest-dom": "^5.14.9",

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentItem/TitleWithHover/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentItem/TitleWithHover/index.tsx
@@ -20,7 +20,7 @@ export type Props = {
   text: string;
 };
 
-export class TitleWithHover extends React.PureComponent<Props> {
+export class TitleWithHover extends React.Component<Props> {
   public render(): React.ReactElement {
     const { text } = this.props;
 

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentItem/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentItem/__tests__/index.spec.tsx
@@ -11,6 +11,7 @@
  */
 
 import { Nav } from '@patternfly/react-core';
+import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
@@ -112,11 +113,12 @@ describe('Navigation Item', () => {
 
 function getComponent(item: NavigationRecentItemObject, activeItem = ''): React.ReactElement {
   const store = new FakeStoreBuilder().build();
+  const history = createMemoryHistory();
   return (
     <Provider store={store}>
       <MemoryRouter>
         <Nav>
-          <NavigationRecentItem item={item} activePath={activeItem} />
+          <NavigationRecentItem history={history} item={item} activePath={activeItem} />
         </Nav>
       </MemoryRouter>
     </Provider>

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
@@ -20,34 +20,38 @@ import { Workspace } from '@/services/workspace-adapter';
 
 import { NavigationRecentItemObject } from '.';
 
-function buildRecentWorkspacesItems(
-  activePath: string,
-  workspaces: Array<Workspace>,
-): Array<React.ReactElement> {
-  return workspaces.map(workspace => {
-    const workspaceName = workspace.name;
-    const namespace = workspace.namespace;
-    const navigateTo = ROUTE.IDE_LOADER.replace(':namespace', namespace).replace(
-      ':workspaceName',
-      workspaceName,
-    );
-    const item: NavigationRecentItemObject = {
-      to: navigateTo,
-      label: workspaceName,
-      workspace,
-    };
-    const history = useHistory();
-    return (
-      <NavigationRecentItem key={item.to} history={history} item={item} activePath={activePath} />
-    );
-  });
+function RecentWorkspaceItem(props: {
+  workspace: Workspace;
+  activePath: string;
+}): React.ReactElement {
+  const workspaceName = props.workspace.name;
+  const namespace = props.workspace.namespace;
+  const navigateTo = ROUTE.IDE_LOADER.replace(':namespace', namespace).replace(
+    ':workspaceName',
+    workspaceName,
+  );
+  const item: NavigationRecentItemObject = {
+    to: navigateTo,
+    label: workspaceName,
+    workspace: props.workspace,
+  };
+  const history = useHistory();
+  return <NavigationRecentItem history={history} item={item} activePath={props.activePath} />;
 }
 
 function NavigationRecentList(props: {
   activePath: string;
   workspaces: Array<Workspace>;
 }): React.ReactElement {
-  const recentWorkspaceItems = buildRecentWorkspacesItems(props.activePath, props.workspaces);
+  const recentWorkspaceItems = props.workspaces.map(workspace => {
+    return (
+      <RecentWorkspaceItem
+        key={workspace.name}
+        workspace={workspace}
+        activePath={props.activePath}
+      />
+    );
+  });
   return (
     <NavList>
       <NavGroup title="RECENT WORKSPACES" style={{ marginTop: '25px' }}>

--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
@@ -12,6 +12,7 @@
 
 import { NavGroup, NavList } from '@patternfly/react-core';
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { NavigationRecentItem } from '@/Layout/Navigation/RecentItem';
 import { ROUTE } from '@/Routes/routes';
@@ -20,8 +21,8 @@ import { Workspace } from '@/services/workspace-adapter';
 import { NavigationRecentItemObject } from '.';
 
 function buildRecentWorkspacesItems(
-  workspaces: Array<Workspace>,
   activePath: string,
+  workspaces: Array<Workspace>,
 ): Array<React.ReactElement> {
   return workspaces.map(workspace => {
     const workspaceName = workspace.name;
@@ -35,15 +36,18 @@ function buildRecentWorkspacesItems(
       label: workspaceName,
       workspace,
     };
-    return <NavigationRecentItem key={item.to} item={item} activePath={activePath} />;
+    const history = useHistory();
+    return (
+      <NavigationRecentItem key={item.to} history={history} item={item} activePath={activePath} />
+    );
   });
 }
 
 function NavigationRecentList(props: {
-  workspaces: Array<Workspace>;
   activePath: string;
+  workspaces: Array<Workspace>;
 }): React.ReactElement {
-  const recentWorkspaceItems = buildRecentWorkspacesItems(props.workspaces, props.activePath);
+  const recentWorkspaceItems = buildRecentWorkspacesItems(props.activePath, props.workspaces);
   return (
     <NavList>
       <NavGroup title="RECENT WORKSPACES" style={{ marginTop: '25px' }}>

--- a/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/index.tsx
@@ -107,7 +107,7 @@ export class Navigation extends React.PureComponent<Props, State> {
     return (
       <Nav aria-label="Navigation" onSelect={selected => this.handleNavSelect(selected)}>
         <NavigationMainList activePath={activeLocation.pathname} />
-        <NavigationRecentList workspaces={recentWorkspaces} activePath={activeLocation.pathname} />
+        <NavigationRecentList activePath={activeLocation.pathname} workspaces={recentWorkspaces} />
       </Nav>
     );
   }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/WorkspaceProgress/ProgressStep';
 import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
+import { lazyInject } from '@/inversify.config';
 import devfileApi from '@/services/devfileApi';
 import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 import {
@@ -37,8 +38,9 @@ import {
   USE_DEFAULT_DEVFILE,
 } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { findTargetWorkspace } from '@/services/helpers/factoryFlow/findTargetWorkspace';
-import { buildIdeLoaderLocation } from '@/services/helpers/location';
+import { buildIdeLoaderLocation, toHref } from '@/services/helpers/location';
 import { AlertItem } from '@/services/helpers/types';
+import { TabManager } from '@/services/tabManager';
 import { Workspace } from '@/services/workspace-adapter';
 import { AppState } from '@/store';
 import { selectDefaultDevfile } from '@/store/DevfileRegistries/selectors';
@@ -70,6 +72,9 @@ export type State = ProgressStepState & {
 
 class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
   protected readonly name = 'Generating a DevWorkspace from the Devfile';
+
+  @lazyInject(TabManager)
+  private readonly tabManager: TabManager;
 
   constructor(props: Props) {
     super(props);
@@ -243,6 +248,10 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
       const nextLocation = buildIdeLoaderLocation(workspace);
       this.props.history.location.pathname = nextLocation.pathname;
       this.props.history.location.search = '';
+
+      const url = toHref(this.props.history, nextLocation);
+      this.tabManager.rename(url);
+
       return true;
     }
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
@@ -25,13 +25,15 @@ import {
 } from '@/components/WorkspaceProgress/ProgressStep';
 import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
+import { lazyInject } from '@/inversify.config';
 import {
   buildFactoryParams,
   FactoryParams,
 } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { findTargetWorkspace } from '@/services/helpers/factoryFlow/findTargetWorkspace';
-import { buildIdeLoaderLocation } from '@/services/helpers/location';
+import { buildIdeLoaderLocation, toHref } from '@/services/helpers/location';
 import { AlertItem } from '@/services/helpers/types';
+import { TabManager } from '@/services/tabManager';
 import { Workspace } from '@/services/workspace-adapter';
 import { AppState } from '@/store';
 import * as DevfileRegistriesStore from '@/store/DevfileRegistries';
@@ -59,6 +61,9 @@ export type State = ProgressStepState & {
 
 class CreatingStepApplyResources extends ProgressStep<Props, State> {
   protected readonly name = 'Applying resources';
+
+  @lazyInject(TabManager)
+  private readonly tabManager: TabManager;
 
   constructor(props: Props) {
     super(props);
@@ -189,6 +194,10 @@ class CreatingStepApplyResources extends ProgressStep<Props, State> {
       const nextLocation = buildIdeLoaderLocation(targetWorkspace);
       this.props.history.location.pathname = nextLocation.pathname;
       this.props.history.location.search = '';
+
+      const url = toHref(this.props.history, nextLocation);
+      this.tabManager.rename(url);
+
       return true;
     }
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
@@ -192,7 +192,7 @@ describe('Starting steps, opening an editor', () => {
 
     await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-    expect(mockLocationReplace).toHaveBeenCalledWith('main-url');
+    await waitFor(() => expect(tabManager.open).toHaveBeenCalledWith('main-url'));
 
     expect(mockOnNextStep).toHaveBeenCalled();
     expect(mockOnError).not.toHaveBeenCalled();

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
@@ -18,10 +18,12 @@ import { Provider } from 'react-redux';
 import { Store } from 'redux';
 
 import { MIN_STEP_DURATION_MS, TIMEOUT_TO_GET_URL_SEC } from '@/components/WorkspaceProgress/const';
+import { container } from '@/inversify.config';
 import { WorkspaceParams } from '@/Routes/routes';
 import getComponentRenderer from '@/services/__mocks__/getComponentRenderer';
 import { getDefer } from '@/services/helpers/deferred';
 import { AlertItem } from '@/services/helpers/types';
+import { TabManager } from '@/services/tabManager';
 import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 
@@ -41,8 +43,6 @@ const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
 const mockOnHideError = jest.fn();
 
-const mockLocationReplace = jest.fn();
-
 const namespace = 'che-user';
 const workspaceName = 'test-workspace';
 const matchParams: WorkspaceParams = {
@@ -51,9 +51,12 @@ const matchParams: WorkspaceParams = {
 };
 
 describe('Starting steps, opening an editor', () => {
+  let tabManager: TabManager;
+
   beforeEach(() => {
-    delete (window as any).location;
-    (window.location as any) = { replace: mockLocationReplace };
+    container.snapshot();
+    tabManager = container.get(TabManager);
+    tabManager.open = jest.fn();
 
     jest.useFakeTimers();
   });
@@ -62,6 +65,7 @@ describe('Starting steps, opening an editor', () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
     jest.useRealTimers();
+    container.restore();
   });
 
   describe('workspace not found', () => {
@@ -256,7 +260,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // wait for opening IDE url
-      await waitFor(() => expect(mockLocationReplace).toHaveBeenCalledWith('main-url'));
+      await waitFor(() => expect(tabManager.open).toHaveBeenCalledWith('main-url'));
     });
 
     test(`mainUrl is propagated after some time`, async () => {
@@ -295,7 +299,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // wait for opening IDE url
-      await waitFor(() => expect(mockLocationReplace).toHaveBeenCalledWith('main-url'));
+      await waitFor(() => expect(tabManager.open).toHaveBeenCalledWith('main-url'));
 
       expect(mockOnError).not.toHaveBeenCalled();
     });
@@ -324,7 +328,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // IDE is not opened
-      expect(mockLocationReplace).not.toHaveBeenCalled();
+      expect(tabManager.open).not.toHaveBeenCalled();
     });
 
     test('mainUrl is propagated after some time', async () => {
@@ -363,7 +367,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // IDE is not opened
-      expect(mockLocationReplace).not.toHaveBeenCalled();
+      expect(tabManager.open).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
@@ -56,7 +56,7 @@ describe('Starting steps, opening an editor', () => {
   beforeEach(() => {
     container.snapshot();
     tabManager = container.get(TabManager);
-    tabManager.open = jest.fn();
+    tabManager.replace = jest.fn();
 
     jest.useFakeTimers();
   });
@@ -192,7 +192,7 @@ describe('Starting steps, opening an editor', () => {
 
     await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-    await waitFor(() => expect(tabManager.open).toHaveBeenCalledWith('main-url'));
+    await waitFor(() => expect(tabManager.replace).toHaveBeenCalledWith('main-url'));
 
     expect(mockOnNextStep).toHaveBeenCalled();
     expect(mockOnError).not.toHaveBeenCalled();
@@ -260,7 +260,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // wait for opening IDE url
-      await waitFor(() => expect(tabManager.open).toHaveBeenCalledWith('main-url'));
+      await waitFor(() => expect(tabManager.replace).toHaveBeenCalledWith('main-url'));
     });
 
     test(`mainUrl is propagated after some time`, async () => {
@@ -299,7 +299,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // wait for opening IDE url
-      await waitFor(() => expect(tabManager.open).toHaveBeenCalledWith('main-url'));
+      await waitFor(() => expect(tabManager.replace).toHaveBeenCalledWith('main-url'));
 
       expect(mockOnError).not.toHaveBeenCalled();
     });
@@ -328,7 +328,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // IDE is not opened
-      expect(tabManager.open).not.toHaveBeenCalled();
+      expect(tabManager.replace).not.toHaveBeenCalled();
     });
 
     test('mainUrl is propagated after some time', async () => {
@@ -367,7 +367,7 @@ describe('Starting steps, opening an editor', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       // IDE is not opened
-      expect(tabManager.open).not.toHaveBeenCalled();
+      expect(tabManager.replace).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
@@ -28,10 +28,12 @@ import {
 } from '@/components/WorkspaceProgress/StartingSteps/StartWorkspace/prepareRestart';
 import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
+import { lazyInject } from '@/inversify.config';
 import { WorkspaceParams } from '@/Routes/routes';
 import { isAvailableEndpoint } from '@/services/helpers/api-ping';
 import { findTargetWorkspace } from '@/services/helpers/factoryFlow/findTargetWorkspace';
 import { AlertItem, DevWorkspaceStatus, LoaderTab } from '@/services/helpers/types';
+import { TabManager } from '@/services/tabManager';
 import { Workspace, WorkspaceAdapter } from '@/services/workspace-adapter';
 import { AppState } from '@/store';
 import { selectApplications } from '@/store/ClusterInfo/selectors';
@@ -46,6 +48,9 @@ export type State = ProgressStepState;
 
 class StartingStepOpenWorkspace extends ProgressStep<Props, State> {
   protected readonly name = 'Open IDE';
+
+  @lazyInject(TabManager)
+  private readonly tabManager: TabManager;
 
   constructor(props: Props) {
     super(props);
@@ -153,7 +158,7 @@ class StartingStepOpenWorkspace extends ProgressStep<Props, State> {
 
     const isAvailable = await isAvailableEndpoint(workspace.ideUrl);
     if (isAvailable) {
-      window.location.replace(workspace.ideUrl);
+      this.tabManager.open(workspace.ideUrl);
       return true;
     }
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
@@ -158,7 +158,7 @@ class StartingStepOpenWorkspace extends ProgressStep<Props, State> {
 
     const isAvailable = await isAvailableEndpoint(workspace.ideUrl);
     if (isAvailable) {
-      this.tabManager.open(workspace.ideUrl);
+      this.tabManager.replace(workspace.ideUrl);
       return true;
     }
 

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/index.spec.tsx
@@ -360,7 +360,7 @@ describe('WorkspaceActionsDropdown', () => {
 
       expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.OPEN_IDE }),
-      ).toHaveAttribute('aria-disabled', 'true');
+      ).toHaveAttribute('aria-disabled', 'false');
       expect(
         screen.getByRole('menuitem', {
           name: 'Action: ' + WorkspaceAction.START_DEBUG_AND_OPEN_LOGS,
@@ -388,7 +388,7 @@ describe('WorkspaceActionsDropdown', () => {
 
       expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.OPEN_IDE }),
-      ).toHaveAttribute('aria-disabled', 'true');
+      ).toHaveAttribute('aria-disabled', 'false');
       expect(
         screen.getByRole('menuitem', {
           name: 'Action: ' + WorkspaceAction.START_DEBUG_AND_OPEN_LOGS,
@@ -416,7 +416,7 @@ describe('WorkspaceActionsDropdown', () => {
 
       expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.OPEN_IDE }),
-      ).toHaveAttribute('aria-disabled', 'true');
+      ).toHaveAttribute('aria-disabled', 'false');
       expect(
         screen.getByRole('menuitem', {
           name: 'Action: ' + WorkspaceAction.START_DEBUG_AND_OPEN_LOGS,
@@ -472,7 +472,7 @@ describe('WorkspaceActionsDropdown', () => {
 
       expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.OPEN_IDE }),
-      ).toHaveAttribute('aria-disabled', 'true');
+      ).toHaveAttribute('aria-disabled', 'false');
       expect(
         screen.getByRole('menuitem', {
           name: 'Action: ' + WorkspaceAction.START_DEBUG_AND_OPEN_LOGS,

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/index.tsx
@@ -158,7 +158,7 @@ export class WorkspaceActionsDropdown extends React.PureComponent<Props, State> 
     };
 
     return [
-      getItem(WorkspaceAction.OPEN_IDE, isTerminating || isStopped === false),
+      getItem(WorkspaceAction.OPEN_IDE, isTerminating),
       getItem(WorkspaceAction.START_DEBUG_AND_OPEN_LOGS, isTerminating || isStopped === false),
       getItem(WorkspaceAction.START_IN_BACKGROUND, isTerminating || isStopped === false),
       getItem(WorkspaceAction.RESTART_WORKSPACE, isTerminating || isStopped),

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
@@ -15,8 +15,10 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { WorkspaceActionsDeleteConfirmation } from '@/contexts/WorkspaceActions/DeleteConfirmation';
+import { lazyInject } from '@/inversify.config';
 import { buildIdeLoaderLocation, toHref } from '@/services/helpers/location';
 import { LoaderTab, WorkspaceAction } from '@/services/helpers/types';
+import { TabManager } from '@/services/tabManager';
 import { Workspace } from '@/services/workspace-adapter';
 import { AppState } from '@/store';
 import * as WorkspacesStore from '@/store/Workspaces';
@@ -41,6 +43,9 @@ export type State = {
 };
 
 class WorkspaceActionsProvider extends React.Component<Props, State> {
+  @lazyInject(TabManager)
+  private readonly tabManager: TabManager;
+
   private deleting: Set<string> = new Set();
 
   constructor(props: Props) {
@@ -56,9 +61,9 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
   /**
    * open the action in a new tab for DevWorkspaces
    */
-  private handleLocation(location: Location, workspace: Workspace): void {
+  private handleLocation(location: Location): void {
     const link = toHref(this.props.history, location);
-    window.open(link, workspace.uid);
+    this.tabManager.open(link);
   }
 
   private async deleteWorkspace(workspace: Workspace): Promise<void> {
@@ -105,7 +110,7 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
 
     switch (action) {
       case WorkspaceAction.OPEN_IDE: {
-        this.handleLocation(buildIdeLoaderLocation(workspace), workspace);
+        this.handleLocation(buildIdeLoaderLocation(workspace));
         break;
       }
       case WorkspaceAction.START_DEBUG_AND_OPEN_LOGS: {
@@ -113,7 +118,7 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
         await this.props.startWorkspace(workspace, {
           'debug-workspace-start': true,
         });
-        this.handleLocation(buildIdeLoaderLocation(workspace, LoaderTab.Logs), workspace);
+        this.handleLocation(buildIdeLoaderLocation(workspace, LoaderTab.Logs));
         break;
       }
       case WorkspaceAction.START_IN_BACKGROUND:

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/Provider.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/Provider.spec.tsx
@@ -205,7 +205,10 @@ describe('WorkspaceActionsProvider', () => {
       await jest.advanceTimersByTimeAsync(1000);
 
       expect(window.open).toHaveBeenCalledTimes(1);
-      expect(window.open).toHaveBeenCalledWith('/ide/user-che/wksp-1234', '1234');
+      expect(window.open).toHaveBeenCalledWith(
+        expect.stringContaining('/ide/user-che/wksp-1234'),
+        expect.stringContaining('/ide/user-che/wksp-1234'),
+      );
     });
 
     test('start debug and open logs', async () => {
@@ -227,7 +230,10 @@ describe('WorkspaceActionsProvider', () => {
         { 'debug-workspace-start': true },
       );
 
-      expect(window.open).toHaveBeenCalledWith('/ide/user-che/wksp-5678?tab=Logs', '5678');
+      expect(window.open).toHaveBeenCalledWith(
+        expect.stringContaining('/ide/user-che/wksp-5678?tab=Logs'),
+        expect.stringContaining('/ide/user-che/wksp-5678?tab=Logs'),
+      );
     });
 
     test('start in background', async () => {

--- a/packages/dashboard-frontend/src/inversify.config.ts
+++ b/packages/dashboard-frontend/src/inversify.config.ts
@@ -20,18 +20,20 @@ import { WebsocketClient } from '@/services/backend-client/websocketClient';
 import { IssuesReporterService } from '@/services/bootstrap/issuesReporter';
 import { WarningsReporterService } from '@/services/bootstrap/warningsReporter';
 import { WorkspaceStoppedDetector } from '@/services/bootstrap/workspaceStoppedDetector';
+import { TabManager } from '@/services/tabManager';
 import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
 import { DevWorkspaceDefaultPluginsHandler } from '@/services/workspace-client/devworkspace/DevWorkspaceDefaultPluginsHandler';
 
 const container = new Container();
 const { lazyInject } = getDecorators(container);
 
-container.bind(IssuesReporterService).toSelf().inSingletonScope();
-container.bind(WebsocketClient).toSelf().inSingletonScope();
-container.bind(DevWorkspaceClient).toSelf().inSingletonScope();
 container.bind(AppAlerts).toSelf().inSingletonScope();
+container.bind(DevWorkspaceClient).toSelf().inSingletonScope();
 container.bind(DevWorkspaceDefaultPluginsHandler).toSelf().inSingletonScope();
-container.bind(WorkspaceStoppedDetector).toSelf().inSingletonScope();
+container.bind(IssuesReporterService).toSelf().inSingletonScope();
+container.bind(TabManager).toSelf().inSingletonScope();
 container.bind(WarningsReporterService).toSelf().inSingletonScope();
+container.bind(WebsocketClient).toSelf().inSingletonScope();
+container.bind(WorkspaceStoppedDetector).toSelf().inSingletonScope();
 
 export { container, lazyInject };

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -127,10 +127,10 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
   }
 
   private buildRows(): RowData[] {
-    const { workspaces } = this.props;
+    const { history, workspaces } = this.props;
     const { filtered, selected, sortBy } = this.state;
 
-    return buildRows(workspaces, [], filtered, selected, sortBy);
+    return buildRows(history, workspaces, [], filtered, selected, sortBy);
   }
 
   private handleFilter(filtered: Workspace[]): void {

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -106,5 +106,5 @@ function _buildLocationObject(pathAndQuery: string): Location {
 
 export function toHref(history: History, location: Location): string {
   const fragment = history.createHref(location);
-  return window.origin + window.location.pathname + fragment;
+  return window.location.origin + window.location.pathname + fragment;
 }

--- a/packages/dashboard-frontend/src/services/helpers/location.ts
+++ b/packages/dashboard-frontend/src/services/helpers/location.ts
@@ -105,5 +105,6 @@ function _buildLocationObject(pathAndQuery: string): Location {
 }
 
 export function toHref(history: History, location: Location): string {
-  return history.createHref(location);
+  const fragment = history.createHref(location);
+  return window.origin + window.location.pathname + fragment;
 }

--- a/packages/dashboard-frontend/src/services/tabManager/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/tabManager/__tests__/index.spec.ts
@@ -24,8 +24,12 @@ describe('TabManager', () => {
     window.open = mockWindowOpen;
     window.close = mockWindowClose;
 
+    const { location } = window;
     delete (window as Partial<Window>).location;
-    window.location = { replace: mockWindowReplace } as unknown as Window['location'];
+    window.location = {
+      origin: location.origin,
+      replace: mockWindowReplace,
+    } as unknown as Window['location'];
   });
 
   afterEach(() => {
@@ -36,7 +40,7 @@ describe('TabManager', () => {
     const stubWindowProxy1 = { focus: jest.fn(), closed: false };
     mockWindowOpen.mockReturnValueOnce(stubWindowProxy1);
 
-    const url = window.origin + '/new-path';
+    const url = window.location.origin + '/new-path';
 
     tabManager.open(url);
     expect(window.open).toHaveBeenCalledTimes(1);
@@ -50,7 +54,7 @@ describe('TabManager', () => {
     const stubWindowProxy2 = { focus: jest.fn(), closed: true };
     mockWindowOpen.mockReturnValueOnce(stubWindowProxy2);
 
-    const url = window.origin + '/new-path';
+    const url = window.location.origin + '/new-path';
 
     tabManager.open(url);
     expect(window.open).toHaveBeenCalledTimes(1);
@@ -63,7 +67,7 @@ describe('TabManager', () => {
   test('fail to open new tab', () => {
     mockWindowOpen.mockReturnValueOnce(null);
 
-    const url = window.origin + '/new-path';
+    const url = window.location.origin + '/new-path';
     tabManager.open(url);
 
     expect(window.open).toHaveBeenCalledWith(url, url);

--- a/packages/dashboard-frontend/src/services/tabManager/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/tabManager/__tests__/index.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { TabManager } from '@/services/tabManager';
+
+const mockWindowOpen = jest.fn();
+const mockWindowClose = jest.fn();
+const mockWindowReplace = jest.fn();
+
+describe('TabManager', () => {
+  let tabManager: TabManager;
+
+  beforeEach(() => {
+    tabManager = new TabManager();
+    window.open = mockWindowOpen;
+    window.close = mockWindowClose;
+
+    delete (window as Partial<Window>).location;
+    window.location = { replace: mockWindowReplace } as unknown as Window['location'];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('new tab remains open, switch to it', () => {
+    const stubWindowProxy1 = { focus: jest.fn(), closed: false };
+    mockWindowOpen.mockReturnValueOnce(stubWindowProxy1);
+
+    const url = window.origin + '/new-path';
+
+    tabManager.open(url);
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(window.open).toHaveBeenCalledWith(url, url);
+
+    tabManager.open(url);
+    expect(window.open).toHaveBeenCalledTimes(1);
+  });
+
+  test('new tab get closed, switch to it', () => {
+    const stubWindowProxy2 = { focus: jest.fn(), closed: true };
+    mockWindowOpen.mockReturnValueOnce(stubWindowProxy2);
+
+    const url = window.origin + '/new-path';
+
+    tabManager.open(url);
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(window.open).toHaveBeenCalledWith(url, url);
+
+    tabManager.open(url);
+    expect(window.open).toHaveBeenCalledTimes(2);
+  });
+
+  test('fail to open new tab', () => {
+    mockWindowOpen.mockReturnValueOnce(null);
+
+    const url = window.origin + '/new-path';
+    tabManager.open(url);
+
+    expect(window.open).toHaveBeenCalledWith(url, url);
+    expect(window.location.replace).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/dashboard-frontend/src/services/tabManager/index.ts
+++ b/packages/dashboard-frontend/src/services/tabManager/index.ts
@@ -71,7 +71,13 @@ export class TabManager {
     }
   }
 
+  // replace the current window with the new URL
   public replace(url: string): void {
     window.location.replace(url);
+  }
+
+  // set the current window browser context
+  public rename(url: string): void {
+    window.name = url;
   }
 }

--- a/packages/dashboard-frontend/src/services/tabManager/index.ts
+++ b/packages/dashboard-frontend/src/services/tabManager/index.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { injectable } from 'inversify';
+
+@injectable()
+export class TabManager {
+  private tabs: { [url: string]: WindowProxy } = {};
+
+  private getTab(url: string): WindowProxy | undefined {
+    return this.tabs[url];
+  }
+
+  private removeClosedTab(url: string): void {
+    const tab = this.getTab(url);
+    if (tab && tab.closed) {
+      delete this.tabs[url];
+    }
+  }
+
+  private focusTab(url: string): boolean {
+    const tab = this.getTab(url);
+    if (this.isSameOrigin(url) && tab && !tab.closed) {
+      tab.focus();
+      return true;
+    }
+    return false;
+  }
+
+  private openNewTab(url: string): boolean {
+    const newTab = window.open(url, url);
+    if (newTab === null) {
+      return false;
+    }
+    if (this.isSameOrigin(url)) {
+      this.tabs[url] = newTab;
+    }
+    return true;
+  }
+
+  private isSameOrigin(_url: string): boolean {
+    try {
+      const url = new URL(_url);
+      return url.origin === window.origin;
+    } catch (e) {
+      // not a valid URL
+      return false;
+    }
+  }
+
+  public open(url: string): void {
+    this.removeClosedTab(url);
+    if (this.focusTab(url)) {
+      return;
+    }
+
+    const success = this.openNewTab(url);
+    if (success === false) {
+      // browser fails to open the tab
+      // redirect to the URL
+      window.location.replace(url);
+    }
+  }
+
+  public closeThis(): void {
+    window.close();
+  }
+}

--- a/packages/dashboard-frontend/src/services/tabManager/index.ts
+++ b/packages/dashboard-frontend/src/services/tabManager/index.ts
@@ -50,7 +50,7 @@ export class TabManager {
   private isSameOrigin(_url: string): boolean {
     try {
       const url = new URL(_url);
-      return url.origin === window.origin;
+      return url.origin === window.location.origin;
     } catch (e) {
       // not a valid URL
       return false;

--- a/packages/dashboard-frontend/src/services/tabManager/index.ts
+++ b/packages/dashboard-frontend/src/services/tabManager/index.ts
@@ -71,7 +71,7 @@ export class TabManager {
     }
   }
 
-  public closeThis(): void {
-    window.close();
+  public replace(url: string): void {
+    window.location.replace(url);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,7 +1707,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/history@^4.7.6":
+"@types/history@^4.7.11", "@types/history@^4.7.6":
   version "4.7.11"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
@@ -1851,6 +1851,23 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
+
+"@types/react-router-dom@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.20"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.20.tgz#88eccaa122a82405ef3efbcaaa5dcdd9f021387c"
+  integrity sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
 
 "@types/react-test-renderer@^18.0.0":
   version "18.0.5"
@@ -10416,7 +10433,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10490,7 +10516,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11638,7 +11671,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11651,6 +11684,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

When opening a workspace, the dashboard looks for an already open tab with the same workspace. If a tab exists, the dashboard focuses it without creating a new tab.

### What issues does this PR fix or reference?

resolves https://github.com/eclipse-che/che/issues/22933

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Create a new workspace, or open an existing one. A new browser tab should be created.
2. Go back to the dashboard tab, and
    - click the same workspace in the Recent Workspaces section, or
    - click "Open" on the same workspace in the workspaces list, or
    - open the workspace actions menu for the same workspace, and click the "Open" item
3. The existing workspace tab should be focused.
