### PR TITLE
fix: selectDefaultDevfile method

### DIFF
--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/helpers.spec.ts
@@ -10,7 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { isSourceAllowed } from '@/store/ServerConfig/helpers';
+import { ServerConfigState } from '@/store/ServerConfig';
+import { getPvcStrategy, isSourceAllowed } from '@/store/ServerConfig/helpers';
 
 describe('helpers', () => {
   describe('isAllowedSourceUrl', () => {
@@ -25,6 +26,51 @@ describe('helpers', () => {
 
     test('disallowed urls', () => {
       expect(isSourceAllowed(['https://a'], 'https://a/b/c/')).toBe(false);
+    });
+  });
+  describe('getPvcStrategy', () => {
+    const getMockState = (pvcStrategy: string) =>
+      ({
+        config: {
+          defaults: {
+            pvcStrategy,
+          },
+        },
+      }) as Partial<ServerConfigState>;
+    test('per-user', () => {
+      const state = getMockState('per-user');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('per-user');
+    });
+    test('per-workspace', () => {
+      const state = getMockState('per-workspace');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('per-workspace');
+    });
+    test('ephemeral', () => {
+      const state = getMockState('ephemeral');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('ephemeral');
+    });
+    test('common', () => {
+      const state = getMockState('common');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('per-user');
+    });
+    test('unknown', () => {
+      const state = getMockState('unknown');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('');
     });
   });
 });

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
@@ -55,7 +55,7 @@ describe('ServerConfig Selectors', () => {
               plugins: ['plugin2'],
             },
           ] as api.IWorkspacesDefaultPlugins[],
-          pvcStrategy: 'strategy',
+          pvcStrategy: 'per-user',
         },
         pluginRegistry: {
           disableInternalRegistry: false,
@@ -129,7 +129,7 @@ describe('ServerConfig Selectors', () => {
 
   it('should select PVC strategy', () => {
     const result = selectPvcStrategy(mockState);
-    expect(result).toEqual('strategy');
+    expect(result).toEqual('per-user');
   });
 
   it('should select start timeout', () => {

--- a/packages/dashboard-frontend/src/store/ServerConfig/helpers.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/helpers.ts
@@ -10,6 +10,9 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { che } from '@/services/models';
+import { ServerConfigState } from '@/store/ServerConfig/index';
+
 export function isSourceAllowed(allowedSourceUrls: string[] | undefined, url: string): boolean {
   if (allowedSourceUrls === undefined || allowedSourceUrls.length === 0) {
     return true;
@@ -37,4 +40,20 @@ export function isSourceAllowed(allowedSourceUrls: string[] | undefined, url: st
   }
 
   return false;
+}
+
+export function getPvcStrategy(state?: Partial<ServerConfigState>): che.WorkspaceStorageType {
+  const pvcStrategy = state?.config?.defaults?.pvcStrategy;
+  switch (pvcStrategy) {
+    case 'per-user':
+      return pvcStrategy;
+    case 'per-workspace':
+      return pvcStrategy;
+    case 'ephemeral':
+      return pvcStrategy;
+    case 'common':
+      return 'per-user';
+    default:
+      return '';
+  }
 }

--- a/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
@@ -12,8 +12,8 @@
 
 import { createSelector } from '@reduxjs/toolkit';
 
-import { che } from '@/services/models';
 import { RootState } from '@/store';
+import { getPvcStrategy } from '@/store/ServerConfig/helpers';
 
 const selectState = (state: RootState) => state.dwServerConfig;
 export const selectServerConfigState = selectState;
@@ -50,10 +50,7 @@ export const selectOpenVSXUrl = createSelector(
   state => state.config.pluginRegistry?.openVSXURL,
 );
 
-export const selectPvcStrategy = createSelector(
-  selectState,
-  state => (state.config.defaults.pvcStrategy || '') as che.WorkspaceStorageType,
-);
+export const selectPvcStrategy = createSelector(selectState, state => getPvcStrategy(state));
 
 export const selectStartTimeout = createSelector(
   selectState,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes restart from default devfile flow. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-8865

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
- Use dashboard image from this PR: quay.io/eclipse/che-dashboard:pr-1344
- Make sure that your CheCluster is set to a storage strategy of `per-workspace`.
- Create a workspace using `https://github.com/cgruver/test-workspace/tree/pvc-fail`
- Create a new file in the project folder.
- Modify the devfile to point to a bad image location - change the tag to badimage
- Restart from local DevFile
- Observe the failure.
- Choose to restart from the default devfile.
- The workspace will restart.
- Check that, as a result, the workspace was restarted with per-workspace storage type, and the file exists in the project
#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
