### PR TITLE
feat: add grouping for samples

### DIFF
--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Selector kebab toggle snapshot 1`] = `
+<div
+  className="pf-c-select selector"
+  data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+  data-ouia-component-type="PF4/Select"
+  data-ouia-safe={true}
+>
+  <button
+    aria-expanded={false}
+    aria-haspopup={null}
+    aria-label="Options menu"
+    aria-labelledby=" pf-select-toggle-id-0"
+    className="pf-c-select__toggle"
+    disabled={false}
+    id="pf-select-toggle-id-0"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <div
+      className="pf-c-select__toggle-wrapper"
+    >
+      <span
+        className="pf-c-select__toggle-text"
+      >
+        Bulk Selector
+      </span>
+    </div>
+    <span
+      className="pf-c-select__toggle-arrow"
+    >
+      <svg
+        aria-hidden={true}
+        aria-labelledby={null}
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style={
+          {
+            "verticalAlign": "-0.125em",
+          }
+        }
+        viewBox="0 0 320 512"
+        width="1em"
+      >
+        <path
+          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+        />
+      </svg>
+    </span>
+  </button>
+</div>
+`;

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/__tests__/index.spec.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import userEvent, { UserEvent } from '@testing-library/user-event';
+import React from 'react';
+
+import { Selector } from '@/pages/GetStarted/SamplesList/Gallery/Selector';
+import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
+
+const { createSnapshot, renderComponent } = getComponentRenderer(getComponent);
+
+const mockOnChange = jest.fn();
+
+describe('Selector', () => {
+  let list: string[];
+  let user: UserEvent;
+
+  beforeEach(() => {
+    list = ['tag1', 'tag2', 'tag3'];
+    user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockOnChange.mockReset();
+  });
+
+  describe('kebab toggle', () => {
+    test('snapshot', () => {
+      const snapshot = createSnapshot(list, 'Bulk Selector');
+      expect(snapshot.toJSON()).toMatchSnapshot();
+    });
+
+    test('open dropdown', async () => {
+      renderComponent(list);
+      const toggle = screen.queryByRole('button');
+
+      expect(toggle).toBeTruthy();
+
+      // dropdown menu is not visible
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      list.forEach(tag => {
+        expect(screen.queryByText(tag)).toBeFalsy();
+      });
+
+      // toggle dropdown
+      await user.click(toggle!);
+
+      // now the dropdown menu is visible
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      list.forEach(tag => {
+        expect(screen.queryByText(tag)).toBeTruthy();
+      });
+    });
+  });
+
+  test('handling selection', async () => {
+    renderComponent(list);
+    // toggle dropdown
+    await user.click(screen.queryByRole('button')!);
+    // select the first item
+    await user.click(screen.queryByText(list[0])!);
+    // expect selected item to be in the selected state
+    expect(mockOnChange).toHaveBeenCalledWith([list[0]]);
+    // select the second item
+    await user.click(screen.queryByText(list[1])!);
+    // expect selected item to be in the selected state
+    expect(mockOnChange).toHaveBeenCalledWith([list[0], list[1]]);
+    // deselect the first item
+    await user.click(screen.queryByText(list[0])!);
+    // expect selected item to be in the selected state
+    expect(mockOnChange).toHaveBeenCalledWith([list[1]]);
+  });
+});
+
+function getComponent(
+  list: string[],
+  placeholderText: string = '-- Select --',
+): React.ReactElement {
+  const component = (
+    <Selector list={list} placeholderText={placeholderText} onChange={mockOnChange} />
+  );
+
+  return component;
+}

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/index.module.css
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/index.module.css
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+.selector .pf-c-select__menu {
+  overflow-y: auto;
+  max-height: 294px;
+}
+
+.selector .pf-c-select__menu > *:first-child {
+  margin-top: -8px;
+}

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Selector/index.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
+import React from 'react';
+
+import styles from '@/pages/GetStarted/SamplesList/Gallery/Selector/index.module.css';
+
+export type Props = {
+  onChange: (tags: string[]) => void;
+  list: string[];
+  placeholderText: string;
+};
+
+export type State = {
+  isOpen: boolean;
+  selected: string[];
+  options: React.ReactElement[];
+};
+
+export class Selector extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    const options = this.getOptions(props.list);
+
+    this.state = {
+      isOpen: false,
+      selected: [],
+      options,
+    };
+  }
+
+  private getOptions(list: string[]): React.ReactElement[] {
+    return list.map(tag => <SelectOption key={tag} value={tag} />);
+  }
+
+  public componentDidUpdate(prevProps: Props): void {
+    const { list } = this.props;
+    if (prevProps.list !== list) {
+      const options = this.getOptions(list);
+      this.setState({
+        options,
+      });
+    }
+  }
+
+  private onToggle(isOpen: boolean): void {
+    this.setState({
+      isOpen,
+    });
+  }
+
+  private onSelect(selection: string) {
+    const selected = [...this.state.selected];
+    const index = selected.indexOf(selection);
+    if (index > -1) {
+      selected.splice(index, 1);
+    } else {
+      selected.push(selection);
+    }
+    this.setState({ selected });
+    this.props.onChange(selected);
+  }
+
+  render(): React.ReactNode {
+    const { placeholderText } = this.props;
+    const { isOpen, selected, options } = this.state;
+
+    if (options.length === 0) {
+      return <></>;
+    }
+
+    return (
+      <Select
+        style={{ minWidth: '200px' }}
+        className={styles.selector}
+        variant={SelectVariant.checkbox}
+        onToggle={isOpen => this.onToggle(isOpen)}
+        onSelect={(
+          _event: React.MouseEvent | React.ChangeEvent,
+          selection: string | SelectOptionObject,
+        ) => this.onSelect(selection.toString())}
+        selections={selected}
+        isOpen={isOpen}
+        placeholderText={placeholderText}
+        isGrouped
+      >
+        {options}
+      </Select>
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/__tests__/index.spec.tsx
@@ -22,7 +22,7 @@ import getComponentRenderer, { screen, within } from '@/services/__mocks__/getCo
 import { BrandingData } from '@/services/bootstrap/branding.constant';
 import { che } from '@/services/models';
 import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
-import { DevfileRegistryMetadata } from '@/store/DevfileRegistries/selectors';
+import { DevfileRegistryMetadata, EMPTY_WORKSPACE_TAG } from '@/store/DevfileRegistries/selectors';
 
 jest.mock('@/pages/GetStarted/SamplesList/Gallery/Card');
 
@@ -84,7 +84,9 @@ describe('Samples List Gallery', () => {
     await userEvent.click(button);
 
     expect(mockOnCardClick).toHaveBeenCalledTimes(1);
-    expect(mockOnCardClick).toHaveBeenCalledWith(metadata[0]);
+    expect(mockOnCardClick).toHaveBeenCalledWith(
+      metadata.find(meta => meta.tags.includes(EMPTY_WORKSPACE_TAG)),
+    );
   });
 });
 

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Toolbar/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Toolbar/__tests__/__snapshots__/index.spec.tsx.snap
@@ -20,9 +20,124 @@ exports[`Samples List Toolbar snapshot 1`] = `
       onFocus={[Function]}
       placeholder="Filter by"
       required={false}
