### PR TITLE
fix: stop using mirror.centos.org repo

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -11,12 +11,13 @@
 # https://github.com/eclipse-che/che-release/blob/main/.github/workflows/update-base-images.yml
 FROM registry.ci.openshift.org/openshift/release:golang-1.20
 
+SHELL ["/bin/bash", "-c"]
+
 # Temporary workaround since mirror.centos.org is down and can be replaced with vault.centos.org
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-SHELL ["/bin/bash", "-c"]
 
 # Install yq, kubectl, chectl cli.
 RUN yum install --assumeyes -d1 python3-pip  httpd-tools nodejs && \

--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -9,7 +9,12 @@
 #
 # Note: if we used a UBI image we could keep this current with
 # https://github.com/eclipse-che/che-release/blob/main/.github/workflows/update-base-images.yml
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.20
+
+# Temporary workaround since mirror.centos.org is down and can be replaced with vault.centos.org
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Replaces usage of http://mirrorlist.centos.org/ repo with http://vault.centos.org/ as http://mirrorlist.centos.org/ is now down that Centos 7 is EOL as of July 1st 2024.
* Without this fix, the Dockerfile fails to build on [Openshift CI](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/eclipse-che_che-dashboard/1144/pull-ci-eclipse-che-che-dashboard-main-v14-dashboard-happy-path/1809377858603192320) with the error:
```
Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error" 
```
* This is more of a temporary work-around as the issue probably should be fixed in the image being used:
`registry.ci.openshift.org/openshift/release:golang-1.20`

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
N/A

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
