### PR TITLE
fix: Unexpected error message No IDE URL after 20 sec during workspace startup

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
@@ -391,6 +391,29 @@ describe('Starting steps, opening an editor', () => {
         .build();
     });
 
+    test('should not show notification alert if STARTING', async () => {
+      store = new FakeStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [
+            new DevWorkspaceBuilder()
+              .withName(workspaceName)
+              .withNamespace(namespace)
+              .withStatus({ phase: 'STARTING' })
+              .build(),
+          ],
+        })
+        .build();
+      renderComponent(store);
+      jest.runAllTimers();
+
+      // trigger timeout
+      const timeoutButton = screen.queryByRole('button', {
+        name: 'onTimeout',
+      });
+      expect(timeoutButton).toBeNull();
+      expect(mockOnError).not.toHaveBeenCalled();
+    });
+
     test('notification alert', async () => {
       renderComponent(store);
       jest.runAllTimers();

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
@@ -233,8 +233,8 @@ class StartingStepOpenWorkspace extends ProgressStep<Props, State> {
   render(): React.ReactNode {
     const { distance, hasChildren } = this.props;
     const { name, lastError } = this.state;
-
-    const isActive = distance === 0;
+    const workspace = this.findTargetWorkspace(this.props);
+    const isActive = workspace?.isRunning && distance === 0;
     const isError = false;
     const isWarning = lastError !== undefined;
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/index.tsx
@@ -233,8 +233,12 @@ class StartingStepOpenWorkspace extends ProgressStep<Props, State> {
   render(): React.ReactNode {
     const { distance, hasChildren } = this.props;
     const { name, lastError } = this.state;
+
+    // status may flicker from starting to running and back to starting
+    // but we need to run the timer only when the workspace is running
     const workspace = this.findTargetWorkspace(this.props);
     const isActive = workspace?.isRunning && distance === 0;
+
     const isError = false;
     const isWarning = lastError !== undefined;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
These changes fixed problems with a workspace status which may flicker from starting to running and back to starting.
A special rule was added and a timer will be restarted each time when the workspace status flicks from starting to running.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Знімок екрана 2024-09-30 о 16 50 32](https://github.com/user-attachments/assets/558813ac-adba-4010-82fb-c0ecff6e713c)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23159

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
See **Steps to reproduce**  from https://github.com/eclipse-che/che/issues/23159 

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