+      style={
+        {
+          "minWidth": "200px",
+        }
+      }
       type="search"
       value=""
     />
+  </div>
+  <div
+    className=""
+  >
+    <div
+      className="pf-c-select selector"
+      data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+      data-ouia-component-type="PF4/Select"
+      data-ouia-safe={true}
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup={null}
+        aria-label="Options menu"
+        aria-labelledby=" pf-select-toggle-id-0"
+        className="pf-c-select__toggle"
+        disabled={false}
+        id="pf-select-toggle-id-0"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        type="button"
+      >
+        <div
+          className="pf-c-select__toggle-wrapper"
+        >
+          <span
+            className="pf-c-select__toggle-text"
+          >
+            Filter by tags
+          </span>
+        </div>
+        <span
+          className="pf-c-select__toggle-arrow"
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className=""
+  >
+    <div
+      className="pf-c-select selector"
+      data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
+      data-ouia-component-type="PF4/Select"
+      data-ouia-safe={true}
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup={null}
+        aria-label="Options menu"
+        aria-labelledby=" pf-select-toggle-id-1"
+        className="pf-c-select__toggle"
+        disabled={false}
+        id="pf-select-toggle-id-1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        type="button"
+      >
+        <div
+          className="pf-c-select__toggle-wrapper"
+        >
+          <span
+            className="pf-c-select__toggle-text"
+          >
+            Filter by languages
+          </span>
+        </div>
+        <span
+          className="pf-c-select__toggle-arrow"
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
   </div>
   <div
     className=""

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Toolbar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Toolbar/__tests__/index.spec.tsx
@@ -81,6 +81,8 @@ describe('Samples List Toolbar', () => {
     const storeNext = new MockStoreBuilder(store.getState())
       .withDevfileRegistries({
         filter: 'bash',
+        tagsFilter: [],
+        languagesFilter: [],
       })
       .build();
 
@@ -117,7 +119,12 @@ function createFakeStore(metadata?: che.DevfileMetaData[]) {
         storageTypes: 'https://docs.location',
       },
     } as BrandingData)
