### PR TITLE
[cherry-pick] fix: default OpenShift console logo (#1330)

### DIFF
--- a/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/clusterInfo.spec.ts
@@ -41,7 +41,7 @@ describe('Cluster Info Route', () => {
     expect(res.json()).toEqual({
       applications: [
         {
-          icon: `${clusterConsoleUrl}/static/assets/redhat.svg`,
+          icon: `${clusterConsoleUrl}/static/assets/public/imgs/openshift-favicon.png`,
           title: 'OpenShift console',
           url: clusterConsoleUrl,
           id: ApplicationId.CLUSTER_CONSOLE,

--- a/packages/dashboard-backend/src/routes/api/clusterInfo.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterInfo.ts
@@ -31,7 +31,9 @@ function buildApplicationInfo(): ClusterInfo {
   const clusterConsoleTitle = process.env['OPENSHIFT_CONSOLE_TITLE'] || 'OpenShift console';
   const clusterConsoleIcon =
     process.env['OPENSHIFT_CONSOLE_ICON'] ||
-    (clusterConsoleUrl ? clusterConsoleUrl + '/static/assets/redhat.svg' : '');
+    (clusterConsoleUrl
+      ? clusterConsoleUrl + '/static/assets/public/imgs/openshift-favicon.png'
+      : '');
   const clusterConsoleGroup = process.env['OPENSHIFT_CONSOLE_GROUP'];
 
   const applications: ApplicationInfo[] = [];


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes the default OpenShift console logo: 

`/static/assets/redhat.svg` -> `/static/assets/public/imgs/openshift-favicon.png`

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1330 to the 7.100.x branch
