### PR TITLE
fix: factory URL flow with untrusted repository

### DIFF
--- a/packages/dashboard-frontend/src/components/UntrustedSourceModal/index.tsx
+++ b/packages/dashboard-frontend/src/components/UntrustedSourceModal/index.tsx
@@ -28,10 +28,8 @@ import { AppAlerts } from '@/services/alerts/appAlerts';
 import { AppState } from '@/store';
 import { selectIsAllowedSourcesConfigured } from '@/store/ServerConfig/selectors';
 import { workspacePreferencesActionCreators } from '@/store/Workspaces/Preferences';
-import {
-  selectPreferencesIsTrustedSource,
-  selectPreferencesTrustedSources,
-} from '@/store/Workspaces/Preferences/selectors';
+import { isTrustedRepo } from '@/store/Workspaces/Preferences/helpers';
+import { selectPreferencesTrustedSources } from '@/store/Workspaces/Preferences/selectors';
 
 export type Props = MappedProps & {
   location: string;
@@ -58,15 +56,15 @@ class UntrustedSourceModal extends React.Component<Props, State> {
     this.state = {
       canContinue: true,
       continueButtonDisabled: false,
-      isTrusted: this.props.isTrustedSource(props.location),
+      isTrusted: isTrustedRepo(props.trustedSources, props.location),
       isAllowedSourcesConfigured: this.props.isAllowedSourcesConfigured,
       trustAllCheckbox: false,
     };
   }
 
   public shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>): boolean {
-    const isTrusted = this.props.isTrustedSource(this.props.location);
-    const nextIsTrusted = nextProps.isTrustedSource(nextProps.location);
+    const isTrusted = isTrustedRepo(this.props.trustedSources, this.props.location);
+    const nextIsTrusted = isTrustedRepo(nextProps.trustedSources, nextProps.location);
     if (isTrusted !== nextIsTrusted) {
       return true;
     }
@@ -101,7 +99,7 @@ class UntrustedSourceModal extends React.Component<Props, State> {
   }
 
   public componentDidUpdate(prevProps: Readonly<Props>): void {
-    const isTrusted = this.props.isTrustedSource(this.props.location);
+    const isTrusted = isTrustedRepo(this.props.trustedSources, this.props.location);
     const isAllowedSourcesConfigured = this.props.isAllowedSourcesConfigured;
 
     this.setState({
@@ -237,7 +235,6 @@ class UntrustedSourceModal extends React.Component<Props, State> {
 
 const mapStateToProps = (state: AppState) => ({
   trustedSources: selectPreferencesTrustedSources(state),
-  isTrustedSource: selectPreferencesIsTrustedSource(state),
   isAllowedSourcesConfigured: selectIsAllowedSourcesConfigured(state),
 });
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -49,7 +49,8 @@ import { Workspace } from '@/services/workspace-adapter';
 import { AppState } from '@/store';
 import { selectIsRegistryDevfile } from '@/store/DevfileRegistries/selectors';
 import * as WorkspaceStore from '@/store/Workspaces';
-import { selectPreferencesIsTrustedSource } from '@/store/Workspaces/Preferences';
+import { selectPreferencesTrustedSources } from '@/store/Workspaces/Preferences';
+import { isTrustedRepo } from '@/store/Workspaces/Preferences/helpers';
 import { selectAllWorkspaces } from '@/store/Workspaces/selectors';
 
 export type Props = MappedProps & {
@@ -162,7 +163,7 @@ class Progress extends React.Component<Props, State> {
       } else {
         // if workspace is not created yet, check if source is trusted
         const { sourceUrl } = this.state.factoryParams;
-        const isTrustedSource = this.props.isTrustedSource(sourceUrl);
+        const isTrustedSource = isTrustedRepo(props.trustedSources, sourceUrl);
         const isRegistryDevfile = this.props.isRegistryDevfile(sourceUrl);
         // trust source if it is taken from the registry or it is in the list of trusted sources
         if (isRegistryDevfile || isTrustedSource) {
@@ -722,7 +723,7 @@ class Progress extends React.Component<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   allWorkspaces: selectAllWorkspaces(state),
   isRegistryDevfile: selectIsRegistryDevfile(state),
-  isTrustedSource: selectPreferencesIsTrustedSource(state),
+  trustedSources: selectPreferencesTrustedSources(state),
 });
 
 const connector = connect(mapStateToProps, WorkspaceStore.actionCreators, null, {

--- a/packages/dashboard-frontend/src/store/Workspaces/Preferences/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/Preferences/__tests__/selectors.spec.ts
@@ -16,7 +16,6 @@ import { FakeStoreBuilder } from '@/store/__mocks__/storeBuilder';
 import {
   selectPreferences,
   selectPreferencesError,
-  selectPreferencesIsTrustedSource,
   selectPreferencesSkipAuthorization,
   selectPreferencesTrustedSources,
 } from '@/store/Workspaces/Preferences/selectors';
@@ -63,53 +62,5 @@ describe('Workspace preferences, selectors', () => {
     const result = selectPreferencesTrustedSources(state);
 
     expect(result).toEqual(mockState.preferences['trusted-sources']);
-  });
-
-  describe('check if a location is a trusted source', () => {
-    it('some sources are trusted', () => {
-      const store = new FakeStoreBuilder()
-        .withWorkspacePreferences({
-          'skip-authorisation': mockState.preferences['skip-authorisation'],
-          'trusted-sources': ['source1'],
-          error: mockState.error,
-        })
-        .build();
-      const state = store.getState();
-      const result = selectPreferencesIsTrustedSource(state);
-
-      expect(result('source1')).toBeTruthy();
-      expect(result('source2')).toBeFalsy();
-    });
-
-    it('all sources are trusted', () => {
-      const store = new FakeStoreBuilder()
-        .withWorkspacePreferences({
-          'skip-authorisation': mockState.preferences['skip-authorisation'],
-          'trusted-sources': '*',
-          error: mockState.error,
-        })
-        .build();
-      const state = store.getState();
-
-      selectPreferences(state);
-      const result = selectPreferencesIsTrustedSource(state);
-
-      expect(result('any-source')).toBeTruthy();
-    });
-
-    it('no sources are trusted', () => {
-      const store = new FakeStoreBuilder()
-        .withWorkspacePreferences({
-          'skip-authorisation': mockState.preferences['skip-authorisation'],
-          'trusted-sources': undefined,
-          error: mockState.error,
-        })
-        .build();
-      const state = store.getState();
-
-      const result = selectPreferencesIsTrustedSource(state);
-
-      expect(result('any-source')).toBeFalsy();
-    });
   });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/Preferences/helpers.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/Preferences/helpers.ts
@@ -108,7 +108,8 @@ export function isTrustedRepo(
 ): boolean {
   if (trustedSources === undefined) {
     return false;
-  } else if (trustedSources === '*') {
+  }
+  if (trustedSources === '*') {
     return true;
   }
 

--- a/packages/dashboard-frontend/src/store/Workspaces/Preferences/helpers.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/Preferences/helpers.ts
@@ -10,6 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { api } from '@eclipse-che/common';
+
 export const gitProviderPatterns = {
   github: {
     https: /^https:\/\/github\.com\/([^\\/]+\/[^\\/]+)(?:\/.*)?$/,
@@ -100,13 +102,22 @@ function getRepoPattern(url: string): RegExp | undefined {
   }
 }
 
-export function isTrustedRepo(trustedUrls: string[], url: string | URL): boolean {
+export function isTrustedRepo(
+  trustedSources: api.TrustedSources | undefined,
+  url: string | URL,
+): boolean {
+  if (trustedSources === undefined) {
+    return false;
+  } else if (trustedSources === '*') {
+    return true;
+  }
+
   const urlString = url.toString();
   const urlPattern = getRepoPattern(urlString);
   const urlRepo = extractRepo(urlString, urlPattern);
 
   // Check if the URL matches any of the trusted repositories
-  return trustedUrls.some(trustedUrl => {
+  return trustedSources.some(trustedUrl => {
     const trustedUrlPattern = getRepoPattern(trustedUrl);
     const trustedUrlRepo = extractRepo(trustedUrl, trustedUrlPattern);
 

--- a/packages/dashboard-frontend/src/store/Workspaces/Preferences/selectors.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/Preferences/selectors.ts
@@ -13,7 +13,6 @@
 import { createSelector } from 'reselect';
 
 import { AppState } from '@/store';
-import { isTrustedRepo } from '@/store/Workspaces/Preferences/helpers';
 
 const selectState = (state: AppState) => state.workspacePreferences;
 
@@ -29,21 +28,4 @@ export const selectPreferencesSkipAuthorization = createSelector(
 export const selectPreferencesTrustedSources = createSelector(
   selectPreferences,
   state => state['trusted-sources'],
-);
-
-export const selectPreferencesIsTrustedSource = createSelector(
-  selectPreferencesTrustedSources,
-  trustedSources => {
-    return (location: string) => {
-      if (!trustedSources || (Array.isArray(trustedSources) && trustedSources.length === 0)) {
-        // no trusted sources yet
-        return false;
-      } else if (trustedSources === '*') {
-        // all sources are trusted
-        return true;
-      }
-
-      return isTrustedRepo(trustedSources, location);
-    };
-  },
 );


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes a bug that blocks the creation of workspaces using a factory link to an untrusted repository.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<details><summary>Before</summary>
<p>


https://github.com/user-attachments/assets/d5aa3f73-3f29-41bf-88c4-9029daa0ed94



</p>
</details> 

<details><summary>After</summary>
<p>


https://github.com/user-attachments/assets/6aad08d1-bfc8-4798-9b39-5f049d7afdc8



</p>
</details> 

### What issues does this PR fix or reference?

fixes https://github.com/eclipse-che/che/issues/23146

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

See the screencast above.


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
