### PR TITLE
Extend the ssh url pattern check

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -694,6 +694,32 @@ describe('Creating steps, fetching a devfile', () => {
     const host = 'che-host';
     const protocol = 'http://';
     const factoryUrl = 'git@github.com:user/repository-name.git';
+    const emptyStore = new MockStoreBuilder().build();
+    const sshPrivateRepoAllertItem = expect.objectContaining({
+      title: 'Warning',
+      variant: AlertVariant.warning,
+      children: (
+        <ExpandableWarning
+          textBefore="Devfile resolve from a privatre repositry via an SSH url is not supported."
+          errorMessage="Could not reach devfile"
+          textAfter="Apply a Personal Access Token to fetch the devfile.yaml content."
+        />
+      ),
+      actionCallbacks: [
+        expect.objectContaining({
+          title: 'Continue with default devfile',
+          callback: expect.any(Function),
+        }),
+        expect.objectContaining({
+          title: 'Reload',
+          callback: expect.any(Function),
+        }),
+        expect.objectContaining({
+          title: 'Open Documentation page',
+          callback: expect.any(Function),
+        }),
+      ],
+    });
 
     let spyWindowLocation: jest.SpyInstance;
     let location: Location;
@@ -746,43 +772,31 @@ describe('Creating steps, fetching a devfile', () => {
     });
 
     it('should show warning on SSH url', async () => {
-      const expectAlertItem = expect.objectContaining({
-        title: 'Warning',
-        variant: AlertVariant.warning,
-        children: (
-          <ExpandableWarning
-            textBefore="Devfile resolve from a privatre repositry via an SSH url is not supported."
-            errorMessage="Could not reach devfile"
-            textAfter="Apply a Personal Access Token to fetch the devfile.yaml content."
-          />
-        ),
-        actionCallbacks: [
-          expect.objectContaining({
-            title: 'Continue with default devfile',
-            callback: expect.any(Function),
-          }),
-          expect.objectContaining({
-            title: 'Reload',
-            callback: expect.any(Function),
-          }),
-          expect.objectContaining({
-            title: 'Open Documentation page',
-            callback: expect.any(Function),
-          }),
-        ],
-      });
       searchParams = new URLSearchParams({
         [FACTORY_URL_ATTR]: 'git@github.com:user/repository.git',
       });
-      const emptyStore = new MockStoreBuilder().build();
+
       renderComponent(emptyStore, searchParams, location);
 
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
-
       await waitFor(() => expect(mockOnNextStep).not.toHaveBeenCalled);
 
       expect(mockOpenOAuthPage).not.toHaveBeenCalled();
-      expect(mockOnError).toHaveBeenCalledWith(expectAlertItem);
+      expect(mockOnError).toHaveBeenCalledWith(sshPrivateRepoAllertItem);
+    });
+
+    it('should show warning on bitbucket-server SSH url', async () => {
+      searchParams = new URLSearchParams({
+        [FACTORY_URL_ATTR]: 'ssh://git@bitbucket-server.com/~user/repository.git',
+      });
+
+      renderComponent(emptyStore, searchParams, location);
+
+      await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
+      await waitFor(() => expect(mockOnNextStep).not.toHaveBeenCalled);
+
+      expect(mockOpenOAuthPage).not.toHaveBeenCalled();
+      expect(mockOnError).toHaveBeenCalledWith(sshPrivateRepoAllertItem);
     });
   });
 });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -77,6 +77,7 @@ export type State = ProgressStepState & {
 
 class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
   protected readonly name = 'Inspecting repo';
+  private readonly sshPattern = new RegExp('(git@|(ssh|git)://).*');
 
   constructor(props: Props) {
     super(props);
@@ -232,7 +233,8 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
         errorMessage === 'Failed to fetch devfile' ||
         errorMessage.startsWith('Could not reach devfile')
       ) {
-        if (sourceUrl.startsWith('git@')) {
+        // check if the source url is an SSH url
+        if (this.sshPattern.test(sourceUrl)) {
           throw new SSHPrivateRepositoryUrlError(errorMessage);
         } else {
           throw new UnsupportedGitProviderError(errorMessage);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add missing ssh patterns to the SSH url check, see https://git-scm.com/docs/git-clone#_git_urls

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23268

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Apply the pull request image: `quay.io/eclipse/che-dashboard:pr-1268`
2. Add an SSH key to the user namespace and to a bitbucket server instance.
3. Start a workspace from an SSH url of a private bitbucket server repository.

See: workspace start interrupts with the specific message:
![screenshot-cluster-admin-che-dashboard-local-server_apps_rosa_yz5n8-rzhzt-sum_vjy8_p3_openshiftapps_com-2024_11_19-13_20_31](https://github.com/user-attachments/assets/b678d809-2786-48a6-a5c5-7757539b6046)


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
