### PR TITLE
Fix devfile.io index route

### DIFF
--- a/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
+++ b/packages/dashboard-frontend/src/services/registry/__tests__/devfiles.spec.ts
@@ -90,10 +90,10 @@ describe('fetch registry metadata', () => {
       await fetchRegistryMetadata(baseUrl, true);
 
       expect(mockFetchData).toHaveBeenCalledWith(
-        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
+        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all',
       );
       expect(mockFetchRemoteData.mock.calls).toEqual([
-        [`https://eclipse-che.github.io/che-devfile-registry/7.71.0/index`],
+        [`https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all`],
         [`https://eclipse-che.github.io/che-devfile-registry/7.71.0/devfiles/index.json`],
       ]);
     });
@@ -117,12 +117,12 @@ describe('fetch registry metadata', () => {
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData).toHaveBeenCalledWith(
-        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
+        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all',
       );
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
-          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index': {
+          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all': {
             metadata: [metadata],
             lastFetched: 1555555555555,
           },
@@ -174,7 +174,7 @@ describe('fetch registry metadata', () => {
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData.mock.calls).toEqual([
-        ['https://eclipse-che.github.io/che-devfile-registry/7.71.0/index'],
+        ['https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all'],
         ['https://eclipse-che.github.io/che-devfile-registry/7.71.0/devfiles/index.json'],
       ]);
       expect(mockSessionStorageServiceUpdate).not.toHaveBeenCalled();
@@ -214,13 +214,13 @@ describe('fetch registry metadata', () => {
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData).toHaveBeenCalledWith(
-        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
+        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all',
       );
       expect(console.warn).toHaveBeenCalledTimes(2);
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
-          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index': {
+          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all': {
             metadata: [metadata],
             lastFetched: 1555555555555,
           },
@@ -244,7 +244,7 @@ describe('fetch registry metadata', () => {
       mockFetchRemoteData.mockResolvedValue([metadata]);
       mockSessionStorageServiceGet.mockReturnValue(
         JSON.stringify({
-          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index': {
+          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all': {
             metadata: [metadata],
             lastFetched: time,
           },
@@ -276,7 +276,7 @@ describe('fetch registry metadata', () => {
       mockFetchRemoteData.mockResolvedValue([metadata]);
       mockSessionStorageServiceGet.mockReturnValue(
         JSON.stringify({
-          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index': {
+          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all': {
             metadata: [metadata],
             lastFetched: time,
           },
@@ -289,12 +289,12 @@ describe('fetch registry metadata', () => {
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
       expect(mockFetchRemoteData).toHaveBeenCalledWith(
-        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index',
+        'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all',
       );
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
-          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index': {
+          'https://eclipse-che.github.io/che-devfile-registry/7.71.0/index/all': {
             metadata: [metadata],
             lastFetched: time + elapsedTime,
           },
@@ -325,11 +325,11 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index/all');
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
-          'https://registry.devfile.io/index': {
+          'https://registry.devfile.io/index/all': {
             metadata: [metadata],
             lastFetched: 1555555555555,
           },
@@ -353,7 +353,7 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index/all');
       expect(mockSessionStorageServiceUpdate).not.toHaveBeenCalled();
       expect(errorMessage).toEqual(
         'Failed to fetch devfiles metadata from registry URL: https://registry.devfile.io/, reason: Returned value is not array.',
@@ -390,12 +390,12 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index/all');
       expect(console.warn).toHaveBeenCalledTimes(2);
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
-          'https://registry.devfile.io/index': {
+          'https://registry.devfile.io/index/all': {
             metadata: [metadata],
             lastFetched: 1555555555555,
           },
@@ -419,7 +419,7 @@ describe('fetch registry metadata', () => {
       mockFetchRemoteData.mockResolvedValue([metadata]);
       mockSessionStorageServiceGet.mockReturnValue(
         JSON.stringify({
-          'https://registry.devfile.io/index': {
+          'https://registry.devfile.io/index/all': {
             metadata: [metadata],
             lastFetched: time,
           },
@@ -451,7 +451,7 @@ describe('fetch registry metadata', () => {
       mockFetchRemoteData.mockResolvedValue([metadata]);
       mockSessionStorageServiceGet.mockReturnValue(
         JSON.stringify({
-          'https://registry.devfile.io/index': {
+          'https://registry.devfile.io/index/all': {
             metadata: [metadata],
             lastFetched: time,
           },
@@ -463,11 +463,11 @@ describe('fetch registry metadata', () => {
       expect(mockSessionStorageServiceGet).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
       );
-      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index');
+      expect(mockFetchRemoteData).toHaveBeenCalledWith('https://registry.devfile.io/index/all');
       expect(mockSessionStorageServiceUpdate).toHaveBeenCalledWith(
         SessionStorageKey.EXTERNAL_REGISTRIES,
         JSON.stringify({
-          'https://registry.devfile.io/index': {
+          'https://registry.devfile.io/index/all': {
             metadata: [metadata],
             lastFetched: time + elapsedTime,
           },

--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -122,7 +122,7 @@ export function getRegistryIndexLocations(registryUrl: string, isExternal: boole
   registryUrl = registryUrl[registryUrl.length - 1] === '/' ? registryUrl : registryUrl + '/';
   const registryIndexLocations: Array<string> = [];
   if (isExternal) {
-    const indexUrl = new URL('index', registryUrl);
+    const indexUrl = new URL('index/all', registryUrl);
     registryIndexLocations.push(indexUrl.href);
 
     const deprecatedIndexUrl = new URL('devfiles/index.json', registryUrl);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Gets **devfiles** from the `/index/all` route for external registries.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Знімок екрана 2025-03-06 о 16 42 18](https://github.com/user-attachments/assets/c4f9ca9b-6e19-4095-a05c-34a3c054ccb1)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23352

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
 - Deploy Che with the dashboard pull request image: `quay.io/eclipse/che-dashboard:pr-1325`.
 - Open `Create-workspace` page.
 - Open console on Chrome. Remove 'external-registries' item from session storage with the command: `sessionStorage.removeItem('external-registries')` and reload the page.
 - Found `{che-server}/dashboard/api/data/resolver` request with params:
  `{url: "https://registry.devfile.io/index/all"}`.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
