### PR TITLE
Fix Change of verbiage to helper text under the 'Import from Git' text box.

### DIFF
--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/__snapshots__/index.spec.tsx.snap
@@ -115,7 +115,7 @@ exports[`GitRepoLocationInput snapshot 1`] = `
               className="pf-c-form__helper-text"
               id="git-repo-url-helper"
             >
-              Import from a Git repository to create your first workspace.
+              Import from a Git repository to launch a Cloud Development Environment.
             </div>
           </div>
         </div>

--- a/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
@@ -180,7 +180,7 @@ class ImportFromGit extends React.PureComponent<Props, State> {
           validated={validated}
           helperTextInvalid={errorMessage}
           helperTextInvalidIcon={<ExclamationCircleIcon />}
-          helperText="Import from a Git repository to create your first workspace."
+          helperText="Import from a Git repository to launch a Cloud Development Environment."
         >
           <Flex>
             <FlexItem grow={{ default: 'grow' }} style={{ maxWidth: '500px', minWidth: '70%' }}>


### PR DESCRIPTION
### What does this PR do?

This PR changes the verbiage of the helper text under the Import from Git text box.

### What issues does this PR fix or reference?

If you have more than zero workspaces, the verbiage doesn't make sense.

### Is it tested? How?

I ran the tests from the devfile command.


### Release Notes

Verbiage update on Create Workspace page.

#### Docs PR

N/A