### PR TITLE
Improve the Devfile is not reachable warning for SSH urls (#1259)

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -13,6 +13,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { FACTORY_LINK_ATTR } from '@eclipse-che/common';
+import { AlertVariant } from '@patternfly/react-core';
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { createMemoryHistory, MemoryHistory } from 'history';
@@ -709,6 +710,7 @@ describe('Creating steps, fetching a devfile', () => {
         [FACTORY_URL_ATTR]: factoryUrl,
       });
 
+      mockIsOAuthResponse.mockReturnValue(false);
       mockRequestFactoryResolver.mockRejectedValue('Could not reach devfile');
 
       spyWindowLocation = createWindowLocationSpy(host, protocol);
@@ -750,6 +752,46 @@ describe('Creating steps, fetching a devfile', () => {
 
       expect(mockOpenOAuthPage).not.toHaveBeenCalled();
       expect(mockOnError).not.toHaveBeenCalled();
+    });
+
+    it('should show warning on SSH url', async () => {
+      const expectAlertItem = expect.objectContaining({
+        title: 'Warning',
+        variant: AlertVariant.warning,
+        children: (
+          <ExpandableWarning
+            textBefore="Devfile resolve from a privatre repositry via an SSH url is not supported."
+            errorMessage="Could not reach devfile"
+            textAfter="Apply a Personal Access Token to fetch the devfile.yaml content."
+          />
+        ),
+        actionCallbacks: [
+          expect.objectContaining({
+            title: 'Continue with default devfile',
+            callback: expect.any(Function),
+          }),
+          expect.objectContaining({
+            title: 'Reload',
+            callback: expect.any(Function),
+          }),
+          expect.objectContaining({
+            title: 'Open Documentation page',
+            callback: expect.any(Function),
+          }),
+        ],
+      });
+      searchParams = new URLSearchParams({
+        [FACTORY_URL_ATTR]: 'git@github.com:user/repository.git',
+      });
+      const emptyStore = new FakeStoreBuilder().build();
+      renderComponent(emptyStore, searchParams, history);
+
+      await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
+
+      await waitFor(() => expect(mockOnNextStep).not.toHaveBeenCalled);
+
+      expect(mockOpenOAuthPage).not.toHaveBeenCalled();
+      expect(mockOnError).toHaveBeenCalledWith(expectAlertItem);
     });
   });
 });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -35,6 +35,7 @@ import { AlertItem } from '@/services/helpers/types';
 import { isOAuthResponse, OAuthService } from '@/services/oauth';
 import SessionStorageService, { SessionStorageKey } from '@/services/session-storage';
 import { AppState } from '@/store';
+import { selectBranding } from '@/store/Branding/selectors';
 import { factoryResolverActionCreators, selectFactoryResolver } from '@/store/FactoryResolver';
 import { selectAllWorkspaces } from '@/store/Workspaces/selectors';
 
@@ -46,6 +47,13 @@ export class ApplyingDevfileError extends Error {
 }
 
 export class UnsupportedGitProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsupportedGitProviderError';
+  }
+}
+
+export class SSHPrivateRepositoryUrlError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'UnsupportedGitProviderError';
@@ -179,6 +187,10 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
     this.clearStepError();
   }
 
+  protected handleOpenDocumentationPage(): void {
+    window.open(this.props.branding.docs.startWorkspaceFromGit, '_blank');
+  }
+
   protected handleTimeout(): void {
     const timeoutError = new Error(
       `Devfile hasn't been resolved in the last ${TIMEOUT_TO_RESOLVE_SEC} seconds.`,
@@ -220,7 +232,11 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
         errorMessage === 'Failed to fetch devfile' ||
         errorMessage.startsWith('Could not reach devfile')
       ) {
-        throw new UnsupportedGitProviderError(errorMessage);
+        if (sourceUrl.startsWith('git@')) {
+          throw new SSHPrivateRepositoryUrlError(errorMessage);
+        } else {
+          throw new UnsupportedGitProviderError(errorMessage);
+        }
       }
       throw e;
     }
@@ -365,6 +381,34 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
         ],
       };
     }
+    if (error instanceof SSHPrivateRepositoryUrlError) {
+      return {
+        key,
+        title: 'Warning',
+        variant: AlertVariant.warning,
+        children: (
+          <ExpandableWarning
+            textBefore="Devfile resolve from a privatre repositry via an SSH url is not supported."
+            errorMessage={helpers.errors.getMessage(error)}
+            textAfter="Apply a Personal Access Token to fetch the devfile.yaml content."
+          />
+        ),
+        actionCallbacks: [
+          {
+            title: 'Continue with default devfile',
+            callback: () => this.handleDefaultDevfile(key),
+          },
+          {
+            title: 'Reload',
+            callback: () => this.handleRestart(key),
+          },
+          {
+            title: 'Open Documentation page',
+            callback: () => this.handleOpenDocumentationPage(),
+          },
+        ],
+      };
+    }
     return {
       key,
       title: 'Failed to create the workspace',
@@ -417,6 +461,7 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   allWorkspaces: selectAllWorkspaces(state),
   factoryResolver: selectFactoryResolver(state),
+  branding: selectBranding(state),
 });
 
 const connector = connect(mapStateToProps, factoryResolverActionCreators, null, {

--- a/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts
@@ -33,6 +33,7 @@ export type BrandingDocs = {
   faq?: string;
   storageTypes: string;
   webSocketTroubleshooting: string;
+  startWorkspaceFromGit: string;
 };
 
 export type BrandingConfiguration = {
@@ -83,6 +84,8 @@ export const BRANDING_DEFAULT: BrandingData = {
       'https://www.eclipse.org/che/docs/stable/end-user-guide/url-parameter-for-the-workspace-storage/',
     webSocketTroubleshooting:
       'https://www.eclipse.org/che/docs/stable/end-user-guide/troubleshooting-network-problems/',
+    startWorkspaceFromGit:
+      'https://eclipse.dev/che/docs/stable/end-user-guide/starting-a-workspace-from-a-git-repository-url/',
   },
   configuration: {},
 };


### PR DESCRIPTION
If the devfile resolve request fails with the devfile not found error, check if the url is an SSH url. If so, interrupt the workspace start with a new warning that describes the problem of the devfile resolve via a private repository SSH url.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
cherry pick from https://github.com/eclipse-che/che-dashboard/pull/1259

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
