### PR TITLE
fix: check if ssh key has newline at the end

### DIFF
--- a/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/index.spec.tsx
@@ -82,14 +82,13 @@ describe('TextFileUpload', () => {
       /* Upload a file */
 
       const fileContent = 'file-content';
-      const fileContentBase64 = Buffer.from(fileContent).toString('base64');
       const file = new File([fileContent], 'file.txt', { type: 'text/plain' });
 
       const fileUploader = screen.getByTestId(fieldId);
       const fileUploadInput = fileUploader.querySelector('input[type="file"]');
       userEvent.upload(fileUploadInput!, file);
 
-      await waitFor(() => expect(mockOnChange).toHaveBeenCalledWith(fileContentBase64, true));
+      await waitFor(() => expect(mockOnChange).toHaveBeenCalledWith(fileContent, true));
 
       expect(fileInput).toHaveValue(file.name);
       expect(clearButton).toBeEnabled();
@@ -118,10 +117,9 @@ describe('TextFileUpload', () => {
       /* Paste a content */
 
       const content = 'content';
-      const contentBase64 = Buffer.from(content).toString('base64');
       userEvent.paste(contentInput, content);
 
-      await waitFor(() => expect(mockOnChange).toHaveBeenCalledWith(contentBase64, false));
+      await waitFor(() => expect(mockOnChange).toHaveBeenCalledWith(content, false));
 
       expect(fileInput).toHaveValue('');
       expect(clearButton).toBeEnabled();

--- a/packages/dashboard-frontend/src/components/TextFileUpload/index.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/index.tsx
@@ -20,9 +20,6 @@ export type Props = {
   fileNamePlaceholder?: string;
   textAreaPlaceholder?: string;
   validated: ValidatedOptions;
-  /**
-   * @param content base64 encoded file content
-   */
   onChange: (content: string, isUpload: boolean) => void;
 };
 
@@ -66,7 +63,7 @@ export class TextFileUpload extends React.PureComponent<Props, State> {
 
   private handleDataChange(content: string): void {
     this.setState({ content });
-    this.props.onChange(btoa(content), true);
+    this.props.onChange(content, true);
   }
 
   private handleTextChange(content: string): void {
@@ -75,7 +72,7 @@ export class TextFileUpload extends React.PureComponent<Props, State> {
       file: undefined,
       filename: undefined,
     });
-    this.props.onChange(btoa(content), false);
+    this.props.onChange(content, false);
   }
 
   public render(): React.ReactElement {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
@@ -45,7 +45,9 @@ describe('SshPrivateKey', () => {
       const sshPrivateKey = 'ssh-private-key';
       userEvent.paste(input, sshPrivateKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshPrivateKey, true);
+      const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, true);
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
@@ -81,7 +83,9 @@ describe('SshPrivateKey', () => {
       const sshPrivateKey = 'ssh-private-key'.repeat(5000);
       userEvent.paste(input, sshPrivateKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshPrivateKey, false);
+      const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, false);
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
@@ -97,10 +101,12 @@ describe('SshPrivateKey', () => {
       const input = screen.getByPlaceholderText('Or paste the PRIVATE key');
 
       // fill the SSH key data field
-      const sshKeyData = 'ssh-key-data';
-      userEvent.paste(input, sshKeyData);
+      const sshPrivateKey = 'ssh-key-data';
+      userEvent.paste(input, sshPrivateKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshKeyData, true);
+      const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, true);
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
@@ -114,8 +120,8 @@ describe('SshPrivateKey', () => {
       const input = screen.getByPlaceholderText('Or paste the PRIVATE key');
 
       // fill the SSH key data field
-      const sshKeyData = 'ssh-key-data';
-      userEvent.paste(input, sshKeyData);
+      const sshPrivateKey = 'ssh-key-data';
+      userEvent.paste(input, sshPrivateKey);
 
       mockOnChange.mockClear();
 
@@ -137,10 +143,12 @@ describe('SshPrivateKey', () => {
       const input = screen.getByPlaceholderText('Or paste the PRIVATE key');
 
       // fill the SSH key data field
-      const sshKeyData = 'ssh-key-data'.repeat(5000);
-      userEvent.paste(input, sshKeyData);
+      const sshPrivateKey = 'ssh-key-data'.repeat(5000);
+      userEvent.paste(input, sshPrivateKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshKeyData, false);
+      const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, false);
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
 
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
@@ -50,6 +50,14 @@ export class SshPrivateKey extends React.Component<Props, State> {
 
   private onChange(privateKey: string, isUpload: boolean): void {
     const { onChange } = this.props;
+
+    privateKey = privateKey.trim()
+      ? btoa(
+          // expect the only new line at the end
+          privateKey.trim() + '\n',
+        )
+      : '';
+
     const validated = this.validate(privateKey);
     const isValid = validated === ValidatedOptions.success;
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/__tests__/index.spec.tsx
@@ -45,7 +45,9 @@ describe('SshPublicKey', () => {
       const sshPublicKey = 'ssh-public-key';
       userEvent.paste(input, sshPublicKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshPublicKey, true);
+      const expectedSshPrivateKey = btoa(sshPublicKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, true);
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
@@ -67,7 +69,7 @@ describe('SshPublicKey', () => {
       const sshPublicKey = '';
       fireEvent.change(input, { target: { value: sshPublicKey } });
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshPublicKey, false);
+      expect(mockOnChange).toHaveBeenCalledWith('', false);
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeTruthy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
@@ -84,7 +86,9 @@ describe('SshPublicKey', () => {
       const sshPublicKey = 'ssh-public-key'.repeat(1000);
       userEvent.paste(input, sshPublicKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshPublicKey, false);
+      const expectedSshPublicKey = btoa(sshPublicKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPublicKey, false);
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
@@ -99,10 +103,12 @@ describe('SshPublicKey', () => {
 
       const input = screen.getByPlaceholderText('Or paste the PUBLIC key');
 
-      const sshKeyData = 'ssh-key-data';
-      userEvent.paste(input, sshKeyData);
+      const sshPublicKey = 'ssh-key-data';
+      userEvent.paste(input, sshPublicKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshKeyData, true);
+      const expectedSshPublicKey = btoa(sshPublicKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPublicKey, true);
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
@@ -137,10 +143,12 @@ describe('SshPublicKey', () => {
       const input = screen.getByPlaceholderText('Or paste the PUBLIC key');
 
       // fill the SSH key data field
-      const sshKeyData = 'ssh-key-data'.repeat(1000);
-      userEvent.paste(input, sshKeyData);
+      const sshPublicKey = 'ssh-key-data'.repeat(1000);
+      userEvent.paste(input, sshPublicKey);
 
-      expect(mockOnChange).toHaveBeenCalledWith(sshKeyData, false);
+      const expectedSshPublicKey = btoa(sshPublicKey.trim() + '\n');
+
+      expect(mockOnChange).toHaveBeenCalledWith(expectedSshPublicKey, false);
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/index.tsx
@@ -50,6 +50,14 @@ export class SshPublicKey extends React.Component<Props, State> {
 
   private onChange(publicKey: string, isUpload: boolean): void {
     const { onChange } = this.props;
+
+    publicKey = publicKey.trim()
+      ? btoa(
+          // expect the only new line at the end
+          publicKey.trim() + '\n',
+        )
+      : '';
+
     const validated = this.validate(publicKey);
     const isValid = validated === ValidatedOptions.success;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes an issue where the trailing newline was lost when copy-pasting SSH keys.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?

fixes https://github.com/eclipse-che/che/issues/23073

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

Based on https://github.com/eclipse-che/che/issues/23073#issue-2450713392:

1. [Generate an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) locally
2. Go to Dashboard -> User Preferences -> SSH Keys
3. Click `Add SSH Key`
4. **IMPORTANT**: extract the content of the generated public and private keys and paste it manually to the inputs.
5. Save the key
6. Try to start a workspace from an ssh url e.g. `git@github.com:vinokurig/test.git`
7. When the workspace starts, the project should be cloned.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
