### PR TITLE
fix: TemporaryStorageField widget

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -182,8 +182,6 @@ export interface IDevWorkspaceList {
 export interface IDevWorkspaceResources {
   devfileContent: string | undefined;
   editorPath: string | undefined;
-  pluginRegistryUrl: string | undefined;
-  editorId: string | undefined;
   editorContent: string | undefined;
 }
 

--- a/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
@@ -31,14 +31,14 @@ export function registerDevworkspaceResourcesRoute(instance: FastifyInstance) {
       `${baseApiPath}/devworkspace-resources`,
       getSchema({ tags, body: devWorkspaceResourcesSchema }),
       async function (request: FastifyRequest) {
-        const { devfileContent, editorPath, pluginRegistryUrl, editorId, editorContent } =
+        const { devfileContent, editorPath, editorContent } =
           request.body as api.IDevWorkspaceResources;
         const context = await generator.generateDevfileContext(
           {
             devfileContent,
             editorPath,
-            pluginRegistryUrl,
-            editorEntry: editorId,
+            pluginRegistryUrl: undefined,
+            editorEntry: undefined,
             editorContent,
             projects: [],
           },

--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/AdvancedOptions/CreateNewIfExistingField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/AdvancedOptions/CreateNewIfExistingField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`TemporaryStorageField switched off snapshot 1`] = `
       data-ouia-component-id="OUIA-Generated-Switch-1"
       data-ouia-component-type="PF4/Switch"
       data-ouia-safe={true}
-      htmlFor="temporary-storage-switch"
+      htmlFor="adv-temporary-storage-switch"
     >
       <input
         aria-label="Temporary Storage"
@@ -34,7 +34,7 @@ exports[`TemporaryStorageField switched off snapshot 1`] = `
         checked={false}
         className="pf-c-switch__input"
         disabled={false}
-        id="temporary-storage-switch"
+        id="adv-temporary-storage-switch"
         onChange={[Function]}
         type="checkbox"
       />
@@ -92,7 +92,7 @@ exports[`TemporaryStorageField switched on snapshot 1`] = `
       data-ouia-component-id="OUIA-Generated-Switch-2"
       data-ouia-component-type="PF4/Switch"
       data-ouia-safe={true}
-      htmlFor="temporary-storage-switch"
+      htmlFor="adv-temporary-storage-switch"
     >
       <input
         aria-label="Temporary Storage"
@@ -100,7 +100,7 @@ exports[`TemporaryStorageField switched on snapshot 1`] = `
         checked={true}
         className="pf-c-switch__input"
         disabled={false}
-        id="temporary-storage-switch"
+        id="adv-temporary-storage-switch"
         onChange={[Function]}
         type="checkbox"
       />

--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/AdvancedOptions/TemporaryStorageField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/AdvancedOptions/TemporaryStorageField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`TemporaryStorageField switched off snapshot 1`] = `
       data-ouia-component-id="OUIA-Generated-Switch-1"
       data-ouia-component-type="PF4/Switch"
       data-ouia-safe={true}
-      htmlFor="temporary-storage-switch"
+      htmlFor="adv-temporary-storage-switch"
     >
       <input
         aria-label="Temporary Storage"
@@ -34,7 +34,7 @@ exports[`TemporaryStorageField switched off snapshot 1`] = `
         checked={false}
         className="pf-c-switch__input"
         disabled={false}
-        id="temporary-storage-switch"
+        id="adv-temporary-storage-switch"
         onChange={[Function]}
         type="checkbox"
       />
@@ -92,7 +92,7 @@ exports[`TemporaryStorageField switched on snapshot 1`] = `
       data-ouia-component-id="OUIA-Generated-Switch-2"
       data-ouia-component-type="PF4/Switch"
       data-ouia-safe={true}
-      htmlFor="temporary-storage-switch"
+      htmlFor="adv-temporary-storage-switch"
     >
       <input
         aria-label="Temporary Storage"
@@ -100,7 +100,7 @@ exports[`TemporaryStorageField switched on snapshot 1`] = `
         checked={true}
         className="pf-c-switch__input"
         disabled={false}
-        id="temporary-storage-switch"
+        id="adv-temporary-storage-switch"
         onChange={[Function]}
         type="checkbox"
       />

--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/AdvancedOptions/TemporaryStorageField/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/AdvancedOptions/TemporaryStorageField/index.tsx
@@ -48,7 +48,7 @@ export class TemporaryStorageField extends React.PureComponent<Props, State> {
     return (
       <FormGroup label="Temporary Storage">
         <Switch
-          id="temporary-storage-switch"
+          id="adv-temporary-storage-switch"
           aria-label="Temporary Storage"
           isChecked={isTemporary}
           onChange={value => this.handleChange(value)}

--- a/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
@@ -269,7 +269,6 @@ describe('Workspace-client helpers', () => {
   });
 
   describe('Look for the custom editor', () => {
-    const pluginRegistryUrl = 'https://dummy-plugin-registry';
     let optionalFilesContent: { [fileName: string]: string };
     let editor: devfileApi.Devfile;
 
@@ -285,7 +284,6 @@ describe('Workspace-client helpers', () => {
     it('should return undefined without optionalFilesContent', async () => {
       const store = new FakeStoreBuilder().build();
       const customEditor = await getCustomEditor(
-        pluginRegistryUrl,
         optionalFilesContent,
         store.dispatch,
         store.getState,
@@ -300,7 +298,6 @@ describe('Workspace-client helpers', () => {
         const store = new FakeStoreBuilder().build();
 
         const customEditor = await getCustomEditor(
-          pluginRegistryUrl,
           optionalFilesContent,
           store.dispatch,
           store.getState,
@@ -324,7 +321,6 @@ describe('Workspace-client helpers', () => {
         const store = new FakeStoreBuilder().build();
 
         const customEditor = await getCustomEditor(
-          pluginRegistryUrl,
           optionalFilesContent,
           store.dispatch,
           store.getState,
@@ -342,12 +338,7 @@ describe('Workspace-client helpers', () => {
         let errorText: string | undefined;
 
         try {
-          await getCustomEditor(
-            pluginRegistryUrl,
-            optionalFilesContent,
-            store.dispatch,
-            store.getState,
-          );
+          await getCustomEditor(optionalFilesContent, store.dispatch, store.getState);
         } catch (e) {
           errorText = common.helpers.errors.getMessage(e);
         }
@@ -393,7 +384,6 @@ describe('Workspace-client helpers', () => {
             .build();
 
           const customEditor = await getCustomEditor(
-            pluginRegistryUrl,
             optionalFilesContent,
             store.dispatch,
             store.getState,
@@ -452,7 +442,6 @@ describe('Workspace-client helpers', () => {
             .build();
 
           const customEditor = await getCustomEditor(
-            pluginRegistryUrl,
             optionalFilesContent,
             store.dispatch,
             store.getState,
@@ -505,12 +494,7 @@ describe('Workspace-client helpers', () => {
 
           let errorText: string | undefined;
           try {
-            await getCustomEditor(
-              pluginRegistryUrl,
-              optionalFilesContent,
-              store.dispatch,
-              store.getState,
-            );
+            await getCustomEditor(optionalFilesContent, store.dispatch, store.getState);
           } catch (e) {
             errorText = common.helpers.errors.getMessage(e);
           }
@@ -539,7 +523,6 @@ describe('Workspace-client helpers', () => {
             .build();
 
           const customEditor = await getCustomEditor(
-            pluginRegistryUrl,
             optionalFilesContent,
             store.dispatch,
             store.getState,
@@ -573,7 +556,6 @@ describe('Workspace-client helpers', () => {
             .build();
 
           const customEditor = await getCustomEditor(
-            pluginRegistryUrl,
             optionalFilesContent,
             store.dispatch,
             store.getState,
@@ -602,12 +584,7 @@ describe('Workspace-client helpers', () => {
 
           let errorText: string | undefined;
           try {
-            await getCustomEditor(
-              pluginRegistryUrl,
-              optionalFilesContent,
-              store.dispatch,
-              store.getState,
-            );
+            await getCustomEditor(optionalFilesContent, store.dispatch, store.getState);
           } catch (e) {
             errorText = common.helpers.errors.getMessage(e);
           }

--- a/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
@@ -137,7 +137,6 @@ export const CHE_EDITOR_YAML_PATH = '.che/che-editor.yaml';
  * Look for the custom editor in .che/che-editor.yaml
  */
 export async function getCustomEditor(
-  pluginRegistryUrl: string | undefined,
   optionalFilesContent: { [fileName: string]: string },
   dispatch: ThunkDispatch<AppState, unknown, KnownAction>,
   getState: () => AppState,

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/index.ts
@@ -721,10 +721,8 @@ export const actionCreators: ActionCreators = {
           editorContent = updateEditorDevfile(editorContent, editorImage);
         }
         const resourcesContent = await fetchResources({
-          pluginRegistryUrl,
           devfileContent: dump(defaultsDevfile),
           editorPath: undefined,
-          editorId: undefined,
           editorContent,
         });
         const resources = loadResourcesContent(resourcesContent);
@@ -877,7 +875,6 @@ export const actionCreators: ActionCreators = {
     ): AppThunk<KnownAction, Promise<void>> =>
     async (dispatch, getState): Promise<void> => {
       const state = getState();
-      const pluginRegistryUrl = selectPluginRegistryUrl(state);
       let devWorkspaceResource: devfileApi.DevWorkspace;
       let devWorkspaceTemplateResource: devfileApi.DevWorkspaceTemplate;
       let editorContent: string | undefined;
@@ -895,12 +892,7 @@ export const actionCreators: ActionCreators = {
       } else {
         // do we have the custom editor in `.che/che-editor.yaml` ?
         try {
-          editorContent = await getCustomEditor(
-            pluginRegistryUrl,
-            optionalFilesContent,
-            dispatch,
-            getState,
-          );
+          editorContent = await getCustomEditor(optionalFilesContent, dispatch, getState);
           if (!editorContent) {
             console.warn('No custom editor found');
           }
@@ -932,10 +924,8 @@ export const actionCreators: ActionCreators = {
         }
         editorContent = updateEditorDevfile(editorContent, params.editorImage);
         const resourcesContent = await fetchResources({
-          pluginRegistryUrl,
           devfileContent: dump(devfile),
           editorPath: undefined,
-          editorId: undefined,
           editorContent: editorContent,
         });
         const resources = loadResourcesContent(resourcesContent);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR changes the temporary storage component **id** to prevent showing several components on the page with the same **id**.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23181

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Open **Create Workspace** page on the dashboard.
3. Put a valid URL into the **Git repo URL** field.
4. Try to switch temporary storage for samples.
5. The temporary storage switch works as expected.

<img width="1557" alt="Знімок екрана 2024-10-08 о 18 17 08" src="https://github.com/user-attachments/assets/f3ddb80b-ee6a-4efa-bd5f-8af8d16add54">


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
