### PR TITLE
[cherry-pick] feat: add the 'Deprecated' tag to the editor definition (#1224)

### DIFF
--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/index.spec.tsx
@@ -96,6 +96,82 @@ describe('Editor Selector Entry', () => {
     });
   });
 
+  describe('Tech Preview label', () => {
+    test('should not show without proper tag', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: [] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).toBeNull();
+    });
+
+    test('show if has proper tag "tech-preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['tech-preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+
+    test('show if has proper tag "tech preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['tech preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+
+    test('show if has proper tag "Tech-Preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['Tech-Preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+
+    test('show if has proper tag "Tech Preview"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['Tech Preview'] })),
+      );
+
+      expect(screen.queryByText('Tech Preview')).not.toBeNull();
+    });
+  });
+
+  describe('Deprecated label', () => {
+    test('should not show without proper tag', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: [] })),
+      );
+
+      expect(screen.queryByText('Deprecated')).toBeNull();
+    });
+
+    test('show if has proper tag "deprecated"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['deprecated'] })),
+      );
+
+      expect(screen.queryByText('Deprecated')).not.toBeNull();
+    });
+
+    test('show if has proper tag "Deprecated"', () => {
+      renderComponent(
+        editorGroup[0].id,
+        [...editorGroup].map(editor => Object.assign({}, editor, { tags: ['Deprecated'] })),
+      );
+
+      expect(screen.queryByText('Deprecated')).not.toBeNull();
+    });
+  });
+
   describe('props change', () => {
     test('sibling editor ID provided later', () => {
       const { reRenderComponent } = renderComponent(editorGroup[0].id, editorGroup);

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
@@ -41,6 +41,8 @@ export type State = {
   isSelectedGroup: boolean;
 };
 
+const allowedTags = ['Tech Preview', 'Deprecated'];
+
 export class EditorSelectorEntry extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -150,14 +152,18 @@ export class EditorSelectorEntry extends React.PureComponent<Props, State> {
       groupIconMediatype === 'image/svg+xml'
         ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(groupIcon)}`
         : groupIcon;
-    const hasTechPreviewTag = (activeEditor.tags || [])
-      .map(tag => tag.toLowerCase())
-      .includes('tech-preview');
+
+    const tags = (activeEditor.tags || [])
+      .map(tag => {
+        const words = tag.trim().toLowerCase().replace(/-/g, ' ').split(' ');
+        return words.map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+      })
+      .filter(tag => allowedTags.includes(tag));
     const tagsGroup = (
       <LabelGroup isVertical>
         <TagLabel type="version" text={activeEditor.version} />
-        {hasTechPreviewTag ? (
-          <TagLabel type="tag" text="Tech Preview" />
+        {tags.length > 0 ? (
+          tags.map(tag => <TagLabel key={tag} type="tag" text={tag} />)
         ) : (
           <span style={{ padding: '0 5px', lineHeight: '12px', visibility: 'hidden' }}>&nbsp;</span>
         )}


### PR DESCRIPTION
* feat: add the 'Deprecated' tag to the editor definition

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR is a cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1224 to the 7.92.x branch
