### PR TITLE
fix: hasTechPreviewTag filter

### DIFF
--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/index.spec.tsx
@@ -67,6 +67,35 @@ describe('Editor Selector Entry', () => {
     expect(snapshot.toJSON()).toMatchSnapshot();
   });
 
+  describe('Tech-Preview labels', () => {
+    test('should not show without proper tag', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: [] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).toBeNull();
+    });
+
+    test('show if has proper tag "tech-preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['tech-preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+
+    test('show if has proper tag "Tech-Preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['Tech-Preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+  });
+
   describe('props change', () => {
     test('sibling editor ID provided later', () => {
       const { reRenderComponent } = renderComponent(editorGroup[0].id, editorGroup);

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
@@ -150,9 +150,9 @@ export class EditorSelectorEntry extends React.PureComponent<Props, State> {
       groupIconMediatype === 'image/svg+xml'
         ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(groupIcon)}`
         : groupIcon;
-    const hasTechPreviewTag =
-      (activeEditor.tags || []).map(tag => tag.toLowerCase()).includes('tech-preview') ||
-      /idea/i.test(activeEditor.id) === true;
+    const hasTechPreviewTag = (activeEditor.tags || [])
+      .map(tag => tag.toLowerCase())
+      .includes('tech-preview');
     const tagsGroup = (
       <LabelGroup isVertical>
         <TagLabel type="version" text={activeEditor.version} />

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
@@ -151,7 +151,7 @@ export class EditorSelectorEntry extends React.PureComponent<Props, State> {
         ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(groupIcon)}`
         : groupIcon;
     const hasTechPreviewTag =
-      (activeEditor.tags || []).includes('tech-preview') === true ||
+      (activeEditor.tags || []).map(tag => tag.toLowerCase()).includes('tech-preview') ||
       /idea/i.test(activeEditor.id) === true;
     const tagsGroup = (
       <LabelGroup isVertical>

--- a/packages/dashboard-frontend/src/store/Plugins/chePlugins/__tests__/helpers.convertToEditorPlugin.spec.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/chePlugins/__tests__/helpers.convertToEditorPlugin.spec.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import common from '@eclipse-che/common';
+
+import devfileApi from '@/services/devfileApi';
+import { che } from '@/services/models';
+import { convertToEditorPlugin } from '@/store/Plugins/chePlugins/helpers';
+
+describe('convertToEditorPlugin', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('should throw the error', () => {
+    let editor: devfileApi.Devfile;
+    let plugin: che.Plugin | undefined;
+    let errorMessage: string | undefined;
+
+    beforeEach(() => {
+      plugin = undefined;
+      errorMessage = undefined;
+      editor = getEditor();
+    });
+
+    test('if metadata.name is empty', () => {
+      editor.metadata.name = '';
+
+      try {
+        plugin = convertToEditorPlugin(editor);
+      } catch (e) {
+        errorMessage = common.helpers.errors.getMessage(e);
+      }
+
+      expect(plugin).toBeUndefined();
+      expect(errorMessage).toBe('Invalid editor metadata');
+    });
+
+    test('if metadata.attributes.version is undefined', () => {
+      editor.metadata.attributes.version = undefined;
+
+      try {
+        plugin = convertToEditorPlugin(editor);
+      } catch (e) {
+        errorMessage = common.helpers.errors.getMessage(e);
+      }
+
+      expect(plugin).toBeUndefined();
+      expect(errorMessage).toBe('Invalid editor metadata');
+    });
+
+    test('if metadata.attributes.publisher is undefined', () => {
+      editor.metadata.attributes.publisher = undefined;
+
+      try {
+        plugin = convertToEditorPlugin(editor);
+      } catch (e) {
+        errorMessage = common.helpers.errors.getMessage(e);
+      }
+
+      expect(plugin).toBeUndefined();
+      expect(errorMessage).toBe('Invalid editor metadata');
+    });
+  });
+
+  test('returns correct editor plugin', async () => {
+    const editor = getEditor();
+
+    const plugin = convertToEditorPlugin(editor);
+
+    expect(plugin).toEqual({
+      description:
+        'Microsoft Visual Studio Code - Open Source IDE for Eclipse Che - Insiders build',
+      displayName: 'VS Code - Open Source',
+      icon: `<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg"></svg>`,
+      iconMediatype: 'image/svg+xml',
+      id: 'che-incubator/che-code/insiders',
+      links: {
+        devfile: '',
+      },
+      name: 'che-code',
+      publisher: 'che-incubator',
+      tags: ['Tech-Preview'],
+      type: 'Che Editor',
+      version: 'insiders',
+    });
+  });
+});
+
+function getEditor(): devfileApi.Devfile {
+  return {
+    commands: [
+      {
+        apply: {
+          component: 'che-code-injector',
+        },
+        id: 'init-container-command',
+      },
+    ],
+    components: [
+      {
+        container: {
+          command: ['/entrypoint-init-container.sh'],
+          image: 'quay.io/che-incubator/che-code:insiders',
+        },
+        name: 'che-code-injector',
+      },
+    ],
+    metadata: {
+      attributes: {
+        firstPublicationDate: '2021-10-31',
+        iconData:
+          '<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg"></svg>',
+        iconMediatype: 'image/svg+xml',
+        publisher: 'che-incubator',
+        repository: 'https://github.com/che-incubator/che-code',
+        title: 'Microsoft Visual Studio Code - Open Source IDE for Eclipse Che - Insiders build',
+        version: 'insiders',
+      },
+      description:
+        'Microsoft Visual Studio Code - Open Source IDE for Eclipse Che - Insiders build',
+      displayName: 'VS Code - Open Source',
+      name: 'che-code',
+      tags: ['Tech-Preview'],
+    },
+    schemaVersion: '2.2.2',
+  } as devfileApi.Devfile;
+}

--- a/packages/dashboard-frontend/src/store/Plugins/chePlugins/helpers.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/chePlugins/helpers.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import devfileApi from '@/services/devfileApi';
+import { che } from '@/services/models';
+
+/** Convert devfile to editor plugin */
+export function convertToEditorPlugin(editor: devfileApi.Devfile): che.Plugin {
+  if (
+    !editor.metadata?.name ||
+    !editor.metadata.attributes?.version ||
+    !editor.metadata.attributes?.publisher
+  ) {
+    throw new Error('Invalid editor metadata');
+  }
+  return {
+    id:
+      editor.metadata.attributes.publisher +
+      '/' +
+      editor.metadata.name +
+      '/' +
+      editor.metadata.attributes.version,
+    name: editor.metadata.name,
+    description: editor.metadata.description,
+    displayName: editor.metadata.displayName,
+    publisher: editor.metadata.attributes.publisher,
+    type: 'Che Editor',
+    tags: editor.metadata.tags,
+    version: editor.metadata.attributes.version,
+    links: {
+      devfile: '',
+    },
+    icon: editor.metadata.attributes.iconData,
+    iconMediatype: editor.metadata.attributes.iconMediatype,
+  };
+}

--- a/packages/dashboard-frontend/src/store/Plugins/chePlugins/index.ts
+++ b/packages/dashboard-frontend/src/store/Plugins/chePlugins/index.ts
@@ -16,6 +16,7 @@ import { Action, Reducer } from 'redux';
 import { che } from '@/services/models';
 import { AppThunk } from '@/store';
 import { createObject } from '@/store/helpers';
+import { convertToEditorPlugin } from '@/store/Plugins/chePlugins/helpers';
 import * as devWorkspacePlugins from '@/store/Plugins/devWorkspacePlugins';
 import { SanityCheckAction } from '@/store/sanityCheckMiddleware';
 
@@ -57,28 +58,7 @@ export const actionCreators: ActionCreators = {
 
         const state = getState();
         const editors = state.dwPlugins.cmEditors || [];
-        const editorsPlugins: che.Plugin[] = editors.map(editor => {
-          return {
-            id:
-              editor.metadata.attributes.publisher +
-              '/' +
-              editor.metadata.name +
-              '/' +
-              editor.metadata.attributes.version,
-            name: editor.metadata.name,
-            description: editor.metadata.description,
-            displayName: editor.metadata.displayName,
-            publisher: editor.metadata.attributes.publisher,
-            type: 'Che Editor',
-            tags: editor.metadata.attributes.tags,
-            version: editor.metadata.attributes.version,
-            links: {
-              devfile: '',
-            },
-            icon: editor.metadata.attributes.iconData,
-            iconMediatype: editor.metadata.attributes.iconMediatype,
-          };
-        });
+        const editorsPlugins = editors.map(editor => convertToEditorPlugin(editor));
         dispatch({
           type: 'RECEIVE_PLUGINS',
           plugins: editorsPlugins,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix hasTechPreviewTag filter.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Знімок екрана 2024-09-30 о 14 53 05](https://github.com/user-attachments/assets/546cf467-2077-498d-a4e1-d204c79e01d1)

![Знімок екрана 2024-09-30 о 14 53 32](https://github.com/user-attachments/assets/bb5068ec-b351-448e-87bf-90c873c5988e)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23161

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Open **Create Workspace** page on the dashboard.
3. Open **Editor Selector/Choose an Editor**.
4. Choose **insiders** tag for **VS Code**.
5. All editors should have a **Tech Preview** label.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
