### PR TITLE
fix: podman login into external registries

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/podmanApi.spec.ts
@@ -73,7 +73,7 @@ describe('podman Config API Service', () => {
         'sh',
         '-c',
         expect.stringContaining(
-          'podman login registry1 -u user1 -p password1 || true\npodman login registry2 -u user2 -p password2 || true',
+          "podman login registry1 -u 'user1' -p 'password1' || true\npodman login registry2 -u 'user2' -p 'password2' || true",
         ),
       ]),
       expect.anything(),

--- a/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/podmanApi.ts
@@ -176,7 +176,7 @@ export class PodmanApiService implements IPodmanApi {
 
         if (username && password) {
           // `|| true` ensures that `podman login` won't fail if credentials are invalid
-          externalDockerRegistriesPodmanLoginCommand += `podman login ${registry} -u ${username} -p ${password} || true\n`;
+          externalDockerRegistriesPodmanLoginCommand += `podman login ${registry} -u '${username}' -p '${password}' || true\n`;
         }
       }
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
fix: podman login into external registries

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/22987

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Yes

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
