### PR TITLE
fix: factory flow with a devfile that uses a parent

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/prepareDevfile.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/prepareDevfile.spec.ts
@@ -11,6 +11,7 @@
  */
 
 import { dump } from 'js-yaml';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { prepareDevfile } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile';
 import devfileApi from '@/services/devfileApi';
@@ -228,31 +229,72 @@ describe('FactoryLoaderContainer/prepareDevfile', () => {
     });
 
     describe('has parent', () => {
+      let devfile: devfileApi.Devfile;
+      let parentDevfile: devfileApi.Devfile;
+      // mute console logs
+      console.warn = jest.fn();
+
+      beforeEach(() => {
+        devfile = {
+          schemaVersion: '2.2.2',
+          metadata: {
+            generateName: 'nodejs',
+          },
+          parent: {},
+        } as devfileApi.Devfile;
+
+        parentDevfile = {
+          schemaVersion: '2.2.0',
+          metadata: {
+            name: 'sample-using-parent',
+          },
+          components: [
+            {
+              name: 'tools',
+              container: {
+                env: [
+                  {
+                    name: 'DEVFILE_ENV_VAR',
+                    value: 'true',
+                  },
+                ],
+              },
+            },
+          ],
+          commands: [
+            {
+              id: 'parent-command',
+              exec: {
+                label: '2. This command from the parent',
+                component: 'tools',
+                commandLine: 'echo "Hello from parent"',
+              },
+            },
+          ],
+        } as devfileApi.Devfile;
+      });
+
       describe('with registryUrl', () => {
         it('with storage-type attribute', () => {
-          // mute console logs
-          console.warn = jest.fn();
-          const devfile = {
-            schemaVersion: '2.2.0',
-            metadata: {
-              name: 'wksp-test',
-            },
-            parent: {
-              id: 'nodejs',
-              registryUrl: 'https://registry.devfile.io/',
-            },
-          } as devfileApi.Devfile;
+          devfile.parent!.id = 'nodejs';
+          devfile.parent!.registryUrl = 'https://registry.devfile.io/';
+          const _devfile = cloneDeep(devfile);
 
-          const newDevfile = prepareDevfile(devfile, factoryId, 'ephemeral', false, {
-            schemaVersion: '2.2.2',
-            metadata: {
-              generateName: 'nodejs',
-            },
-            attributes: {
-              'controller.devfile.io/storage-type': 'ephemeral',
-            },
-          } as devfileApi.Devfile);
+          parentDevfile.attributes = {
+            'controller.devfile.io/storage-type': 'ephemeral',
+          };
+          const _parentDevfile = cloneDeep(parentDevfile);
 
+          const newDevfile = prepareDevfile(
+            _devfile,
+            factoryId,
+            'ephemeral',
+            false,
+            _parentDevfile,
+          );
+
+          expect(_devfile).toEqual(devfile);
+          expect(_parentDevfile).toEqual(parentDevfile);
           expect(console.warn).toHaveBeenCalledWith(
             'Unable to apply controller.devfile.io/storage-type attribute.',
           );
@@ -260,51 +302,45 @@ describe('FactoryLoaderContainer/prepareDevfile', () => {
         });
 
         it('without storage-type attribute', () => {
-          const devfile = {
-            schemaVersion: '2.2.0',
-            metadata: {
-              name: 'wksp-test',
-            },
-            parent: {
-              id: 'nodejs',
-              registryUrl: 'https://registry.devfile.io/',
-            },
-          } as devfileApi.Devfile;
+          devfile.parent!.id = 'nodejs';
+          devfile.parent!.registryUrl = 'https://registry.devfile.io/';
+          const _devfile = cloneDeep(devfile);
 
-          const newDevfile = prepareDevfile(devfile, factoryId, 'ephemeral', false, {
-            schemaVersion: '2.2.2',
-            metadata: {
-              generateName: 'nodejs',
-            },
-          } as devfileApi.Devfile);
+          const _parentDevfile = cloneDeep(parentDevfile);
 
+          const newDevfile = prepareDevfile(
+            _devfile,
+            factoryId,
+            'ephemeral',
+            false,
+            _parentDevfile,
+          );
+
+          expect(_devfile).toEqual(devfile);
+          expect(_parentDevfile).toEqual(parentDevfile);
           expect(newDevfile.attributes?.[DEVWORKSPACE_STORAGE_TYPE_ATTR]).toEqual('ephemeral');
         });
       });
       describe('with uri', () => {
         it('with storage-type attribute', () => {
-          // mute console logs
-          console.warn = jest.fn();
-          const devfile = {
-            schemaVersion: '2.2.0',
-            metadata: {
-              name: 'wksp-test',
-            },
-            parent: {
-              uri: 'https://raw.githubusercontent.com/test/devfile.yaml',
-            },
-          } as devfileApi.Devfile;
+          devfile.parent!.uri = 'https://raw.githubusercontent.com/test/devfile.yaml';
+          const _devfile = cloneDeep(devfile);
 
-          const newDevfile = prepareDevfile(devfile, factoryId, 'ephemeral', false, {
-            schemaVersion: '2.2.2',
-            metadata: {
-              generateName: 'nodejs',
-            },
-            attributes: {
-              'controller.devfile.io/storage-type': 'ephemeral',
-            },
-          } as devfileApi.Devfile);
+          parentDevfile.attributes = {
+            'controller.devfile.io/storage-type': 'ephemeral',
+          };
+          const _parentDevfile = cloneDeep(parentDevfile);
 
+          const newDevfile = prepareDevfile(
+            _devfile,
+            factoryId,
+            'ephemeral',
+            false,
+            _parentDevfile,
+          );
+
+          expect(_devfile).toEqual(devfile);
+          expect(_parentDevfile).toEqual(parentDevfile);
           expect(console.warn).toHaveBeenCalledWith(
             'Unable to apply controller.devfile.io/storage-type attribute.',
           );
@@ -312,23 +348,21 @@ describe('FactoryLoaderContainer/prepareDevfile', () => {
         });
 
         it('without storage-type attribute', () => {
-          const devfile = {
-            schemaVersion: '2.2.0',
-            metadata: {
-              name: 'wksp-test',
-            },
-            parent: {
-              uri: 'https://raw.githubusercontent.com/test/devfile.yaml',
-            },
-          } as devfileApi.Devfile;
+          devfile.parent!.uri = 'https://raw.githubusercontent.com/test/devfile.yaml';
+          const _devfile = cloneDeep(devfile);
 
-          const newDevfile = prepareDevfile(devfile, factoryId, 'ephemeral', false, {
-            schemaVersion: '2.2.2',
-            metadata: {
-              generateName: 'nodejs',
-            },
-          } as devfileApi.Devfile);
+          const _parentDevfile = cloneDeep(parentDevfile);
 
+          const newDevfile = prepareDevfile(
+            _devfile,
+            factoryId,
+            'ephemeral',
+            false,
+            _parentDevfile,
+          );
+
+          expect(_devfile).toEqual(devfile);
+          expect(_parentDevfile).toEqual(parentDevfile);
           expect(newDevfile.attributes?.[DEVWORKSPACE_STORAGE_TYPE_ATTR]).toEqual('ephemeral');
         });
       });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile.ts
@@ -31,9 +31,10 @@ export function prepareDevfile(
   factoryId: string,
   storageType: che.WorkspaceStorageType | undefined,
   appendSuffix: boolean,
-  parentDevfile?: devfileApi.Devfile | undefined,
+  _parentDevfile?: devfileApi.Devfile | undefined,
 ): devfileApi.Devfile {
   const devfile = cloneDeep(_devfile);
+  const parentDevfile = cloneDeep(_parentDevfile);
   const attributes = DevfileAdapter.getAttributes(devfile);
   if (
     !attributes[DEVWORKSPACE_METADATA_ANNOTATION] ||

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -205,10 +205,9 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
       return true;
     }
 
-    let resolveDone = false;
     try {
       // start resolving the devfile
-      resolveDone = await this.resolveDevfile(sourceUrl);
+      await this.resolveDevfile(sourceUrl);
     } catch (e) {
       const errorMessage = common.helpers.errors.getMessage(e);
       // check if it is a scheme validation error
@@ -224,9 +223,6 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
         return true;
       }
       throw e;
-    }
-    if (!resolveDone) {
-      return false;
     }
 
     // wait for the devfile resolving to complete

--- a/packages/dashboard-frontend/src/services/devfile/adapter.ts
+++ b/packages/dashboard-frontend/src/services/devfile/adapter.ts
@@ -20,18 +20,19 @@ export class DevfileAdapter {
   }
 
   public static getAttributes(devfile: devfileApi.Devfile) {
-    const attributes = {};
+    const attributes = {} as any;
+
     if (devfile.schemaVersion?.startsWith('2.0')) {
       if (!devfile.metadata.attributes) {
         devfile.metadata.attributes = attributes;
       }
       return devfile.metadata.attributes;
-    } else {
-      if (!devfile.attributes) {
-        devfile.attributes = attributes;
-      }
-      return devfile.attributes;
     }
+    if (!devfile.attributes) {
+      devfile.attributes = attributes;
+    }
+
+    return devfile.attributes;
   }
 
   get attributes() {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes factory flow with a devfile that uses a parent.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Знімок екрана 2025-02-19 о 07 08 52](https://github.com/user-attachments/assets/00a0c184-4422-4ca1-86e5-dbe8221638ba)

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23353

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Try to create a new workspace from the **Git repo URL**:
```
https://github.com/testsfactory/parentDevfile.git
```
3. The target workspace should be created successfully.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
