### PR TITLE
fix: use absolute path in local-run script to get air-gap samples

### DIFF
--- a/run/local-run.sh
+++ b/run/local-run.sh
@@ -100,8 +100,8 @@ if [ ! -d $DASHBOARD_FRONTEND/lib/public/dashboard/devfile-registry ]; then
 
   echo "[INFO] Downloading airgap projects"
   . "${SCRIPT_DIR}/../scripts/airgap.sh" \
-      -o "$DASHBOARD_FRONTEND/lib/public/dashboard/devfile-registry/air-gap" \
-      -i "packages/devfile-registry/air-gap/index.json"
+      -o "$(pwd)/$DASHBOARD_FRONTEND/lib/public/dashboard/devfile-registry/air-gap" \
+      -i "$(pwd)/packages/devfile-registry/air-gap/index.json"
 
   if [ -s "$DASHBOARD_FRONTEND/lib/public/dashboard/devfile-registry/air-gap/index.json" ]; then
     $(pwd)/scripts/sed_in_place.sh 's|CHE_DASHBOARD_INTERNAL_URL|http://localhost:8080|g' "$DASHBOARD_FRONTEND/lib/public/dashboard/devfile-registry/air-gap/index.json"


### PR DESCRIPTION
### What does this PR do?

Update the script to ensure it runs correctly in a local environment.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-7938

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Try to execute local-run.sh script

#### Release Notes
<!-- markdown to be included in marketing announcement -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A