### PR TITLE
Change the git-userdata configmap to secret

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCoreV1API.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/helpers/prepareCoreV1API.ts
@@ -22,6 +22,7 @@ export type CoreV1API = Pick<
   | 'listNamespacedEvent'
   | 'listNamespacedPod'
   | 'listNamespacedSecret'
+  | 'patchNamespacedSecret'
   | 'patchNamespacedConfigMap'
   | 'readNamespacedConfigMap'
   | 'readNamespacedPod'
@@ -48,6 +49,8 @@ export function prepareCoreV1API(kc: k8s.KubeConfig): CoreV1API {
       retryableExec(() => coreV1API.listNamespacedSecret(...args)),
     patchNamespacedConfigMap: (...args: Parameters<typeof coreV1API.patchNamespacedConfigMap>) =>
       retryableExec(() => coreV1API.patchNamespacedConfigMap(...args)),
+    patchNamespacedSecret: (...args: Parameters<typeof coreV1API.patchNamespacedSecret>) =>
+      retryableExec(() => coreV1API.patchNamespacedSecret(...args)),
     readNamespacedConfigMap: (...args: Parameters<typeof coreV1API.readNamespacedConfigMap>) =>
       retryableExec(() => coreV1API.readNamespacedConfigMap(...args)),
     readNamespacedPod: (...args: Parameters<typeof coreV1API.readNamespacedPod>) =>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Store the gitconfig automaunt content to secret instead of configmap. This is needed to have all gitconfig automaunt values in one secret as devworkspace operator does not support mount to gitconfig from multiple objects.

The goal of having a single place to mount gitconfig values is that we need to mount additional gitconfig section apart from the `[user]` section. Currently we mount only username and email from the `workspace-userdata-gitconfig-configmap` configmap but in the scope of the[ Azure devops server support](https://github.com/eclipse-che/che-server/pull/754) we also need to mount azure token as an http.extraHeader value:
```
[http]
    extraHeader: Bearer <azure token>
``` 
We can not mount the `http` section in a separate secret because devworkspace operator does not support gitconfig mount from multiple objects, see https://github.com/devfile/devworkspace-operator/blob/a6ec0bfb254ae1f63283b507475fba69b9768ac5/pkg/provision/automount/common.go#L223-L225.
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23306

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to the user preferences -> Gitconfig
2. Set up username and email

See: the data is stored to the `devworkspace-gitconfig-automaunt-secret` Secret in the user namespace.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
