### PR TITLE
Align the oauth items filter with changes from server

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/StatusIcon/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/StatusIcon/index.tsx
@@ -29,18 +29,12 @@ export type Props = {
 export class GitServiceStatusIcon extends React.PureComponent<Props> {
   private isSkipOauth(): boolean {
     const { gitProvider, skipOauthProviders } = this.props;
-    // Use includes filter to handle the bitbucket-server oauth 2 provider.
-    // The bitbucket server oauth2 provider name is 'bitbucket',
-    // but the corresponding 'skip oauth' item is 'bitbucket-server'.
-    return skipOauthProviders.some(s => s.includes(gitProvider));
+    return skipOauthProviders.includes(gitProvider);
   }
 
   private hasOauthToken(): boolean {
     const { gitProvider, providersWithToken } = this.props;
-    // Use includes filter to handle the bitbucket-server oauth 2 provider.
-    // The bitbucket server oauth2 provider name is 'bitbucket',
-    // but the corresponding 'provider with token' item is 'bitbucket-server'.
-    return providersWithToken.some(p => p.includes(gitProvider));
+    return providersWithToken.includes(gitProvider);
   }
 
   public render(): React.ReactElement {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
@@ -191,10 +191,7 @@ export class GitServicesList extends React.PureComponent<Props, State> {
   }
 
   private hasSkipOauth(providerName: api.GitOauthProvider): boolean {
-    // Use includes filter to handle the bitbucket-server oauth 2 provider.
-    // The bitbucket server oauth2 provider name is 'bitbucket',
-    // but the corresponding 'skip oauth' item is 'bitbucket-server'.
-    return this.props.skipOauthProviders.some(s => s.includes(providerName));
+    return this.props.skipOauthProviders.includes(providerName);
   }
 
   private hasOauthToken(providerName: api.GitOauthProvider): boolean {
@@ -207,10 +204,7 @@ export class GitServicesList extends React.PureComponent<Props, State> {
   }
 
   private handleClearService(service: IGitOauth): void {
-    // Use includes filter to handle the bitbucket-server oauth 2 provider.
-    // The bitbucket server oauth2 provider name is 'bitbucket',
-    // but the corresponding 'skip oauth' item is 'bitbucket-server'.
-    const serviceToClear = this.props.skipOauthProviders.find(s => s.includes(service.name));
+    const serviceToClear = this.props.skipOauthProviders.find(s => s === service.name);
     if (serviceToClear != undefined) {
       this.props.onClearService(serviceToClear);
       this.deselectServices([service]);

--- a/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
@@ -16,7 +16,7 @@ export const GIT_OAUTH_PROVIDERS: Record<api.GitOauthProvider, string> = {
   'azure-devops': 'Microsoft Azure DevOps',
   // Either Bitbucket Cloud or Bitbucket Server
   // https://github.com/eclipse-che/che-server/blob/main/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
-  'bitbucket-server': 'Bitbucket (OAuth 1.0)',
+  'bitbucket-server': 'Bitbucket',
   // Bitbucket Server only
   // https://github.com/eclipse-che/che-server/blob/main/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/BitbucketServerOAuthAuthenticator.java
   bitbucket: 'Bitbucket',


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Since che-server returns `bitbucket-server` for self-hosted Bitbucket authenticators, both oauth1 and oauth2, remove the includes filter.

see https://github.com/eclipse-che/che-dashboard/pull/1121

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/22971
**DO NOT MERGE**:  depends on https://github.com/eclipse-che/che-server/pull/689

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
see https://github.com/eclipse-che/che/issues/22971

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