-    .withDevfileRegistries({ registries })
+    .withDevfileRegistries({
+      registries,
+      filter: '',
+      tagsFilter: [],
+      languagesFilter: [],
+    })
     .build();
 }
 

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/__tests__/index.spec.tsx
@@ -177,7 +177,7 @@ describe('Samples List', () => {
       await userEvent.click(sampleCardButton);
 
       expect(mockWindowOpen).toHaveBeenCalledWith(
-        `${origin}#${sampleUrl}?df=devfile2.yaml&che-editor=che-incubator%2Fche-code%2Finsiders&devWorkspace=registry-url%2Fdevfile-registry%2Fdevfiles%2Fquarkus%2Fdevworkspace-che-code-insiders.yaml&editor-image=custom-editor-image&storageType=persistent`,
+        `${origin}#${sampleUrl}?df=devfile2.yaml&che-editor=che-incubator%2Fche-code%2Finsiders&devWorkspace=registry-url%2Fdevfile-registry%2Fdevfiles%2Fquarkus%2Fdevworkspace-che-code-insiders.yaml&editor-image=custom-editor-image&storageType=ephemeral`,
         '_blank',
       );
       expect(mockWindowOpen).toHaveBeenCalledTimes(1);

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/index.tsx
@@ -49,7 +49,7 @@ class SamplesList extends React.PureComponent<Props, State> {
     super(props);
 
     this.state = {
-      isTemporary: this.props.preferredStorageType === 'ephemeral' ? true : false,
+      isTemporary: this.props.preferredStorageType === 'ephemeral',
     };
   }
 
@@ -65,7 +65,7 @@ class SamplesList extends React.PureComponent<Props, State> {
       return 'ephemeral';
     }
 
-    return preferredStorageType === 'ephemeral' ? 'persistent' : preferredStorageType;
+    return preferredStorageType;
   }
 
   private async handleSampleCardClick(metadata: DevfileRegistryMetadata): Promise<void> {

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -111,7 +111,11 @@ function getPoliciesCreate(searchParams: URLSearchParams): PoliciesCreate {
 
 function getStorageType(searchParams: URLSearchParams): che.WorkspaceStorageType | undefined {
   const storageType = searchParams.get(STORAGE_TYPE_ATTR) as che.WorkspaceStorageType;
-  if (storageType === 'async' || storageType === 'ephemeral' || storageType === 'persistent') {
+  if (
+    storageType === 'per-workspace' ||
+    storageType === 'ephemeral' ||
+    storageType === 'per-user'
+  ) {
     return storageType;
   }
 }

--- a/packages/dashboard-frontend/src/services/models/che.ts
+++ b/packages/dashboard-frontend/src/services/models/che.ts
@@ -12,14 +12,7 @@
 
 export { che as api } from '@eclipse-che/api';
 
-export type WorkspaceStorageType =
-  | 'async'
-  | 'ephemeral'
-  | 'persistent'
-  | 'per-workspace'
-  | 'per-user'
-  | 'common'
-  | '';
+export type WorkspaceStorageType = 'ephemeral' | 'per-workspace' | 'per-user' | '';
 
 export interface Plugin {
   id: string;
@@ -45,6 +38,7 @@ export interface WorkspaceDevfileAttributes {
 export interface DevfileMetaData {
   displayName: string;
   description?: string;
+  language?: string;
   globalMemoryLimit?: string;
   registry?: string;
   icon: string | { base64data: string; mediatype: string };

--- a/packages/dashboard-frontend/src/services/registry/devfiles.ts
+++ b/packages/dashboard-frontend/src/services/registry/devfiles.ts
@@ -203,6 +203,12 @@ export async function fetchRegistryMetadata(
       meta.icon = resolveIconUrl(meta, registryUrl);
       meta.links = resolveLinks(meta, registryUrl, isExternal);
       meta.tags = resolveTags(meta, registryUrl, isExternal);
+      if (!meta.language) {
+        const language = getLanguage(meta);
+        if (language) {
+          meta.language = language;
+        }
+      }
       return meta;
     });
     if (isExternal) {
@@ -216,6 +222,25 @@ export async function fetchRegistryMetadata(
     console.error(errorMessage);
     throw errorMessage;
   }
+}
+
+export function getLanguage(metadata: che.DevfileMetaData): string | undefined {
+  if (metadata.language) {
+    return metadata.language;
+  }
+  const languages = [
+    '.NET',
+    'C++',
+    'Go',
+    'Java',
+    'JavaScript',
+    'NodeJS',
+    'PHP',
+    'Python',
+    'Rust',
+    'TypeScript',
+  ];
+  return languages.find(lang => metadata.tags.includes(lang));
 }
 
 function getExternalRegistryMetadataFromStorage(url: string): che.DevfileMetaData[] | undefined {

--- a/packages/dashboard-frontend/src/services/storageTypes.ts
+++ b/packages/dashboard-frontend/src/services/storageTypes.ts
@@ -13,9 +13,7 @@
 import { che } from '@/services/models';
 
 export enum StorageTypeTitle {
-  async = 'Asynchronous',
   ephemeral = 'Ephemeral',
-  persistent = 'Persistent',
   'per-user' = 'Per-user',
   'per-workspace' = 'Per-workspace',
   '' = 'Not defined',

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/actions.spec.ts
@@ -23,12 +23,16 @@ import {
   devfileRequestAction,
   filterClearAction,
   filterSetAction,
+  languagesFilterClearAction,
+  languagesFilterSetAction,
   registryMetadataErrorAction,
   registryMetadataReceiveAction,
   registryMetadataRequestAction,
   resourcesErrorAction,
   resourcesReceiveAction,
   resourcesRequestAction,
+  tagsFilterClearAction,
+  tagsFilterSetAction,
 } from '@/store/DevfileRegistries/actions';
 import { verifyAuthorized } from '@/store/SanityCheck';
 
@@ -200,6 +204,34 @@ describe('DevfileRegistries, actions', () => {
 
       const actions = store.getActions();
       expect(actions[0]).toEqual(filterClearAction());
+    });
+
+    it('should dispatch setTagsFilter action', () => {
+      store.dispatch(actionCreators.setTagsFilter(['tag1', 'tag2']));
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(tagsFilterSetAction(['tag1', 'tag2']));
+    });
+
+    it('should dispatch clearTagsFilter action', () => {
+      store.dispatch(actionCreators.clearTagsFilter());
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(tagsFilterClearAction());
+    });
+
+    it('should dispatch setLanguagesFilter action', () => {
+      store.dispatch(actionCreators.setLanguagesFilter(['JavaScript', 'TypeScript']));
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(languagesFilterSetAction(['JavaScript', 'TypeScript']));
+    });
+
+    it('should dispatch clearLanguagesFilter action', () => {
+      store.dispatch(actionCreators.clearLanguagesFilter());
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(languagesFilterClearAction());
     });
   });
 });

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/selectors.spec.ts
@@ -81,6 +81,8 @@ describe('DevfileRegistries, selectors', () => {
             ],
           },
         },
+        tagsFilter: [],
+        languagesFilter: [],
         filter: 'Devfile 1',
         isLoading: false,
       },

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/actions.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/actions.ts
@@ -72,6 +72,14 @@ export const resourcesErrorAction = createAction<resourcesErrorAction>('resource
 export const filterSetAction = createAction<string>('devfileRegistries/setFilter');
 export const filterClearAction = createAction('devfileRegistries/clearFilter');
 
+export const tagsFilterSetAction = createAction<string[]>('devfileRegistries/setTagsFilter');
+export const tagsFilterClearAction = createAction('devfileRegistries/clearTagsFilter');
+
+export const languagesFilterSetAction = createAction<string[]>(
+  'devfileRegistries/setLanguagesFilter',
+);
+export const languagesFilterClearAction = createAction('devfileRegistries/clearLanguagesFilter');
+
 export const actionCreators = {
   /**
    * Request devfile metadata from available registries. `registryUrls` is space-separated list of urls.
@@ -164,4 +172,16 @@ export const actionCreators = {
     dispatch =>
       dispatch(filterSetAction(value)),
   clearFilter: (): AppThunk<void> => dispatch => dispatch(filterClearAction()),
+
+  setTagsFilter:
+    (value: string[]): AppThunk<void> =>
+    dispatch =>
+      dispatch(tagsFilterSetAction(value)),
+  clearTagsFilter: (): AppThunk<void> => dispatch => dispatch(tagsFilterClearAction()),
+
+  setLanguagesFilter:
+    (value: string[]): AppThunk<void> =>
+    dispatch =>
+      dispatch(languagesFilterSetAction(value)),
+  clearLanguagesFilter: (): AppThunk<void> => dispatch => dispatch(languagesFilterClearAction()),
 };

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/reducer.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/reducer.ts
@@ -19,12 +19,16 @@ import {
   devfileRequestAction,
   filterClearAction,
   filterSetAction,
+  languagesFilterClearAction,
+  languagesFilterSetAction,
   registryMetadataErrorAction,
   registryMetadataReceiveAction,
   registryMetadataRequestAction,
   resourcesErrorAction,
   resourcesReceiveAction,
   resourcesRequestAction,
+  tagsFilterClearAction,
+  tagsFilterSetAction,
 } from '@/store/DevfileRegistries/actions';
 
 export type DevWorkspaceResources = [devfileApi.DevWorkspace, devfileApi.DevWorkspaceTemplate];
@@ -52,6 +56,8 @@ export interface State {
 
   // current filter value
   filter: string;
+  tagsFilter: string[];
+  languagesFilter: string[];
 }
 
 export const unloadedState: State = {
@@ -61,6 +67,8 @@ export const unloadedState: State = {
   devWorkspaceResources: {},
 
   filter: '',
+  tagsFilter: [],
+  languagesFilter: [],
 };
 
 export const reducer = createReducer(unloadedState, builder =>
@@ -110,6 +118,18 @@ export const reducer = createReducer(unloadedState, builder =>
     })
     .addCase(filterClearAction, state => {
       state.filter = '';
+    })
+    .addCase(tagsFilterSetAction, (state, action) => {
+      state.tagsFilter = action.payload;
+    })
+    .addCase(tagsFilterClearAction, state => {
+      state.tagsFilter = [];
+    })
+    .addCase(languagesFilterSetAction, (state, action) => {
+      state.languagesFilter = action.payload;
+    })
+    .addCase(languagesFilterClearAction, state => {
+      state.languagesFilter = [];
     })
     .addDefaultCase(state => state),
 );

--- a/packages/dashboard-frontend/src/store/__mocks__/mockStore.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/mockStore.ts
@@ -215,6 +215,8 @@ export class MockStoreBuilder {
         [location: string]: { resources?: DevWorkspaceResources; error?: string };
       };
       filter?: string;
+      tagsFilter?: [];
+      languagesFilter?: [];
     },
     isLoading = false,
   ): MockStoreBuilder {
@@ -229,6 +231,8 @@ export class MockStoreBuilder {
           this.state.devfileRegistries?.devWorkspaceResources ??
           {},
         filter: options.filter || '',
+        tagsFilter: options.tagsFilter || [],
+        languagesFilter: options.languagesFilter || [],
       },
     } as RootState;
     return this;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds grouping for samples.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Знімок екрана 2025-04-14 о 05 10 07](https://github.com/user-attachments/assets/4a6049e0-c024-467f-b533-1dd8309f08d5)
![Знімок екрана 2025-04-14 о 05 10 22](https://github.com/user-attachments/assets/fda61623-e1f2-4de8-b7d1-92a012584597)
![Знімок екрана 2025-04-14 о 05 09 45](https://github.com/user-attachments/assets/3e6ca136-b7e5-4667-9a07-2303507714be)

### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-8362

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Open **Create Workspace** page `{che-server}/dashboard/#/create-workspace`.
3. All samples will be grouped by language if we have 3 or more samples with the same language.
The first part includes all other samples.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
