### PR TITLE
Do not skip SSH urls from resolving devfile (#1252)

### DIFF
--- a/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceResources.ts
@@ -37,8 +37,6 @@ export function registerDevworkspaceResourcesRoute(instance: FastifyInstance) {
           {
             devfileContent,
             editorPath,
-            pluginRegistryUrl: undefined,
-            editorEntry: undefined,
             editorContent,
             projects: [],
           },

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -114,21 +114,6 @@ describe('Creating steps, fetching a devfile', () => {
     jest.useRealTimers();
   });
 
-  test('factory should not resolve the SSH location', async () => {
-    const searchParams = new URLSearchParams({
-      [FACTORY_URL_ATTR]: 'git@github.com:eclipse-che/che-dashboard.git',
-    });
-
-    renderComponent(store, searchParams);
-
-    await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
-
-    await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
-    expect(mockOnError).not.toHaveBeenCalled();
-    expect(mockOnRestart).not.toHaveBeenCalled();
-    expect(mockRequestFactoryResolver).not.toHaveBeenCalled();
-  });
-
   test('devfile is already resolved', async () => {
     renderComponent(store, searchParams);
 
@@ -734,9 +719,21 @@ describe('Creating steps, fetching a devfile', () => {
     });
 
     it('should go to next step', async () => {
-      const emptyStore = new FakeStoreBuilder().build();
-
-      renderComponent(emptyStore, searchParams, location);
+      const nextStore = new FakeStoreBuilder()
+        .withFactoryResolver({
+          resolver: {
+            location: factoryUrl,
+            devfile: {
+              schemaVersion: '2.3.0',
+              metadata: {
+                name: 'my-project',
+                namespace: 'user-che',
+              },
+            },
+          },
+        })
+        .build();
+      renderComponent(nextStore, searchParams, location);
 
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -26,7 +26,6 @@ import {
 } from '@/components/WorkspaceProgress/ProgressStep';
 import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
-import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 import {
   buildFactoryParams,
   FactoryParams,
@@ -75,9 +74,7 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
     super(props);
 
     const factoryParams = buildFactoryParams(props.searchParams);
-    const name = FactoryLocationAdapter.isHttpLocation(factoryParams.sourceUrl)
-      ? `Inspecting repo ${factoryParams.sourceUrl} for a devfile`
-      : 'Applying default devfile';
+    const name = `Inspecting repo ${factoryParams.sourceUrl} for a devfile`;
 
     this.state = {
       factoryParams,
@@ -206,12 +203,6 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
 
     if (shouldResolve === false && useDefaultDevfile) {
       // go to the next step
-      return true;
-    }
-
-    // do not resolve a devfile if git+SSH URL is provided
-    if (FactoryLocationAdapter.isSshLocation(sourceUrl)) {
-      this.handleDefaultDevfile('');
       return true;
     }
 


### PR DESCRIPTION
Revert the condition that does not allow to resolve devfile for SSH factory urls.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Cherry pick from https://github.com/eclipse-che/che-dashboard/pull/1252

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
