### PR TITLE
chore: use git clone instead of curl to get airgap samples

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -11,7 +11,7 @@
 FROM docker.io/node:18.19.1-alpine3.19 as builder
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache python3 py3-pip make g++ jq curl
+RUN apk add --no-cache python3 py3-pip make g++ jq curl git zip
 RUN pip3 install yq --break-system-packages
 
 COPY .yarn/releases /dashboard/.yarn/releases/


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Uses `git clone`  to get airgap samples instead of `curl` with GH token

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-7938

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. It could be tested by adding samples into packages/devfile-registry/air-gap/index.json

<details>
  <summary>index.json</summary>

```json
[
  {
    "id": "php",
    "displayName": "PHP",
    "description": "PHP Stack with PHP",
    "tags": [
      "Tech-Preview",
      "PHP",
      "UBI8"
    ],
    "url": "https://github.com/devspaces-samples/php-hello-world/tree/devspaces-3.17-rhel-8",
    "icon": {
      "mediatype": "image/svg+xml",
      "base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0KCiAgICBDb3B5cmlnaHQgKGMpIDIwMTgtMjAyMSBSZWQgSGF0LCBJbmMuCiAgICBBbGwgcmlnaHRzIHJlc2VydmVkLiBUaGlzIHByb2dyYW0gYW5kIHRoZSBhY2NvbXBhbnlpbmcgbWF0ZXJpYWxzCiAgICBhcmUgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIHRlcm1zIG9mIHRoZSBFY2xpcHNlIFB1YmxpYyBMaWNlbnNlIHYyLjAKICAgIHdoaWNoIGFjY29tcGFuaWVzIHRoaXMgZGlzdHJpYnV0aW9uLCBhbmQgaXMgYXZhaWxhYmxlIGF0CiAgICBodHRwOi8vd3d3LmVjbGlwc2Uub3JnL2xlZ2FsL2VwbC0yLjAKCiAgICBDb250cmlidXRvcnM6CiAgICAgIFJlZCBIYXQsIEluYy4gLSBpbml0aWFsIEFQSSBhbmQgaW1wbGVtZW50YXRpb24KCi0tPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiCiAgICAgdmVyc2lvbj0iMS4xIgogICAgIHZpZXdCb3g9IjE1IC0xMCAxNjMgMTE4Ij4KICAgIDxnIHRyYW5zZm9ybT0ibWF0cml4KDIsMCwwLDIsLTE4My4xODI0NywtOTM5Ljc3NDI2KSIKICAgICAgICBzdHlsZT0iZm9udC1zaXplOjUzcHg7Zm9udC1zdHlsZTppdGFsaWM7Zm9udC12YXJpYW50Om5vcm1hbDtmb250LXdlaWdodDo1MDA7Zm9udC1zdHJldGNoOm5vcm1hbDtsaW5lLWhlaWdodDoxMjUlO2xldHRlci1zcGFjaW5nOjBweDt3b3JkLXNwYWNpbmc6MHB4O2ZpbGw6IzAwMDAwMDtmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTtmb250LWZhbWlseTpIYW5kZWwgR290aGljOy1pbmtzY2FwZS1mb250LXNwZWNpZmljYXRpb246SGFuZGVsIEdvdGhpYyBJdGFsaWMiPgogICAgICAgIDxwYXRoIGQ9Im0gMTM2Ljk1MjQ3LDQ4MS42MjU2NiAtMy43MzYyNSwxOC42NTA2MyAzLjU4MzEyLDAgMi4xMjg0NCwtMTAuNjcyODEgMi44Nzg3NSwwLjAyMyBjIDAuOTE3NiwxMGUtNiAxLjUxNDU0LDAuMTgwMDIgMS43OTE1NiwwLjU0MzU5IDAuMjc3LDAuMzYzNTkgMC4zMzM4OSwwLjk3OTUgMC4xNjA3OCwxLjg0NTE2IGwgLTEuNjYxNCw4LjI2MTA5IDMuNjI5MDYsMCAxLjc0NTYyLC04LjY1MTU2IGMgMC4zNjM1NywtMS45MzkwOCAwLjEwMjAzLC0zLjI1MDQzIC0wLjc4MDkzLC0zLjk0Mjk3IC0wLjg2NTY5LC0wLjY5MjUyIC0yLjE4NDY4LC0xLjA2MDIgLTMuOTUwNjMsLTEuMDk0ODQgbCAtMy4yMTU2MiwwIDEuMDEwNjIsLTQuOTYxMjUgLTMuNTgzMTIsMCB6IG0gLTE2LjQyMjY2LDQuOTYxMjUgLTMuNzEzMjgsMTguNjIgMy42MDYwOSwwIDAuOTg3NjYsLTQuOTMwNjIgMy4xMTYwOSwwIGMgMS4wNTYxLDAgMi4wODMyOCwtMC4xMjUxMSAzLjA3MDE2LC0wLjM2NzUgMC45ODY4NCwtMC4yNDIzOSAxLjkxMzU0LC0wLjgwNzA1IDIuNzc5MjIsLTEuNzA3MzQgMC43MDk4MywtMC43MDk4NSAxLjI2MzE4LC0xLjUxMzQyIDEuNjYxNCwtMi4zOTY0MSAwLjQxNTUxLC0wLjg4Mjk3IDAuNjgyNywtMS43NzczOSAwLjgwMzkxLC0yLjY5NSAwLjMxMTYyLC0yLjAwODM0IDAuMDA2LC0zLjU5NDUzIC0wLjkxMTA5LC00Ljc1NDUzIC0wLjkxNzYzLC0xLjE1OTk4IC0yLjM5NzY3LC0xLjc1MTI1IC00LjQ0MDYzLC0xLjc2ODYgbCAtNi45NTk1MywwIHogbSAzMC43ODU3OCwwIC0zLjcxMzI4LDE4LjYyIDMuNjEzNzUsMCAwLjk4NzY2LC00LjkzMDYyIDMuMTE2MDksMCBjIDEuMDU2MSwwIDIuMDc1NjMsLTAuMTI1MTEgMy4wNjI1LC0wLjM2NzUgMC45ODY4NCwtMC4yNDIzOSAxLjkxMzU0LC0wLjgwNzA1IDIuNzc5MjIsLTEuNzA3MzQgMC43MDk4MiwtMC43MDk4NSAxLjI2MzE4LC0xLjUxMzQyIDEuNjYxNCwtMi4zOTY0MSAwLjQxNTUxLC0wLjg4Mjk3IDAuNjgyNywtMS43NzczOSAwLjgwMzkxLC0yLjY5NSAwLjMxMTYyLC0yLjAwODM0IDAuMDA2LC0zLjU5NDUzIC0wLjkxMTA5LC00Ljc1NDUzIC0wLjkxNzYyLC0xLjE1OTk4IC0yLjM5NzY4LC0xLjc1MTI1IC00LjQ0MDYzLC0xLjc2ODYgbCAtNi45NTk1MywwIHogbSAtMjYuNjI4NDQsMi45NjI5NyBjIDEuMzg1MDYsLTAuMDE3MyAyLjUzNTM1LDAuMTEzNDcgMy40NTI5NywwLjM5MDQ3IDAuOTM0OSwwLjI3NzAyIDEuMjQ1NjksMS4zMjExNyAwLjkzNDA2LDMuMTM5MDYgLTAuMzgwOSwyLjE2NDE4IC0xLjEyNzU4LDMuNDMzOTMgLTIuMjM1NjIsMy43OTc1IC0xLjEwODA3LDAuMzQ2MjcgLTIuNDg3NjIsMC41MDczIC00LjE0OTY5LDAuNDkgbCAtMC4zNjc1LDAgYyAtMC4xMDM4OSwwIC0wLjIxMDA0LC0wLjAwNiAtMC4zMTM5LC0wLjAyMyBsIDEuNTU0MjEsLTcuNzcxMDkgYyAwLjE4NDYxLDFlLTUgMC4zNjAwMiwxZS01IDAuNTI4MjksMCAwLjE5MDQzLDAgMC4zODk0MSwtMC4wMDYgMC41OTcxOCwtMC4wMjMgeiBtIDMwLjc4NTc4LDAgYyAxLjM4NTA2LC0wLjAxNzMgMi41MzUzNSwwLjExMzQ3IDMuNDUyOTcsMC4zOTA0NyAwLjkzNDkxLDAuMjc3MDIgMS4yNDU2OSwxLjMyMTE3IDAuOTM0MDcsMy4xMzkwNiAtMC4zODA5MSwyLjE2NDE4IC0xLjExOTkzLDMuNDMzOTMgLTIuMjI3OTcsMy43OTc1IC0xLjEwODA3LDAuMzQ2MjcgLTIuNDk1MjgsMC41MDczIC00LjE1NzM1LDAuNDkgbCAtMC4zNjc1LDAgYyAtMC4xMDM4OCwwIC0wLjIwMjM3LC0wLjAwNiAtMC4zMDYyNSwtMC4wMjMgbCAxLjU0NjU3LC03Ljc3MTA5IGMgMC4xODQ1OSwxZS01IDAuMzYwMDEsMWUtNSAwLjUyODI4LDAgMC4xOTA0MywwIDAuMzg5NDIsLTAuMDA2IDAuNTk3MTgsLTAuMDIzIHoiLz4KICAgIDwvZz4KICAgIDxwYXRoIGQ9Im0gOTYuMDg5MTcsMTEuMTY1NDEgYyAtMTQuNTg5ODM1LDAgLTI4LjIzMjA0MiwxLjk3MiAtMzkuODYzMjk4LDUuMzk4NTUxIEMgMzMuOTA5MTI1LDIzLjEzODQ0MiAxOC45OTU0MiwzNS4wNjc2NTQgMTguOTk1NDIsNDguNjk2NjYgYyAwLDIwLjczMjMwMiAzNC41MTA1NzcsMzcuNTMxMjUgNzcuMDkzNzUsMzcuNTMxMjUgNDIuNTgzMTgsMCA3Ny4xMjUsLTE2Ljc5ODk0OCA3Ny4xMjUsLTM3LjUzMTI1IDAsLTIwLjczMjMwMiAtMzQuNTQxODIsLTM3LjUzMTI1IC03Ny4xMjUsLTM3LjUzMTI1IHogbSAwLjEyNSwxLjYyNSBjIDQuNTUwNjYsMCA5LjAwNzAzLDAuMTkxOTU1IDEzLjMzNTM0LDAuNTU5ODA5IDM1LjI3MTUzLDIuOTk3NjUxIDYyLjAzOTY2LDE3LjY3NjEzNCA2Mi4wMzk2NiwzNS4zNDY0NDEgMCwxOS44Mzg3MDcgLTMzLjc0MDg4LDM1LjkzNzUgLTc1LjM3NSwzNS45Mzc1IC00MS42MzQxMjIsMCAtNzUuNDA2MjUsLTE2LjA5ODc5MyAtNzUuNDA2MjUsLTM1LjkzNzUgMCwtMTkuODM4NzAyIDMzLjc3MjEyOCwtMzUuOTA2MjUgNzUuNDA2MjUsLTM1LjkwNjI1IHoiCiAgICAgICAgICBzdHlsZT0iZmlsbDojMDAwMDAwO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDo3Ljk0MDUxMTc7c3Ryb2tlLW1pdGVybGltaXQ6NDtzdHJva2Utb3BhY2l0eToxIi8+Cjwvc3ZnPgo="
    }
  },
  {
    "id": "ansible",
    "displayName": "Ansible",
    "description": "Development environment for Ansible playbook creation, testing with Molecule, and ansible-lint checks",
    "tags": [
      "Community",
      "Ansible",
      "Molecule"
    ],
    "url": "https://github.com/redhat-developer-demos/ansible-devspaces-demo/tree/devspaces-3.18-rhel-9",
    "icon": {
      "mediatype": "image/svg+xml",
      "base64data": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii05Ny42MiAtMTQ3LjI0IDY0IDY0IiB3aWR0aD0iNjQiIGhlaWdodD0iNjQiPjxwYXRoIGQ9Ik0tMzMuNjItMTE1LjI0YzAgMTcuNjc0LTE0LjMyNiAzMi0zMiAzMnMtMzItMTQuMzI2LTMyLTMyIDE0LjMyOC0zMiAzMi0zMiAzMiAxNC4zMjggMzIgMzIiIGZpbGw9IiMxYTE5MTgiLz48cGF0aCBkPSJNLTY1LjA4LTEyNy42OTJsOC4yOCAyMC40MzgtMTIuNTA4LTkuODUzem0xNC43IDI1LjE0N0wtNjMuMTA4LTEzMy4yYy0uMzY0LS44ODQtMS4xLTEuMzUyLTEuOTczLTEuMzUycy0xLjY2NC40NjgtMi4wMjggMS4zNTJMLTgxLjEtOTkuNTc2aDQuNzgzbDUuNTM0LTEzLjg2MyAxNi41MTUgMTMuMzQzYy42NjQuNTM3IDEuMTQ0Ljc4IDEuNzY3Ljc4IDEuMjQ4IDAgMi4zMzgtLjkzNiAyLjMzOC0yLjI4NiAwLS4yMi0uMDc4LS41Ny0uMjE4LS45NDR6IiBmaWxsPSIjZmZmIi8+PC9zdmc+Cg=="
    }
  }
]
```
</details>

2. Build the image and check samples and devfiles in /public/dashboard/devfile-registry/air-gap
3. Patch Che to use new image and try to start a ws from the sample 
#### Release Notes
<!-- markdown to be included in marketing announcement -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A