### PR TITLE
Fix the bug when kubeconfig file content is collapsed to one line after workspace restart

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/fixtures/kubeconfig.yaml
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/fixtures/kubeconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: inCluster
+    cluster:
+      server: https://0.0.0.0:443
+      certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure-skip-tls-verify: false
+users:
+  - name: developer
+    user:
+      token: token
+contexts:
+  - name: logged-user
+    context:
+      user: developer
+      cluster: inCluster
+      name: logged-user
+preferences: {}
+current-context: logged-user

--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/exec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/exec.ts
@@ -104,8 +104,7 @@ export async function exec(
           return;
         }
 
-        let message = Buffer.from(event.data.substr(1), 'base64').toString('utf-8');
-        message = message.replace(/\n/g, ' ').trim();
+        const message = Buffer.from(event.data.substr(1), 'base64').toString('utf-8').trim();
 
         if (channel === CHANNELS[CHANNELS.STD_OUT]) {
           stdOut += message;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
1. Change the parse format from JSON to YAML as the default format of the `oc` and `kubectl` tools is YAML.
2. Do not substring new line when fetching the kubeconfig file content.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23238

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Che with the dashboard pull request image: `quay.io/eclipse/che-dashboard:pr-1279`
2. Apply [Persistent user home](https://eclipse.dev/che/docs/stable/administration-guide/about-persistent-user-home/).
3. Start a workspace, open the `/home/user/.kube/config` file, see that the content is YAML.
4. Open a new terminal and oc login to a kubernetes cluster.
5. Restart the workspace, execute `oc whoami` from the terminal.

See: the oc command works, the kubeconfig file is valid.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
