### PR TITLE
fix: warning message styles

### DIFF
--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/DeleteWarning/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/DeleteWarning/__tests__/index.spec.tsx
@@ -55,7 +55,7 @@ describe('WorkspaceActionsDeleteWarning', () => {
 
       expect(dialog).toBeTruthy();
       expect(dialog).toHaveTextContent(
-        'One of deleting workspaces has Per-user storage type. There is a possibility that Per-user storage type e.g. common PVC is used for all workspaces and that PVC has the RWO access mode. Learn more To prevent possible problems with removal, you need to stop other workspaces with Per-user storage type before deleting.',
+        'One of deleting workspaces has Per-user storage type. There is a possibility that the Per-user storage type e.g. common PVC is used for all workspaces and that PVC has the RWO access mode. Learn more To prevent possible problems with removal, you need to stop other workspaces with Per-user storage type before deleting.',
       );
     });
   });

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/DeleteWarning/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/DeleteWarning/index.tsx
@@ -50,15 +50,15 @@ export class WorkspaceActionsDeleteWarning extends React.PureComponent<Props> {
         <TextContent>
           <Text>
             <b>{workspaceName}</b> workspace has <b>Per-user</b> storage type. There is a
-            possibility that the&nbsp;<b>Per-user</b>&nbsp;storage type e.g. common PVC is used for
-            all workspaces and that PVC has the RWO access mode.&emsp;
+            possibility that the <b>Per-user</b> storage type e.g. common PVC is used for all
+            workspaces and that PVC has the RWO access mode.&emsp;
             <a
-              href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes"
               target="_blank"
               rel="noopener noreferrer"
+              style={{ whiteSpace: 'nowrap' }}
+              href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes"
             >
-              Learn&nbsp;more&nbsp;
-              <ExternalLinkAltIcon />
+              Learn more <ExternalLinkAltIcon />
             </a>
           </Text>
           <Text>
@@ -71,16 +71,16 @@ export class WorkspaceActionsDeleteWarning extends React.PureComponent<Props> {
       warningMessage = (
         <TextContent>
           <Text>
-            One of deleting workspaces has <b>Per-user</b> storage type. There is a possibility
-            that&nbsp;<b>Per-user</b>&nbsp;storage type e.g. common PVC is used for all workspaces
-            and that PVC has the RWO access mode.&emsp;
+            One of deleting workspaces has <b>Per-user</b> storage type. There is a possibility that
+            the <b>Per-user</b> storage type e.g. common PVC is used for all workspaces and that PVC
+            has the RWO access mode.&emsp;
             <a
-              href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes"
               target="_blank"
               rel="noopener noreferrer"
+              style={{ whiteSpace: 'nowrap' }}
+              href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes"
             >
-              Learn&nbsp;more&nbsp;
-              <ExternalLinkAltIcon />
+              Learn more <ExternalLinkAltIcon />
             </a>
           </Text>
           <Text>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix styles for delete workspace warning messages. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Before:
![Знімок екрана 2025-04-07 о 10 47 19](https://github.com/user-attachments/assets/25640306-e863-4d6f-8951-c63d381dfcdc)
After:
![Знімок екрана 2025-04-07 о 10 50 15](https://github.com/user-attachments/assets/59e8ab85-5737-4bf2-9deb-bc123b4bfa87)


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
- deploy Che
- configure CheCluster to run more one workspace
```
spec:
  devEnvironments:
    maxNumberOfRunningWorkspacesPerUser: 10000
```
- run two workspaces from Dashbord samples
- try to delete a workspace

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
