### PR TITLE
chore: bump devfile/api to 2.3.0; bump devworkspace generator

### DIFF
--- a/.deps/EXCLUDED/dev.md
+++ b/.deps/EXCLUDED/dev.md
@@ -14,3 +14,4 @@ This file contains a manual contribution to .deps/dev.md and it's needed because
 | `fsevents@2.3.3` | transitive dependency |
 | `node-gyp@10.1.0` | transitive dependency |
 | `nx@19.0.7` | transitive dependency |
+| `@devfile/api@2.3.0-1721400636` | trusted dependency |

--- a/.deps/EXCLUDED/dev.md
+++ b/.deps/EXCLUDED/dev.md
@@ -14,4 +14,4 @@ This file contains a manual contribution to .deps/dev.md and it's needed because
 | `fsevents@2.3.3` | transitive dependency |
 | `node-gyp@10.1.0` | transitive dependency |
 | `nx@19.0.7` | transitive dependency |
-| `@devfile/api@2.3.0-1721400636` | trusted dependency |
+| `@devfile/api@2.3.0-1721400636` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1721400636) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -47,10 +47,10 @@
 | [`@csstools/css-tokenizer@2.2.1`](https://github.com/csstools/postcss-plugins.git) | MIT | clearlydefined |
 | [`@csstools/media-query-list-parser@2.1.5`](https://github.com/csstools/postcss-plugins.git) | MIT | clearlydefined |
 | [`@csstools/selector-specificity@3.0.0`](https://github.com/csstools/postcss-plugins.git) | MIT-0 | transitive dependency |
-| [`@devfile/api@2.2.2-1715367693`](https://github.com/GIT_USER_ID/GIT_REPO_ID.git) | Apache-2.0 | clearlydefined |
+| [`@devfile/api@2.3.0-1721400636`](https://github.com/GIT_USER_ID/GIT_REPO_ID.git) | Apache-2.0 | trusted dependency |
 | [`@discoveryjs/json-ext@0.5.7`](https://github.com/discoveryjs/json-ext.git) | MIT | clearlydefined |
 | `@eclipse-che/api@7.86.0` | EPL-2.0 | ecd.che |
-| [`@eslint-community/eslint-utils@4.4.0`](https://github.com/eslint-community/eslint-utils) | MIT | #8032 |
+| [`@eslint-community/eslint-utils@4.4.0`](https://github.com/eslint-community/eslint-utils) | MIT | #15285 |
 | [`@eslint-community/regexpp@4.10.0`](https://github.com/eslint-community/regexpp) | MIT | clearlydefined |
 | [`@eslint/eslintrc@2.1.3`](https://github.com/eslint/eslintrc.git) | MIT | #9908 |
 | [`@eslint/js@8.53.0`](https://github.com/eslint/eslint.git) | MIT | #11438 |
@@ -303,7 +303,7 @@
 | [`char-regex@1.0.2`](https://github.com/Richienb/char-regex.git) | MIT | clearlydefined |
 | [`chardet@0.7.0`](git@github.com:runk/node-chardet.git) | MIT | clearlydefined |
 | [`chownr@2.0.0`](git://github.com/isaacs/chownr.git) | ISC | clearlydefined |
-| [`chrome-trace-event@1.0.3`](https://github.com/samccone/chrome-trace-event.git) | MIT | #2414 |
+| [`chrome-trace-event@1.0.3`](https://github.com/samccone/chrome-trace-event.git) | MIT | #15406 |
 | [`ci-info@3.9.0`](https://github.com/watson/ci-info.git) | MIT | clearlydefined |
 | [`cjs-module-lexer@1.2.3`](git+https://github.com/nodejs/cjs-module-lexer.git) | MIT | #9069 |
 | [`clean-css@5.3.2`](https://github.com/clean-css/clean-css.git) | MIT | clearlydefined |
@@ -387,7 +387,7 @@
 | [`detect-newline@3.1.0`](https://github.com/sindresorhus/detect-newline.git) | MIT | clearlydefined |
 | [`diff-sequences@29.6.3`](https://github.com/jestjs/jest.git) | MIT | clearlydefined |
 | [`dir-glob@3.0.1`](https://github.com/kevva/dir-glob.git) | MIT | clearlydefined |
-| [`doctrine@2.1.0`](https://github.com/eslint/doctrine.git) | Apache-2.0 | #1987 |
+| [`doctrine@2.1.0`](https://github.com/eslint/doctrine.git) | Apache-2.0 | #15247 |
 | [`dom-accessibility-api@0.5.16`](https://github.com/eps1lon/dom-accessibility-api.git) | MIT | clearlydefined |
 | [`dom-converter@0.2.0`](https://github.com/AriaMinaei/dom-converter) | MIT | clearlydefined |
 | [`dom-serializer@1.4.1`](git://github.com/cheeriojs/dom-renderer.git) | MIT | clearlydefined |
@@ -430,10 +430,10 @@
 | [`eslint-plugin-react@7.33.2`](https://github.com/jsx-eslint/eslint-plugin-react) | MIT | #9877 |
 | [`eslint-plugin-simple-import-sort@10.0.0`](https://github.com/lydell/eslint-plugin-simple-import-sort.git) | MIT | clearlydefined |
 | [`eslint-scope@5.1.1`](https://github.com/eslint/eslint-scope.git) | BSD-2-Clause | clearlydefined |
-| [`eslint-visitor-keys@3.4.3`](https://github.com/eslint/eslint-visitor-keys.git) | Apache-2.0 | #7729 |
+| [`eslint-visitor-keys@3.4.3`](https://github.com/eslint/eslint-visitor-keys.git) | Apache-2.0 | #15274 |
 | [`eslint-webpack-plugin@4.0.1`](https://github.com/webpack-contrib/eslint-webpack-plugin.git) | MIT | clearlydefined |
 | [`eslint@8.53.0`](https://github.com/eslint/eslint.git) | MIT | #11437 |
-| [`espree@9.6.1`](https://github.com/eslint/espree.git) | BSD-2-Clause | #9308 |
+| [`espree@9.6.1`](https://github.com/eslint/espree.git) | BSD-2-Clause | #15293 |
 | [`esprima@4.0.1`](https://github.com/jquery/esprima.git) | BSD-2-Clause | #995 |
 | [`esquery@1.5.0`](https://github.com/estools/esquery.git) | BSD-3-Clause | #7469 |
 | [`esrecurse@4.3.0`](https://github.com/estools/esrecurse.git) | BSD-2-Clause | clearlydefined |
@@ -452,7 +452,7 @@
 | [`fast-diff@1.3.0`](https://github.com/jhchen/fast-diff) | Apache-2.0 | clearlydefined |
 | [`fast-glob@3.3.2`](https://github.com/mrmlnc/fast-glob.git) | MIT | #9307 |
 | [`fast-json-stable-stringify@2.1.0`](git://github.com/epoberezkin/fast-json-stable-stringify.git) | MIT | clearlydefined |
-| [`fast-levenshtein@2.0.6`](https://github.com/hiddentao/fast-levenshtein.git) | MIT | #2428 |
+| [`fast-levenshtein@2.0.6`](https://github.com/hiddentao/fast-levenshtein.git) | MIT | #15236 |
 | [`fastest-levenshtein@1.0.16`](git+https://github.com/ka-weihe/fastest-levenshtein.git) | MIT | clearlydefined |
 | [`fb-watchman@2.0.2`](git@github.com:facebook/watchman.git) | Apache-2.0 | #5379 |
 | [`figures@3.2.0`](https://github.com/sindresorhus/figures.git) | MIT | clearlydefined |
@@ -466,7 +466,7 @@
 | [`find-up@4.1.0`](https://github.com/sindresorhus/find-up.git) | MIT | clearlydefined |
 | [`flat-cache@3.1.1`](https://github.com/jaredwray/flat-cache.git) | MIT | clearlydefined |
 | [`flat@5.0.2`](git://github.com/hughsk/flat.git) | BSD-3-Clause | clearlydefined |
-| [`flatted@3.2.9`](git+https://github.com/WebReflection/flatted.git) | ISC | #2430 |
+| [`flatted@3.2.9`](git+https://github.com/WebReflection/flatted.git) | ISC | #15360 |
 | [`for-each@0.3.3`](git://github.com/Raynos/for-each.git) | MIT | clearlydefined |
 | [`foreground-child@3.1.1`](git+https://github.com/tapjs/foreground-child.git) | ISC | #8232 |
 | [`forever-agent@0.6.1`](https://github.com/mikeal/forever-agent) | Apache-2.0 | clearlydefined |
@@ -645,7 +645,7 @@
 | [`json-stable-stringify-without-jsonify@1.0.1`](git://github.com/samn/json-stable-stringify.git) | MIT | clearlydefined |
 | [`json-stringify-nice@1.1.4`](https://github.com/isaacs/json-stringify-nice) | ISC | clearlydefined |
 | [`json-stringify-safe@5.0.1`](git://github.com/isaacs/json-stringify-safe) | ISC | clearlydefined |
-| [`json5@2.2.3`](git+https://github.com/json5/json5.git) | MIT | #2126 |
+| [`json5@2.2.3`](git+https://github.com/json5/json5.git) | MIT | #15226 |
 | [`jsonc-parser@3.2.0`](https://github.com/microsoft/node-jsonc-parser) | MIT | #12891 |
 | [`jsonfile@6.1.0`](git@github.com:jprichardson/node-jsonfile.git) | MIT | clearlydefined |
 | [`jsonparse@1.3.1`](http://github.com/creationix/jsonparse.git) | MIT | clearlydefined |
@@ -742,7 +742,7 @@
 | [`oauth-sign@0.9.0`](https://github.com/mikeal/oauth-sign) | Apache-2.0 | clearlydefined |
 | [`object-hash@2.2.0`](https://github.com/puleos/object-hash) | MIT | clearlydefined |
 | [`object-keys@1.1.1`](git://github.com/ljharb/object-keys.git) | MIT | clearlydefined |
-| [`object.assign@4.1.4`](git://github.com/ljharb/object.assign.git) | MIT | #3232 |
+| [`object.assign@4.1.4`](git://github.com/ljharb/object.assign.git) | MIT | #15306 |
 | [`object.entries@1.1.7`](git://github.com/es-shims/Object.entries.git) | MIT | #4671 |
 | [`object.fromentries@2.0.7`](git://github.com/es-shims/Object.fromEntries.git) | MIT | #4600 |
 | [`object.hasown@1.1.3`](https://github.com/es-shims/Object.hasOwn.git) | MIT | #4667 |
@@ -866,7 +866,7 @@
 | [`resolve-cwd@3.0.0`](https://github.com/sindresorhus/resolve-cwd.git) | MIT | clearlydefined |
 | [`resolve-from@5.0.0`](https://github.com/sindresorhus/resolve-from.git) | MIT | clearlydefined |
 | [`resolve.exports@2.0.2`](https://github.com/lukeed/resolve.exports.git) | MIT | clearlydefined |
-| [`resolve@1.22.8`](git://github.com/browserify/resolve.git) | MIT | #2409 |
+| [`resolve@1.22.8`](git://github.com/browserify/resolve.git) | MIT | #15315 |
 | [`restore-cursor@3.1.0`](https://github.com/sindresorhus/restore-cursor.git) | MIT | clearlydefined |
 | [`retry@0.12.0`](git://github.com/tim-kos/node-retry.git) | MIT | clearlydefined |
 | [`reusify@1.0.4`](git+https://github.com/mcollina/reusify.git) | MIT | clearlydefined |
@@ -996,7 +996,7 @@
 | [`uri-js@4.4.1`](http://github.com/garycourt/uri-js) | BSD-2-Clause | #1086 |
 | [`url-parse@1.5.10`](https://github.com/unshiftio/url-parse.git) | MIT | clearlydefined |
 | [`utila@0.4.0`](https://github.com/AriaMinaei/utila.git) | MIT | clearlydefined |
-| [`uuid@8.3.2`](https://github.com/uuidjs/uuid.git) | MIT | #2438 |
+| [`uuid@8.3.2`](https://github.com/uuidjs/uuid.git) | MIT | #15399 |
 | [`v8-compile-cache@2.3.0`](https://github.com/zertosh/v8-compile-cache.git) | MIT | clearlydefined |
 | [`v8-to-istanbul@9.1.3`](https://github.com/istanbuljs/v8-to-istanbul.git) | ISC | clearlydefined |
 | [`validate-npm-package-license@3.0.4`](https://github.com/kemitchell/validate-npm-package-license.js.git) | Apache-2.0 | #2562 |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -47,7 +47,7 @@
 | [`@csstools/css-tokenizer@2.2.1`](https://github.com/csstools/postcss-plugins.git) | MIT | clearlydefined |
 | [`@csstools/media-query-list-parser@2.1.5`](https://github.com/csstools/postcss-plugins.git) | MIT | clearlydefined |
 | [`@csstools/selector-specificity@3.0.0`](https://github.com/csstools/postcss-plugins.git) | MIT-0 | transitive dependency |
-| [`@devfile/api@2.3.0-1721400636`](https://github.com/GIT_USER_ID/GIT_REPO_ID.git) | Apache-2.0 | trusted dependency |
+| [`@devfile/api@2.3.0-1721400636`](https://github.com/GIT_USER_ID/GIT_REPO_ID.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1721400636) |
 | [`@discoveryjs/json-ext@0.5.7`](https://github.com/discoveryjs/json-ext.git) | MIT | clearlydefined |
 | `@eclipse-che/api@7.86.0` | EPL-2.0 | ecd.che |
 | [`@eslint-community/eslint-utils@4.4.0`](https://github.com/eslint-community/eslint-utils) | MIT | #15285 |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -3,9 +3,9 @@
 | Packages | License | Resolved CQs |
 | --- | --- | --- |
 | [`@babel/runtime@7.23.2`](https://github.com/babel/babel.git) | MIT | #10718 |
-| [`@eclipse-che/common@7.88.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-backend@7.88.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
-| [`@eclipse-che/dashboard-frontend@7.88.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/common@7.90.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-backend@7.90.0-next`](https://github.com/eclipse-che/che-dashboard) | EPL-2.0 | ecd.che |
+| [`@eclipse-che/dashboard-frontend@7.90.0-next`](git://github.com/eclipse/che-dashboard.git) | EPL-2.0 | ecd.che |
 | [`@patternfly/react-core@4.278.0`](https://github.com/patternfly/patternfly-react.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-core/4.278.0) |
 | [`@patternfly/react-icons@4.93.7`](https://github.com/patternfly/patternfly-react.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-icons/4.93.7) |
 | `@patternfly/react-styles@4.92.8` | MIT | clearlydefined |
@@ -98,6 +98,7 @@
 | [`mime-types@2.1.35`](https://github.com/jshttp/mime-types.git) | MIT | clearlydefined |
 | [`minimalistic-assert@1.0.1`](https://github.com/calvinmetcalf/minimalistic-assert.git) | ISC | clearlydefined |
 | [`minimalistic-crypto-utils@1.0.1`](git+ssh://git@github.com/indutny/minimalistic-crypto-utils.git) | MIT | clearlydefined |
+| [`multi-ini@2.3.2`](git://github.com/evangelion1204/multi-ini.git) | MIT | clearlydefined |
 | [`nanoid@3.3.7`](https://github.com/ai/nanoid.git) | MIT | #7571 |
 | [`object-assign@4.1.1`](https://github.com/sindresorhus/object-assign.git) | MIT | clearlydefined |
 | [`object-inspect@1.13.1`](git://github.com/inspect-js/object-inspect.git) | MIT | #11078 |
@@ -146,7 +147,7 @@
 | [`set-function-length@1.2.2`](git+https://github.com/ljharb/set-function-length.git) | MIT | #12772 |
 | [`sha.js@2.4.11`](git://github.com/crypto-browserify/sha.js.git) | (MIT AND BSD-3-Clause) | #1031 |
 | [`side-channel@1.0.6`](git+https://github.com/ljharb/side-channel.git) | MIT | clearlydefined |
-| [`source-map-js@1.0.2`](https://github.com/7rulnik/source-map-js.git) | BSD-3-Clause | #2412 |
+| [`source-map-js@1.0.2`](https://github.com/7rulnik/source-map-js.git) | BSD-3-Clause | #15401 |
 | [`stream-browserify@3.0.0`](git://github.com/browserify/stream-browserify.git) | MIT | clearlydefined |
 | [`string_decoder@1.3.0`](git://github.com/nodejs/string_decoder.git) | MIT | clearlydefined |
 | [`tabbable@5.3.3`](git+https://github.com/focus-trap/tabbable.git) | MIT | clearlydefined |

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,7 @@
     "test:watch": "yarn test --watch"
   },
   "devDependencies": {
-    "@devfile/api": "2.2.2-1715367693",
+    "@devfile/api": "2.3.0-1721400636",
     "@kubernetes/client-node": "^0.21.0",
     "@types/jest": "^29.5.3",
     "@typescript-eslint/eslint-plugin": "^6.3.0",

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -12,8 +12,8 @@
 
 import {
   V1alpha2DevWorkspace,
-  V222Devfile,
-  V222DevfileComponents,
+  V230Devfile,
+  V230DevfileComponents,
 } from '@devfile/api';
 import { CoreV1EventList, V1PodList } from '@kubernetes/client-node';
 import * as webSocket from './webSocket';
@@ -108,7 +108,7 @@ export interface IServerConfig {
   };
   defaults: {
     editor: string | undefined;
-    components: V222DevfileComponents[];
+    components: V230DevfileComponents[];
     plugins: IWorkspacesDefaultPlugins[];
     pvcStrategy: string | undefined;
   };
@@ -160,7 +160,7 @@ export interface IDevWorkspacePreferences {
   [key: string]: string | string[];
 }
 
-export type IEditors = Array<V222Devfile>;
+export type IEditors = Array<V230Devfile>;
 
 export type IEventList = CoreV1EventList;
 export type IPodList = V1PodList;

--- a/packages/dashboard-backend/package.json
+++ b/packages/dashboard-backend/package.json
@@ -26,8 +26,8 @@
   ],
   "license": "EPL-2.0",
   "dependencies": {
-    "@devfile/api": "2.2.2-1715367693",
-    "@eclipse-che/che-devworkspace-generator": "7.88.0-next-a2e5c63",
+    "@devfile/api": "2.3.0-1721400636",
+    "@eclipse-che/che-devworkspace-generator": "7.89.0-next-784dff2",
     "@eclipse-che/common": "file:../common",
     "@fastify/cors": "^9.0.1",
     "@fastify/error": "^3.4.1",

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/editorsApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/editorsApi.spec.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222Devfile } from '@devfile/api';
+import { V230Devfile } from '@devfile/api';
 import { V1ConfigMapList } from '@kubernetes/client-node/dist/gen/model/v1ConfigMapList';
 import http from 'http';
 import * as yaml from 'js-yaml';
@@ -70,7 +70,7 @@ describe('EditorsApiService', () => {
       (yaml.load as jest.Mock).mockReturnValue({ schemaVersion: '2.2.2' });
 
       const result = await editorsApiService.list();
-      expect(result).toEqual([{ schemaVersion: '2.2.2' } as V222Devfile]);
+      expect(result).toEqual([{ schemaVersion: '2.2.2' } as V230Devfile]);
       expect(coreV1API.listNamespacedConfigMap).toHaveBeenCalledWith(
         'test-namespace',
         undefined,
@@ -166,7 +166,7 @@ describe('EditorsApiService', () => {
             version: 'insiders',
           },
         },
-      } as V222Devfile);
+      } as V230Devfile);
     });
 
     it('should return matching editor yaml when provided with editorId when multiple editors exist', async () => {
@@ -232,7 +232,7 @@ describe('EditorsApiService', () => {
             version: 'latest',
           },
         },
-      } as V222Devfile);
+      } as V230Devfile);
     });
 
     it('should throw exception if no matching editor exists', async () => {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/editorsApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/editorsApi.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222Devfile } from '@devfile/api';
+import { V230Devfile } from '@devfile/api';
 import { V1ConfigMapList } from '@kubernetes/client-node/dist/gen/model/v1ConfigMapList';
 import http from 'http';
 import * as yaml from 'js-yaml';
@@ -50,7 +50,7 @@ export class EditorsApiService implements IEditorsApi {
     };
   }
 
-  async list(): Promise<V222Devfile[]> {
+  async list(): Promise<V230Devfile[]> {
     if (!this.env.NAMESPACE) {
       logger.warn('Mandatory environment variables are not defined: $CHECLUSTER_CR_NAMESPACE');
       return [];
@@ -71,7 +71,7 @@ export class EditorsApiService implements IEditorsApi {
       throw createError(error, API_ERROR_LABEL, additionalMessage);
     }
 
-    const editors: V222Devfile[] = [];
+    const editors: V230Devfile[] = [];
 
     for (const cm of response.body.items) {
       if (cm.data === undefined) {
@@ -80,7 +80,7 @@ export class EditorsApiService implements IEditorsApi {
 
       for (const key in cm.data) {
         try {
-          const editor = yaml.load(cm.data[key]) as V222Devfile;
+          const editor = yaml.load(cm.data[key]) as V230Devfile;
           editors.push(editor);
         } catch (error) {
           logger.error(
@@ -96,7 +96,7 @@ export class EditorsApiService implements IEditorsApi {
     return editors;
   }
 
-  async get(id: string): Promise<V222Devfile> {
+  async get(id: string): Promise<V230Devfile> {
     const editors = await this.list();
     const matches = editors.filter(editor => {
       const currId =

--- a/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/serverConfigApi.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222DevfileComponents } from '@devfile/api';
+import { V230DevfileComponents } from '@devfile/api';
 import { api } from '@eclipse-che/common';
 import * as k8s from '@kubernetes/client-node';
 import { readFileSync } from 'fs';
@@ -131,7 +131,7 @@ export class ServerConfigApiService implements IServerConfigApi {
     );
   }
 
-  getDefaultComponents(cheCustomResource: CheClusterCustomResource): V222DevfileComponents[] {
+  getDefaultComponents(cheCustomResource: CheClusterCustomResource): V230DevfileComponents[] {
     if (cheCustomResource.spec.devEnvironments?.defaultComponents) {
       return cheCustomResource.spec.devEnvironments.defaultComponents;
     }

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -13,9 +13,9 @@
 import {
   V1alpha2DevWorkspace,
   V1alpha2DevWorkspaceTemplate,
-  V222DevfileComponents,
+  V230DevfileComponents,
 } from '@devfile/api';
-import { V222Devfile } from '@devfile/api';
+import { V230Devfile } from '@devfile/api';
 import { api } from '@eclipse-che/common';
 import * as k8s from '@kubernetes/client-node';
 import { IncomingHttpHeaders } from 'http';
@@ -150,7 +150,7 @@ export type CheClusterCustomResourceSpecDevEnvironments = {
   containerBuildConfiguration?: {
     openShiftSecurityContextConstraint?: string;
   };
-  defaultComponents?: V222DevfileComponents[];
+  defaultComponents?: V230DevfileComponents[];
   defaultNamespace?: {
     autoProvision?: boolean;
     template?: string;
@@ -280,7 +280,7 @@ export interface IServerConfigApi {
    * Returns the default components applied to DevWorkspaces.
    * These default components are meant to be used when a Devfile does not contain any components.
    */
-  getDefaultComponents(cheCustomResource: CheClusterCustomResource): V222DevfileComponents[];
+  getDefaultComponents(cheCustomResource: CheClusterCustomResource): V230DevfileComponents[];
   /**
    * Returns the plugin registry.
    */
@@ -456,14 +456,14 @@ export interface IEditorsApi {
   /**
    * Reads all Editors from ConfigMaps.
    */
-  list(): Promise<Array<V222Devfile>>;
+  list(): Promise<Array<V230Devfile>>;
 
   /**
    * Returns an Editor from ConfigMap by its editorId.
    * @param id editorId in the format of publisher/name/version
    * @throws EditorNotFoundError if editor is not found
    */
-  get(id: string): Promise<V222Devfile>;
+  get(id: string): Promise<V230Devfile>;
 }
 
 export interface IShhKeysApi {

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -15,8 +15,8 @@
 import {
   V1alpha2DevWorkspace,
   V1alpha2DevWorkspaceTemplate,
-  V222Devfile,
-  V222DevfileComponents,
+  V230Devfile,
+  V230DevfileComponents,
 } from '@devfile/api';
 import { api } from '@eclipse-che/common';
 import { IncomingHttpHeaders } from 'http';
@@ -43,7 +43,7 @@ export const stubContainerBuild = {
   disableContainerBuildCapabilities: true,
 };
 export const stubDashboardWarning = 'Dashboard warning';
-export const stubDefaultComponents: V222DevfileComponents[] = [];
+export const stubDefaultComponents: V230DevfileComponents[] = [];
 export const stubDefaultEditor = undefined;
 export const stubDefaultPlugins: api.IWorkspacesDefaultPlugins[] = [];
 export const stubPluginRegistry = { openVSXURL: 'openvsx-url' };
@@ -103,7 +103,7 @@ export const stubEventsList: api.IEventList = {
   items: [],
 };
 
-export const editorsArray: V222Devfile[] = [
+export const editorsArray: V230Devfile[] = [
   {
     schemaVersion: '2.2.2',
     metadata: {

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -70,7 +70,7 @@
     "stream-browserify": "^3.0.0"
   },
   "devDependencies": {
-    "@devfile/api": "2.2.2-1715367693",
+    "@devfile/api": "2.3.0-1721400636",
     "@eclipse-che/api": "^7.86.0",
     "@kubernetes/client-node": "^0.21.0",
     "@react-mock/state": "^0.1.8",

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222DevfileProjects, V222DevfileProjectsItemsGit } from '@devfile/api';
+import { V230DevfileProjects, V230DevfileProjectsItemsGit } from '@devfile/api';
 import common from '@eclipse-che/common';
 
 import { getProjectFromLocation } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getProjectFromLocation';
@@ -171,7 +171,7 @@ export function configureProjectRemotes(
 /**
  * Returns the Git project to replace remotes for
  */
-function getGitProjectForConfiguringRemotes(projects: V222DevfileProjects[] | undefined) {
+function getGitProjectForConfiguringRemotes(projects: V230DevfileProjects[] | undefined) {
   if (!projects) {
     return undefined;
   }
@@ -197,7 +197,7 @@ function getGitProjectForConfiguringRemotes(projects: V222DevfileProjects[] | un
  * @param newRemotes The array of new Git remotes to add
  */
 function addRemotesToProject(
-  gitProject: V222DevfileProjectsItemsGit,
+  gitProject: V230DevfileProjectsItemsGit,
   checkoutRemote: GitRemote,
   newRemotes: GitRemote[],
 ): void {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getProjectFromLocation.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getProjectFromLocation.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222DevfileProjects } from '@devfile/api';
+import { V230DevfileProjects } from '@devfile/api';
 
 import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 import { getProjectName } from '@/services/helpers/getProjectName';
@@ -18,7 +18,7 @@ import { getProjectName } from '@/services/helpers/getProjectName';
 export function getProjectFromLocation(
   location: string,
   remoteName = 'origin',
-): V222DevfileProjects {
+): V230DevfileProjects {
   const name = getProjectName(location);
   if (FactoryLocationAdapter.isSshLocation(location)) {
     const origin = location;

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/index.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/index.ts
@@ -10,11 +10,11 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222Devfile } from '@devfile/api';
+import { V230Devfile } from '@devfile/api';
 
 import { DevfileMetadata, DevfileMetadataLike } from '@/services/devfileApi/devfile/metadata';
 
-export type DevfileLike = V222Devfile & {
+export type DevfileLike = V230Devfile & {
   metadata?: DevfileMetadataLike;
 };
 

--- a/packages/dashboard-frontend/src/services/devfileApi/devfile/metadata.ts
+++ b/packages/dashboard-frontend/src/services/devfileApi/devfile/metadata.ts
@@ -10,9 +10,9 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222DevfileMetadata } from '@devfile/api';
+import { V230DevfileMetadata } from '@devfile/api';
 
-export type DevfileMetadataLike = V222DevfileMetadata & {
+export type DevfileMetadataLike = V230DevfileMetadata & {
   namespace?: string;
   generateName?: string;
 };

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/editorDefinitions.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/editorDefinitions.ts
@@ -10,9 +10,9 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222Devfile } from '@devfile/api';
+import { V230Devfile } from '@devfile/api';
 
-const getVSCodeEditorDefinition = (): V222Devfile => {
+const getVSCodeEditorDefinition = (): V230Devfile => {
   return {
     attributes: {
       version: null,

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -14,7 +14,7 @@ import {
   V1alpha2DevWorkspaceSpecTemplateComponents,
   V1alpha2DevWorkspaceTemplateSpec,
   V1alpha2DevWorkspaceTemplateSpecComponents,
-  V222DevfileComponentsItemsContainer,
+  V230DevfileComponentsItemsContainer,
 } from '@devfile/api';
 import { api } from '@eclipse-che/common';
 import { inject, injectable } from 'inversify';
@@ -58,7 +58,7 @@ export const DEVWORKSPACE_DEVFILE = 'che.eclipse.org/devfile';
 
 export const DEVWORKSPACE_METADATA_ANNOTATION = 'dw.metadata.annotations';
 
-export interface ICheEditorOverrideContainer extends V222DevfileComponentsItemsContainer {
+export interface ICheEditorOverrideContainer extends V230DevfileComponentsItemsContainer {
   name: string;
 }
 export interface ICheEditorYaml {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/helpers.normalizeDevfileV2.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/helpers.normalizeDevfileV2.spec.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222Devfile, V222DevfileComponents } from '@devfile/api';
+import { V230Devfile, V230DevfileComponents } from '@devfile/api';
 
 import { FactoryResolver } from '@/services/helpers/types';
 import { che } from '@/services/models';
@@ -67,7 +67,7 @@ describe('buildDevfileV2', () => {
 });
 
 describe('Normalize Devfile V2', () => {
-  let defaultComponents: V222DevfileComponents[];
+  let defaultComponents: V230DevfileComponents[];
 
   beforeEach(() => {
     defaultComponents = [
@@ -94,7 +94,7 @@ describe('Normalize Devfile V2', () => {
           name: 'custom-image',
         },
       ],
-    } as V222Devfile;
+    } as V230Devfile;
 
     const targetDevfile = normalizeDevfile(
       {
@@ -130,7 +130,7 @@ describe('Normalize Devfile V2', () => {
         version: '1.2.0',
       },
       components: [],
-    } as V222Devfile;
+    } as V230Devfile;
 
     const targetDevfile = normalizeDevfile(
       {
@@ -157,7 +157,7 @@ describe('Normalize Devfile V2', () => {
   it('should apply metadata name and namespace', () => {
     const devfile = {
       schemaVersion: '2.2.2',
-    } as V222Devfile;
+    } as V230Devfile;
 
     const targetDevfile = normalizeDevfile(
       {
@@ -180,7 +180,7 @@ describe('Normalize Devfile V2', () => {
         generateName: 'empty',
       },
       components: [],
-    } as V222Devfile;
+    } as V230Devfile;
 
     const targetDevfile = normalizeDevfile(
       {
@@ -218,7 +218,7 @@ describe('Normalize Devfile V2', () => {
           name: 'developer-image',
         },
       ],
-    } as V222Devfile;
+    } as V230Devfile;
     const factoryParams = {
       image: 'quay.io/devfile/universal-developer-image:test',
     };
@@ -253,7 +253,7 @@ describe('Normalize Devfile V2', () => {
       metadata: {
         generateName: 'empty',
       },
-    } as V222Devfile;
+    } as V230Devfile;
     const factoryParams = {
       image: 'quay.io/devfile/universal-developer-image:test',
     };

--- a/packages/dashboard-frontend/src/store/FactoryResolver/helpers.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/helpers.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222DevfileComponents, V222DevfileProjects } from '@devfile/api';
+import { V230DevfileComponents, V230DevfileProjects } from '@devfile/api';
 import common, { api } from '@eclipse-che/common';
 import axios from 'axios';
 import { dump } from 'js-yaml';
@@ -127,7 +127,7 @@ export function buildDevfileV2(
       .replace(/^-+|-+$/g, '')
       .toLowerCase();
 
-    const devfileV2Project: V222DevfileProjects = {
+    const devfileV2Project: V230DevfileProjects = {
       attributes: {},
       name: projectName,
     };
@@ -166,7 +166,7 @@ export function buildDevfileV2(
 export function normalizeDevfile(
   data: FactoryResolver,
   location: string,
-  defaultComponents: V222DevfileComponents[],
+  defaultComponents: V230DevfileComponents[],
   namespace: string,
   factoryParams: Partial<FactoryParams>,
 ): devfileApi.Devfile {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/editorImage.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V222DevfileComponents } from '@devfile/api';
+import { V230DevfileComponents } from '@devfile/api';
 import common from '@eclipse-che/common';
 import { dump, load } from 'js-yaml';
 import cloneDeep from 'lodash/cloneDeep';
@@ -83,7 +83,7 @@ export function getEditorImage(workspace: devfileApi.DevWorkspace): string | und
 }
 
 function updateComponents(
-  components: V222DevfileComponents[] | undefined,
+  components: V230DevfileComponents[] | undefined,
   editorImage: string,
 ): boolean {
   if (!components) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -349,10 +349,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@devfile/api@2.2.2-1715367693":
-  version "2.2.2-1715367693"
-  resolved "https://registry.yarnpkg.com/@devfile/api/-/api-2.2.2-1715367693.tgz#0e0bbd8a54b5d4f05c2aa9b6cc725a2404629a5c"
-  integrity sha512-dWGyC7I6cV3L+K2TMOY/hUzmMqp+X1wMp3M3OusoXZrKWExvQVcZZwVd9BB6vPot+0THEHK56U8qYTEy/Ojy0w==
+"@devfile/api@2.3.0-1721400636":
+  version "2.3.0-1721400636"
+  resolved "https://registry.yarnpkg.com/@devfile/api/-/api-2.3.0-1721400636.tgz#94f7ba0f45b294beb8cd023ffeaa8aa5ff228b44"
+  integrity sha512-W6g9uYSo22VcAeLj49YyVzOWTWZh5sRWP8fzgRcao6DRLd7FwkG3w4ZWCMTY5tMgyfcpaNBBoV1mqlRJuCvhTA==
   dependencies:
     "@types/node" "*"
     "@types/node-fetch" "^2.5.7"
@@ -371,22 +371,22 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.86.0.tgz#c4bfe23fb0a34e864ba5a45cd3d5b7f3332cef13"
   integrity sha512-WDmnzopqKXPO3jozfrZ8mXVxdy/7KnzOv/+o3SzIqKYfEXXcmulG2+FYxzWUAA37T3wgqE1lQ+MACwO7v4PhtA==
 
-"@eclipse-che/che-devworkspace-generator@7.88.0-next-a2e5c63":
-  version "7.88.0-next-a2e5c63"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-7.88.0-next-a2e5c63.tgz#2516aad6674fefeb9376974cf27855d573e2de36"
-  integrity sha512-70VbsUzONiyJr9pe/rslzta/SM4RvDsSR/kLIxMS4EbS9YgxEvT3rSM9B8eFLMbeZksnCuEQYxiyjSN6P4UV7A==
+"@eclipse-che/che-devworkspace-generator@7.89.0-next-784dff2":
+  version "7.89.0-next-784dff2"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/che-devworkspace-generator/-/che-devworkspace-generator-7.89.0-next-784dff2.tgz#3ed9aa348712e78e100d1c4445ca146430ed5576"
+  integrity sha512-Mqkxw2VJB+p4B5QH5fXAU+Q68gXfaY2TphodqHxLHwAW0zBpLqyPTYbAwVk4ESUzy6BLXrSktYXJ3AA5ZIjrMg==
   dependencies:
-    "@devfile/api" "2.2.2-1715367693"
+    "@devfile/api" "2.3.0-1721400636"
     axios "^1.7.0"
-    fs-extra "^10.0.0"
-    inversify "^5.0.1"
+    fs-extra "^11.2.0"
+    inversify "^6.0.2"
     js-yaml "^4.0.0"
     jsonc-parser "^3.0.0"
     jsonschema "^1.4.1"
-    reflect-metadata "^0.1.13"
+    reflect-metadata "^0.2.2"
 
 "@eclipse-che/common@file:packages/common":
-  version "7.88.0-next"
+  version "7.90.0-next"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -5282,19 +5282,19 @@ fs-extra@9.1.0, fs-extra@^9.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+fs-extra@^11.1.0, fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.1.0, fs-extra@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
-  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+fs-extra@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
+  integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -6208,11 +6208,6 @@ inversify-react@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/inversify-react/-/inversify-react-1.1.1.tgz#4c1e4aeaed857b5da82f224bd68ae901d4a8cd9b"
   integrity sha512-uYkR5PqiGqb78wPgQ9d49mLL3BgmgT7UCQ60hsnLbrYYh9Zktwk2Qi3qWvHyDLZ+ZsyzlTEzaEOD6cMCNzc1Yg==
-
-inversify@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.1.1.tgz#6fbd668c591337404e005a1946bfe0d802c08730"
-  integrity sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ==
 
 inversify@^6.0.2:
   version "6.0.2"
@@ -10010,6 +10005,11 @@ reflect-metadata@^0.1.14:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.14.tgz#24cf721fe60677146bb77eeb0e1f9dece3d65859"
   integrity sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==
+
+reflect-metadata@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
- Upgrade devfile/api to 2.3.0 version
- Upgrade devworkspace generator tool to 7.89.0-next-784dff2 

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23041

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
- check Build PR check
- patch OS cluster with final image and try to start a workspace