### PR TITLE
chore: upgrade jsonpath-plus to 10.0.6

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -14,6 +14,6 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `fastify@5.0.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/5.0.0) |
 | `glob@11.0.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/glob/11.0.0) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |
-| `jsonpath-plus@10.0.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.1) |
+| `jsonpath-plus@10.0.6` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.6) |
 | `real-require@0.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/real-require/0.2.0) |
 | `light-my-request@6.0.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/light-my-request/6.0.0) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -267,7 +267,7 @@
 | [`json-stringify-safe@5.0.1`](git://github.com/isaacs/json-stringify-safe) | ISC | clearlydefined |
 | [`jsonc-parser@3.2.0`](https://github.com/microsoft/node-jsonc-parser) | MIT | #12891 |
 | [`jsonfile@6.1.0`](git@github.com:jprichardson/node-jsonfile.git) | MIT | clearlydefined |
-| [`jsonpath-plus@10.0.1`](git://github.com/s3u/JSONPath.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.1) |
+| [`jsonpath-plus@10.0.6`](git://github.com/s3u/JSONPath.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.6) |
 | [`jsonschema@1.4.1`](git://github.com/tdegrunt/jsonschema.git) | MIT | clearlydefined |
 | [`jsprim@1.4.2`](git://github.com/joyent/node-jsprim.git) | MIT | clearlydefined |
 | `leven@2.1.0` | MIT | clearlydefined |

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "find-my-way": "9.0.1",
     "webpack": "^5.94.0",
     "ws": "^8.17.1",
-    "jsonpath-plus": "10.0.1"
+    "jsonpath-plus": "10.0.6"
   }
 }

--- a/scripts/yarn/old_version/.deps/EXCLUDED/prod.md
+++ b/scripts/yarn/old_version/.deps/EXCLUDED/prod.md
@@ -14,6 +14,6 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `fastify@5.0.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/5.0.0) |
 | `glob@11.0.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/glob/11.0.0) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |
-| `jsonpath-plus@10.0.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.1) |
+| `jsonpath-plus@10.0.6` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.6) |
 | `real-require@0.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/real-require/0.2.0) |
 | `light-my-request@6.0.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/light-my-request/6.0.0) |

--- a/scripts/yarn/old_version/.deps/prod.md
+++ b/scripts/yarn/old_version/.deps/prod.md
@@ -222,7 +222,7 @@
 | [`json-stringify-safe@5.0.1`](git://github.com/isaacs/json-stringify-safe) | ISC | clearlydefined |
 | [`jsonc-parser@3.2.0`](https://github.com/microsoft/node-jsonc-parser) | MIT | #12891 |
 | [`jsonfile@6.1.0`](git@github.com:jprichardson/node-jsonfile.git) | MIT | clearlydefined |
-| [`jsonpath-plus@10.0.1`](git://github.com/s3u/JSONPath.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.1) |
+| [`jsonpath-plus@10.0.6`](git://github.com/s3u/JSONPath.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonpath-plus/10.0.6) |
 | [`jsonschema@1.4.1`](git://github.com/tdegrunt/jsonschema.git) | MIT | clearlydefined |
 | [`jsprim@1.4.2`](git://github.com/joyent/node-jsprim.git) | MIT | clearlydefined |
 | [`leven@2.1.0`](https://github.com/sindresorhus/leven.git) | MIT | clearlydefined |

--- a/scripts/yarn/old_version/yarn.lock
+++ b/scripts/yarn/old_version/yarn.lock
@@ -7098,10 +7098,10 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonpath-plus@10.0.1, jsonpath-plus@^8.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
-  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
+jsonpath-plus@10.0.6, jsonpath-plus@^8.0.0:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.6.tgz#09c4db1670a533c3022ec3f59df61a33de975a00"
+  integrity sha512-Q0KCash90S0WQnPnE/W0uVXQSww4NkO34COfs+gbq0fk+Kv03FYpZ+uU2I7soLLaS4d/ywsm9PxplZsTMmfBmg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9669,9 +9669,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:10.0.1":
-  version: 10.0.1
-  resolution: "jsonpath-plus@npm:10.0.1"
+"jsonpath-plus@npm:10.0.6":
+  version: 10.0.6
+  resolution: "jsonpath-plus@npm:10.0.6"
   dependencies:
     "@jsep-plugin/assignment": ^1.2.1
     "@jsep-plugin/regex": ^1.0.3
@@ -9679,7 +9679,7 @@ __metadata:
   bin:
     jsonpath: bin/jsonpath-cli.js
     jsonpath-plus: bin/jsonpath-cli.js
-  checksum: 292310f15807903b3afcf5238c54c7e2a4da0c26ed2d490014b5f960eea0b7b9df54ab56c081c530912a52671dae801c8a68ee6de1e7a3e992d619d66d760caa
+  checksum: ce78d0073da111502342afe6f1974586760c0cb3f47fabd43a85dd5ad3a887c7c6e8766da826de89b3ecb068886e3282cf7c398c764e1c05e2c0c301950a7cf7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR upgrades the **jsonpath-plus** to v10.0.6
