### PR TITLE
Remove conditions before restart a workspace

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/utils.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/utils.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { getStartWorkspaceConditions } from '@/components/WorkspaceProgress/utils';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+
+describe('WorkspaceProgress utils', () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getStartWorkspaceCondition', () => {
+    it('should return an empty array as a default value', () => {
+      const devWorkspace = new DevWorkspaceBuilder().build();
+
+      expect(devWorkspace.status?.conditions).toBeUndefined();
+
+      const conditions = getStartWorkspaceConditions(devWorkspace);
+
+      expect(conditions).toEqual([]);
+    });
+    it('should return conditions from the devWorkspace', () => {
+      const status = {
+        conditions: [
+          {
+            type: 'Stopped',
+            status: 'False',
+            reason: 'LimitReached',
+            message: 'Workspace stopped due to error.',
+          },
+        ],
+      };
+      const devWorkspace = new DevWorkspaceBuilder().withStatus(status).build();
+
+      const conditions = getStartWorkspaceConditions(devWorkspace);
+
+      expect(conditions).toEqual(status.conditions);
+    });
+  });
+  it('should filter conditions that are not related to the workspace start', () => {
+    const status = {
+      conditions: [
+        {
+          message: 'DevWorkspace is starting',
+          status: 'True',
+          type: 'Started',
+        },
+        {
+          message: 'Resolved plugins and parents from DevWorkspace',
+          status: 'True',
+          type: 'DevWorkspaceResolved',
+        },
+        {
+          message: 'Storage ready',
+          status: 'True',
+          type: 'StorageReady',
+        },
+        {
+          message: 'Networking ready',
+          status: 'True',
+          type: 'RoutingReady',
+        },
+        {
+          message: 'DevWorkspace serviceaccount ready',
+          status: 'True',
+          type: 'ServiceAccountReady',
+        },
+        {
+          message: 'Waiting for workspace deployment',
+          status: 'False',
+          type: 'DeploymentReady',
+        },
+      ],
+    };
+    const devWorkspace = new DevWorkspaceBuilder().withStatus(status).build();
+
+    const conditions = getStartWorkspaceConditions(devWorkspace);
+
+    expect(conditions).not.toEqual(status.conditions);
+    expect(conditions).toEqual([
+      {
+        message: 'DevWorkspace is starting',
+        status: 'True',
+        type: 'Started',
+      },
+      {
+        message: 'Resolved plugins and parents from DevWorkspace',
+        status: 'True',
+        type: 'DevWorkspaceResolved',
+      },
+      {
+        message: 'Storage ready',
+        status: 'True',
+        type: 'StorageReady',
+      },
+      {
+        message: 'Networking ready',
+        status: 'True',
+        type: 'RoutingReady',
+      },
+      {
+        message: 'DevWorkspace serviceaccount ready',
+        status: 'True',
+        type: 'ServiceAccountReady',
+      },
+    ]);
+  });
+});

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -30,7 +30,11 @@ import StartingStepInitialize from '@/components/WorkspaceProgress/StartingSteps
 import StartingStepOpenWorkspace from '@/components/WorkspaceProgress/StartingSteps/OpenWorkspace';
 import StartingStepStartWorkspace from '@/components/WorkspaceProgress/StartingSteps/StartWorkspace';
 import StartingStepWorkspaceConditions from '@/components/WorkspaceProgress/StartingSteps/WorkspaceConditions';
-import { ConditionType, isWorkspaceStatusCondition } from '@/components/WorkspaceProgress/utils';
+import {
+  ConditionType,
+  getStartWorkspaceConditions,
+  isWorkspaceStatusCondition,
+} from '@/components/WorkspaceProgress/utils';
 import WorkspaceProgressWizard, {
   WorkspaceProgressWizardStep,
 } from '@/components/WorkspaceProgress/Wizard';
