### PR TITLE
Update che-devworkspace generator dependency version

### DIFF
--- a/packages/dashboard-backend/package.json
+++ b/packages/dashboard-backend/package.json
@@ -27,7 +27,7 @@
   "license": "EPL-2.0",
   "dependencies": {
     "@devfile/api": "2.2.2-1715367693",
-    "@eclipse-che/che-devworkspace-generator": "7.87.0-next-68df316",
+    "@eclipse-che/che-devworkspace-generator": "7.88.0-next-a2e5c63",
     "@eclipse-che/common": "file:../common",
     "@fastify/cors": "^9.0.1",
     "@fastify/error": "^3.4.1",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Update che-devworkspace generator dependency version

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/22997

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Try to start a workspace from a repository with a dvfile version `2.3.0`
See: workspace starts successfully.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
