### PR TITLE
Implement editors/devfile route

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/__mocks__/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/__mocks__/index.ts
@@ -15,6 +15,7 @@ import {
   IDevWorkspacePreferencesApi,
   IDevWorkspaceTemplateApi,
   IDockerConfigApi,
+  IEditorsApi,
   IEventApi,
   IGettingStartedSampleApi,
   IGitConfigApi,
@@ -70,6 +71,10 @@ export class DevWorkspaceClient implements IDevWorkspaceClient {
     throw new Error('Method not implemented.');
   }
   get devWorkspacePreferencesApi(): IDevWorkspacePreferencesApi {
+    throw new Error('Method not implemented.');
+  }
+
+  get editorsApi(): IEditorsApi {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/editorsApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/editorsApi.spec.ts
@@ -15,7 +15,7 @@ import { V1ConfigMapList } from '@kubernetes/client-node/dist/gen/model/v1Config
 import http from 'http';
 import * as yaml from 'js-yaml';
 
-import { EditorsApiService } from '@/devworkspaceClient/services/editorsApi';
+import { EditorNotFoundError, EditorsApiService } from '@/devworkspaceClient/services/editorsApi';
 import { createError } from '@/devworkspaceClient/services/helpers/createError';
 import { prepareCoreV1API } from '@/devworkspaceClient/services/helpers/prepareCoreV1API';
 import { logger } from '@/utils/logger';
@@ -43,80 +43,236 @@ describe('EditorsApiService', () => {
     jest.clearAllMocks();
   });
 
-  it('should return an empty list if NAMESPACE is not defined', async () => {
-    delete process.env.CHECLUSTER_CR_NAMESPACE;
-    const result = await editorsApiService.list();
-    expect(result).toEqual([]);
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Mandatory environment variables are not defined: $CHECLUSTER_CR_NAMESPACE',
-    );
-  });
-
-  it('should return a list of editors', async () => {
-    const configMapData = {
-      'editor.yaml': 'apiVersion: 2.2.2',
-    };
-    const configMap = {
-      metadata: { name: 'editor-configmap' },
-      data: configMapData,
-    };
-    const configMapList = {
-      items: [configMap],
-    } as V1ConfigMapList;
-    const response = { response: {} as http.IncomingMessage, body: configMapList };
-
-    (coreV1API.listNamespacedConfigMap as jest.Mock).mockResolvedValue(response);
-    (yaml.load as jest.Mock).mockReturnValue({ schemaVersion: '2.2.2' });
-
-    const result = await editorsApiService.list();
-    expect(result).toEqual([{ schemaVersion: '2.2.2' } as V222Devfile]);
-    expect(coreV1API.listNamespacedConfigMap).toHaveBeenCalledWith(
-      'test-namespace',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      'app.kubernetes.io/component=editor-definition,app.kubernetes.io/part-of=che.eclipse.org',
-    );
-  });
-
-  it('should handle errors from the Kubernetes API', async () => {
-    const error = new Error('API error');
-    const additionalMessage = 'Unable to list editors ConfigMap';
-
-    (coreV1API.listNamespacedConfigMap as jest.Mock).mockRejectedValue(error);
-    (createError as jest.Mock).mockReturnValue(new Error(`${additionalMessage}`));
-
-    await expect(editorsApiService.list()).rejects.toThrow(`${additionalMessage}`);
-    expect(createError).toHaveBeenCalledWith(error, 'CORE_V1_API_ERROR', additionalMessage);
-  });
-
-  it('should handle YAML parsing errors', async () => {
-    const configMapData = {
-      'editor.yaml': 'invalid yaml',
-    };
-    const configMap = {
-      metadata: { name: 'editor-configmap' },
-      data: configMapData,
-    };
-    const configMapList = {
-      items: [configMap],
-    } as V1ConfigMapList;
-    const response = { response: {} as http.IncomingMessage, body: configMapList };
-    const parseError = new Error('YAML parse error');
-
-    (coreV1API.listNamespacedConfigMap as jest.Mock).mockResolvedValue(response);
-    (yaml.load as jest.Mock).mockImplementation(() => {
-      throw parseError;
+  describe('list', () => {
+    it('should return an empty list if NAMESPACE is not defined', async () => {
+      delete process.env.CHECLUSTER_CR_NAMESPACE;
+      const result = await editorsApiService.list();
+      expect(result).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Mandatory environment variables are not defined: $CHECLUSTER_CR_NAMESPACE',
+      );
     });
 
-    const result = await editorsApiService.list();
-    expect(result).toEqual([]);
-    expect(logger.error).toHaveBeenCalledWith(
-      parseError,
-      'Failed to parse editor: %s from %s Config Map',
-      'editor.yaml',
-      'editor-configmap',
-    );
+    it('should return a list of editors', async () => {
+      const configMapData = {
+        'editor.yaml': 'apiVersion: 2.2.2',
+      };
+      const configMap = {
+        metadata: { name: 'editor-configmap' },
+        data: configMapData,
+      };
+      const configMapList = {
+        items: [configMap],
+      } as V1ConfigMapList;
+      const response = { response: {} as http.IncomingMessage, body: configMapList };
+
+      (coreV1API.listNamespacedConfigMap as jest.Mock).mockResolvedValue(response);
+      (yaml.load as jest.Mock).mockReturnValue({ schemaVersion: '2.2.2' });
+
+      const result = await editorsApiService.list();
+      expect(result).toEqual([{ schemaVersion: '2.2.2' } as V222Devfile]);
+      expect(coreV1API.listNamespacedConfigMap).toHaveBeenCalledWith(
+        'test-namespace',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'app.kubernetes.io/component=editor-definition,app.kubernetes.io/part-of=che.eclipse.org',
+      );
+    });
+
+    it('should handle errors from the Kubernetes API', async () => {
+      const error = new Error('API error');
+      const additionalMessage = 'Unable to list editors ConfigMap';
+
+      (coreV1API.listNamespacedConfigMap as jest.Mock).mockRejectedValue(error);
+      (createError as jest.Mock).mockReturnValue(new Error(`${additionalMessage}`));
+
+      await expect(editorsApiService.list()).rejects.toThrow(`${additionalMessage}`);
+      expect(createError).toHaveBeenCalledWith(error, 'CORE_V1_API_ERROR', additionalMessage);
+    });
+
+    it('should handle YAML parsing errors', async () => {
+      const configMapData = {
+        'editor.yaml': 'invalid yaml',
+      };
+      const configMap = {
+        metadata: { name: 'editor-configmap' },
+        data: configMapData,
+      };
+      const configMapList = {
+        items: [configMap],
+      } as V1ConfigMapList;
+      const response = { response: {} as http.IncomingMessage, body: configMapList };
+      const parseError = new Error('YAML parse error');
+
+      (coreV1API.listNamespacedConfigMap as jest.Mock).mockResolvedValue(response);
+      (yaml.load as jest.Mock).mockImplementation(() => {
+        throw parseError;
+      });
+
+      const result = await editorsApiService.list();
+      expect(result).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(
+        parseError,
+        'Failed to parse editor: %s from %s Config Map',
+        'editor.yaml',
+        'editor-configmap',
+      );
+    });
+  });
+
+  describe('get', () => {
+    it('should return matching editor yaml when provided with editorId', async () => {
+      const editor = `
+      apiVersion: 2.2.2
+      metadata:
+        name: che-code
+        attributes:
+          publisher: che-incubator
+          version: insiders
+      `;
+      const configMapData = {
+        'editor.yaml': editor,
+      };
+      const configMap = {
+        metadata: { name: 'editor-configmap' },
+        data: configMapData,
+      };
+      const configMapList = {
+        items: [configMap],
+      } as V1ConfigMapList;
+      const response = { response: {} as http.IncomingMessage, body: configMapList };
+
+      (coreV1API.listNamespacedConfigMap as jest.Mock).mockResolvedValue(response);
+      (yaml.load as jest.Mock).mockReturnValue({
+        schemaVersion: '2.2.2',
+        metadata: {
+          name: 'che-code',
+          attributes: {
+            publisher: 'che-incubator',
+            version: 'insiders',
+          },
+        },
+      });
+
+      const result = await editorsApiService.get('che-incubator/che-code/insiders');
+      expect(result).toEqual({
+        schemaVersion: '2.2.2',
+        metadata: {
+          name: 'che-code',
+          attributes: {
+            publisher: 'che-incubator',
+            version: 'insiders',
+          },
+        },
+      } as V222Devfile);
+    });
+
+    it('should return matching editor yaml when provided with editorId when multiple editors exist', async () => {
+      const editor1 = `
+      apiVersion: 2.2.2
+      metadata:
+        name: che-code
+        attributes:
+          publisher: che-incubator
+          version: insiders
+      `;
+      const editor2 = `
+      apiVersion: 2.2.2
+      metadata:
+        name: che-code
+        attributes:
+          publisher: che-incubator
+          version: latest
+      `;
+      const configMapData = {
+        'editor1.yaml': editor1,
+        'editor2.yaml': editor2,
+      };
+      const configMap = {
+        metadata: { name: 'editor-configmap' },
+        data: configMapData,
+      };
+      const configMapList = {
+        items: [configMap],
+      } as V1ConfigMapList;
+      const response = { response: {} as http.IncomingMessage, body: configMapList };
+
+      (coreV1API.listNamespacedConfigMap as jest.Mock).mockResolvedValue(response);
+      (yaml.load as jest.Mock)
+        .mockReturnValueOnce({
+          schemaVersion: '2.2.2',
+          metadata: {
+            name: 'che-code',
+            attributes: {
+              publisher: 'che-incubator',
+              version: 'insiders',
+            },
+          },
+        })
+        .mockReturnValueOnce({
+          schemaVersion: '2.2.2',
+          metadata: {
+            name: 'che-code',
+            attributes: {
+              publisher: 'che-incubator',
+              version: 'latest',
+            },
+          },
+        });
+
+      const result = await editorsApiService.get('che-incubator/che-code/latest');
+      expect(result).toEqual({
+        schemaVersion: '2.2.2',
+        metadata: {
+          name: 'che-code',
+          attributes: {
+            publisher: 'che-incubator',
+            version: 'latest',
+          },
+        },
+      } as V222Devfile);
+    });
+
+    it('should throw exception if no matching editor exists', async () => {
+      const editor = `
+      apiVersion: 2.2.2
+      metadata:
+        name: che-code
+        attributes:
+          publisher: che-incubator
+          version: insiders
+      `;
+      const configMapData = {
+        'editor.yaml': editor,
+      };
+      const configMap = {
+        metadata: { name: 'editor-configmap' },
+        data: configMapData,
+      };
+      const configMapList = {
+        items: [configMap],
+      } as V1ConfigMapList;
+      const response = { response: {} as http.IncomingMessage, body: configMapList };
+
+      (coreV1API.listNamespacedConfigMap as jest.Mock).mockResolvedValue(response);
+      (yaml.load as jest.Mock).mockReturnValue({
+        schemaVersion: '2.2.2',
+        metadata: {
+          name: 'che-code',
+          attributes: {
+            publisher: 'che-incubator',
+            version: 'insiders',
+          },
+        },
+      });
+      const expectedError = new EditorNotFoundError(
+        "Editor with id: 'che-incubator/che-code/latest' not found",
+      );
+      await expect(editorsApiService.get('che-incubator/che-code/latest')).rejects.toThrow(
+        expectedError,
+      );
+    });
   });
 });

--- a/packages/dashboard-backend/src/devworkspaceClient/services/editorsApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/editorsApi.ts
@@ -28,6 +28,13 @@ const API_ERROR_LABEL = 'CORE_V1_API_ERROR';
 const EDITOR_METADATA_LABEL_SELECTOR =
   'app.kubernetes.io/component=editor-definition,app.kubernetes.io/part-of=che.eclipse.org';
 
+export class EditorNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EditorNotFoundError';
+  }
+}
+
 export class EditorsApiService implements IEditorsApi {
   private readonly coreV1API: CoreV1API;
   constructor() {
@@ -87,5 +94,23 @@ export class EditorsApiService implements IEditorsApi {
     }
 
     return editors;
+  }
+
+  async get(id: string): Promise<V222Devfile> {
+    const editors = await this.list();
+    const matches = editors.filter(editor => {
+      const currId =
+        editor.metadata?.attributes.publisher +
+        '/' +
+        editor.metadata?.name +
+        '/' +
+        editor.metadata?.attributes.version;
+
+      return currId === id;
+    });
+    if (matches.length === 0) {
+      throw new EditorNotFoundError(`Editor with id: '${id}' not found`);
+    }
+    return matches[0];
   }
 }

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -428,6 +428,7 @@ export interface IDevWorkspaceClient {
   gettingStartedSampleApi: IGettingStartedSampleApi;
   sshKeysApi: IShhKeysApi;
   devWorkspacePreferencesApi: IDevWorkspacePreferencesApi;
+  editorsApi: IEditorsApi;
 }
 
 export interface IWatcherService<T = Record<string, unknown>> {

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -456,6 +456,13 @@ export interface IEditorsApi {
    * Reads all Editors from ConfigMaps.
    */
   list(): Promise<Array<V222Devfile>>;
+
+  /**
+   * Returns an Editor from ConfigMap by its editorId.
+   * @param id editorId in the format of publisher/name/version
+   * @throws EditorNotFoundError if editor is not found
+   */
+  get(id: string): Promise<V222Devfile>;
 }
 
 export interface IShhKeysApi {

--- a/packages/dashboard-backend/src/routes/api/__tests__/editors.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/editors.spec.ts
@@ -19,6 +19,10 @@ import { setup, teardown } from '@/utils/appBuilder';
 jest.mock('@/routes/api/helpers/getServiceAccountToken');
 jest.mock('@/routes/api/helpers/getDevWorkspaceClient');
 
+import { DevWorkspaceClient } from '@/devworkspaceClient';
+import { EditorNotFoundError } from '@/devworkspaceClient/services/editorsApi';
+import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
+
 describe('Editors Route', () => {
   let app: FastifyInstance;
 
@@ -36,5 +40,41 @@ describe('Editors Route', () => {
 
     expect(res.statusCode).toEqual(200);
     expect(res.json()).toEqual(editorsArray);
+  });
+
+  test('GET ${baseApiPath}/editors/devfile', async () => {
+    const res = await app.inject().get(`${baseApiPath}/editors/devfile`);
+    expect(res.statusCode).toEqual(400);
+  });
+
+  test('GET ${baseApiPath}/editors/devfile with che-editor queryparam', async () => {
+    const expectedDevfile = `schemaVersion: 2.2.2
+metadata:
+  name: che-code
+  attributes:
+    publisher: che-incubator
+    version: latest
+`;
+
+    const res = await app
+      .inject()
+      .get(`${baseApiPath}/editors/devfile?che-editor=che-incubator/che-code/latest`);
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual(expectedDevfile);
+  });
+
+  test('GET ${baseApiPath}/editors/devfile handle throw EditorNotFoundError', async () => {
+    (getDevWorkspaceClient as jest.Mock).mockImplementation(() => {
+      return {
+        editorsApi: {
+          get: () => Promise.reject(new EditorNotFoundError('Error')),
+        },
+      } as unknown as DevWorkspaceClient;
+    });
+
+    const res = await app
+      .inject()
+      .get(`${baseApiPath}/editors/devfile?che-editor=che-incubator/che-code/latest`);
+    expect(res.statusCode).toEqual(404);
   });
 });

--- a/packages/dashboard-backend/src/routes/api/__tests__/editors.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/editors.spec.ts
@@ -77,4 +77,19 @@ metadata:
       .get(`${baseApiPath}/editors/devfile?che-editor=che-incubator/che-code/latest`);
     expect(res.statusCode).toEqual(404);
   });
