### PR TITLE
fix: remove check if the .kube/config exist and prevent replacing or reading it

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/kubeConfigApi.spec.ts
@@ -40,17 +40,15 @@ const spyExec = jest
     if (command.some(c => c === 'printenv HOME')) {
       // directory where to create the kubeconfig
       return mockExecPrintenvHome();
-    } else if (
-      command.some(c =>
-        c.startsWith(`[ -f ${kubeConfigDir}/config ] || cat ${kubeConfigDir}/config`),
-      )
-    ) {
+    } else if (command.some(c => c.startsWith(`cat ${kubeConfigDir}/config`))) {
       // file empty
       return mockExecCatKubeConfig();
     } else if (command.some(c => c.startsWith('mkdir -p'))) {
       // crete the directory
       return Promise.resolve();
-    } else if (command.some(c => c.startsWith(`[ -f ${homeUserDir}`))) {
+    } else if (
+      command.some(c => c.startsWith(`echo '`) && c.endsWith(`' > ${kubeConfigDir}/config`))
+    ) {
       // sync config
       return Promise.resolve();
     }
@@ -134,7 +132,7 @@ describe('Kubernetes Config API Service', () => {
       workspaceName,
       namespace,
       containerName,
-      ['sh', '-c', `[ -f ${kubeConfigDir}/config ] || cat ${kubeConfigDir}/config`],
+      ['sh', '-c', `cat ${kubeConfigDir}/config`],
       expect.anything(),
     );
 
@@ -144,7 +142,7 @@ describe('Kubernetes Config API Service', () => {
       workspaceName,
       namespace,
       containerName,
-      ['sh', '-c', `[ -f ${kubeConfigDir}/config ] || echo '${config}' > ${kubeConfigDir}/config`],
+      ['sh', '-c', `echo '${config}' > ${kubeConfigDir}/config`],
       expect.anything(),
     );
   });

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -93,9 +93,11 @@ export class KubeConfigApiService implements IKubeConfigApi {
           this.getServerConfig(),
         );
 
+        // If there is no kubeconfig in the container, stdOut will be empty and stdError will container the error
         if (stdError !== '') {
           logger.warn(`Error reading kubeconfig from container: ${stdError}`);
         }
+        // If no error and stdout is not empty, merge the kubeconfig
         if (stdError === '' && stdOut !== '') {
           kubeConfig = this.mergeKubeConfig(stdOut, kubeConfig);
         }
@@ -224,6 +226,8 @@ export class KubeConfigApiService implements IKubeConfigApi {
     }
   }
 
+  // Merge the kubeconfig from the source into the generated kubeconfig
+  // If the inbounds kubeconfig match the kubeconfig format then merge them
   private mergeKubeConfig(kubeconfigSource: string, generatedKubeconfig: string): string {
     try {
       const kubeConfigJson = JSON.parse(kubeconfigSource);

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -89,7 +89,7 @@ export class KubeConfigApiService implements IKubeConfigApi {
           podName,
           namespace,
           containerName,
-          ['sh', '-c', `[ -f ${kubeConfigDirectory}/config ] || cat ${kubeConfigDirectory}/config`],
+          ['sh', '-c', `cat ${kubeConfigDirectory}/config`],
           this.getServerConfig(),
         );
 
@@ -104,11 +104,7 @@ export class KubeConfigApiService implements IKubeConfigApi {
           podName,
           namespace,
           containerName,
-          [
-            'sh',
-            '-c',
-            `[ -f ${kubeConfigDirectory}/config ] || echo '${kubeConfig}' > ${kubeConfigDirectory}/config`,
-          ],
+          ['sh', '-c', `echo '${kubeConfig}' > ${kubeConfigDirectory}/config`],
           this.getServerConfig(),
         );
 
@@ -256,7 +252,7 @@ export class KubeConfigApiService implements IKubeConfigApi {
       }
       return JSON.stringify(kubeConfigJson, undefined, '  ');
     } catch (e) {
-      logger.error(e, 'Failed to merge kubeconfig');
+      logger.error(e, 'Failed to merge kubeconfig, returning source');
       return kubeconfigSource;
     }
   }


### PR DESCRIPTION
### What does this PR do?

Fix an error made in #1141 (a copy and paste error), I forgot to remove the ```[ -f ${kubeConfigDirectory}/config ] ``` that check if the file exists, and the goal here was either to replace the 

### What issues does this PR fix or reference?

https://github.com/eclipse-che/che/issues/22924

### Is it tested? How?

1. Fix test file to match the new form of the command
2. Build the image (podman build / podman push)
3. fix che cluster with the image and delete pod
4. Start a new workspace and check that it work
5. edit the current kubeconfig by adding random char in the middle of the token
6. Reload the IDE and check that the metrics doesn't show up
7. Reload workspaces
8. Check that the metrics show up
9.  Start an old workspace (fixed by removing the ssh key :D )  that wasn't showing metrics
10. See that the metrics are up



#### Release Notes

N/A

#### Docs PR

N/A