@@ -184,7 +188,7 @@ class Progress extends React.Component<Props, State> {
         workspace.status === DevWorkspaceStatus.FAILING ||
         workspace.status === DevWorkspaceStatus.FAILED)
     ) {
-      const conditions = workspace.ref.status?.conditions || [];
+      const conditions = getStartWorkspaceConditions(workspace.ref);
 
       const lastScore = this.scoreConditions(this.state.conditions);
       const score = this.scoreConditions(conditions);

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/utils.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/utils.ts
@@ -12,6 +12,8 @@
 
 import { V1alpha2DevWorkspaceStatusConditions } from '@devfile/api';
 
+import devfileApi from '@/services/devfileApi';
+
 export type ConditionType = V1alpha2DevWorkspaceStatusConditions & {
   status: 'True' | 'False' | 'Unknown';
 };
@@ -35,6 +37,24 @@ export function isConditionReady(
     condition.status === 'True' ||
     (condition.status === 'Unknown' && prevCondition?.status === 'True')
   );
+}
+
+export function getStartWorkspaceConditions(
+  workspace: devfileApi.DevWorkspace,
+): V1alpha2DevWorkspaceStatusConditions[] {
+  if (!workspace.status?.conditions || workspace.status.conditions.length === 0) {
+    return [];
+  }
+  const conditions = [...workspace.status.conditions];
+  // remove all conditions that are not related to the workspace start
+  for (let i = conditions.length; i > 0; i--) {
+    if (conditions[i - 1].type === 'ServiceAccountReady') {
+      conditions.length = i;
+      break;
+    }
+  }
+
+  return conditions;
 }
 
 export function isConditionError(

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/__tests__/actions.spec.ts
@@ -450,6 +450,75 @@ describe('DevWorkspace store, actions', () => {
       expect(actions).toStrictEqual(expectedActions);
     });
 
+    it('should remove all workspace conditions in the store before start a DevWorkspace', async () => {
+      (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => undefined);
+      (isRunningDevWorkspacesClusterLimitExceeded as jest.Mock).mockReturnValue(
+        Promise.resolve(true),
+      );
+
+      // set a condition with an error message to the devWorkspace
+      devWorkspace.status = {
+        devworkspaceId: '1234',
+        conditions: [
+          {
+            type: 'Stopped',
+            status: 'False',
+            reason: 'LimitReached',
+            message: 'Workspace stopped due to error.',
+          },
+        ],
+      };
+
+      const store = storeBuilder.withDevWorkspaces({ workspaces: [devWorkspace] }).build();
+
+      await store.dispatch(testStore.actionCreators.startWorkspace(devWorkspace));
+
+      const actions = store.getActions();
+
+      const expectedDevWorkspaceWithEmptyConditions = Object.assign({}, devWorkspace, {
+        status: {
+          devworkspaceId: '1234',
+          conditions: [],
+        },
+      });
+
+      const expectedActions: Array<
+        | testStore.KnownAction
+        | testDevWorkspaceClusterStore.KnownAction
+        | ServerConfigStore.KnownAction
+      > = [
+        {
+          type: testStore.Type.UPDATE_DEVWORKSPACE,
+          workspace: expectedDevWorkspaceWithEmptyConditions,
+        },
+        {
+          type: testDevWorkspaceClusterStore.Type.REQUEST_DEVWORKSPACES_CLUSTER,
+          check: AUTHORIZED,
+        },
+        {
+          type: testDevWorkspaceClusterStore.Type.RECEIVED_DEVWORKSPACES_CLUSTER,
+          isRunningDevWorkspacesClusterLimitExceeded: true,
+        },
+        {
+          type: testStore.Type.REQUEST_DEVWORKSPACE,
+          check: AUTHORIZED,
+        },
+        {
+          type: 'REQUEST_DW_SERVER_CONFIG',
+        },
+        {
+          config: {} as api.IServerConfig,
+          type: 'RECEIVE_DW_SERVER_CONFIG',
+        },
+        {
+          type: testStore.Type.UPDATE_DEVWORKSPACE,
+          workspace: devWorkspace,
+        },
+      ];
+
+      expect(actions).toStrictEqual(expectedActions);
+    });
+
     it('should create REQUEST_DEVWORKSPACE and RECEIVE_DEVWORKSPACE_ERROR when failed to start a DevWorkspace', async () => {
       (checkRunningWorkspacesLimit as jest.Mock).mockImplementation(() => {
         throw new Error('Limit reached.');

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -311,6 +311,13 @@ export const actionCreators: ActionCreators = {
         console.warn(`Workspace ${_workspace.metadata.name} already started`);
         return;
       }
+      if (workspace.status?.conditions && workspace.status?.conditions?.length > 0) {
+        workspace.status.conditions = [];
+        dispatch({
+          type: Type.UPDATE_DEVWORKSPACE,
+          workspace,
+        });
+      }
       try {
         await OAuthService.refreshTokenIfProjectExists(workspace);
       } catch (e: unknown) {
@@ -421,8 +428,6 @@ export const actionCreators: ActionCreators = {
         const startingTimeout = 10000;
         await Promise.race([defer.promise, delay(startingTimeout)]);
         toDispose.dispose();
-
-        getDevWorkspaceClient().checkForDevWorkspaceError(startingWorkspace);
       } catch (e) {
         // Skip unauthorised errors. The page is redirecting to an SCM authentication page.
         if (common.helpers.errors.includesAxiosResponse(e) && isOAuthResponse(e.response.data)) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove conditions before restart a workspace

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Знімок екрана 2024-09-16 о 14 41 29](https://github.com/user-attachments/assets/c2b1a26e-7410-4eb9-858c-c230631b3670)

![Знімок екрана 2024-09-16 о 14 41 07](https://github.com/user-attachments/assets/ab1ef335-a9ae-4b51-803e-29f2b1dac865)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6587

### Is it tested? How?
1. Deploy Eclipse-Che with the image from this PR.
2. Open **Create Workspace** page on the dashboard.
3. Put `https://raw.githubusercontent.com/dmytro-ndp/devfile-with-typo/main/devfile.yaml` factory into **Git repo URL**.
4. Click **Create & Open**.
5. The workspace should fails with an error **ImagePullBackOff**.
6. Open a new tab with the swagger link `{CHE-Server}/dashboard/api/swagger`.
7.  And apply the patch to fix the target devvorkspace:
```
[
 {
   "op": "replace",
   "path": "/spec/template/components/0/container/image",
   "value": "quay.io/devfile/universal-developer-image:ubi8-latest"
  }
]
```
8. Open **Starting workspace** page and click **Restart**
9. The target workspace should restart without any warnings or errors.


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
