### PR TITLE
fix: Git provider endpoint validation

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
@@ -52,6 +52,19 @@ describe('GitProviderEndpoint', () => {
     expect(screen.queryByText('The URL is not valid.')).toBeFalsy();
   });
 
+  it('should handle a correct endpoint with the port part', () => {
+    const endpoint = 'https://bitbucket.org:8443';
+    renderComponent(undefined);
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+
+    const input = screen.getByRole('textbox');
+    userEvent.paste(input, endpoint);
+
+    expect(mockOnChange).toHaveBeenCalledWith(expect.stringContaining(endpoint), true);
+    expect(screen.queryByText('The URL is not valid.')).toBeFalsy();
+  });
+
   it('should handle endpoint started with an incorrect protocol', () => {
     const endpoint = 'asdf://provider/endpoint';
     renderComponent(undefined);

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
@@ -99,7 +99,8 @@ export class GitProviderEndpoint extends React.PureComponent<Props, State> {
     validated: ValidatedOptions;
     sanitized: string;
   } {
-    const validationRe = /^https?:\/\/(?:(?:[a-z\d]+(?:-[a-z\d]+)*)\.)+[a-z]{2,}(?:\/[^\s]*)?$/i;
+    const validationRe =
+      /^https?:\/\/(?:(?:[a-z\d]+(?:-[a-z\d]+)*)\.)+[a-z]{2,}(?:\/[^\s]*)?(?::\d+)?$/i;
 
     if (validationRe.test(providerEndpoint) === false) {
       return {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes Git provider endpoint validation.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23013

