### PR TITLE
Add isOauth boolean parameter to the PersonalAccessToken type

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -43,6 +43,7 @@ export type PersonalAccessToken = {
   tokenName: string;
   tokenData: string; // base64 encoded
   gitProviderEndpoint: string;
+  isOauth: boolean;
 } & (
   | {
       gitProvider: Exclude<GitProvider, 'azure-devops'>;

--- a/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/helpers.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/__tests__/helpers.spec.ts
@@ -104,6 +104,7 @@ describe('Helpers for Personal Access Token API', () => {
         gitProviderEndpoint: 'https://github.com',
         gitProviderOrganization: undefined,
         tokenData: DUMMY_TOKEN_DATA,
+        isOauth: false,
       });
     });
 
@@ -128,6 +129,7 @@ describe('Helpers for Personal Access Token API', () => {
         gitProvider: 'github',
         gitProviderEndpoint: 'https://github.com',
         tokenData: 'base64-encoded-token-data',
+        isOauth: false,
       };
 
       const secret = toSecret(namespace, token);
@@ -163,6 +165,7 @@ describe('Helpers for Personal Access Token API', () => {
         gitProviderEndpoint: 'https://dev.azure.com',
         gitProviderOrganization: 'azure-org',
         tokenData: 'base64-encoded-token-data',
+        isOauth: false,
       };
 
       const secret = toSecret(namespace, token);
@@ -198,6 +201,7 @@ describe('Helpers for Personal Access Token API', () => {
         gitProvider: 'github',
         gitProviderEndpoint: 'https://github.com',
         tokenData: DUMMY_TOKEN_DATA,
+        isOauth: false,
       };
 
       expect(() => toSecret(namespace, token)).toThrowError();

--- a/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/helpers.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/personalAccessTokenApi/helpers.ts
@@ -80,6 +80,10 @@ export function toToken(secret: k8s.V1Secret): api.PersonalAccessToken {
     gitProvider: secret.metadata.annotations['che.eclipse.org/scm-provider-name'],
     gitProviderEndpoint: secret.metadata.annotations['che.eclipse.org/scm-url'],
     gitProviderOrganization: secret.metadata.annotations['che.eclipse.org/scm-organization'],
+    isOauth:
+      secret.metadata.annotations['che.eclipse.org/scm-personal-access-token-name'].startsWith(
+        'oauth2-',
+      ),
     tokenData: DUMMY_TOKEN_DATA,
   };
 }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/__tests__/index.spec.tsx
@@ -71,6 +71,7 @@ describe('AddEditModalForm', () => {
       tokenData,
       gitProvider,
       gitProviderEndpoint,
+      isOauth: false,
     };
     patWithOrganization = {
       ...pat,

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/index.tsx
@@ -92,6 +92,7 @@ export class AddEditModalForm extends React.PureComponent<Props, State> {
         gitProviderOrganization,
         tokenName,
         tokenData,
+        isOauth: false,
       };
       const isValid =
         gitProviderEndpointIsValid &&
@@ -106,6 +107,7 @@ export class AddEditModalForm extends React.PureComponent<Props, State> {
         gitProvider,
         tokenName,
         tokenData,
+        isOauth: false,
       };
       const isValid = gitProviderEndpointIsValid && tokenNameIsValid && tokenDataIsValid;
       this.props.onChange(token, isValid);

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/DeleteModal/__tests__/stub.ts
@@ -18,6 +18,7 @@ export const token1: api.PersonalAccessToken = {
   gitProviderEndpoint: 'https://github.com',
   tokenData: 'token-data-1',
   tokenName: 'token-name-1',
+  isOauth: false,
 };
 
 export const token2: api.PersonalAccessToken = {
@@ -26,4 +27,5 @@ export const token2: api.PersonalAccessToken = {
   gitProviderEndpoint: 'https://github.com',
   tokenData: 'token-data-2',
   tokenName: 'token-name-2',
+  isOauth: false,
 };

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/List/index.tsx
@@ -29,7 +29,7 @@ import { PersonalAccessTokenListToolbar } from '@/pages/UserPreferences/Personal
 
 const COLUMN_NAMES: Omit<
   Record<keyof api.PersonalAccessToken, string>,
-  'cheUserId' | 'tokenData'
+  'cheUserId' | 'tokenData' | 'isOauth'
 > = {
   tokenName: 'Name',
   gitProvider: 'Provider',

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/__tests__/stub.ts
@@ -18,6 +18,7 @@ export const token1: api.PersonalAccessToken = {
   gitProviderEndpoint: 'https://github.com',
   tokenData: 'token-data-1',
   tokenName: 'token-name-1',
+  isOauth: false,
 };
 
 export const token2: api.PersonalAccessToken = {
@@ -26,4 +27,5 @@ export const token2: api.PersonalAccessToken = {
   gitProviderEndpoint: 'https://github.com',
   tokenData: 'token-data-2',
   tokenName: 'token-name-2',
+  isOauth: false,
 };

--- a/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/GitOauthConfig/__tests__/actions.spec.ts
@@ -294,7 +294,7 @@ describe('GitOauthConfig', () => {
     });
   });
 
-  describe('findUserToken', () => {
+  describe('findOauthToken', () => {
     const mockGitOauth = {
       name: 'github',
       endpointUrl: 'https://github.com/',

--- a/packages/dashboard-frontend/src/store/PersonalAccessTokens/__tests__/stub.ts
+++ b/packages/dashboard-frontend/src/store/PersonalAccessTokens/__tests__/stub.ts
@@ -18,6 +18,7 @@ export const token1: api.PersonalAccessToken = {
   gitProviderEndpoint: 'https://github.com',
   tokenData: 'token-data-1',
   tokenName: 'token-name-1',
+  isOauth: false,
 };
 
 export const token2: api.PersonalAccessToken = {
@@ -26,4 +27,5 @@ export const token2: api.PersonalAccessToken = {
   gitProviderEndpoint: 'https://github.com',
   tokenData: 'token-data-2',
   tokenName: 'token-name-2',
+  isOauth: false,
 };


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add `isOauth` boolean parameter to the `PersonalAccessToken` type to be able to filter tokens that was generated from oAuth. The `tokenName` parameter does not work for this case, because it is set from the original kubernetes secret object name, but not from the `che.eclipse.org/scm-personal-access-token-name` label.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23241

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy the dashboard pull request image: `quay.io/eclipse/che-dashboard:pr-1269`
2. Configure [GitHub oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/), but do not authenticate it.
3. Go to the dashboard `User Preferences` -> `Personal Access Tokens` tab and add a GitHub PAT.
4. Go to the `User Preferences` -> `Git Services` tab and see that the GitHub authorisation is present but the authorisation status is empty and the kebab icon is disabled.

#### Release Notes
<!-- markdown to be included in marketing announcement -->

With this fix all git services items will have the authorized status, only if a related oAuth token was generated, but not with a manually added Personal Access Token.
#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
