### PR TITLE
fix: If persistHome is enabled, the token in .kube/config isn't renewed

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "@adobe/css-tools": "^4.3.2",
     "ip": "^2.0.1",
     "undici": "^5.28.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/dashboard-backend/package.json
+++ b/packages/dashboard-backend/package.json
@@ -11,7 +11,7 @@
     "lint:check": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}'",
     "lint:fix": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}' --fix",
     "start:debug": "nodemon --inspect lib/server/backend.js",
-    "test": "jest",
+    "test": "jest --silent=false",
     "test:watch": "yarn test --watch"
   },
   "contributors": [

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -76,6 +76,11 @@ export class KubeConfigApiService implements IKubeConfigApi {
         );
 
         // if -f ${kubeConfigDirectory}/config is not found then sync kubeconfig to the container
+        // https://github.com/eclipse-che/che/issues/22924#issuecomment-2059944557
+        // TODO:
+        //  - Create a function that will check if the kubeconfig look's like one created by this function
+        //  - Check if the kubeconfig is mounted from a secret/configmap
+        //  - Check if the token is valid, if not replace the config
         const kubeConfig = this.setNamespaceInContext(this.kubeConfig, namespace);
         await exec(
           podName,

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -75,13 +75,31 @@ export class KubeConfigApiService implements IKubeConfigApi {
           this.getServerConfig(),
         );
 
-        // if -f ${kubeConfigDirectory}/config is not found then sync kubeconfig to the container
-        // https://github.com/eclipse-che/che/issues/22924#issuecomment-2059944557
-        // TODO:
-        //  - Create a function that will check if the kubeconfig look's like one created by this function
-        //  - Check if the kubeconfig is mounted from a secret/configmap
-        //  - Check if the token is valid, if not replace the config
-        const kubeConfig = this.setNamespaceInContext(this.kubeConfig, namespace);
+        // check if the kubeconfig is already mounted
+        if (container.volumeMounts?.some(vm => vm.mountPath.includes(kubeConfigDirectory))) {
+          logger.info(
+            `Kubeconfig is already mounted in ${namespace}/${podName}/${containerName} skipping...`,
+          );
+          continue;
+        }
+        let kubeConfig = this.setNamespaceInContext(this.kubeConfig, namespace);
+
+        // Get the kubeconfig from the container
+        const { stdOut, stdError } = await exec(
+          podName,
+          namespace,
+          containerName,
+          ['sh', '-c', `[ -f ${kubeConfigDirectory}/config ] || cat ${kubeConfigDirectory}/config`],
+          this.getServerConfig(),
+        );
+
+        if (stdError !== '') {
+          logger.warn(`Error reading kubeconfig from container: ${stdError}`);
+        }
+        if (stdError === '' && stdOut !== '') {
+          kubeConfig = this.mergeKubeConfig(stdOut, kubeConfig);
+        }
+
         await exec(
           podName,
           namespace,
@@ -207,6 +225,39 @@ export class KubeConfigApiService implements IKubeConfigApi {
     } catch (e) {
       logger.error(e, 'Failed to parse kubeconfig');
       return kubeConfig;
+    }
+  }
+
+  private mergeKubeConfig(kubeconfigSource: string, generatedKubeconfig: string): string {
+    try {
+      const kubeConfigJson = JSON.parse(kubeconfigSource);
+      const generatedKubeConfigJson = JSON.parse(generatedKubeconfig);
+      for (const context of generatedKubeConfigJson.contexts) {
+        if (kubeConfigJson.contexts.find((c: any) => c.name === context.name)) {
+          kubeConfigJson.contexts = kubeConfigJson.contexts.filter(
+            (c: any) => c.name !== context.name,
+          );
+        }
+        kubeConfigJson.contexts.push(context);
+      }
+      for (const cluster of generatedKubeConfigJson.clusters) {
+        if (kubeConfigJson.clusters.find((c: any) => c.name === cluster.name)) {
+          kubeConfigJson.clusters = kubeConfigJson.clusters.filter(
+            (c: any) => c.name !== cluster.name,
+          );
+        }
+        kubeConfigJson.clusters.push(cluster);
+      }
+      for (const user of generatedKubeConfigJson.users) {
+        if (kubeConfigJson.users.find((c: any) => c.name === user.name)) {
+          kubeConfigJson.users = kubeConfigJson.users.filter((c: any) => c.name !== user.name);
+        }
+        kubeConfigJson.users.push(user);
+      }
+      return JSON.stringify(kubeConfigJson, undefined, '  ');
+    } catch (e) {
+      logger.error(e, 'Failed to merge kubeconfig');
+      return kubeconfigSource;
     }
   }
 }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -76,7 +76,7 @@ export class KubeConfigApiService implements IKubeConfigApi {
         );
 
         // check if the kubeconfig is already mounted
-        if (container.volumeMounts?.some(vm => vm.mountPath.includes(kubeConfigDirectory))) {
+        if (container.volumeMounts?.some(vm => vm.mountPath === kubeConfigDirectory)) {
           logger.info(
             `Kubeconfig is already mounted in ${namespace}/${podName}/${containerName} skipping...`,
           );


### PR DESCRIPTION
### What does this PR do?

This PR has for goal to fix [this issue](https://github.com/eclipse-che/che/issues/22924).
The aforementioned issue present a situation where if the persist Home option is enabled in che's conf, the kubeconfig that should be in ~/.kube/config isn't updated any more with an up-to-date token. This situation hinder further work and prevent the monitoring extension in VsCode to work properly.

So, this PR patch the function that should inject into each container the Kubeconfig with:
- A check that will not inject the kubeconfig in the case where the user manually inject the kubeconfig 
- A fetch that will take the existing kubeconfig inside the container and try to merge it with the generated one. The merge is based on the name, if a block with the same name exist in the existing kubeconfig it will be replaced. 


### What issues does this PR fix or reference?

<https://github.com/eclipse-che/che/issues/22924>


### Is it tested? How?

The Lerna  (Test/Lint) command has been executed, and I set it up in my own che server.


#### Release Notes

N/A

#### Docs PR

I don't think that this should add a doc entry has it is a bug.
