### PR TITLE
Fix set branch function for Gitlab repositories with subgroups

### DIFF
--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
@@ -206,6 +206,19 @@ describe('helpers', () => {
             helpers.setBranchToLocation('https://gitlab.com/eclipse-che/che-dashboard.git', branch),
           ).toBe(`https://gitlab.com/eclipse-che/che-dashboard.git/-/tree/${branch}`);
         });
+        test('repository with subgroups', () => {
+          expect(
+            helpers.setBranchToLocation('https://gitlab.com/group/subgroup/repository.git', branch),
+          ).toBe(`https://gitlab.com/group/subgroup/repository.git/-/tree/${branch}`);
+        });
+        test('repository with subgroups and branch', () => {
+          expect(
+            helpers.setBranchToLocation(
+              'https://gitlab.com/group/subgroup/repository.git/-/tree/branch',
+              branch,
+            ),
+          ).toBe(`https://gitlab.com/group/subgroup/repository.git/-/tree/${branch}`);
+        });
       });
       describe('Bitbucket', () => {
         test('should return the location without branch', () => {

--- a/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
@@ -140,9 +140,9 @@ function setBranchToAzureDevOpsLocation(location: string, branch: string | undef
 
 export function setBranchToLocation(location: string, branch: string | undefined): string {
   const url = new URL(location);
-  const pathname = url.pathname;
+  const pathname = url.pathname.replace(/^\//, '').replace(/\/$/, '');
 
-  const [user, project] = pathname.replace(/^\//, '').replace(/\/$/, '').split('/');
+  const [user, project] = pathname.split('/');
 
   const service = getSupportedGitService(location);
   if (!branch) {
@@ -157,7 +157,7 @@ export function setBranchToLocation(location: string, branch: string | undefined
         url.pathname = `${user}/${project}/tree/${branch}`;
         break;
       case 'gitlab':
-        url.pathname = `${user}/${project}/-/tree/${branch}`;
+        url.pathname = `${pathname.replace(/\/-\/tree\/.*$/, '')}/-/tree/${branch}`;
         break;
       case 'bitbucket-server':
         url.pathname = `${user}/${project}/src/${branch}`;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Support Gitlab repository urls with multiple subgroups when handling branch name from Git Repo Options menu.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-8615

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Apply the pull request image: `quay.io/eclipse/che-dashboard:pr-1342`.
2. Go to `Create Workspace` -> `Import from Git` and input a Gitlab repository url with multiple groups, e.g. `https://gitlab.com/group422630/subgroup/test.git`.
3. Set a non default branch In the `Git Repo Options` menu, e.g. `newbranch`.
4. Click the `Create & Open` button.

See: workspace starts and the project is checkouted to the specified branch.
#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
