### PR TITLE
Add whitespace to the is Http check regex pattern

### DIFF
--- a/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/__tests__/factoryLocationAdapter.spec.ts
@@ -142,6 +142,10 @@ describe('FactoryLocationAdapter Service', () => {
         'https://git-test.com/dummy.git?remotes={{origin,https://git-test.com/origin.git},{upstream,https://git-test.com/upstream.git}}';
       expect(FactoryLocationAdapter.isHttpLocation(location)).toBeTruthy();
     });
+    it('should return true for https git url with whitespace', () => {
+      const location = 'https://git-test.com/dum my.git';
+      expect(FactoryLocationAdapter.isHttpLocation(location)).toBeTruthy();
+    });
   });
 
   it('should return factory reference without oauth params', () => {

--- a/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/factory-location-adapter/index.ts
@@ -54,7 +54,7 @@ export class FactoryLocationAdapter implements FactoryLocation {
   }
 
   public static isHttpLocation(href: string): boolean {
-    return /^(https?:\/\/.)[-a-zA-Z0-9@:%._+~#=]{2,}\b([-a-zA-Z0-9@:%_+.~#?&/={},]*)$/.test(href);
+    return /^(https?:\/\/.)[-a-zA-Z0-9@:%._+~#=]{2,}\b([-a-zA-Z0-9@:%_+.~#?&/={}, ]*)$/.test(href);
   }
 
   public static isSshLocation(href: string): boolean {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add whitespace to the `isHttpLocation` check regex pattern.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6790

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Try to start a workspace from a repository url with whitespace, e.g. `https://vinokurig@dev.azure.com/vinokurig/public/_git/re po`

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
