### PR TITLE
feat: add ability to edit/import gitconfig when no configmap exists

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
@@ -13,6 +13,7 @@
 import { api } from '@eclipse-che/common';
 import * as mockClient from '@kubernetes/client-node';
 import { CoreV1Api, V1ConfigMap } from '@kubernetes/client-node';
+import { exec } from 'child_process';
 import { IncomingMessage } from 'http';
 
 import { GitConfigApiService } from '..';
@@ -29,198 +30,266 @@ const responseBody = {
 describe('Gitconfig API', () => {
   let gitConfigApiService: GitConfigApiService;
 
-  const stubCoreV1Api = {
-    readNamespacedConfigMap: () => {
-      return Promise.resolve({
-        body: responseBody as V1ConfigMap,
-        response: {} as IncomingMessage,
-      });
-    },
-    patchNamespacedConfigMap: () => {
-      return Promise.resolve({
-        body: responseBody as V1ConfigMap,
-        response: {} as IncomingMessage,
-      });
-    },
-  } as unknown as CoreV1Api;
-  const spyReadNamespacedConfigMap = jest.spyOn(stubCoreV1Api, 'readNamespacedConfigMap');
-  const spyPatchNamespacedConfigMap = jest.spyOn(stubCoreV1Api, 'patchNamespacedConfigMap');
+  describe('configmap not found', () => {
+    const stubCoreV1Api = {
+      createNamespacedConfigMap: () => {
+        return Promise.resolve({
+          body: responseBody as V1ConfigMap,
+          response: {} as IncomingMessage,
+        });
+      },
+      readNamespacedConfigMap: () => {
+        return Promise.reject({
+          body: {},
+          response: {} as IncomingMessage,
+          statusCode: 404,
+          name: 'HttpError',
+          message: 'Not Found',
+        });
+      },
+    } as unknown as CoreV1Api;
+    const spyCreateNamespacedConfigMap = jest.spyOn(stubCoreV1Api, 'createNamespacedConfigMap');
 
-  beforeEach(() => {
-    const { KubeConfig } = mockClient;
-    const kubeConfig = new KubeConfig();
-    kubeConfig.makeApiClient = jest.fn().mockImplementation(() => stubCoreV1Api);
+    beforeEach(() => {
+      const { KubeConfig } = mockClient;
+      const kubeConfig = new KubeConfig();
+      kubeConfig.makeApiClient = jest.fn().mockImplementation(() => stubCoreV1Api);
 
-    gitConfigApiService = new GitConfigApiService(kubeConfig);
-  });
+      gitConfigApiService = new GitConfigApiService(kubeConfig);
+    });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
-  describe('reading gitconfig', () => {
-    it('should return gitconfig', async () => {
+    it('should create the configmap and return gitconfig', async () => {
       const resp = await gitConfigApiService.read(namespace);
 
-      expect(resp.gitconfig).toStrictEqual(
-        expect.objectContaining({
-          user: expect.objectContaining({
-            name: 'User One',
-            email: 'user-1@che',
-          }),
-        }),
-      );
+      expect(resp.gitconfig).toStrictEqual({
+        user: {
+          name: 'User One',
+          email: 'user-1@che',
+        },
+      });
 
-      expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
-      expect(spyPatchNamespacedConfigMap).not.toHaveBeenCalled();
-    });
-
-    it('should throw', async () => {
-      spyReadNamespacedConfigMap.mockRejectedValueOnce('404 not found');
-
-      try {
-        await gitConfigApiService.read(namespace);
-
-        // should not reach here
-        expect(false).toBeTruthy();
-      } catch (e) {
-        expect((e as Error).message).toBe(
-          'Unable to read gitconfig in the namespace "user-che": 404 not found',
-        );
-      }
-
-      expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
-      expect(spyPatchNamespacedConfigMap).not.toHaveBeenCalled();
+      expect(spyCreateNamespacedConfigMap).toHaveBeenCalledTimes(1);
+      expect(spyCreateNamespacedConfigMap).toHaveBeenCalledWith(namespace, {
+        data: {
+          gitconfig: `[user]
+name=""
+email=""
+`,
+        },
+        metadata: {
+          annotations: {
+            'controller.devfile.io/mount-as': 'subpath',
+            'controller.devfile.io/mount-path': '/etc/',
+          },
+          labels: {
+            'controller.devfile.io/mount-to-devworkspace': 'true',
+            'controller.devfile.io/watch-configmap': 'true',
+          },
+          name: 'workspace-userdata-gitconfig-configmap',
+          namespace,
+        },
+      });
     });
   });
 
-  describe('patching gitconfig', () => {
-    it('should patch and return gitconfig', async () => {
-      const newGitConfig = {
-        gitconfig: {
-          user: {
-            email: 'user-2@che',
-            name: 'User Two',
-          },
-        },
-      } as api.IGitConfig;
-      await gitConfigApiService.patch(namespace, newGitConfig);
+  describe('configmap found', () => {
+    const stubCoreV1Api = {
+      readNamespacedConfigMap: () => {
+        return Promise.resolve({
+          body: responseBody as V1ConfigMap,
+          response: {} as IncomingMessage,
+        });
+      },
+      patchNamespacedConfigMap: () => {
+        return Promise.resolve({
+          body: responseBody as V1ConfigMap,
+          response: {} as IncomingMessage,
+        });
+      },
+    } as unknown as CoreV1Api;
+    const spyReadNamespacedConfigMap = jest.spyOn(stubCoreV1Api, 'readNamespacedConfigMap');
+    const spyPatchNamespacedConfigMap = jest.spyOn(stubCoreV1Api, 'patchNamespacedConfigMap');
 
-      expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
-      expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(1);
-      expect(spyPatchNamespacedConfigMap).toHaveBeenCalledWith(
-        'workspace-userdata-gitconfig-configmap',
-        'user-che',
-        {
-          data: {
-            gitconfig: `[user]
-email="user-2@che"
-name="User Two"
-`,
-          },
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { headers: { 'content-type': 'application/strategic-merge-patch+json' } },
-      );
+    beforeEach(() => {
+      const { KubeConfig } = mockClient;
+      const kubeConfig = new KubeConfig();
+      kubeConfig.makeApiClient = jest.fn().mockImplementation(() => stubCoreV1Api);
+
+      gitConfigApiService = new GitConfigApiService(kubeConfig);
     });
 
-    it('should throw when can`t read the ConfigMap', async () => {
-      spyReadNamespacedConfigMap.mockRejectedValueOnce('404 not found');
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
-      const newGitConfig = {
-        gitconfig: {
-          user: {
-            email: 'user-2@che',
-            name: 'User Two',
-          },
-        },
-      } as api.IGitConfig;
+    describe('reading gitconfig', () => {
+      it('should return gitconfig', async () => {
+        const resp = await gitConfigApiService.read(namespace);
 
-      try {
-        await gitConfigApiService.patch(namespace, newGitConfig);
-
-        // should not reach here
-        expect(false).toBeTruthy();
-      } catch (e) {
-        expect((e as Error).message).toBe(
-          'Unable to update gitconfig in the namespace "user-che".',
+        expect(resp.gitconfig).toStrictEqual(
+          expect.objectContaining({
+            user: expect.objectContaining({
+              name: 'User One',
+              email: 'user-1@che',
+            }),
+          }),
         );
-      }
 
-      expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
-      expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(0);
-    });
-
-    it('should throw when failed to patch the ConfigMap', async () => {
-      spyPatchNamespacedConfigMap.mockRejectedValueOnce('some error');
-
-      const newGitConfig = {
-        gitconfig: {
-          user: {
-            email: 'user-2@che',
-            name: 'User Two',
-          },
-        },
-      } as api.IGitConfig;
-
-      try {
-        await gitConfigApiService.patch(namespace, newGitConfig);
-
-        // should not reach here
-        expect(false).toBeTruthy();
-      } catch (e) {
-        expect((e as Error).message).toBe(
-          'Unable to update gitconfig in the namespace "user-che": some error',
-        );
-      }
-
-      expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
-      expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(1);
-    });
-
-    it('should throw when conflict detected', async () => {
-      spyReadNamespacedConfigMap.mockResolvedValueOnce({
-        body: {
-          metadata: {
-            resourceVersion: '2',
-          },
-          data: {
-            gitconfig: `[user]
-name="User Two"
-email="user-2@che"
-`,
-          },
-        } as V1ConfigMap,
-        response: {} as IncomingMessage,
+        expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
+        expect(spyPatchNamespacedConfigMap).not.toHaveBeenCalled();
       });
 
-      const newGitConfig = {
-        gitconfig: {
-          user: {
-            email: 'user-2@che',
-            name: 'User Two',
-          },
-        },
-        resourceVersion: '1',
-      } as api.IGitConfig;
+      it('should throw', async () => {
+        spyReadNamespacedConfigMap.mockRejectedValueOnce('404 not found');
 
-      try {
+        try {
+          await gitConfigApiService.read(namespace);
+
+          // should not reach here
+          expect(false).toBeTruthy();
+        } catch (e) {
+          expect((e as Error).message).toBe(
+            'Unable to read gitconfig in the namespace "user-che": 404 not found',
+          );
+        }
+
+        expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
+        expect(spyPatchNamespacedConfigMap).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('patching gitconfig', () => {
+      it('should patch and return gitconfig', async () => {
+        const newGitConfig = {
+          gitconfig: {
+            user: {
+              email: 'user-2@che',
+              name: 'User Two',
+            },
+          },
+        } as api.IGitConfig;
         await gitConfigApiService.patch(namespace, newGitConfig);
 
-        // should not reach here
-        expect(false).toBeTruthy();
-      } catch (e) {
-        expect((e as Error).message).toBe(
-          'Conflict detected. The gitconfig was modified in the namespace "user-che".',
+        expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
+        expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(1);
+        expect(spyPatchNamespacedConfigMap).toHaveBeenCalledWith(
+          'workspace-userdata-gitconfig-configmap',
+          'user-che',
+          {
+            data: {
+              gitconfig: `[user]
+email="user-2@che"
+name="User Two"
+`,
+            },
+          },
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { headers: { 'content-type': 'application/strategic-merge-patch+json' } },
         );
-      }
+      });
 
-      expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
-      expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(0);
+      it('should throw when can`t read the ConfigMap', async () => {
+        spyReadNamespacedConfigMap.mockRejectedValueOnce('404 not found');
+
+        const newGitConfig = {
+          gitconfig: {
+            user: {
+              email: 'user-2@che',
+              name: 'User Two',
+            },
+          },
+        } as api.IGitConfig;
+
+        try {
+          await gitConfigApiService.patch(namespace, newGitConfig);
+
+          // should not reach here
+          expect(false).toBeTruthy();
+        } catch (e) {
+          expect((e as Error).message).toBe(
+            'Unable to update gitconfig in the namespace "user-che".',
+          );
+        }
+
+        expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
+        expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(0);
+      });
+
+      it('should throw when failed to patch the ConfigMap', async () => {
+        spyPatchNamespacedConfigMap.mockRejectedValueOnce('some error');
+
+        const newGitConfig = {
+          gitconfig: {
+            user: {
+              email: 'user-2@che',
+              name: 'User Two',
+            },
+          },
+        } as api.IGitConfig;
+
+        try {
+          await gitConfigApiService.patch(namespace, newGitConfig);
+
+          // should not reach here
+          expect(false).toBeTruthy();
+        } catch (e) {
+          expect((e as Error).message).toBe(
+            'Unable to update gitconfig in the namespace "user-che": some error',
+          );
+        }
+
+        expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
+        expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(1);
+      });
+
+      it('should throw when conflict detected', async () => {
+        spyReadNamespacedConfigMap.mockResolvedValueOnce({
+          body: {
+            metadata: {
+              resourceVersion: '2',
+            },
+            data: {
+              gitconfig: `[user]
+name="User Two"
+email="user-2@che"
+`,
+            },
+          } as V1ConfigMap,
+          response: {} as IncomingMessage,
+        });
+
+        const newGitConfig = {
+          gitconfig: {
+            user: {
+              email: 'user-2@che',
+              name: 'User Two',
+            },
+          },
+          resourceVersion: '1',
+        } as api.IGitConfig;
+
+        try {
+          await gitConfigApiService.patch(namespace, newGitConfig);
+
+          // should not reach here
+          expect(false).toBeTruthy();
+        } catch (e) {
+          expect((e as Error).message).toBe(
+            'Conflict detected. The gitconfig was modified in the namespace "user-che".',
+          );
+        }
+
+        expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
+        expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(0);
+      });
     });
   });
 });

--- a/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
@@ -275,20 +275,20 @@ email="user-2@che"
           resourceVersion: '1',
         } as api.IGitConfig;
 
-      let isPatched = false;
-      let errorMessage = '';
+        let isPatched = false;
+        let errorMessage = '';
 
-      try {
-        await gitConfigApiService.patch(namespace, newGitConfig);
-        isPatched = true;
-      } catch (e: unknown) {
-        errorMessage = (e as Error).message;
-      }
+        try {
+          await gitConfigApiService.patch(namespace, newGitConfig);
+          isPatched = true;
+        } catch (e: unknown) {
+          errorMessage = (e as Error).message;
+        }
 
-      expect(isPatched).toBe(false);
-      expect(errorMessage).toBe(
-        'Conflict detected. The gitconfig was modified in the namespace "user-che".',
-      );
+        expect(isPatched).toBe(false);
+        expect(errorMessage).toBe(
+          'Conflict detected. The gitconfig was modified in the namespace "user-che".',
+        );
 
         expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
         expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(0);

--- a/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
@@ -13,7 +13,6 @@
 import { api } from '@eclipse-che/common';
 import * as mockClient from '@kubernetes/client-node';
 import { CoreV1Api, V1ConfigMap } from '@kubernetes/client-node';
-import { exec } from 'child_process';
 import { IncomingMessage } from 'http';
 
 import { GitConfigApiService } from '..';

--- a/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/gitConfigApi/__tests__/index.spec.ts
@@ -275,16 +275,20 @@ email="user-2@che"
           resourceVersion: '1',
         } as api.IGitConfig;
 
-        try {
-          await gitConfigApiService.patch(namespace, newGitConfig);
+      let isPatched = false;
+      let errorMessage = '';
 
-          // should not reach here
-          expect(false).toBeTruthy();
-        } catch (e) {
-          expect((e as Error).message).toBe(
-            'Conflict detected. The gitconfig was modified in the namespace "user-che".',
-          );
-        }
+      try {
+        await gitConfigApiService.patch(namespace, newGitConfig);
+        isPatched = true;
+      } catch (e: unknown) {
+        errorMessage = (e as Error).message;
+      }
+
+      expect(isPatched).toBe(false);
+      expect(errorMessage).toBe(
+        'Conflict detected. The gitconfig was modified in the namespace "user-che".',
+      );
 
         expect(spyReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
         expect(spyPatchNamespacedConfigMap).toHaveBeenCalledTimes(0);

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCoreV1API.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCoreV1API.ts
@@ -16,6 +16,7 @@ import { retryableExec } from '@/devworkspaceClient/services/helpers/retryableEx
 
 export type CoreV1API = Pick<
   k8s.CoreV1Api,
+  | 'createNamespacedConfigMap'
   | 'createNamespacedSecret'
   | 'listNamespace'
   | 'listNamespacedEvent'
@@ -33,6 +34,8 @@ export type CoreV1API = Pick<
 export function prepareCoreV1API(kc: k8s.KubeConfig): CoreV1API {
   const coreV1API = kc.makeApiClient(k8s.CoreV1Api);
   return {
+    createNamespacedConfigMap: (...args: Parameters<typeof coreV1API.createNamespacedConfigMap>) =>
+      retryableExec(() => coreV1API.createNamespacedConfigMap(...args)),
     createNamespacedSecret: (...args: Parameters<typeof coreV1API.createNamespacedSecret>) =>
       retryableExec(() => coreV1API.createNamespacedSecret(...args)),
     listNamespace: (...args: Parameters<typeof coreV1API.listNamespace>) =>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/__tests__/__snapshots__/index.spec.tsx.snap
@@ -31,7 +31,7 @@ exports[`GitConfigUserEmail snapshot 1`] = `
   >
     <div>
       <input
-        aria-invalid={true}
+        aria-invalid={false}
         aria-label={null}
         className="pf-c-form-control"
         data-ouia-component-id="OUIA-Generated-TextInputBase-2"
@@ -49,7 +49,7 @@ exports[`GitConfigUserEmail snapshot 1`] = `
       <span
         data-testid="validated"
       >
-        error
+        default
       </span>
       <button
         aria-disabled={false}
@@ -63,13 +63,6 @@ exports[`GitConfigUserEmail snapshot 1`] = `
         role={null}
         type="button"
       />
-    </div>
-    <div
-      aria-live="polite"
-      className="pf-c-form__helper-text pf-m-error"
-      id="gitconfig-user-email-helper"
-    >
-      The value is not a valid email address.
     </div>
   </div>
 </div>
@@ -106,7 +99,7 @@ exports[`GitConfigUserEmail snapshot, not loading 1`] = `
   >
     <div>
       <input
-        aria-invalid={true}
+        aria-invalid={false}
         aria-label={null}
         className="pf-c-form-control"
         data-ouia-component-id="OUIA-Generated-TextInputBase-1"
@@ -124,7 +117,7 @@ exports[`GitConfigUserEmail snapshot, not loading 1`] = `
       <span
         data-testid="validated"
       >
-        error
+        default
       </span>
       <button
         aria-disabled={false}
@@ -138,13 +131,6 @@ exports[`GitConfigUserEmail snapshot, not loading 1`] = `
         role={null}
         type="button"
       />
-    </div>
-    <div
-      aria-live="polite"
-      className="pf-c-form__helper-text pf-m-error"
-      id="gitconfig-user-email-helper"
-    >
-      The value is not a valid email address.
     </div>
   </div>
 </div>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/__tests__/index.spec.tsx
@@ -11,12 +11,15 @@
  */
 
 import { ValidatedOptions } from '@patternfly/react-core';
+import { StateMock } from '@react-mock/state';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
-
-import { GitConfigUserEmail } from '..';
+import {
+  GitConfigUserEmail,
+  State,
+} from '@/pages/UserPreferences/GitConfig/Form/SectionUser/Email';
+import getComponentRenderer, { screen, waitFor } from '@/services/__mocks__/getComponentRenderer';
 
 jest.mock('@/components/InputGroupExtended');
 
@@ -67,14 +70,18 @@ describe('GitConfigUserEmail', () => {
     expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.error);
   });
 
-  it('should re-validate on component update', () => {
-    const { reRenderComponent } = renderComponent('', false);
+  it('should reset validation', async () => {
+    const localState: Partial<State> = {
+      value: '',
+      validated: ValidatedOptions.error,
+    };
+    const { reRenderComponent } = renderComponent('user@che.org', true, localState);
 
-    expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.error);
+    reRenderComponent('user@che.org', false, localState);
 
-    reRenderComponent('user@che.com', false);
-
-    expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.default);
+    await waitFor(() =>
+      expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.default),
+    );
   });
 
   it('should handle value changing', async () => {
@@ -88,6 +95,17 @@ describe('GitConfigUserEmail', () => {
   });
 });
 
-function getComponent(value: string, isLoading: boolean): React.ReactElement {
+function getComponent(
+  value: string,
+  isLoading: boolean,
+  localState?: Partial<State>,
+): React.ReactElement {
+  if (localState) {
+    return (
+      <StateMock state={localState}>
+        <GitConfigUserEmail isLoading={isLoading} value={value} onChange={mockOnChange} />
+      </StateMock>
+    );
+  }
   return <GitConfigUserEmail isLoading={isLoading} value={value} onChange={mockOnChange} />;
 }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/index.tsx
@@ -28,8 +28,8 @@ export type Props = {
   onChange: (value: string, isValid: boolean) => void;
 };
 export type State = {
-  errorMessage?: string;
   validated: ValidatedOptions | undefined;
+  value: string | undefined;
 };
 
 export class GitConfigUserEmail extends React.PureComponent<Props, State> {
@@ -37,59 +37,59 @@ export class GitConfigUserEmail extends React.PureComponent<Props, State> {
     super(props);
 
     this.state = {
-      validated: undefined,
+      validated: ValidatedOptions.default,
+      value: props.value,
     };
   }
 
-  public componentDidMount(): void {
-    const { value } = this.props;
-    this.validate(value, true);
-  }
-
-  public componentDidUpdate(prevProps: Readonly<Props>): void {
-    const { value } = this.props;
-    if (value !== prevProps.value) {
-      this.validate(value, true);
+  public componentDidUpdate(_prevProps: Readonly<Props>, prevState: Readonly<State>): void {
+    if (prevState.value === this.state.value && this.props.value !== this.state.value) {
+      // reset the initial value
+      this.setState({
+        value: this.props.value,
+        validated: ValidatedOptions.default,
+      });
     }
   }
 
   private handleChange(value: string): void {
-    const isValid = this.validate(value);
+    const validate = this.validate(value);
+    const isValid = validate === ValidatedOptions.success;
+
+    this.setState({
+      value,
+      validated: validate,
+    });
     this.props.onChange(value, isValid);
   }
 
-  private validate(value: string, initial = false): boolean {
+  private validate(value: string): ValidatedOptions {
     if (value.length === 0) {
-      this.setState({
-        errorMessage: ERROR_REQUIRED_VALUE,
-        validated: ValidatedOptions.error,
-      });
-      return false;
+      return ValidatedOptions.error;
     }
     if (value.length > MAX_LENGTH) {
-      this.setState({
-        errorMessage: ERROR_MAX_LENGTH,
-        validated: ValidatedOptions.error,
-      });
-      return false;
+      return ValidatedOptions.error;
     }
     if (!REGEX.test(value)) {
-      this.setState({
-        errorMessage: ERROR_INVALID_EMAIL,
-        validated: ValidatedOptions.error,
-      });
-      return false;
+      return ValidatedOptions.error;
     }
-    this.setState({
-      errorMessage: undefined,
-      validated: initial === true ? ValidatedOptions.default : ValidatedOptions.success,
-    });
-    return true;
+    return ValidatedOptions.success;
   }
 
   public render(): React.ReactElement {
-    const { isLoading, value } = this.props;
-    const { errorMessage, validated } = this.state;
+    const { isLoading } = this.props;
+    const { value = '', validated } = this.state;
+
+    let errorMessage: string;
+    if (value.length === 0) {
+      errorMessage = ERROR_REQUIRED_VALUE;
+    } else if (value.length > MAX_LENGTH) {
+      errorMessage = ERROR_MAX_LENGTH;
+    } else if (!REGEX.test(value)) {
+      errorMessage = ERROR_INVALID_EMAIL;
+    } else {
+      errorMessage = '';
+    }
 
     const fieldId = 'gitconfig-user-email';
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Name/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Name/__tests__/index.spec.tsx
@@ -11,12 +11,12 @@
  */
 
 import { ValidatedOptions } from '@patternfly/react-core';
+import { StateMock } from '@react-mock/state';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
-
-import { GitConfigUserName } from '..';
+import { GitConfigUserName, State } from '@/pages/UserPreferences/GitConfig/Form/SectionUser/Name';
+import getComponentRenderer, { screen, waitFor } from '@/services/__mocks__/getComponentRenderer';
 
 jest.mock('@/components/InputGroupExtended');
 
@@ -58,14 +58,20 @@ describe('GitConfigUserName', () => {
     expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.error);
   });
 
-  it('should re-validate on component update', () => {
-    const { reRenderComponent } = renderComponent('', false);
+  it('should reset validation', async () => {
+    const initialValue = 'user name';
+    const localState: Partial<State> = {
+      value: '',
+      validated: ValidatedOptions.error,
+    };
 
-    expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.error);
+    const { reRenderComponent } = renderComponent(initialValue, true, localState);
 
-    reRenderComponent('valid name', false);
+    reRenderComponent(initialValue, false, localState);
 
-    expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.default);
+    await waitFor(() =>
+      expect(screen.getByTestId('validated')).toHaveTextContent(ValidatedOptions.default),
+    );
   });
 
   it('should handle value changing', async () => {
@@ -79,6 +85,17 @@ describe('GitConfigUserName', () => {
   });
 });
 
-function getComponent(value: string, isLoading: boolean): React.ReactElement {
+function getComponent(
+  value: string,
+  isLoading: boolean,
+  localState?: Partial<State>,
+): React.ReactElement {
+  if (localState) {
+    return (
+      <StateMock state={localState}>
+        <GitConfigUserName isLoading={isLoading} value={value} onChange={mockOnChange} />
+      </StateMock>
+    );
+  }
   return <GitConfigUserName isLoading={isLoading} value={value} onChange={mockOnChange} />;
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

If it does not exist, the Dashboard creates a `workspace-userdata-gitconfig-configmap` Configmap with a data section like this

```yaml
data:
  gitconfig: |
    [user]
    name=""
    email=""
```

This will allow users to edit this Git configuration, or import the entire `.gitconfig` file.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


https://github.com/user-attachments/assets/02a3423a-e537-4063-abc4-d5ac7155dc95



### What issues does this PR fix or reference?

resolves https://github.com/eclipse-che/che/issues/23147

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

See screencast section

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
