### PR TITLE
Do not dispatch a warning, if the git provider is not supported

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -37,6 +37,7 @@ import SessionStorageService, { SessionStorageKey } from '@/services/session-sto
 import { RootState } from '@/store';
 import { selectBranding } from '@/store/Branding';
 import { factoryResolverActionCreators, selectFactoryResolver } from '@/store/FactoryResolver';
+import { FACTORY_RESOLVER_NOT_FOUND_ERROR_MESSAGE } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/const';
 import { selectAllWorkspaces } from '@/store/Workspaces/selectors';
 
 export class ApplyingDevfileError extends Error {
@@ -212,8 +213,7 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
       }
       if (
         errorMessage === 'Failed to fetch devfile' ||
-        errorMessage ===
-          'Cannot build factory with any of the provided parameters. Please check parameters correctness, and resend query.' ||
+        errorMessage === FACTORY_RESOLVER_NOT_FOUND_ERROR_MESSAGE ||
         errorMessage.startsWith('Could not reach devfile')
       ) {
         this.setState({ useDefaultDevfile: true });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/const.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/const.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export const FACTORY_RESOLVER_NOT_FOUND_ERROR_MESSAGE =
+  'Cannot build factory with any of the provided parameters. Please check parameters correctness, and resend query.';

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/startWorkspace.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/startWorkspace.ts
@@ -21,6 +21,7 @@ import {
   devWorkspacesClusterActionCreators,
 } from '@/store/DevWorkspacesCluster';
 import { verifyAuthorized } from '@/store/SanityCheck';
+import { FACTORY_RESOLVER_NOT_FOUND_ERROR_MESSAGE } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/const';
 import {
   checkDevWorkspaceNextStartAnnotation,
   checkRunningWorkspacesLimit,
@@ -61,9 +62,9 @@ export const startWorkspace =
         await OAuthService.refreshTokenIfProjectExists(workspace);
       } catch (e: unknown) {
         // Do not interrupt the workspace start, but show a warning notification.
-
         const warnMessage = getWarningFromResponse(e);
-        if (warnMessage) {
+        // Do not dispatch a warning, if the git provider is not supported.
+        if (warnMessage && warnMessage !== FACTORY_RESOLVER_NOT_FOUND_ERROR_MESSAGE) {
           dispatch(devWorkspaceWarningUpdateAction({ workspace, warning: warnMessage }));
         }
       }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Do not dispatch a warning, if the git provider is not supported.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23304

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Che with the pull request image: `quay.io/eclipse/che-dashboard:pr-1306`
2. Start a workspace from an unsupported git provider repository e.g `https://gitea.com/ivinokur/test.git`

See workspace starts from the default devfile without any warnings.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
