### PR TITLE
Fix editor selector cards

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -11,6 +11,7 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `blueimp-md5@2.19.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/blueimp-md5/2.19.0) |
 | `codemirror@5.65.16` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/codemirror/5.65.16) |
 | `cookie-signature@1.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cookie-signature/1.2.1) |
+| `ecc-jsbn@0.1.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/ecc-jsbn/0.1.2) |
 | `fast-uri@2.4.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.4.0) |
 | `fastify@4.28.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/4.28.1) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |

--- a/packages/dashboard-frontend/jest.setup.tsx
+++ b/packages/dashboard-frontend/jest.setup.tsx
@@ -41,6 +41,6 @@ jest.mock('@/components/CheTooltip', () => {
 
 jest.mock('react-markdown', () => {
   return jest.fn(props => {
-    return React.createElement('div', null, props.children, props.content);
+    return React.createElement('a', null, props.children, props.content);
   });
 });

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.module.css
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.module.css
@@ -18,3 +18,7 @@
 .activeCard {
   color: #000;
 }
+
+.provider {
+  font-size: 75%;
+}

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/__tests__/index.spec.tsx
@@ -130,6 +130,34 @@ describe('EditorGallery', () => {
       expect(sortedEditors[1].version).toEqual('1.0.0');
     });
 
+    test('1.0.0(Deprecated) <=> latest', () => {
+      const editorA = editors[0];
+      editorA.tags = ['Deprecated'];
+      editorA.version = '1.0.0';
+      editorA.id = `${editorA.publisher}/${editorA.name}/${editorA.version}`;
+
+      const editorB = editors[1]; // latest
+
+      const sortedEditors = sortEditors([editorA, editorB]);
+
+      expect(sortedEditors[0].version).toEqual('latest');
+      expect(sortedEditors[1].version).toEqual('1.0.0'); // Deprecated
+    });
+
+    test('1.0.0 <=> latest(Deprecated)', () => {
+      const editorA = editors[0];
+      editorA.version = '1.0.0';
+      editorA.id = `${editorA.publisher}/${editorA.name}/${editorA.version}`;
+
+      const editorB = editors[1]; // latest
+      editorB.tags = ['Deprecated'];
+
+      const sortedEditors = sortEditors([editorA, editorB]);
+
+      expect(sortedEditors[0].version).toEqual('1.0.0');
+      expect(sortedEditors[1].version).toEqual('latest'); // Deprecated
+    });
+
     test('insiders <=> 1.0.0', () => {
       const editorA = editors[0]; // insiders
       const editorB = editors[1];
@@ -140,6 +168,34 @@ describe('EditorGallery', () => {
 
       expect(sortedEditors[0].version).toEqual('insiders');
       expect(sortedEditors[1].version).toEqual('1.0.0');
+    });
+
+    test('insiders(Deprecated) <=> 1.0.0', () => {
+      const editorA = editors[0]; // insiders
+      editorA.id = `${editorA.publisher}/${editorA.name}/${editorA.version}`;
+      editorA.tags = ['Deprecated'];
+
+      const editorB = editors[1];
+      editorB.version = '1.0.0';
+
+      const sortedEditors = sortEditors([editorA, editorB]);
+
+      expect(sortedEditors[0].version).toEqual('1.0.0');
+      expect(sortedEditors[1].version).toEqual('insiders'); // Deprecated
+    });
+
+    test('insiders <=> 1.0.0(Deprecated)', () => {
+      const editorA = editors[0]; // insiders
+      editorA.id = `${editorA.publisher}/${editorA.name}/${editorA.version}`;
+
+      const editorB = editors[1];
+      editorB.version = '1.0.0';
+      editorB.tags = ['Deprecated'];
+
+      const sortedEditors = sortEditors([editorA, editorB]);
+
+      expect(sortedEditors[0].version).toEqual('insiders');
+      expect(sortedEditors[1].version).toEqual('1.0.0'); // Deprecated
     });
   });
 

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/index.tsx
@@ -135,23 +135,41 @@ export class EditorGallery extends React.PureComponent<Props, State> {
 }
 
 const VERSION_PRIORITY: ReadonlyArray<string> = ['insiders', 'next', 'latest'];
+const DEPRECATED_TAG = 'Deprecated';
 export function sortEditors(editors: che.Plugin[]) {
-  const sorted = editors.sort((a, b) => {
-    if (a.name === b.name) {
-      const aPriority = VERSION_PRIORITY.indexOf(a.version);
-      const bPriority = VERSION_PRIORITY.indexOf(b.version);
+  const sorted = editors
+    .sort((a, b) => {
+      if (a.name === b.name) {
+        const aPriority = VERSION_PRIORITY.indexOf(a.version);
+        const bPriority = VERSION_PRIORITY.indexOf(b.version);
 
-      if (aPriority !== -1 && bPriority !== -1) {
-        return aPriority - bPriority;
-      } else if (aPriority !== -1) {
-        return -1;
-      } else if (bPriority !== -1) {
-        return 1;
+        if (aPriority !== -1 && bPriority !== -1) {
+          return aPriority - bPriority;
+        } else if (aPriority !== -1) {
+          return -1;
+        } else if (bPriority !== -1) {
+          return 1;
+        }
       }
-    }
 
-    return a.id.localeCompare(b.id);
-  });
+      return a.id.localeCompare(b.id);
+    })
+    .sort((a, b) => {
+      if (a.name === b.name) {
+        const aPriority = a.tags?.includes(DEPRECATED_TAG) ? -1 : 1;
+        const bPriority = b.tags?.includes(DEPRECATED_TAG) ? -1 : 1;
+
+        if (aPriority !== -1 && bPriority !== -1) {
+          return 0;
+        } else if (aPriority !== -1) {
+          return -1;
+        } else if (bPriority !== -1) {
+          return 1;
+        }
+      }
+
+      return a.id.localeCompare(b.id);
+    });
 
   return sorted;
 }

--- a/scripts/yarn/old_version/.deps/EXCLUDED/prod.md
+++ b/scripts/yarn/old_version/.deps/EXCLUDED/prod.md
@@ -11,6 +11,7 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `blueimp-md5@2.19.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/blueimp-md5/2.19.0) |
 | `codemirror@5.65.16` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/codemirror/5.65.16) |
 | `cookie-signature@1.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cookie-signature/1.2.1) |
+| `ecc-jsbn@0.1.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/ecc-jsbn/0.1.2) |
 | `fast-uri@2.4.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.4.0) |
 | `fastify@4.28.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/4.28.1) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes UI for **Editor Selector** cards:
 - align the editor provider text (Provided by ...) to the same line - bottom of tile
 - clicking on the links (Jet Brains, License) will open a page in a new browser's tab
 - editor dropdown will show the deprecated ones at the end of the list

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Знімок екрана 2024-11-02 о 00 32 09](https://github.com/user-attachments/assets/5f6b4abc-53c6-4814-9f07-d9bdec155b02)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23222

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Open **Create Workspace** page on the dashboard and  **Choose an EDitor**.
3. Check on the editor provider text (**Provided by** ...) in the bottom.
4. Click on the links (**Jet Brains, License**) should open a page in a new browser's tab.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
