### PR TITLE
workspace status flickering on startup

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
@@ -408,66 +408,6 @@ describe('Starting steps, starting a workspace', () => {
     expect(mockOnRestart).not.toHaveBeenCalled();
   });
 
-  test('workspace is STARTING then STOPPED', async () => {
-    const store = new FakeStoreBuilder()
-      .withDwServerConfig(serverConfig)
-      .withDevWorkspaces({
-        workspaces: [
-          new DevWorkspaceBuilder()
-            .withName(workspaceName)
-            .withNamespace(namespace)
-            .withStatus({ phase: 'STARTING' })
-            .build(),
-        ],
-      })
-      .build();
-
-    const { reRenderComponent } = renderComponent(store);
-
-    await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
-
-    // no errors at this moment
-    expect(mockOnError).not.toHaveBeenCalled();
-
-    const nextStore = new FakeStoreBuilder()
-      .withDevWorkspaces({
-        workspaces: [
-          new DevWorkspaceBuilder()
-            .withName(workspaceName)
-            .withNamespace(namespace)
-            .withStatus({ phase: 'STOPPED' })
-            .build(),
-        ],
-      })
-      .build();
-    reRenderComponent(nextStore);
-
-    await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
-
-    // should report the error
-    const expectAlertItem = expect.objectContaining({
-      title: 'Failed to open the workspace',
-      children: 'The workspace status changed unexpectedly to "Stopped".',
-      actionCallbacks: [
-        expect.objectContaining({
-          title: 'Restart',
-          callback: expect.any(Function),
-        }),
-        expect.objectContaining({
-          title: 'Restart with default devfile',
-          callback: expect.any(Function),
-        }),
-      ],
-    });
-    await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
-
-    // should not start the workspace
-    expect(mockStartWorkspace).not.toHaveBeenCalled();
-
-    expect(mockOnNextStep).not.toHaveBeenCalled();
-    expect(mockOnRestart).not.toHaveBeenCalled();
-  });
-
   test('workspace is STARTING then FAILING', async () => {
     const store = new FakeStoreBuilder()
       .withDwServerConfig(serverConfig)

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
@@ -177,8 +177,7 @@ class StartingStepStartWorkspace extends ProgressStep<Props, State> {
 
     if (
       workspaceStatusIs(workspace, DevWorkspaceStatus.TERMINATING) ||
-      (this.state.shouldStart === false &&
-        workspaceStatusIs(workspace, DevWorkspaceStatus.STOPPED, DevWorkspaceStatus.FAILED))
+      (this.state.shouldStart === false && workspaceStatusIs(workspace, DevWorkspaceStatus.FAILED))
     ) {
       throw new Error(
         workspace.error || `The workspace status changed unexpectedly to "${workspace.status}".`,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

- Removed the unwanted ability to overwrite a newer workspace status with an older one;
- Workspace startup page: Fixed status glitches during a workspace start.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-6287

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Che and patch the CR using the command from the github-actions bot.
2. Create and start workspaces. There should be no `Status changed unexpectedly to "Stopped"` warning message while the workspace continues to start.
