### PR TITLE
Throw an error on workspace start if ssl_exception error received

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__tests__/index.spec.tsx
@@ -69,6 +69,7 @@ describe('Creating steps, initializing', () => {
     window.location.reload = reload;
 
     jest.clearAllMocks();
+    jest.resetAllMocks();
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -375,6 +376,33 @@ describe('Creating steps, initializing', () => {
     expect(stepTitleNext.textContent).not.toContain('untrusted source');
 
     expect(mockOnNextStep).toHaveBeenCalled();
+  });
+
+  test('`ssl_exception` error code', async () => {
+    const searchParams = new URLSearchParams({
+      [FACTORY_URL_ATTR]: factoryUrl,
+      [ERROR_CODE_ATTR]: 'ssl_exception',
+    });
+
+    renderComponent(store, searchParams);
+
+    await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
+
+    const expectAlertItem = expect.objectContaining({
+      title: 'Failed to create the workspace',
+      children: expect.stringContaining(
+        'SSL handshake failed. Please, contact the cluster administrator.',
+      ),
+      actionCallbacks: [
+        expect.objectContaining({
+          title: 'Click to try again',
+          callback: expect.any(Function),
+        }),
+      ],
+    });
+    await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
+
+    expect(mockOnNextStep).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/index.tsx
@@ -149,6 +149,8 @@ class CreatingStepInitialize extends ProgressStep<Props, State> {
       throw new Error(
         'Could not resolve devfile from private repository because authentication request is missing a parameter, contains an invalid parameter, includes a parameter more than once, or is otherwise invalid.',
       );
+    } else if (errorCode === 'ssl_exception') {
+      throw new Error('SSL handshake failed. Please, contact the cluster administrator.');
     }
 
     // validate creation policies

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -63,7 +63,7 @@ export type FactoryParams = {
 
 export type PoliciesCreate = 'perclick' | 'peruser';
 
-export type ErrorCode = 'invalid_request' | 'access_denied';
+export type ErrorCode = 'invalid_request' | 'access_denied' | 'ssl_exception';
 
 export function buildFactoryParams(searchParams: URLSearchParams): FactoryParams {
   return {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Throw an error on workspace start if ssl_exception error received

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6940

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
see https://github.com/eclipse-che/che-server/pull/710

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