+
+  test('GET ${baseApiPath}/editors/devfile handle throw Error', async () => {
+    (getDevWorkspaceClient as jest.Mock).mockImplementation(() => {
+      return {
+        editorsApi: {
+          get: () => Promise.reject(new Error('Error')),
+        },
+      } as unknown as DevWorkspaceClient;
+    });
+
+    const res = await app
+      .inject()
+      .get(`${baseApiPath}/editors/devfile?che-editor=che-incubator/che-code/latest`);
+    expect(res.statusCode).toEqual(500);
+  });
 });

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -107,7 +107,21 @@ export const editorsArray: V222Devfile[] = [
   {
     schemaVersion: '2.2.2',
     metadata: {
-      name: 'editor',
+      name: 'che-code',
+      attributes: {
+        publisher: 'che-incubator',
+        version: 'latest',
+      },
+    },
+  },
+  {
+    schemaVersion: '2.2.2',
+    metadata: {
+      name: 'che-code',
+      attributes: {
+        publisher: 'che-incubator',
+        version: 'insiders',
+      },
     },
   },
 ];
@@ -140,89 +154,90 @@ export const stubAutoProvision = true;
 
 export const stubAdvancedAuthorization = {};
 
-export function getDevWorkspaceClient(
-  ..._args: Parameters<typeof helper>
-): ReturnType<typeof helper> {
-  return {
-    serverConfigApi: {
-      fetchCheCustomResource: () => ({}),
-      getDashboardWarning: _cheCustomResource => stubDashboardWarning,
-      getContainerBuild: _cheCustomResource => stubContainerBuild,
-      getDefaultComponents: _cheCustomResource => stubDefaultComponents,
-      getDefaultEditor: _cheCustomResource => stubDefaultEditor,
-      getDefaultPlugins: _cheCustomResource => stubDefaultPlugins,
-      getPluginRegistry: _cheCustomResource => stubPluginRegistry,
-      getPvcStrategy: _cheCustomResource => stubPvcStrategy,
-      getRunningWorkspacesLimit: _cheCustomResource => stubRunningWorkspacesLimit,
-      getAllWorkspacesLimit: _cheCustomResource => stubAllWorkspacesLimit,
-      getWorkspaceInactivityTimeout: _cheCustomResource => stubWorkspaceInactivityTimeout,
-      getWorkspaceRunTimeout: _cheCustomResource => stubWorkspaceRunTimeout,
-      getWorkspaceStartTimeout: _cheCustomResource => stubWorkspaceStartupTimeout,
-      getDefaultDevfileRegistryUrl: _cheCustomResource => defaultDevfileRegistryUrl,
-      getDefaultPluginRegistryUrl: _cheCustomResource => defaultPluginRegistryUrl,
-      getExternalDevfileRegistries: _cheCustomResource => externalDevfileRegistries,
-      getInternalRegistryDisableStatus: _cheCustomResource => internalRegistryDisableStatus,
-      getDashboardLogo: _cheCustomResource => dashboardLogo,
-      getAutoProvision: _cheCustomResource => stubAutoProvision,
-      getAdvancedAuthorization: _cheCustomResource => stubAdvancedAuthorization,
-    } as IServerConfigApi,
-    devworkspaceApi: {
-      create: (_devworkspace, _namespace) =>
-        Promise.resolve({ devWorkspace: stubDevWorkspace, headers: stubHeaders }),
-      delete: (_namespace, _name) => Promise.resolve(undefined),
-      getByName: (_namespace, _name) => Promise.resolve(stubDevWorkspace),
-      listInNamespace: _namespace => Promise.resolve(stubDevWorkspacesList),
-      patch: (_namespace, _name, _patches) =>
-        Promise.resolve({ devWorkspace: stubDevWorkspace, headers: stubHeaders }),
-    } as IDevWorkspaceApi,
-    dockerConfigApi: {
-      read: _namespace => Promise.resolve(stubDockerConfig),
-      update: (_namespace, _dockerCfg) => Promise.resolve(stubDockerConfig),
-    } as IDockerConfigApi,
-    kubeConfigApi: {
-      injectKubeConfig: (_namespace, _devworkspaceId) => Promise.resolve(undefined),
-    } as IKubeConfigApi,
-    devWorkspaceTemplateApi: {
-      create: _template => Promise.resolve(stubDevWorkspaceTemplate),
-      listInNamespace: _namespace => Promise.resolve(stubDevWorkspaceTemplatesList),
-      getByName: (_namespace, _name) => Promise.resolve(stubDevWorkspaceTemplate),
-      patch: (_namespace, _name, _patches) => Promise.resolve(stubDevWorkspaceTemplate),
-      delete: (_namespace, _name) => Promise.resolve(undefined),
-    } as IDevWorkspaceTemplateApi,
-    userProfileApi: {
-      getUserProfile: _namespace => Promise.resolve(stubUserProfile),
-    } as IUserProfileApi,
-    editorsApi: {
-      list: () => Promise.resolve(editorsArray),
-    } as IEditorsApi,
-    eventApi: {
-      listInNamespace: _namespace => Promise.resolve(stubEventsList),
-      watchInNamespace: _namespace => Promise.resolve(),
-      stopWatching: () => undefined,
-    } as IEventApi,
-    podApi: {
-      listInNamespace: _namespace => Promise.resolve(stubPodsList),
-      stopWatching: () => undefined,
-      watchInNamespace: _namespace => Promise.resolve(),
-    } as IPodApi,
-    logsApi: {
-      stopWatching: () => undefined,
-      watchInNamespace: (_namespace, _name) => Promise.resolve(),
-    } as ILogsApi,
-    personalAccessTokenApi: {
-      create: (_namespace, _token) => Promise.resolve({} as api.PersonalAccessToken),
-      delete: (_namespace, _tokenName) => Promise.resolve(),
-      listInNamespace: _namespace => Promise.resolve(stubPersonalAccessTokenList),
-      replace: (_namespace, _token) => Promise.resolve({} as api.PersonalAccessToken),
-    } as IPersonalAccessTokenApi,
-    gitConfigApi: {
-      read: _namespace => Promise.resolve({} as api.IGitConfig),
-      patch: (_namespace, _gitconfig) => Promise.resolve({} as api.IGitConfig),
-    } as IGitConfigApi,
-    sshKeysApi: {
-      add: (_namespace, _sshKey) => Promise.resolve({} as api.SshKey),
-      delete: (_namespace, _name) => Promise.resolve(),
-      list: _namespace => Promise.resolve(stubSshKeysList),
-    } as IShhKeysApi,
-  } as DevWorkspaceClient;
-}
+export const getDevWorkspaceClient = jest.fn(
+  (..._args: Parameters<typeof helper>): ReturnType<typeof helper> => {
+    return {
+      serverConfigApi: {
+        fetchCheCustomResource: () => ({}),
+        getDashboardWarning: _cheCustomResource => stubDashboardWarning,
+        getContainerBuild: _cheCustomResource => stubContainerBuild,
+        getDefaultComponents: _cheCustomResource => stubDefaultComponents,
+        getDefaultEditor: _cheCustomResource => stubDefaultEditor,
+        getDefaultPlugins: _cheCustomResource => stubDefaultPlugins,
+        getPluginRegistry: _cheCustomResource => stubPluginRegistry,
+        getPvcStrategy: _cheCustomResource => stubPvcStrategy,
+        getRunningWorkspacesLimit: _cheCustomResource => stubRunningWorkspacesLimit,
+        getAllWorkspacesLimit: _cheCustomResource => stubAllWorkspacesLimit,
+        getWorkspaceInactivityTimeout: _cheCustomResource => stubWorkspaceInactivityTimeout,
+        getWorkspaceRunTimeout: _cheCustomResource => stubWorkspaceRunTimeout,
+        getWorkspaceStartTimeout: _cheCustomResource => stubWorkspaceStartupTimeout,
+        getDefaultDevfileRegistryUrl: _cheCustomResource => defaultDevfileRegistryUrl,
+        getDefaultPluginRegistryUrl: _cheCustomResource => defaultPluginRegistryUrl,
+        getExternalDevfileRegistries: _cheCustomResource => externalDevfileRegistries,
+        getInternalRegistryDisableStatus: _cheCustomResource => internalRegistryDisableStatus,
+        getDashboardLogo: _cheCustomResource => dashboardLogo,
+        getAutoProvision: _cheCustomResource => stubAutoProvision,
+        getAdvancedAuthorization: _cheCustomResource => stubAdvancedAuthorization,
+      } as IServerConfigApi,
+      devworkspaceApi: {
+        create: (_devworkspace, _namespace) =>
+          Promise.resolve({ devWorkspace: stubDevWorkspace, headers: stubHeaders }),
+        delete: (_namespace, _name) => Promise.resolve(undefined),
+        getByName: (_namespace, _name) => Promise.resolve(stubDevWorkspace),
+        listInNamespace: _namespace => Promise.resolve(stubDevWorkspacesList),
+        patch: (_namespace, _name, _patches) =>
+          Promise.resolve({ devWorkspace: stubDevWorkspace, headers: stubHeaders }),
+      } as IDevWorkspaceApi,
+      dockerConfigApi: {
+        read: _namespace => Promise.resolve(stubDockerConfig),
+        update: (_namespace, _dockerCfg) => Promise.resolve(stubDockerConfig),
+      } as IDockerConfigApi,
+      kubeConfigApi: {
+        injectKubeConfig: (_namespace, _devworkspaceId) => Promise.resolve(undefined),
+      } as IKubeConfigApi,
+      devWorkspaceTemplateApi: {
+        create: _template => Promise.resolve(stubDevWorkspaceTemplate),
+        listInNamespace: _namespace => Promise.resolve(stubDevWorkspaceTemplatesList),
+        getByName: (_namespace, _name) => Promise.resolve(stubDevWorkspaceTemplate),
+        patch: (_namespace, _name, _patches) => Promise.resolve(stubDevWorkspaceTemplate),
+        delete: (_namespace, _name) => Promise.resolve(undefined),
+      } as IDevWorkspaceTemplateApi,
+      userProfileApi: {
+        getUserProfile: _namespace => Promise.resolve(stubUserProfile),
+      } as IUserProfileApi,
+      editorsApi: {
+        list: () => Promise.resolve(editorsArray),
+        get: _id => Promise.resolve(editorsArray[0]),
+      } as IEditorsApi,
+      eventApi: {
+        listInNamespace: _namespace => Promise.resolve(stubEventsList),
+        watchInNamespace: _namespace => Promise.resolve(),
+        stopWatching: () => undefined,
+      } as IEventApi,
+      podApi: {
+        listInNamespace: _namespace => Promise.resolve(stubPodsList),
+        stopWatching: () => undefined,
+        watchInNamespace: _namespace => Promise.resolve(),
+      } as IPodApi,
+      logsApi: {
+        stopWatching: () => undefined,
+        watchInNamespace: (_namespace, _name) => Promise.resolve(),
+      } as ILogsApi,
+      personalAccessTokenApi: {
+        create: (_namespace, _token) => Promise.resolve({} as api.PersonalAccessToken),
+        delete: (_namespace, _tokenName) => Promise.resolve(),
+        listInNamespace: _namespace => Promise.resolve(stubPersonalAccessTokenList),
+        replace: (_namespace, _token) => Promise.resolve({} as api.PersonalAccessToken),
+      } as IPersonalAccessTokenApi,
+      gitConfigApi: {
+        read: _namespace => Promise.resolve({} as api.IGitConfig),
+        patch: (_namespace, _gitconfig) => Promise.resolve({} as api.IGitConfig),
+      } as IGitConfigApi,
+      sshKeysApi: {
+        add: (_namespace, _sshKey) => Promise.resolve({} as api.SshKey),
+        delete: (_namespace, _name) => Promise.resolve(),
+        list: _namespace => Promise.resolve(stubSshKeysList),
+      } as IShhKeysApi,
+    } as DevWorkspaceClient;
+  },
+);

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/BulkDeleteButton/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/BulkDeleteButton/__mocks__/index.tsx
@@ -21,8 +21,8 @@ export class WorkspaceActionsBulkDeleteButton extends React.Component<Props> {
     const { isDisabled, onAction, workspaces } = this.props;
 
     const handleAction = () =>
-      workspaces.map(workspace =>
-        onAction?.(WorkspaceAction.DELETE_WORKSPACE, workspace.uid, true),
+      workspaces.map(
+        workspace => onAction?.(WorkspaceAction.DELETE_WORKSPACE, workspace.uid, true),
       );
 
     return (

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/BulkDeleteButton/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/BulkDeleteButton/__mocks__/index.tsx
@@ -21,8 +21,8 @@ export class WorkspaceActionsBulkDeleteButton extends React.Component<Props> {
     const { isDisabled, onAction, workspaces } = this.props;
 
     const handleAction = () =>
-      workspaces.map(
-        workspace => onAction?.(WorkspaceAction.DELETE_WORKSPACE, workspace.uid, true),
+      workspaces.map(workspace =>
+        onAction?.(WorkspaceAction.DELETE_WORKSPACE, workspace.uid, true),
       );
 
     return (


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds a new route exposed by the dashboard backend:
![image](https://github.com/eclipse-che/che-dashboard/assets/83611742/add9030e-0968-4e75-8f6e-cbc576c9a8bb)


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/22994

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
When testing on Eclipse Che, access the following link and verify that the `che-code/latest` devfile is returned:
```
<CHE-HOST>/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest
```


If no `che-editor` query param is provided, then there is a 400 error:
```
<CHE-HOST>/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest
```

If there is not editor with id `che-editor`, there is a 404 error:
```
<CHE-HOST>/dashboard/api/editors/devfile?che-editor=doesnotexist
```

Additionally, create this following devworkspace and verify that the workspace starts and verify that you can access the editor:
```
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: my-devworkspace
spec:
  routingClass: che
  started: true
  contributions:
    - name: ide
      uri: http://che-dashboard.eclipse-che.svc.cluster.local:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest
  template:
    projects:
      - name: my-project-name
        git:
          remotes:
            origin: https://github.com/eclipse-che/che-docs
    components:
      - name: tooling-container
        container:
          image: quay.io/devfile/universal-developer-image:ubi8-latest
```
#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
