### PR TITLE
fix: axios instance timeout

### DIFF
--- a/packages/dashboard-frontend/src/services/axios-wrapper/getAxiosInstance.ts
+++ b/packages/dashboard-frontend/src/services/axios-wrapper/getAxiosInstance.ts
@@ -17,7 +17,7 @@ class CheAxiosInstance {
   private readonly axiosInstance: AxiosInstance;
 
   private constructor() {
-    this.axiosInstance = axios.create({ timeout: 15000 });
+    this.axiosInstance = axios.create({ timeout: 30000 });
   }
 
   public static getInstance(): CheAxiosInstance {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Increase  **axios** instance timeout to 30 seconds:

``` js
    this.axiosInstance = axios.create({ timeout: 30000 });
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23354

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
