### PR TITLE
Start workspace from default devfile on private repository SSH url (#…

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
@@ -238,6 +238,7 @@ describe('Creating steps, applying a devfile', () => {
         expect(prepareDevfile).toHaveBeenCalledWith(
           expect.objectContaining({
             attributes: {
+              'controller.devfile.io/bootstrap-devworkspace': true,
               defaultDevfile: true,
             },
           }),

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -31,7 +31,6 @@ import { ProgressStepTitle } from '@/components/WorkspaceProgress/StepTitle';
 import { TimeLimit } from '@/components/WorkspaceProgress/TimeLimit';
 import { lazyInject } from '@/inversify.config';
 import devfileApi from '@/services/devfileApi';
-import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 import {
   buildFactoryParams,
   FactoryParams,
@@ -181,13 +180,11 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
 
     // when using the default devfile instead of a user devfile
     if (factoryResolver === undefined && isEqual(devfile, defaultDevfile)) {
-      if (FactoryLocationAdapter.isSshLocation(factoryParams.sourceUrl)) {
-        if (!devfile.attributes) {
-          devfile.attributes = {};
-        }
-
-        devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
+      if (!devfile.attributes) {
+        devfile.attributes = {};
       }
+
+      devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
 
       if (devfile.projects === undefined) {
         devfile.projects = [];
@@ -203,13 +200,11 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
         }
       }
     } else if (factoryResolver?.source === 'repo') {
-      if (FactoryLocationAdapter.isSshLocation(factoryParams.sourceUrl)) {
-        if (!devfile.attributes) {
-          devfile.attributes = {};
-        }
-
-        devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
+      if (!devfile.attributes) {
+        devfile.attributes = {};
       }
+
+      devfile.attributes['controller.devfile.io/bootstrap-devworkspace'] = true;
     }
 
     if (remotes) {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -13,7 +13,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { FACTORY_LINK_ATTR } from '@eclipse-che/common';
-import { AlertVariant } from '@patternfly/react-core';
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import React from 'react';
@@ -346,7 +345,7 @@ describe('Creating steps, fetching a devfile', () => {
     });
   });
 
-  describe('unsupported git provider error', () => {
+  describe('unsupported git provider', () => {
     let emptyStore: Store;
     const rejectReason = 'Failed to fetch devfile';
 
@@ -355,110 +354,13 @@ describe('Creating steps, fetching a devfile', () => {
       mockRequestFactoryResolver.mockRejectedValueOnce(rejectReason);
     });
 
-    test('alert title', async () => {
+    test('should continue with the default devfile', async () => {
       renderComponent(emptyStore, searchParams);
 
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
-      const expectAlertItem = expect.objectContaining({
-        title: 'Warning',
-        actionCallbacks: [
-          expect.objectContaining({
-            title: 'Continue with default devfile',
-            callback: expect.any(Function),
-          }),
-          expect.objectContaining({
-            title: 'Reload',
-            callback: expect.any(Function),
-          }),
-        ],
-      });
-      await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
-
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-    });
-
-    test('action "Continue with default devfile"', async () => {
-      // this deferred object will help run the callback at the right time
-      const deferred = getDefer();
-
-      const actionTitle = 'Continue with default devfile';
-      mockOnError.mockImplementationOnce((alertItem: AlertItem) => {
-        const action = alertItem.actionCallbacks?.find(_action =>
-          _action.title.startsWith(actionTitle),
-        );
-        expect(action).toBeDefined();
-
-        if (action) {
-          deferred.promise.then(action.callback);
-        } else {
-          throw new Error('Action not found');
-        }
-      });
-
-      renderComponent(emptyStore, searchParams);
-      await jest.runAllTimersAsync();
-
-      await waitFor(() => expect(mockOnError).toHaveBeenCalled());
-      expect(mockOnRestart).not.toHaveBeenCalled();
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-
-      mockOnError.mockClear();
-
-      /* test the action */
-      await jest.runOnlyPendingTimersAsync();
-
-      // resolve deferred to trigger the callback
-      deferred.resolve();
-
-      await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
-      expect(mockOnRestart).not.toHaveBeenCalled();
-      expect(mockOnError).not.toHaveBeenCalled();
-    });
-
-    test('action "Reload"', async () => {
-      // this deferred object will help run the callback at the right time
-      const deferred = getDefer();
-
-      const actionTitle = 'Reload';
-      mockOnError.mockImplementationOnce(async (alertItem: AlertItem) => {
-        const action = alertItem.actionCallbacks?.find(_action =>
-          _action.title.startsWith(actionTitle),
-        );
-        expect(action).toBeDefined();
-
-        if (action) {
-          deferred.promise.then(action.callback);
-        } else {
-          throw new Error('Action not found');
-        }
-      });
-
-      renderComponent(emptyStore, searchParams);
-      await jest.runAllTimersAsync();
-
-      await waitFor(() => expect(mockOnError).toHaveBeenCalled());
-      expect(mockOnRestart).not.toHaveBeenCalled();
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-
-      // first call resolves with error
-      expect(mockRequestFactoryResolver).toHaveBeenCalledTimes(1);
-
-      mockOnError.mockClear();
-
-      /* test the action */
-
-      await jest.runAllTimersAsync();
-
-      // resolve deferred to trigger the callback
-      deferred.resolve();
-
-      await waitFor(() => expect(mockOnRestart).toHaveBeenCalled());
-      expect(mockOnNextStep).not.toHaveBeenCalled();
-      expect(mockOnError).not.toHaveBeenCalled();
-
-      // should request the factory resolver for the second time
-      await waitFor(() => expect(mockRequestFactoryResolver).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(mockOnError).not.toHaveBeenCalled());
+      expect(mockOnNextStep).toHaveBeenCalled();
     });
   });
 
@@ -694,6 +596,7 @@ describe('Creating steps, fetching a devfile', () => {
     const host = 'che-host';
     const protocol = 'http://';
     const factoryUrl = 'git@github.com:user/repository-name.git';
+    const emptyStore = new MockStoreBuilder().build();
 
     let spyWindowLocation: jest.SpyInstance;
     let location: Location;
@@ -745,44 +648,32 @@ describe('Creating steps, fetching a devfile', () => {
       expect(mockOnError).not.toHaveBeenCalled();
     });
 
-    it('should show warning on SSH url', async () => {
-      const expectAlertItem = expect.objectContaining({
-        title: 'Warning',
-        variant: AlertVariant.warning,
-        children: (
-          <ExpandableWarning
-            textBefore="Devfile resolve from a privatre repositry via an SSH url is not supported."
-            errorMessage="Could not reach devfile"
-            textAfter="Apply a Personal Access Token to fetch the devfile.yaml content."
-          />
-        ),
-        actionCallbacks: [
-          expect.objectContaining({
-            title: 'Continue with default devfile',
-            callback: expect.any(Function),
-          }),
-          expect.objectContaining({
-            title: 'Reload',
-            callback: expect.any(Function),
-          }),
-          expect.objectContaining({
-            title: 'Open Documentation page',
-            callback: expect.any(Function),
-          }),
-        ],
-      });
+    it('should use default devfile on private SSH url', async () => {
       searchParams = new URLSearchParams({
         [FACTORY_URL_ATTR]: 'git@github.com:user/repository.git',
       });
-      const emptyStore = new MockStoreBuilder().build();
+
       renderComponent(emptyStore, searchParams, location);
 
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
-
-      await waitFor(() => expect(mockOnNextStep).not.toHaveBeenCalled);
+      await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
 
       expect(mockOpenOAuthPage).not.toHaveBeenCalled();
-      expect(mockOnError).toHaveBeenCalledWith(expectAlertItem);
+      expect(mockOnError).not.toHaveBeenCalled();
+    });
+
+    it('should use default devfile on bitbucket-server SSH url', async () => {
+      searchParams = new URLSearchParams({
+        [FACTORY_URL_ATTR]: 'ssh://git@bitbucket-server.com/~user/repository.git',
+      });
+
+      renderComponent(emptyStore, searchParams, location);
+
+      await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
+      await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled);
+
+      expect(mockOpenOAuthPage).not.toHaveBeenCalled();
+      expect(mockOnError).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
…1286)

Remove the Devfile resolve from a privatre repositry via an SSH url is not supported warning and start workspace from the default devfile in this case.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
backport from https://github.com/eclipse-che/che-dashboard/pull/1286

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
