### PR TITLE
feat: Allow to configure 2 gitlab providers simultaneously

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -25,6 +25,7 @@ export type GitOauthProvider =
   | 'github'
   | 'github_2'
   | 'gitlab'
+  | 'gitlab_2'
   | 'bitbucket'
   | 'bitbucket-server'
   | 'azure-devops';

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
@@ -35,6 +35,7 @@ export const CAN_REVOKE_FROM_DASHBOARD: ReadonlyArray<api.GitOauthProvider> = [
   'github',
   'github_2',
   'gitlab',
+  'gitlab_2',
 ];
 
 export type Props = {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/index.tsx
@@ -32,8 +32,6 @@ import {
 import { IGitOauth } from '@/store/GitOauthConfig/types';
 import * as PersonalAccessTokenStore from '@/store/PersonalAccessToken';
 
-export const enabledProviders: api.GitOauthProvider[] = ['github', 'github_2', 'gitlab'];
-
 type Props = MappedProps;
 
 type State = {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
@@ -23,6 +23,7 @@ export const GIT_OAUTH_PROVIDERS: Record<api.GitOauthProvider, string> = {
   github: 'GitHub',
   github_2: 'GitHub (The second provider)',
   gitlab: 'GitLab',
+  gitlab_2: 'GitLab (The second provider)',
 } as const;
 
 export const DEFAULT_GIT_OAUTH_PROVIDER: api.GitOauthProvider = 'github';


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Allow to configure 2 gitlab providers simultaneously

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-7142

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
see https://github.com/eclipse-che/che-server/pull/731

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
