### PR TITLE
Do not show modal for trusted repositories

### DIFF
--- a/build/dockerfiles/skaffold.Dockerfile
+++ b/build/dockerfiles/skaffold.Dockerfile
@@ -10,6 +10,8 @@
 
 FROM docker.io/node:18.19.1-alpine3.19
 
+LABEL quay.expires-after=1w
+
 ENV FRONTEND_LIB=../../packages/dashboard-frontend/lib/public
 ENV BACKEND_LIB=../../packages/dashboard-backend/lib
 ENV BACKEND_NODE_MODULES=../../packages/dashboard-backend/node_modules

--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
@@ -22,6 +22,8 @@ import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 
 const { createSnapshot, renderComponent } = getComponentRenderer(getComponent);
 
+jest.mock('@/components/UntrustedSourceModal');
+
 const history = createMemoryHistory({
   initialEntries: ['/'],
 });
@@ -81,63 +83,6 @@ describe('GitRepoLocationInput', () => {
     expect(window.open).not.toHaveBeenCalled();
   });
 
-  describe('trusted/untrusted source', () => {
-    jest.mock('@/components/UntrustedSourceModal');
-
-    test('untrusted source', () => {
-      const store = new FakeStoreBuilder()
-        .withDwServerConfig({
-          defaults: {
-            editor: defaultEditorId,
-            components: [],
-            plugins: [],
-            pvcStrategy: 'per-workspace',
-          },
-        })
-        .withWorkspacePreferences({
-          'trusted-sources': ['repo1', 'repo2'],
-        })
-        .build();
-      renderComponent(store);
-
-      const input = screen.getByRole('textbox');
-      expect(input).toBeValid();
-
-      userEvent.paste(input, 'http://test-location');
-
-      expect(input).toHaveValue('http://test-location');
-
-      const button = screen.getByRole('button', { name: 'Create & Open' });
-      userEvent.click(button);
-
-      const untrustedSourceModal = screen.queryByRole('dialog', {
-        name: /Do you trust the authors of this repository/i,
-      });
-      expect(untrustedSourceModal).not.toBeNull();
-
-      expect(window.open).not.toHaveBeenCalled();
-    });
-
-    test('trusted source', () => {
-      renderComponent(store);
-
-      const input = screen.getByRole('textbox');
-      expect(input).toBeValid();
-
-      userEvent.paste(input, 'http://test-location');
-
-      expect(input).toHaveValue('http://test-location');
-
-      const button = screen.getByRole('button', { name: 'Create & Open' });
-      userEvent.click(button);
-
-      const untrustedSourceModal = screen.queryByRole('dialog', { name: /untrusted source/i });
-      expect(untrustedSourceModal).toBeNull();
-
-      expect(window.open).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('valid HTTP location', () => {
     describe('factory URL w/o other parameters', () => {
       test('trim spaces from the input value', () => {
@@ -156,16 +101,19 @@ describe('GitRepoLocationInput', () => {
         expect(button).toBeEnabled();
 
         userEvent.click(button);
+
+        // trust the resource
+        const continueButton = screen.getByRole('button', { name: 'Continue' });
+        userEvent.click(continueButton);
+
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
           'http://localhost/#http://test-location/',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
-
-        userEvent.type(input, '{enter}');
-        expect(window.open).toHaveBeenCalledTimes(2);
       });
+
       test('editor definition and image are empty', () => {
         renderComponent(store);
 
@@ -181,15 +129,17 @@ describe('GitRepoLocationInput', () => {
         expect(button).toBeEnabled();
 
         userEvent.click(button);
+
+        // trust the resource
+        const continueButton = screen.getByRole('button', { name: 'Continue' });
+        userEvent.click(continueButton);
+
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
           'http://localhost/#http://test-location/',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
-
-        userEvent.type(input, '{enter}');
-        expect(window.open).toHaveBeenCalledTimes(2);
       });
 
       test('editor definition is defined, editor image is empty', () => {
@@ -207,15 +157,17 @@ describe('GitRepoLocationInput', () => {
         expect(button).toBeEnabled();
 
         userEvent.click(button);
+
+        // trust the resource
+        const continueButton = screen.getByRole('button', { name: 'Continue' });
+        userEvent.click(continueButton);
+
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
           'http://localhost/#http://test-location/?che-editor=che-incubator%2Fche-code%2Finsiders',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
-
-        userEvent.type(input, '{enter}');
-        expect(window.open).toHaveBeenCalledTimes(2);
       });
 
       test('editor definition is empty, editor image is defined', () => {
@@ -233,15 +185,17 @@ describe('GitRepoLocationInput', () => {
         expect(button).toBeEnabled();
 
         userEvent.click(button);
+
+        // trust the resource
+        const continueButton = screen.getByRole('button', { name: 'Continue' });
+        userEvent.click(continueButton);
+
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
           'http://localhost/#http://test-location/?editor-image=custom-editor-image',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
-
-        userEvent.type(input, '{enter}');
-        expect(window.open).toHaveBeenCalledTimes(2);
       });
 
       test('editor definition and editor image are defined', () => {
@@ -259,15 +213,17 @@ describe('GitRepoLocationInput', () => {
         expect(button).toBeEnabled();
 
         userEvent.click(button);
+
+        // trust the resource
+        const continueButton = screen.getByRole('button', { name: 'Continue' });
+        userEvent.click(continueButton);
+
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
           'http://localhost/#http://test-location/?che-editor=che-incubator%2Fche-code%2Finsiders&editor-image=custom-editor-image',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
-
-        userEvent.type(input, '{enter}');
-        expect(window.open).toHaveBeenCalledTimes(2);
       });
     });
 
@@ -287,15 +243,17 @@ describe('GitRepoLocationInput', () => {
         expect(button).toBeEnabled();
 
         userEvent.click(button);
+
+        // trust the resource
+        const continueButton = screen.getByRole('button', { name: 'Continue' });
+        userEvent.click(continueButton);
+
         // the selected editor ID should NOT be added to the URL, as the URL parameter has higher priority
         expect(window.open).toHaveBeenLastCalledWith(
           'http://localhost/#http://test-location/?che-editor=other-editor-id',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
-
-        userEvent.type(input, '{enter}');
-        expect(window.open).toHaveBeenCalledTimes(2);
       });
 
       test('editor definition and editor image are defined, and `editor-image` is provided', () => {
@@ -313,6 +271,11 @@ describe('GitRepoLocationInput', () => {
         expect(button).toBeEnabled();
 
         userEvent.click(button);
+
+        // trust the resource
+        const continueButton = screen.getByRole('button', { name: 'Continue' });
+        userEvent.click(continueButton);
+
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
           'http://localhost/#http://test-location/?editor-image=custom-editor-image',
@@ -369,6 +332,10 @@ describe('GitRepoLocationInput', () => {
 
       userEvent.click(buttonCreate);
 
+      // trust the resource
+      const continueButton = screen.getByRole('button', { name: 'Continue' });
+      userEvent.click(continueButton);
+
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(window.open).toHaveBeenLastCalledWith(
         'http://localhost/#git@github.com:user/repo.git?che-editor=che-incubator%2Fche-code%2Finsiders&editor-image=custom-editor-image',
@@ -397,6 +364,10 @@ describe('GitRepoLocationInput', () => {
       expect(buttonCreate).toBeEnabled();
 
       userEvent.click(buttonCreate);
+
+      // trust the resource
+      const continueButton = screen.getByRole('button', { name: 'Continue' });
+      userEvent.click(continueButton);
 
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(window.open).toHaveBeenLastCalledWith(

--- a/packages/dashboard-frontend/src/components/UntrustedSourceModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/UntrustedSourceModal/__tests__/index.spec.tsx
@@ -108,12 +108,14 @@ describe('Untrusted Repo Warning Modal', () => {
   });
 
   test('click the continue button', async () => {
+    jest.useFakeTimers();
+
     const store = storeBuilder
       .withWorkspacePreferences({
         'trusted-sources': ['repo1', 'repo2'],
       })
       .build();
-    renderComponent(store, 'source-location');
+    const { reRenderComponent } = renderComponent(store, 'source-location');
 
     const continueButton = screen.getByRole('button', { name: 'Continue' });
 
@@ -122,10 +124,20 @@ describe('Untrusted Repo Warning Modal', () => {
 
     continueButton.click();
 
-    await waitFor(() => expect(mockOnContinue).toHaveBeenCalled());
+    const nextStore = new FakeStoreBuilder()
+      .withWorkspacePreferences({
+        'trusted-sources': ['repo1', 'repo2', 'source-location'],
+      })
+      .build();
+    reRenderComponent(nextStore, 'source-location');
+
+    await jest.advanceTimersByTimeAsync(5000);
 
     expect(mockAddTrustedSource).toHaveBeenCalledTimes(1);
     expect(mockAddTrustedSource).toHaveBeenCalledWith('source-location');
+    expect(mockOnContinue).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
   });
 
   test('trust all checkbox is clicked', () => {

--- a/packages/dashboard-frontend/src/components/UntrustedSourceModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/UntrustedSourceModal/__tests__/index.spec.tsx
@@ -175,6 +175,28 @@ describe('Untrusted Repo Warning Modal', () => {
 
     expect(mockOnContinue).toHaveBeenCalledTimes(1);
   });
+
+  test('re-check if source is trusted', () => {
+    const store = storeBuilder
+      .withWorkspacePreferences({
+        'trusted-sources': ['source-location'],
+      })
+      .build();
+    const { reRenderComponent } = renderComponent(store, 'source-location', false);
+
+    // no warning window
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    // should not call onContinue
+    expect(mockOnContinue).not.toHaveBeenCalled();
+
+    // open the modal
+    reRenderComponent(store, 'source-location', true);
+
+    // should call mockOnContinue
+    expect(mockOnContinue).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
 });
 
 function getComponent(store: Store, location: string, isOpen = true): React.ReactElement {

--- a/packages/dashboard-frontend/src/components/UntrustedSourceModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/UntrustedSourceModal/__tests__/index.spec.tsx
@@ -15,7 +15,7 @@ import { Provider } from 'react-redux';
 import { Action, Store } from 'redux';
 
 import UntrustedSourceModal from '@/components/UntrustedSourceModal';
-import getComponentRenderer, { screen, waitFor } from '@/services/__mocks__/getComponentRenderer';
+import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
 import { AppThunk } from '@/store';
 import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 import { WorkspacePreferencesActionCreators } from '@/store/Workspaces/Preferences';

--- a/packages/dashboard-frontend/src/components/UntrustedSourceModal/index.tsx
+++ b/packages/dashboard-frontend/src/components/UntrustedSourceModal/index.tsx
@@ -39,7 +39,9 @@ export type Props = MappedProps & {
   onContinue: () => void;
 };
 export type State = {
-  continueDisabled: boolean;
+  // true if `onContinue` can be called
+  canContinue: boolean;
+  continueButtonDisabled: boolean;
   isTrusted: boolean;
   trustAllCheckbox: boolean;
 };
@@ -52,20 +54,21 @@ class UntrustedSourceModal extends React.Component<Props, State> {
     super(props);
 
     this.state = {
-      continueDisabled: false,
-      isTrusted: this.props.isTrusted(props.location),
+      canContinue: true,
+      continueButtonDisabled: false,
+      isTrusted: this.props.isTrustedSource(props.location),
       trustAllCheckbox: false,
     };
   }
 
   public shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>): boolean {
-    const isTrusted = this.props.isTrusted(this.props.location);
-    const nextIsTrusted = nextProps.isTrusted(nextProps.location);
-    if (isTrusted !== nextIsTrusted || this.state.isTrusted !== nextState.isTrusted) {
+    const isTrusted = this.props.isTrustedSource(this.props.location);
+    const nextIsTrusted = nextProps.isTrustedSource(nextProps.location);
+    if (isTrusted !== nextIsTrusted) {
       return true;
     }
 
-    if (this.state.continueDisabled !== nextState.continueDisabled) {
+    if (this.state.continueButtonDisabled !== nextState.continueButtonDisabled) {
       return true;
     }
 
@@ -85,27 +88,11 @@ class UntrustedSourceModal extends React.Component<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.init();
-  }
-
-  public componentDidUpdate(): void {
-    this.init();
-  }
-
-  private init() {
-    const isTrusted = this.props.isTrusted(this.props.location);
-    if (this.props.isOpen && isTrusted) {
+    if (this.props.isOpen && this.state.isTrusted) {
       this.setState({
-        continueDisabled: false,
-        isTrusted,
-        trustAllCheckbox: false,
+        canContinue: false,
       });
-
       this.props.onContinue();
-    } else {
-      this.setState({
-        isTrusted,
-      });
     }
   }
 
@@ -115,7 +102,8 @@ class UntrustedSourceModal extends React.Component<Props, State> {
 
   private handleClose(): void {
     this.setState({
-      continueDisabled: false,
+      canContinue: true,
+      continueButtonDisabled: false,
       trustAllCheckbox: false,
     });
 
@@ -124,7 +112,10 @@ class UntrustedSourceModal extends React.Component<Props, State> {
 
   private async handleContinue(): Promise<void> {
     try {
-      this.setState({ continueDisabled: true });
+      this.setState({
+        canContinue: false,
+        continueButtonDisabled: true,
+      });
 
       await this.updateTrustedSources();
 
@@ -137,8 +128,7 @@ class UntrustedSourceModal extends React.Component<Props, State> {
       });
     }
 
-    this.setState({ continueDisabled: false, trustAllCheckbox: false });
-    this.props.onClose?.();
+    this.handleClose();
   }
 
   private async updateTrustedSources(): Promise<void> {
@@ -155,7 +145,7 @@ class UntrustedSourceModal extends React.Component<Props, State> {
   }
 
   private buildModalFooter(): React.ReactNode {
-    const { continueDisabled } = this.state;
+    const { continueButtonDisabled } = this.state;
 
     return (
       <React.Fragment>
@@ -163,7 +153,7 @@ class UntrustedSourceModal extends React.Component<Props, State> {
           key="continue"
           variant={ButtonVariant.primary}
           onClick={() => this.handleContinue()}
-          isDisabled={continueDisabled}
+          isDisabled={continueButtonDisabled}
         >
           Continue
         </Button>
@@ -222,7 +212,7 @@ class UntrustedSourceModal extends React.Component<Props, State> {
 
 const mapStateToProps = (state: AppState) => ({
   trustedSources: selectPreferencesTrustedSources(state),
-  isTrusted: selectPreferencesIsTrustedSource(state),
+  isTrustedSource: selectPreferencesIsTrustedSource(state),
 });
 
 const connector = connect(mapStateToProps, workspacePreferencesActionCreators, null, {

--- a/packages/dashboard-frontend/src/components/UntrustedSourceModal/index.tsx
+++ b/packages/dashboard-frontend/src/components/UntrustedSourceModal/index.tsx
@@ -96,6 +96,26 @@ class UntrustedSourceModal extends React.Component<Props, State> {
     }
   }
 
+  public componentDidUpdate(prevProps: Readonly<Props>): void {
+    const isTrusted = this.props.isTrustedSource(this.props.location);
+
+    this.setState({
+      isTrusted,
+    });
+
+    if (
+      prevProps.isOpen === false &&
+      this.props.isOpen === true &&
+      isTrusted === true &&
+      this.state.canContinue === true
+    ) {
+      this.setState({
+        canContinue: false,
+      });
+      this.props.onContinue();
+    }
+  }
+
   private handleTrustAllToggle(checked: boolean): void {
     this.setState({ trustAllCheckbox: checked });
   }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -244,10 +244,13 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
 
     const workspace = this.findTargetWorkspace(this.props, this.state);
     if (workspace !== undefined) {
+      // preserve the current active tab
+      const tabName = new URLSearchParams(this.props.history.location.search).get('tab');
+
       // the workspace has been created, go to the next step
       const nextLocation = buildIdeLoaderLocation(workspace);
       this.props.history.location.pathname = nextLocation.pathname;
-      this.props.history.location.search = '';
+      this.props.history.location.search = tabName ? `?tab=${tabName}` : '';
 
       const url = toHref(this.props.history, nextLocation);
       this.tabManager.rename(url);

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
@@ -190,10 +190,13 @@ class CreatingStepApplyResources extends ProgressStep<Props, State> {
 
     const targetWorkspace = this.findTargetWorkspace(this.props, this.state);
     if (targetWorkspace) {
+      // preserve the current active tab
+      const tabName = new URLSearchParams(this.props.history.location.search).get('tab');
+
       // the workspace has been created, go to the next step
       const nextLocation = buildIdeLoaderLocation(targetWorkspace);
       this.props.history.location.pathname = nextLocation.pathname;
-      this.props.history.location.search = '';
+      this.props.history.location.search = tabName ? `?tab=${tabName}` : '';
 
       const url = toHref(this.props.history, nextLocation);
       this.tabManager.rename(url);

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -97,7 +97,7 @@ class Progress extends React.Component<Props, State> {
       doneSteps: [],
       factoryParams,
       initialLoaderMode,
-      isSourceTrustedWarningOpen: false,
+      isSourceTrustedWarningOpen: true,
     };
   }
 
@@ -144,14 +144,23 @@ class Progress extends React.Component<Props, State> {
 
   private init(props: Props, state: State, prevProps: Props | undefined): void {
     if (this.state.isSourceTrustedWarningOpen === true) {
-      const { sourceUrl } = this.state.factoryParams;
-      const isTrustedSource = this.props.isTrustedSource(sourceUrl);
-      const isRegistryDevfile = this.props.isRegistryDevfile(sourceUrl);
-      // trust source if it is taken from the registry or it is in the list of trusted sources
-      if (isRegistryDevfile || isTrustedSource) {
+      const workspace = this.findTargetWorkspace(props);
+      if (workspace !== undefined) {
+        // if workspace is created, close the warning
         this.setState({
           isSourceTrustedWarningOpen: false,
         });
+      } else {
+        // if workspace is not created yet, check if source is trusted
+        const { sourceUrl } = this.state.factoryParams;
+        const isTrustedSource = this.props.isTrustedSource(sourceUrl);
+        const isRegistryDevfile = this.props.isRegistryDevfile(sourceUrl);
+        // trust source if it is taken from the registry or it is in the list of trusted sources
+        if (isRegistryDevfile || isTrustedSource) {
+          this.setState({
+            isSourceTrustedWarningOpen: false,
+          });
+        }
       }
     }
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -97,7 +97,7 @@ class Progress extends React.Component<Props, State> {
       doneSteps: [],
       factoryParams,
       initialLoaderMode,
-      isSourceTrustedWarningOpen: true,
+      isSourceTrustedWarningOpen: false,
     };
   }
 

--- a/packages/dashboard-frontend/src/pages/Loader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/index.tsx
@@ -91,6 +91,9 @@ export class LoaderPage extends React.PureComponent<Props, State> {
     }
     const showToastAlert = activeTabKey !== LoaderTab.Progress;
 
+    const isLogsTabDisabled = workspace === undefined;
+    const isEventsTabDisabled = workspace === undefined;
+
     return (
       <React.Fragment>
         <Head pageName={pageTitle} />
@@ -126,6 +129,8 @@ export class LoaderPage extends React.PureComponent<Props, State> {
               title={LoaderTab.Logs}
               data-testid="loader-logs-tab"
               id="loader-logs-tab"
+              isDisabled={isLogsTabDisabled}
+              isAriaDisabled={isLogsTabDisabled}
             >
               <WorkspaceLogs workspaceUID={workspace?.uid} />
             </Tab>
@@ -134,6 +139,8 @@ export class LoaderPage extends React.PureComponent<Props, State> {
               title={LoaderTab.Events}
               data-testid="loader-events-tab"
               id="loader-events-tab"
+              isDisabled={isEventsTabDisabled}
+              isAriaDisabled={isEventsTabDisabled}
             >
               <WorkspaceEvents workspaceUID={workspace?.uid} />
             </Tab>

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/selectors.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/selectors.ts
@@ -35,7 +35,20 @@ export const selectRegistriesMetadata = createSelector(selectState, devfileRegis
 
 export const selectIsRegistryDevfile = createSelector(selectState, state => {
   const registriesUrls = Object.keys(state.registries);
-  return (url: string) => registriesUrls.some(registryUrl => url.startsWith(registryUrl));
+
+  return (url: string) =>
+    registriesUrls.some(registryUrl => {
+      const matchRegistryUrl = url.startsWith(registryUrl);
+      if (matchRegistryUrl === true) {
+        return true;
+      }
+
+      // if the url is not a subpath of the registry url,
+      // check if it equals to a sample source url
+      const registryMetadata = state.registries[registryUrl].metadata || [];
+
+      return registryMetadata.some(meta => meta.links?.v2 === url);
+    });
 });
 
 export const selectRegistriesErrors = createSelector(selectState, state => {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes
- the behavior of the Untrusted Repository modal, so that it doesn't reappear for already trusted repositories (see "Bug # 1);
- when switching to either the Logs or Events tab during the workspace creation phase, and staying there for a while, then the warning about the limit of running workspaces appears (see "Bug # 2"). The workaround for this bug is to disable the Logs and Events tab until the workspace is fully created;
- do not show the Untrusted Repository modal when starting an existing workspaces;
- do not show the Untrusted Repository modal when creating a workspace from the sample project on the Getting Started page.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<details>
<Summary>Bug # 1</Summary>

https://github.com/user-attachments/assets/0f7653b6-a6cd-4edc-b043-e53c5e1faeca
</details>

<details>
<summary>Bug # 2</summary>


https://github.com/user-attachments/assets/f6b07753-a1ed-4af4-b724-d9fb70722a16
</details>

<details>
<summary>With fixes</summary>


https://github.com/user-attachments/assets/e4662b3f-1e86-42f1-994e-c8d20cf2f988
</details>



### What issues does this PR fix or reference?


fixes https://github.com/eclipse-che/che/issues/23097
fixes https://github.com/eclipse-che/che/issues/23107
fixes https://github.com/eclipse-che/che/issues/23106
fixes [CRW-7139](https://issues.redhat.com//browse/CRW-7139)

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

See the screencasts.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
