### PR TITLE
feat: add the 'Deprecated' tag to the editor definition

### DIFF
--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/index.spec.tsx
@@ -67,7 +67,7 @@ describe('Editor Selector Entry', () => {
     expect(snapshot.toJSON()).toMatchSnapshot();
   });
 
-  describe('Tech-Preview labels', () => {
+  describe('Tech Preview label', () => {
     test('should not show without proper tag', () => {
       renderComponent(
         editorGroup[0].id,
@@ -86,6 +86,15 @@ describe('Editor Selector Entry', () => {
       expect(screen.queryByText('Tech Preview')).not.toBeNull();
     });
 
+    test('show if has proper tag "tech preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['tech preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+
     test('show if has proper tag "Tech-Preview"', () => {
       renderComponent(
         editorGroup[0].id,
@@ -93,6 +102,44 @@ describe('Editor Selector Entry', () => {
       );
 
       expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+
+    test('show if has proper tag "Tech Preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['Tech Preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+  });
+
+  describe('Deprecated label', () => {
+    test('should not show without proper tag', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: [] })),
+      );
+
+      expect(screen.queryByText('Deprecated')).toBeNull();
+    });
+
+    test('show if has proper tag "deprecated"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['deprecated'] })),
+      );
+
+      expect(screen.queryByText('Deprecated')).not.toBeNull();
+    });
+
+    test('show if has proper tag "Deprecated"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['Deprecated'] })),
+      );
+
+      expect(screen.queryByText('Deprecated')).not.toBeNull();
     });
   });
 

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
@@ -41,6 +41,8 @@ export type State = {
   isSelectedGroup: boolean;
 };
 
+const allowedTags = ['Tech Preview', 'Deprecated'];
+
 export class EditorSelectorEntry extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -150,14 +152,20 @@ export class EditorSelectorEntry extends React.PureComponent<Props, State> {
       groupIconMediatype === 'image/svg+xml'
         ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(groupIcon)}`
         : groupIcon;
-    const hasTechPreviewTag = (activeEditor.tags || [])
-      .map(tag => tag.toLowerCase())
-      .includes('tech-preview');
+
+    const tags = (activeEditor.tags || [])
+      .map(tag => {
+        const words = tag.trim().toLowerCase().replace(/-/g, ' ').split(' ');
+        return words.map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+      })
+      .filter(tag => allowedTags.includes(tag));
     const tagsGroup = (
       <LabelGroup isVertical>
         <TagLabel type="version" text={activeEditor.version} />
-        {hasTechPreviewTag ? (
-          <TagLabel type="tag" text="Tech Preview" />
+        {tags.length > 0 ? (
+          tags.map((tag: string, index: number) => (
+            <TagLabel key={`tag-${index}`} type="tag" text={tag} />
+          ))
         ) : (
           <span style={{ padding: '0 5px', lineHeight: '12px', visibility: 'hidden' }}>&nbsp;</span>
         )}

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
@@ -163,9 +163,7 @@ export class EditorSelectorEntry extends React.PureComponent<Props, State> {
       <LabelGroup isVertical>
         <TagLabel type="version" text={activeEditor.version} />
         {tags.length > 0 ? (
-          tags.map((tag: string, index: number) => (
-            <TagLabel key={`tag-${index}`} type="tag" text={tag} />
-          ))
+          tags.map(tag => <TagLabel key={tag} type="tag" text={tag} />)
         ) : (
           <span style={{ padding: '0 5px', lineHeight: '12px', visibility: 'hidden' }}>&nbsp;</span>
         )}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add the `Deprecated` tag to the editor definition.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Знімок екрана 2024-10-15 о 03 53 02](https://github.com/user-attachments/assets/eb032621-99ba-4281-98fb-5c4e92bc986a)

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23172

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Open **Create Workspace** page on the dashboard.
3. Open **Editor Selector**/**Choose an Editor**
4. **IntelliJ IDEA Community** editor should have a `Deprecated` tag.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
