### PR TITLE
Fix editor update flow

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
@@ -11,6 +11,7 @@
  */
 
 import devfileApi from '@/services/devfileApi';
+import { EDITOR_DEVFILE_API_QUERY } from '@/store/DevfileRegistries/const';
 
 const getVSCodeDevWorkspaceTemplate = (cpuLimit = '1500m'): devfileApi.DevWorkspaceTemplate => {
   return {
@@ -19,8 +20,7 @@ const getVSCodeDevWorkspaceTemplate = (cpuLimit = '1500m'): devfileApi.DevWorksp
     metadata: {
       annotations: {
         'che.eclipse.org/components-update-policy': 'managed',
-        'che.eclipse.org/plugin-registry-url':
-          'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest',
+        'che.eclipse.org/plugin-registry-url': `${EDITOR_DEVFILE_API_QUERY}che-incubator/che-code/latest`,
       },
       creationTimestamp: new Date('2024-05-30T12:51:45Z'),
       generation: 1,

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/devWorkspaceSpecTemplates.ts
@@ -19,7 +19,8 @@ const getVSCodeDevWorkspaceTemplate = (cpuLimit = '1500m'): devfileApi.DevWorksp
     metadata: {
       annotations: {
         'che.eclipse.org/components-update-policy': 'managed',
-        'che.eclipse.org/plugin-registry-url': 'che-incubator/che-code/latest',
+        'che.eclipse.org/plugin-registry-url':
+          'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest',
       },
       creationTimestamp: new Date('2024-05-30T12:51:45Z'),
       generation: 1,

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/editorDefinitions.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/__mocks__/editorDefinitions.ts
@@ -12,7 +12,7 @@
 
 import { V230Devfile } from '@devfile/api';
 
-const getVSCodeEditorDefinition = (): V230Devfile => {
+const getVSCodeEditorDefinition = (cpuLimit = '500m'): V230Devfile => {
   return {
     attributes: {
       version: null,
@@ -36,7 +36,7 @@ const getVSCodeEditorDefinition = (): V230Devfile => {
       {
         container: {
           command: ['/entrypoint-init-container.sh'],
-          cpuLimit: '500m',
+          cpuLimit,
           cpuRequest: '30m',
           image: 'quay.io/che-incubator/che-code:latest',
           memoryLimit: '256Mi',

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -11,6 +11,7 @@
  */
 
 import mockAxios from 'axios';
+import { dump } from 'js-yaml';
 
 import { container } from '@/inversify.config';
 import { dashboardBackendPrefix } from '@/services/backend-client/const';
@@ -23,11 +24,6 @@ import {
   DevWorkspaceClient,
   REGISTRY_URL,
 } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
-
-const mockFetchData = jest.fn();
-jest.mock('@/services/registry/fetchData', () => ({
-  fetchData: (...args: unknown[]) => mockFetchData(...args),
-}));
 
 describe('DevWorkspace client editor update', () => {
   const namespace = 'admin-che';
@@ -134,53 +130,49 @@ describe('DevWorkspace client editor update', () => {
 
   describe('DevWorkspaceTemplate with plugin registry URL', () => {
     it('should return patch for an editor if it has been updated', async () => {
-      const template = getVSCodeDevWorkspaceTemplate('1000m');
+      const editor = getVSCodeEditorDefinition('1000m') as devfileApi.Devfile;
+      const template = getVSCodeDevWorkspaceTemplate('500m');
       template.metadata.annotations = {
         'che.eclipse.org/components-update-policy': 'managed',
         'che.eclipse.org/plugin-registry-url':
-          'https://192.168.64.24.nip.io/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml',
+          'https://192.168.64.24.nip.io/che-incubator/che-code/devfile.yaml',
       };
 
-      const mockPatch = mockAxios.get as jest.Mock;
-      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
+      const mockGet = mockAxios.get as jest.Mock;
+      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
 
-      // if cpuLimit changed from '1000m' to '500m'
-      const newTemplate = getVSCodeDevWorkspaceTemplate('500m');
-      newTemplate.metadata.annotations = {
-        'che.eclipse.org/components-update-policy': 'managed',
-        'che.eclipse.org/plugin-registry-url':
-          'https://192.168.64.24.nip.io/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml',
-      };
+      const mockPost = mockAxios.post as jest.Mock;
+      mockPost.mockResolvedValueOnce(new Promise(resolve => resolve({ data: dump(editor) })));
 
-      const editors: devfileApi.Devfile[] = [getVSCodeEditorDefinition() as devfileApi.Devfile];
-      const editorName = newTemplate.metadata.name;
+      const editorName = template.metadata.name;
 
       const patch = await client.checkForTemplatesUpdate(
         editorName,
         namespace,
-        editors,
+        [editor],
         pluginRegistryUrl,
         pluginRegistryInternalUrl,
         undefined,
       );
 
-      expect(mockPatch.mock.calls).toEqual([
+      expect(mockGet.mock.calls).toEqual([
         [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${editorName}`],
+      ]);
+
+      expect(mockPost.mock.calls).toEqual([
+        [
+          `${dashboardBackendPrefix}/data/resolver`,
+          {
+            url: 'https://192.168.64.24.nip.io/che-incubator/che-code/devfile.yaml',
+          },
+        ],
       ]);
 
       expect(patch).toEqual([
         {
           op: 'replace',
-          path: '/metadata/annotations',
-          value: {
-            [COMPONENT_UPDATE_POLICY]: 'managed',
-            [REGISTRY_URL]: 'che-incubator/che-code/latest',
-          },
-        },
-        {
-          op: 'replace',
           path: '/spec',
-          value: newTemplate.spec,
+          value: getVSCodeDevWorkspaceTemplate('1000m').spec,
         },
       ]);
     });
@@ -196,16 +188,13 @@ describe('DevWorkspace client editor update', () => {
       const mockPatch = mockAxios.get as jest.Mock;
       mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
 
-      // if cpuLimit changed from '1000m' to '500m'
-      const newTemplate = getVSCodeDevWorkspaceTemplate('500m');
-      newTemplate.metadata.annotations = {
-        'che.eclipse.org/components-update-policy': 'managed',
-        'che.eclipse.org/plugin-registry-url':
-          'https://192.168.64.24.nip.io/custom-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml',
-      };
+      const editors: devfileApi.Devfile[] = [
+        getVSCodeEditorDefinition('1000m') as devfileApi.Devfile,
+      ];
+      const editorName = template.metadata.name;
 
-      const editors: devfileApi.Devfile[] = [getVSCodeEditorDefinition() as devfileApi.Devfile];
-      const editorName = newTemplate.metadata.name;
+      const mockPost = mockAxios.post as jest.Mock;
+      mockPost.mockResolvedValueOnce(new Promise(resolve => resolve({ data: editors[0] })));
 
       const patch = await client.checkForTemplatesUpdate(
         editorName,
@@ -216,8 +205,13 @@ describe('DevWorkspace client editor update', () => {
         undefined,
       );
 
-      expect(mockPatch.mock.calls).toEqual([
-        [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${editorName}`],
+      expect(mockPost.mock.calls).toEqual([
+        [
+          `${dashboardBackendPrefix}/data/resolver`,
+          {
+            url: 'https://192.168.64.24.nip.io/custom-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml',
+          },
+        ],
       ]);
 
       expect(patch).toEqual([]);
@@ -230,10 +224,6 @@ describe('DevWorkspace client editor update', () => {
         'che.eclipse.org/plugin-registry-url':
           'https://192.168.64.24.nip.io/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml',
       };
-
-      const mockPatch = mockAxios.get as jest.Mock;
-      mockPatch.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
-
       // if cpuLimit changed from '1000m' to '500m'
       const newTemplate = getVSCodeDevWorkspaceTemplate('500m');
       newTemplate.metadata.annotations = {
@@ -241,6 +231,9 @@ describe('DevWorkspace client editor update', () => {
         'che.eclipse.org/plugin-registry-url':
           'https://192.168.64.24.nip.io/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml',
       };
+
+      const mockGet = mockAxios.get as jest.Mock;
+      mockGet.mockResolvedValueOnce(new Promise(resolve => resolve({ data: template })));
 
       const editors: devfileApi.Devfile[] = [getVSCodeEditorDefinition() as devfileApi.Devfile];
       const editorName = newTemplate.metadata.name;
@@ -254,7 +247,7 @@ describe('DevWorkspace client editor update', () => {
         undefined,
       );
 
-      expect(mockPatch.mock.calls).toEqual([
+      expect(mockGet.mock.calls).toEqual([
         [`${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${editorName}`],
       ]);
 
@@ -264,7 +257,8 @@ describe('DevWorkspace client editor update', () => {
           path: '/metadata/annotations',
           value: {
             [COMPONENT_UPDATE_POLICY]: 'managed',
-            [REGISTRY_URL]: 'che-incubator/che-code/latest',
+            [REGISTRY_URL]:
+              'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest',
           },
         },
       ]);
@@ -311,7 +305,8 @@ describe('DevWorkspace client editor update', () => {
           path: '/metadata/annotations',
           value: {
             [COMPONENT_UPDATE_POLICY]: 'managed',
-            [REGISTRY_URL]: 'che-incubator/custom-editor/latest',
+            [REGISTRY_URL]:
+              'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/custom-editor/latest',
           },
         },
       ]);

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.editorUpdate.spec.ts
@@ -24,6 +24,7 @@ import {
   DevWorkspaceClient,
   REGISTRY_URL,
 } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+import { EDITOR_DEVFILE_API_QUERY } from '@/store/DevfileRegistries/const';
 
 describe('DevWorkspace client editor update', () => {
   const namespace = 'admin-che';
@@ -257,8 +258,7 @@ describe('DevWorkspace client editor update', () => {
           path: '/metadata/annotations',
           value: {
             [COMPONENT_UPDATE_POLICY]: 'managed',
-            [REGISTRY_URL]:
-              'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest',
+            [REGISTRY_URL]: `${EDITOR_DEVFILE_API_QUERY}che-incubator/che-code/latest`,
           },
         },
       ]);
@@ -305,8 +305,7 @@ describe('DevWorkspace client editor update', () => {
           path: '/metadata/annotations',
           value: {
             [COMPONENT_UPDATE_POLICY]: 'managed',
-            [REGISTRY_URL]:
-              'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/custom-editor/latest',
+            [REGISTRY_URL]: `${EDITOR_DEVFILE_API_QUERY}che-incubator/custom-editor/latest`,
           },
         },
       ]);

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
@@ -16,6 +16,7 @@ import { dump } from 'js-yaml';
 import devfileApi from '@/services/devfileApi';
 import { RootState } from '@/store';
 import { actionCreators } from '@/store/DevfileRegistries/actions';
+import { EDITOR_DEVFILE_API_QUERY } from '@/store/DevfileRegistries/const';
 import { getEditor } from '@/store/DevfileRegistries/getEditor';
 import { State } from '@/store/DevfileRegistries/reducer';
 
@@ -140,8 +141,7 @@ describe('getEditor', () => {
 
     expect(result).toEqual({
       content: 'dumped devfile content',
-      editorYamlUrl:
-        'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-idea/next',
+      editorYamlUrl: `${EDITOR_DEVFILE_API_QUERY}che-incubator/che-idea/next`,
     });
     expect(dispatch).not.toHaveBeenCalled();
   });

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/getEditor.spec.ts
@@ -140,7 +140,8 @@ describe('getEditor', () => {
 
     expect(result).toEqual({
       content: 'dumped devfile content',
-      editorYamlUrl: 'che-incubator/che-idea/next',
+      editorYamlUrl:
+        'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-idea/next',
     });
     expect(dispatch).not.toHaveBeenCalled();
   });

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/const.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/const.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export const EDITOR_DEVFILE_API_QUERY =
+  'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=';

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/getEditor.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/getEditor.ts
@@ -41,11 +41,13 @@ export async function getEditor(
     if (devfileObj) {
       const content = devfileObj.content;
       const error = devfileObj.error;
-      return Object.assign({ content, editorYamlUrl, error });
+      return { content, editorYamlUrl, error };
     }
     throw new Error(`Failed to fetch editor yaml by URL: ${editorYamlUrl}.`);
   } else {
     const editors = state.dwPlugins.cmEditors || [];
+    const editorId = editorIdOrPath;
+    // Find the editor by id
     const editor: devfileApi.Devfile | undefined = editors.find(e => {
       return (
         e.metadata.attributes.publisher +
@@ -53,11 +55,14 @@ export async function getEditor(
           e.metadata.name +
           '/' +
           e.metadata.attributes.version ===
-        editorIdOrPath
+        editorId
       );
     });
     if (editor) {
-      return Object.assign({ content: dump(editor), editorYamlUrl: editorIdOrPath });
+      return {
+        content: dump(editor),
+        editorYamlUrl: `http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=${editorId}`,
+      };
     } else {
       throw new Error(`Failed to fetch editor yaml by id: ${editorIdOrPath}.`);
     }

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/getEditor.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/getEditor.ts
@@ -16,6 +16,7 @@ import { dump } from 'js-yaml';
 import devfileApi from '@/services/devfileApi';
 import { RootState } from '@/store';
 import { actionCreators } from '@/store/DevfileRegistries/actions';
+import { EDITOR_DEVFILE_API_QUERY } from '@/store/DevfileRegistries/const';
 
 export async function getEditor(
   editorIdOrPath: string,
@@ -61,7 +62,7 @@ export async function getEditor(
     if (editor) {
       return {
         content: dump(editor),
-        editorYamlUrl: `http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=${editorId}`,
+        editorYamlUrl: `${EDITOR_DEVFILE_API_QUERY}${editorId}`,
       };
     } else {
       throw new Error(`Failed to fetch editor yaml by id: ${editorIdOrPath}.`);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes the editor update flow and changes the approach of how to store `editorYamlUrl` variable in the `devworkspace.metadata.annotations[REGISTRY_URL]`. 
The existing implementation allows using **editorId** instead of **URL**.
With these changes, a correct API request `http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=${editorId}` will be stored instead of an **editorID**.

### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-7936

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy **Eclipse-Che** with the image from this **PR**.
2. Create a new workspace from the source:
```
https://github.com/eclipse-che/che-dashboard.git
```
3. Stop the workspace. Open **Swagger**: ```{che-server}/dashboard/api/swagger```.
 Use **Devworkspace Template** API and find the **templateName**.
4. Modify(remove field `/spec/commands`) the target template with the next patch:
```json
[
  {
    "op": "replace",
    "path": "/spec/commands",
    "value": []
  }
]
```
5. Check the target template. The field `/spec/commands` should be empty.
6. Start the target workspace. Check the additional request with the **template/spec** data:
![Знімок екрана 2025-02-04 о 01 47 16](https://github.com/user-attachments/assets/a1394010-c4d1-4246-88b3-055c4c62d2e7)
7. Check the target template. The field `/spec/commands` should be restored.

