### PR TITLE
Start workspace from default devfile on private repository SSH url

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
@@ -238,6 +238,7 @@ describe('Creating steps, applying a devfile', () => {
         expect(prepareDevfile).toHaveBeenCalledWith(
           expect.objectContaining({
             attributes: {
+              'controller.devfile.io/bootstrap-devworkspace': true,
               defaultDevfile: true,
             },
           }),

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -31,7 +31,6 @@ import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
 import { lazyInject } from '@/inversify.config';
 import devfileApi from '@/services/devfileApi';
-import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 import {
   buildFactoryParams,
   FactoryParams,
@@ -181,13 +180,11 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
 
     // when using the default devfile instead of a user devfile
     if (factoryResolver === undefined && isEqual(devfile, defaultDevfile)) {
-      if (FactoryLocationAdapter.isSshLocation(factoryParams.sourceUrl)) {
-        if (!devfile.attributes) {
-          devfile.attributes = {};
-        }
-
-        devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
+      if (!devfile.attributes) {
+        devfile.attributes = {};
       }
+
+      devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
 
       if (devfile.projects === undefined) {
         devfile.projects = [];
@@ -203,13 +200,11 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
         }
       }
     } else if (factoryResolver?.source === 'repo') {
-      if (FactoryLocationAdapter.isSshLocation(factoryParams.sourceUrl)) {
-        if (!devfile.attributes) {
-          devfile.attributes = {};
-        }
-
-        devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
+      if (!devfile.attributes) {
+        devfile.attributes = {};
       }
+
+      devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
     }
 
     if (remotes) {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -13,7 +13,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { FACTORY_LINK_ATTR } from '@eclipse-che/common';
-import { AlertVariant } from '@patternfly/react-core';
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import React from 'react';
@@ -695,31 +694,6 @@ describe('Creating steps, fetching a devfile', () => {
     const protocol = 'http://';
     const factoryUrl = 'git@github.com:user/repository-name.git';
     const emptyStore = new MockStoreBuilder().build();
-    const sshPrivateRepoAllertItem = expect.objectContaining({
-      title: 'Warning',
-      variant: AlertVariant.warning,
-      children: (
-        <ExpandableWarning
-          textBefore="Devfile resolve from a privatre repositry via an SSH url is not supported."
-          errorMessage="Could not reach devfile"
-          textAfter="Apply a Personal Access Token to fetch the devfile.yaml content."
-        />
-      ),
-      actionCallbacks: [
-        expect.objectContaining({
-          title: 'Continue with default devfile',
-          callback: expect.any(Function),
-        }),
-        expect.objectContaining({
-          title: 'Reload',
-          callback: expect.any(Function),
-        }),
-        expect.objectContaining({
-          title: 'Open Documentation page',
-          callback: expect.any(Function),
-        }),
-      ],
-    });
 
     let spyWindowLocation: jest.SpyInstance;
     let location: Location;
@@ -771,7 +745,7 @@ describe('Creating steps, fetching a devfile', () => {
       expect(mockOnError).not.toHaveBeenCalled();
     });
 
-    it('should show warning on SSH url', async () => {
+    it('should use default devfile on private SSH url', async () => {
       searchParams = new URLSearchParams({
         [FACTORY_URL_ATTR]: 'git@github.com:user/repository.git',
       });
@@ -779,13 +753,13 @@ describe('Creating steps, fetching a devfile', () => {
       renderComponent(emptyStore, searchParams, location);
 
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
-      await waitFor(() => expect(mockOnNextStep).not.toHaveBeenCalled);
+      await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
 
       expect(mockOpenOAuthPage).not.toHaveBeenCalled();
-      expect(mockOnError).toHaveBeenCalledWith(sshPrivateRepoAllertItem);
+      expect(mockOnError).not.toHaveBeenCalled();
     });
 
-    it('should show warning on bitbucket-server SSH url', async () => {
+    it('should use default devfile on bitbucket-server SSH url', async () => {
       searchParams = new URLSearchParams({
         [FACTORY_URL_ATTR]: 'ssh://git@bitbucket-server.com/~user/repository.git',
       });
@@ -793,10 +767,10 @@ describe('Creating steps, fetching a devfile', () => {
       renderComponent(emptyStore, searchParams, location);
 
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
-      await waitFor(() => expect(mockOnNextStep).not.toHaveBeenCalled);
+      await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled);
 
       expect(mockOpenOAuthPage).not.toHaveBeenCalled();
-      expect(mockOnError).toHaveBeenCalledWith(sshPrivateRepoAllertItem);
+      expect(mockOnError).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -345,7 +345,7 @@ describe('Creating steps, fetching a devfile', () => {
     });
   });
 
-  describe('unsupported git provider error', () => {
+  describe('unsupported git provider', () => {
     let emptyStore: Store;
     const rejectReason = 'Failed to fetch devfile';
 
@@ -354,110 +354,13 @@ describe('Creating steps, fetching a devfile', () => {
       mockRequestFactoryResolver.mockRejectedValueOnce(rejectReason);
     });
 
-    test('alert title', async () => {
+    test('should continue with the default devfile', async () => {
       renderComponent(emptyStore, searchParams);
 
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-      const expectAlertItem = expect.objectContaining({
-        title: 'Warning',
-        actionCallbacks: [
-          expect.objectContaining({
-            title: 'Continue with default devfile',
-            callback: expect.any(Function),
-          }),
-          expect.objectContaining({
-            title: 'Reload',
-            callback: expect.any(Function),
-          }),
-        ],
-      });
-      await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
-
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-    });
-
-    test('action "Continue with default devfile"', async () => {
-      // this deferred object will help run the callback at the right time
-      const deferred = getDefer();
-
-      const actionTitle = 'Continue with default devfile';
-      mockOnError.mockImplementationOnce((alertItem: AlertItem) => {
-        const action = alertItem.actionCallbacks?.find(_action =>
-          _action.title.startsWith(actionTitle),
-        );
-        expect(action).toBeDefined();
-
-        if (action) {
-          deferred.promise.then(action.callback);
-        } else {
-          throw new Error('Action not found');
-        }
-      });
-
-      renderComponent(emptyStore, searchParams);
-      await jest.runAllTimersAsync();
-
-      await waitFor(() => expect(mockOnError).toHaveBeenCalled());
-      expect(mockOnRestart).not.toHaveBeenCalled();
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-
-      mockOnError.mockClear();
-
-      /* test the action */
-      await jest.runOnlyPendingTimersAsync();
-
-      // resolve deferred to trigger the callback
-      deferred.resolve();
-
-      await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
-      expect(mockOnRestart).not.toHaveBeenCalled();
-      expect(mockOnError).not.toHaveBeenCalled();
-    });
-
-    test('action "Reload"', async () => {
-      // this deferred object will help run the callback at the right time
-      const deferred = getDefer();
-
-      const actionTitle = 'Reload';
-      mockOnError.mockImplementationOnce(async (alertItem: AlertItem) => {
-        const action = alertItem.actionCallbacks?.find(_action =>
-          _action.title.startsWith(actionTitle),
-        );
-        expect(action).toBeDefined();
-
-        if (action) {
-          deferred.promise.then(action.callback);
-        } else {
-          throw new Error('Action not found');
-        }
-      });
-
-      renderComponent(emptyStore, searchParams);
-      await jest.runAllTimersAsync();
-
-      await waitFor(() => expect(mockOnError).toHaveBeenCalled());
-      expect(mockOnRestart).not.toHaveBeenCalled();
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-
-      // first call resolves with error
-      expect(mockRequestFactoryResolver).toHaveBeenCalledTimes(1);
-
-      mockOnError.mockClear();
-
-      /* test the action */
-
-      await jest.runAllTimersAsync();
-
-      // resolve deferred to trigger the callback
-      deferred.resolve();
-
-      await waitFor(() => expect(mockOnRestart).toHaveBeenCalled());
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-      expect(mockOnError).not.toHaveBeenCalled();
-
-      // should request the factory resolver for the second time
-      await waitFor(() => expect(mockRequestFactoryResolver).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(mockOnError).not.toHaveBeenCalled());
+      expect(mockOnNextStep).toHaveBeenCalled();
     });
   });
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -53,13 +53,6 @@ export class UnsupportedGitProviderError extends Error {
   }
 }
 
-export class SSHPrivateRepositoryUrlError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'UnsupportedGitProviderError';
-  }
-}
-
 const RELOADS_LIMIT = 2;
 type ReloadsInfo = {
   [url: string]: number;
@@ -188,10 +181,6 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
     this.clearStepError();
   }
 
-  protected handleOpenDocumentationPage(): void {
-    window.open(this.props.branding.docs.startWorkspaceFromGit, '_blank');
-  }
-
   protected handleTimeout(): void {
     const timeoutError = new Error(
       `Devfile hasn't been resolved in the last ${TIMEOUT_TO_RESOLVE_SEC} seconds.`,
@@ -235,7 +224,8 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
       ) {
         // check if the source url is an SSH url
         if (this.sshPattern.test(sourceUrl)) {
-          throw new SSHPrivateRepositoryUrlError(errorMessage);
+          this.setState({ useDefaultDevfile: true });
+          return true;
         } else {
           throw new UnsupportedGitProviderError(errorMessage);
         }
@@ -379,34 +369,6 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
           {
             title: 'Reload',
             callback: () => this.handleRestart(key),
-          },
-        ],
-      };
-    }
-    if (error instanceof SSHPrivateRepositoryUrlError) {
-      return {
-        key,
-        title: 'Warning',
-        variant: AlertVariant.warning,
-        children: (
-          <ExpandableWarning
-            textBefore="Devfile resolve from a privatre repositry via an SSH url is not supported."
-            errorMessage={helpers.errors.getMessage(error)}
-            textAfter="Apply a Personal Access Token to fetch the devfile.yaml content."
-          />
-        ),
-        actionCallbacks: [
-          {
-            title: 'Continue with default devfile',
-            callback: () => this.handleDefaultDevfile(key),
-          },
-          {
-            title: 'Reload',
-            callback: () => this.handleRestart(key),
-          },
-          {
-            title: 'Open Documentation page',
-            callback: () => this.handleOpenDocumentationPage(),
           },
         ],
       };


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove the `Devfile resolve from a privatre repositry via an SSH url is not supported` warning and start workspace from the default devfile in this case.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23277

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Apply the `che-dashboard` pull request image: `quay.io/eclipse/che-dashboard:pr-1286`
2. Add an SSH key via the user preferences page.
3. Start a workspace from a private repository with a devfile, using SSH url.

See: workspace starts without interruption, local devfile is applied.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
