### PR TITLE
[cherry-pick] fixes getStorageType and selectDefaultDevfile methods

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -2,9 +2,11 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 
 | Packages | Resolved CQs |
 | --- | --- |
-| `@devfile/api@2.3.0-1738854228` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1738854228) |
+| `@devfile/api@2.3.0-1746644330` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1746644330) |
 | `@fastify/cors@9.0.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@fastify/cors/9.0.1) |
 | `@hapi/hoek@10.0.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/hoek/10.0.1) |
+| `@inversifyjs/common@1.5.0` | transitive dependency |
+| `@inversifyjs/container@1.9.1` | transitive dependency |
 | `@patternfly/react-core@4.278.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-core/4.278.0) |
 | `@patternfly/react-icons@4.93.7` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-icons/4.93.7) |
 | `@patternfly/react-table@4.113.6` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-table/4.113.6) |
@@ -13,6 +15,7 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `elliptic@6.6.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/elliptic/6.6.1) |
 | `fast-uri@2.4.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.4.0) |
 | `fastify@4.28.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/4.28.1) |
+| `inversify@7.5.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/inversify/7.5.1) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |
 | `light-my-request@5.14.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/light-my-request/5.14.0) |
 | `real-require@0.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/real-require/0.2.0) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -22,7 +22,7 @@
 | [`@babel/helper-validator-identifier@7.25.9`](https://github.com/babel/babel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@babel/helper-validator-identifier/7.25.9) |
 | [`@babel/helper-validator-option@7.22.15`](https://github.com/babel/babel.git) | MIT | #8961 |
 | [`@babel/helpers@7.26.10`](https://github.com/babel/babel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@babel/helpers/7.26.10) |
-| [`@babel/parser@7.27.0`](https://github.com/babel/babel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@babel/parser/7.27.0) |
+| [`@babel/parser@7.27.0`](https://github.com/babel/babel.git) | MIT | #21023 |
 | [`@babel/plugin-syntax-jsx@7.22.5`](https://github.com/babel/babel.git) | MIT | #9014 |
 | [`@babel/plugin-syntax-typescript@7.22.5`](https://github.com/babel/babel.git) | MIT | #8994 |
 | [`@babel/template@7.26.9`](https://github.com/babel/babel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@babel/template/7.26.9) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -3,9 +3,8 @@
 | Packages | License | Resolved CQs |
 | --- | --- | --- |
 | [`@babel/runtime@7.27.0`](https://github.com/babel/babel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@babel/runtime/7.27.0) |
-| [`@devfile/api@2.3.0-1738342178`](https://github.com/GIT_USER_ID/GIT_REPO_ID.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1738342178) |
-| [`@devfile/api@2.3.0-1738854228`](https://github.com/devfile/api) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1738854228) |
-| [`@eclipse-che/che-devworkspace-generator@7.99.0-next-1ccb963`](git+https://github.com/devfile/devworkspace-generator.git) | EPL-2.0 | ecd.che |
+| [`@devfile/api@2.3.0-1746644330`](https://github.com/devfile/api) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1746644330) |
+| [`@eclipse-che/che-devworkspace-generator@7.103.0-next-4e46cbe`](git+https://github.com/devfile/devworkspace-generator.git) | EPL-2.0 | ecd.che |
 | [`@fastify/accept-negotiator@1.1.0`](git+https://github.com/fastify/accept-negotiator.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@fastify/accept-negotiator/1.1.0) |
 | [`@fastify/ajv-compiler@3.6.0`](git+https://github.com/fastify/ajv-compiler.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@fastify/ajv-compiler/3.6.0) |
 | [`@fastify/busboy@2.0.0`](https://github.com/fastify/busboy.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@fastify/busboy/2.0.0) |
@@ -29,6 +28,11 @@
 | `@hapi/hoek@10.0.1` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/hoek/10.0.1) |
 | `@hapi/topo@5.1.0` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/topo/5.1.0) |
 | `@hapi/wreck@18.0.1` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/wreck/18.0.1) |
+| [`@inversifyjs/common@1.5.0`](git+https://github.com/inversify/monorepo.git) | MIT | transitive dependency |
+| [`@inversifyjs/container@1.9.1`](git+https://github.com/inversify/monorepo.git) | MIT | transitive dependency |
+| [`@inversifyjs/core@5.2.0`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/core/5.2.0) |
+| [`@inversifyjs/prototype-utils@0.1.0`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/prototype-utils/0.1.0) |
+| [`@inversifyjs/reflect-metadata-utils@1.1.0`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/reflect-metadata-utils/1.1.0) |
 | `@isaacs/cliui@8.0.2` | ISC | #8260 |
 | [`@isaacs/fs-minipass@4.0.1`](https://github.com/npm/fs-minipass.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@isaacs/fs-minipass/4.0.1) |
 | [`@jsep-plugin/assignment@1.2.1`](EricSmekens/jsep) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@jsep-plugin/assignment/1.2.1) |
@@ -234,6 +238,7 @@
 | [`inversify-inject-decorators@3.1.0`](git+https://github.com/inversify/inversify-inject-decorators.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/inversify-inject-decorators/3.1.0) |
 | [`inversify-react@1.1.1`](https://github.com/Kukkimonsuta/inversify-react.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/inversify-react/1.1.1) |
 | [`inversify@6.0.2`](https://github.com/inversify/InversifyJS.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/inversify/6.0.2) |
+| [`inversify@7.5.1`](https://github.com/inversify/InversifyJS.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/inversify/7.5.1) |
 | [`ip-address@9.0.5`](git://github.com/beaugunderson/ip-address.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/ip-address/9.0.5) |
 | `ipaddr.js@1.9.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/ipaddr.js/1.9.1) |
 | `is-fullwidth-code-point@3.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-fullwidth-code-point/3.0.0) |
@@ -418,7 +423,7 @@
 | [`sprintf-js@1.1.3`](https://github.com/alexei/sprintf.js.git) | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/sprintf-js/1.1.3) |
 | [`sshpk@1.18.0`](git+https://github.com/joyent/node-sshpk.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/sshpk/1.18.0) |
 | [`ssri@10.0.5`](https://github.com/npm/ssri.git) | ISC | #5768 |
-| `statuses@2.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/statuses/2.0.1) |
+| `statuses@2.0.1` | MIT | #20906 |
 | [`stream-buffers@3.0.2`](https://github.com/samcday/node-stream-buffer.git) | Unlicense | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/stream-buffers/3.0.2) |
 | [`stream-shift@1.0.3`](https://github.com/mafintosh/stream-shift.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/stream-shift/1.0.3) |
 | `string-width@4.2.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/string-width/4.2.3) |

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,7 @@
     "test:watch": "yarn test --watch"
   },
   "devDependencies": {
-    "@devfile/api": "2.3.0-1738854228",
+    "@devfile/api": "2.3.0-1746644330",
     "@kubernetes/client-node": "^0.22.1",
     "@types/jest": "^29.5.3",
     "@typescript-eslint/eslint-plugin": "^6.3.0",

--- a/packages/dashboard-backend/package.json
+++ b/packages/dashboard-backend/package.json
@@ -26,8 +26,8 @@
   ],
   "license": "EPL-2.0",
   "dependencies": {
-    "@devfile/api": "2.3.0-1738854228",
-    "@eclipse-che/che-devworkspace-generator": "7.102.0",
+    "@devfile/api": "2.3.0-1746644330",
+    "@eclipse-che/che-devworkspace-generator": "7.103.0-next-4e46cbe",
     "@fastify/cors": "^9.0.1",
     "@fastify/error": "^3.4.1",
     "@fastify/http-proxy": "^9.5.0",

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -66,7 +66,7 @@
     "sanitize-html": "^2.11.0"
   },
   "devDependencies": {
-    "@devfile/api": "2.3.0-1738854228",
+    "@devfile/api": "2.3.0-1746644330",
     "@eclipse-che/api": "^7.86.0",
     "@kubernetes/client-node": "^0.22.1",
     "@react-mock/state": "^0.1.8",

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -22,6 +22,7 @@ import { TIMEOUT_TO_CREATE_SEC } from '@/components/WorkspaceProgress/const';
 import { configureProjectRemotes } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes';
 import { getProjectFromLocation } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getProjectFromLocation';
 import { prepareDevfile } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile';
+import { getStorageType } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile';
 import {
   ProgressStep,
   ProgressStepProps,
@@ -176,7 +177,7 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
   }
 
   private updateCurrentDevfile(devfile: devfileApi.Devfile): void {
-    const { factoryResolver, allWorkspaces, defaultDevfile } = this.props;
+    const { factoryResolver, allWorkspaces, defaultDevfile, preferredStorageType } = this.props;
     const { factoryParams } = this.state;
     const { factoryId, policiesCreate, sourceUrl, remotes } = factoryParams;
 
@@ -216,7 +217,8 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
     // test the devfile name to decide if we need to append a suffix to is
     const nameConflict = allWorkspaces.some(w => devfile.metadata.name === w.name);
 
-    const storageType = factoryParams.storageType || this.props.preferredStorageType || undefined;
+    const storageType = getStorageType(factoryParams, devfile, preferredStorageType);
+
     const appendSuffix = policiesCreate === 'perclick' || nameConflict;
     const parentDevfile = factoryResolver?.parentDevfile;
     const updatedDevfile = prepareDevfile(

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/prepareDevfile.ts
@@ -16,6 +16,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { DevfileAdapter } from '@/services/devfile/adapter';
 import devfileApi from '@/services/devfileApi';
 import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
+import { FactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { generateWorkspaceName } from '@/services/helpers/generateName';
 import sanitizeName from '@/services/helpers/sanitizeName';
 import { che } from '@/services/models';
@@ -74,4 +75,24 @@ export function prepareDevfile(
   }
 
   return devfile;
+}
+
+export function getStorageType(
+  factoryParams: FactoryParams,
+  devfile: devfileApi.Devfile | undefined,
+  preferredStorageType: che.WorkspaceStorageType,
+): che.WorkspaceStorageType | undefined {
+  let attributes: {
+    DEVWORKSPACE_STORAGE_TYPE_ATTR?: che.WorkspaceStorageType;
+  } = {};
+  if (devfile) {
+    attributes = DevfileAdapter.getAttributes(cloneDeep(devfile));
+  }
+
+  return (
+    factoryParams.storageType ||
+    attributes[DEVWORKSPACE_STORAGE_TYPE_ATTR] ||
+    preferredStorageType ||
+    undefined
+  );
 }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/prepareResources.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/prepareResources.spec.ts
@@ -13,8 +13,12 @@
 import { V1alpha2DevWorkspace } from '@devfile/api';
 
 import prepareResources from '@/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources';
+import { getStorageType } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources';
+import devfileApi from '@/services/devfileApi';
 import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
+import { FactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { generateSuffix } from '@/services/helpers/generateName';
+import { che } from '@/services/models';
 import { DEVWORKSPACE_DEVFILE_SOURCE } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
 import { DevWorkspaceResources } from '@/store/DevfileRegistries';
 
@@ -177,6 +181,55 @@ describe('FactoryLoaderContainer/prepareResources', () => {
           },
         ]),
       );
+    });
+  });
+
+  describe('get storageType', () => {
+    let devWorkspace: devfileApi.DevWorkspace;
+    beforeEach(() => {
+      devWorkspace = resources[0];
+      devWorkspace.spec.template.attributes = {};
+    });
+    test('apply storageType from factoryParams', () => {
+      devWorkspace.spec.template.attributes = {
+        [DEVWORKSPACE_STORAGE_TYPE_ATTR]: 'per-workspace',
+      };
+      const factoryParams = { storageType: 'ephemeral' } as FactoryParams;
+      const preferredStorageType = 'per-user' as che.WorkspaceStorageType;
+
+      const storageType = getStorageType(factoryParams, devWorkspace, preferredStorageType);
+
+      expect(storageType).toEqual('ephemeral');
+    });
+
+    test('apply storageType from Devfile', () => {
+      devWorkspace.spec.template.attributes = {
+        [DEVWORKSPACE_STORAGE_TYPE_ATTR]: 'per-workspace',
+      };
+      const factoryParams = {} as FactoryParams;
+      const preferredStorageType = 'per-user' as che.WorkspaceStorageType;
+
+      const storageType = getStorageType(factoryParams, devWorkspace, preferredStorageType);
+
+      expect(storageType).toEqual('per-workspace');
+    });
+
+    test('apply storageType from preferredStorageType', () => {
+      const factoryParams = {} as FactoryParams;
+      const preferredStorageType = 'per-user' as che.WorkspaceStorageType;
+
+      const storageType = getStorageType(factoryParams, devWorkspace, preferredStorageType);
+
+      expect(storageType).toEqual('per-user');
+    });
+
+    test('should return undefined', () => {
+      const factoryParams = {} as FactoryParams;
+      const preferredStorageType = '' as che.WorkspaceStorageType;
+
+      const storageType = getStorageType(factoryParams, devWorkspace, preferredStorageType);
+
+      expect(storageType).toBeUndefined();
     });
   });
 });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
@@ -17,7 +17,9 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { TIMEOUT_TO_CREATE_SEC } from '@/components/WorkspaceProgress/const';
-import prepareResources from '@/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources';
+import prepareResources, {
+  getStorageType,
+} from '@/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources';
 import {
   ProgressStep,
   ProgressStepProps,
@@ -173,7 +175,7 @@ class CreatingStepApplyResources extends ProgressStep<Props, State> {
   }
 
   protected async runStep(): Promise<boolean> {
-    const { devWorkspaceResources } = this.props;
+    const { devWorkspaceResources, preferredStorageType } = this.props;
     const { factoryParams, shouldCreate, resources, warning } = this.state;
     const { cheEditor, factoryId, sourceUrl, policiesCreate } = factoryParams;
 
@@ -219,7 +221,7 @@ class CreatingStepApplyResources extends ProgressStep<Props, State> {
       );
       const appendSuffix = policiesCreate === 'perclick' || nameConflict;
 
-      const storageType = factoryParams.storageType || this.props.preferredStorageType || undefined;
+      const storageType = getStorageType(factoryParams, _resources[0], preferredStorageType);
       // create a workspace using pre-generated resources
       const [devWorkspace, devWorkspaceTemplate] = prepareResources(
         _resources,

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/prepareResources.ts
@@ -13,9 +13,11 @@
 import { dump } from 'js-yaml';
 import cloneDeep from 'lodash/cloneDeep';
 
+import devfileApi from '@/services/devfileApi';
 import { DevWorkspaceTemplate } from '@/services/devfileApi/devfileApi';
 import { DevWorkspace } from '@/services/devfileApi/devWorkspace';
 import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
+import { FactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { generateSuffix } from '@/services/helpers/generateName';
 import { che } from '@/services/models';
 import { DEVWORKSPACE_DEVFILE_SOURCE } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
@@ -93,4 +95,17 @@ function addSuffix(devWorkspace: DevWorkspace, devWorkspaceTemplate: DevWorkspac
       }
     });
   }
+}
+
+export function getStorageType(
+  factoryParams: FactoryParams,
+  devWorkspace: devfileApi.DevWorkspace,
+  preferredStorageType: che.WorkspaceStorageType,
+): che.WorkspaceStorageType | undefined {
+  return (
+    factoryParams.storageType ||
+    devWorkspace.spec?.template?.attributes?.[DEVWORKSPACE_STORAGE_TYPE_ATTR] ||
+    preferredStorageType ||
+    undefined
+  );
 }

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/__tests__/selectors.spec.ts
@@ -25,6 +25,7 @@ import {
   selectRegistriesErrors,
   selectRegistriesMetadata,
 } from '@/store/DevfileRegistries/selectors';
+import { ServerConfigState } from '@/store/ServerConfig';
 
 jest.mock('js-yaml', () => ({
   load: jest.fn(),
@@ -41,6 +42,13 @@ describe('DevfileRegistries, selectors', () => {
 
   beforeEach(() => {
     mockState = {
+      dwServerConfig: {
+        config: {
+          defaults: {
+            pvcStrategy: 'per-user',
+          },
+        },
+      } as Partial<ServerConfigState>,
       devfileRegistries: {
         registries: {
           'https://registry1.com': {
@@ -231,7 +239,8 @@ describe('DevfileRegistries, selectors', () => {
   });
 
   describe('selectDefaultDevfile', () => {
-    it('should select default devfile', () => {
+    it('should select devfile without storage-type', () => {
+      delete mockState.dwServerConfig.config.defaults.pvcStrategy;
       const mockDevfile = {
         schemaVersion: '2.2.0',
         metadata: {
@@ -247,6 +256,59 @@ describe('DevfileRegistries, selectors', () => {
       expect(result).toEqual(
         Object.assign({}, mockDevfile, {
           attributes: {
+            'dw.metadata.annotations': {
+              'che.eclipse.org/devfile': mockDevfileStr,
+            },
+          },
+          components: [],
+        }),
+      );
+    });
+    it('should select devfile with default storage-type', () => {
+      const mockDevfile = {
+        schemaVersion: '2.2.0',
+        metadata: {
+          name: 'empty',
+        },
+      };
+      const mockDevfileStr = 'schemaVersion: 2.2.0\nmetadata:\n  name: empty\n';
+
+      (load as jest.Mock).mockReturnValue(mockDevfile);
+      (dump as jest.Mock).mockReturnValue(mockDevfileStr);
+
+      const result = selectDefaultDevfile(mockState);
+      expect(result).toEqual(
+        Object.assign({}, mockDevfile, {
+          attributes: {
+            'controller.devfile.io/storage-type': 'per-user',
+            'dw.metadata.annotations': {
+              'che.eclipse.org/devfile': mockDevfileStr,
+            },
+          },
+          components: [],
+        }),
+      );
+    });
+    it('should select devfile with storage-type', () => {
+      const mockDevfile = {
+        schemaVersion: '2.2.0',
+        metadata: {
+          name: 'empty',
+        },
+        attributes: {
+          'controller.devfile.io/storage-type': 'per-workspace',
+        },
+      };
+      const mockDevfileStr = 'schemaVersion: 2.2.0\nmetadata:\n  name: empty\n';
+
+      (load as jest.Mock).mockReturnValue(mockDevfile);
+      (dump as jest.Mock).mockReturnValue(mockDevfileStr);
+
+      const result = selectDefaultDevfile(mockState);
+      expect(result).toEqual(
+        Object.assign({}, mockDevfile, {
+          attributes: {
+            'controller.devfile.io/storage-type': 'per-workspace',
             'dw.metadata.annotations': {
               'che.eclipse.org/devfile': mockDevfileStr,
             },

--- a/packages/dashboard-frontend/src/store/DevfileRegistries/selectors.ts
+++ b/packages/dashboard-frontend/src/store/DevfileRegistries/selectors.ts
@@ -16,6 +16,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import { DevfileAdapter } from '@/services/devfile/adapter';
 import devfileApi from '@/services/devfileApi';
+import { DEVWORKSPACE_STORAGE_TYPE_ATTR } from '@/services/devfileApi/devWorkspace/spec/template';
 import stringify from '@/services/helpers/editor';
 import match from '@/services/helpers/filter';
 import { che } from '@/services/models';
@@ -24,11 +25,13 @@ import {
   DEVWORKSPACE_METADATA_ANNOTATION,
 } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
 import { RootState } from '@/store';
+import { getPvcStrategy } from '@/store/ServerConfig/helpers';
 import { selectDefaultComponents } from '@/store/ServerConfig/selectors';
 
 export const EMPTY_WORKSPACE_TAG = 'Empty';
 
 const selectState = (state: RootState) => state.devfileRegistries;
+const selectServerConfigState = (state: RootState) => state.dwServerConfig;
 
 export const selectRegistriesMetadata = createSelector(selectState, devfileRegistriesState => {
   const registriesMetadata = Object.keys(devfileRegistriesState.registries).map(registry => {
@@ -90,11 +93,16 @@ export const selectEmptyWorkspaceUrl = createSelector(selectRegistriesMetadata, 
   return emptyWorkspaceMetadata?.links?.v2;
 });
 
+export const selectPvcStrategy = createSelector(selectServerConfigState, state =>
+  getPvcStrategy(state),
+);
+
 export const selectDefaultDevfile = createSelector(
   selectState,
+  selectPvcStrategy,
   selectDefaultComponents,
   selectEmptyWorkspaceUrl,
-  (state, defaultComponents, devfileLocation) => {
+  (state, pvcStrategy, defaultComponents, devfileLocation) => {
     if (!devfileLocation) {
       return undefined;
     }
@@ -108,6 +116,10 @@ export const selectDefaultDevfile = createSelector(
           devfileAttr[DEVWORKSPACE_METADATA_ANNOTATION] = {};
         }
         devfileAttr[DEVWORKSPACE_METADATA_ANNOTATION][DEVWORKSPACE_DEVFILE] = stringify(_devfile);
+        // set default storage type if not set
+        if (!devfileAttr[DEVWORKSPACE_STORAGE_TYPE_ATTR] && pvcStrategy) {
+          devfileAttr[DEVWORKSPACE_STORAGE_TYPE_ATTR] = pvcStrategy;
+        }
         // propagate default components
         if (!devfile.components || devfile.components.length === 0) {
           devfile.components = defaultComponents;

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/helpers.spec.ts
@@ -10,7 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { isSourceAllowed } from '@/store/ServerConfig/helpers';
+import { ServerConfigState } from '@/store/ServerConfig';
+import { getPvcStrategy, isSourceAllowed } from '@/store/ServerConfig/helpers';
 
 describe('helpers', () => {
   describe('isAllowedSourceUrl', () => {
@@ -25,6 +26,51 @@ describe('helpers', () => {
 
     test('disallowed urls', () => {
       expect(isSourceAllowed(['https://a'], 'https://a/b/c/')).toBe(false);
+    });
+  });
+  describe('getPvcStrategy', () => {
+    const getMockState = (pvcStrategy: string) =>
+      ({
+        config: {
+          defaults: {
+            pvcStrategy,
+          },
+        },
+      }) as Partial<ServerConfigState>;
+    test('per-user', () => {
+      const state = getMockState('per-user');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('per-user');
+    });
+    test('per-workspace', () => {
+      const state = getMockState('per-workspace');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('per-workspace');
+    });
+    test('ephemeral', () => {
+      const state = getMockState('ephemeral');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('ephemeral');
+    });
+    test('common', () => {
+      const state = getMockState('common');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('per-user');
+    });
+    test('unknown', () => {
+      const state = getMockState('unknown');
+
+      const pvcStrategy = getPvcStrategy(state);
+
+      expect(pvcStrategy).toBe('');
     });
   });
 });

--- a/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/__tests__/selectors.spec.ts
@@ -55,7 +55,7 @@ describe('ServerConfig Selectors', () => {
               plugins: ['plugin2'],
             },
           ] as api.IWorkspacesDefaultPlugins[],
-          pvcStrategy: 'strategy',
+          pvcStrategy: 'per-user',
         },
         pluginRegistry: {
           disableInternalRegistry: false,
@@ -129,7 +129,7 @@ describe('ServerConfig Selectors', () => {
 
   it('should select PVC strategy', () => {
     const result = selectPvcStrategy(mockState);
-    expect(result).toEqual('strategy');
+    expect(result).toEqual('per-user');
   });
 
   it('should select start timeout', () => {

--- a/packages/dashboard-frontend/src/store/ServerConfig/helpers.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/helpers.ts
@@ -10,6 +10,9 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { che } from '@/services/models';
+import { ServerConfigState } from '@/store/ServerConfig/index';
+
 export function isSourceAllowed(allowedSourceUrls: string[] | undefined, url: string): boolean {
   if (allowedSourceUrls === undefined || allowedSourceUrls.length === 0) {
     return true;
@@ -37,4 +40,20 @@ export function isSourceAllowed(allowedSourceUrls: string[] | undefined, url: st
   }
 
   return false;
+}
+
+export function getPvcStrategy(state?: Partial<ServerConfigState>): che.WorkspaceStorageType {
+  const pvcStrategy = state?.config?.defaults?.pvcStrategy;
+  switch (pvcStrategy) {
+    case 'per-user':
+      return pvcStrategy;
+    case 'per-workspace':
+      return pvcStrategy;
+    case 'ephemeral':
+      return pvcStrategy;
+    case 'common':
+      return 'per-user';
+    default:
+      return '';
+  }
 }

--- a/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ServerConfig/selectors.ts
@@ -12,8 +12,8 @@
 
 import { createSelector } from '@reduxjs/toolkit';
 
-import { che } from '@/services/models';
 import { RootState } from '@/store';
+import { getPvcStrategy } from '@/store/ServerConfig/helpers';
 
 const selectState = (state: RootState) => state.dwServerConfig;
 export const selectServerConfigState = selectState;
@@ -50,10 +50,7 @@ export const selectOpenVSXUrl = createSelector(
   state => state.config.pluginRegistry?.openVSXURL,
 );
 
-export const selectPvcStrategy = createSelector(
-  selectState,
-  state => (state.config.defaults.pvcStrategy || '') as che.WorkspaceStorageType,
-);
+export const selectPvcStrategy = createSelector(selectState, state => getPvcStrategy(state));
 
 export const selectStartTimeout = createSelector(
   selectState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,9 +477,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@devfile/api@npm:2.3.0-1738854228":
-  version: 2.3.0-1738854228
-  resolution: "@devfile/api@npm:2.3.0-1738854228"
+"@devfile/api@npm:2.3.0-1746644330":
+  version: 2.3.0-1746644330
+  resolution: "@devfile/api@npm:2.3.0-1746644330"
   dependencies:
     "@types/node": "npm:*"
     "@types/node-fetch": "npm:^2.5.7"
@@ -487,21 +487,7 @@ __metadata:
     form-data: "npm:^2.5.0"
     node-fetch: "npm:^2.6.0"
     url-parse: "npm:^1.4.3"
-  checksum: 10/d0e740b91f25d4369b40ffdb5bde5af8338b0c38ecf0aaf67599a4174370e62a2c6a7d7a57f6e23ec5130352d1d38cd7ded236e98a2a11e3dce460f9289b6518
-  languageName: node
-  linkType: hard
-
-"@devfile/api@npm:2.3.0-1741179368":
-  version: 2.3.0-1741179368
-  resolution: "@devfile/api@npm:2.3.0-1741179368"
-  dependencies:
-    "@types/node": "npm:*"
-    "@types/node-fetch": "npm:^2.5.7"
-    es6-promise: "npm:^4.2.4"
-    form-data: "npm:^2.5.0"
-    node-fetch: "npm:^2.6.0"
-    url-parse: "npm:^1.4.3"
-  checksum: 10/4b4579c566df2e9843d2b659f975f53da74e2f0765b78deff8fb7fc2b680134e5ffc16a4d3b7d41dfa67daef0efff33e34e7e4ebaf729e9f6b71163201f251ba
+  checksum: 10/cb9f3caa8b849a74cbb6f99f221a66baf1932bee0a7b390a03ada62bfcb69a725ae63886931470b89610845bd88ddec1c779fc11ca2bc39ab6b3eb0a86463a97
   languageName: node
   linkType: hard
 
@@ -526,11 +512,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eclipse-che/che-devworkspace-generator@npm:7.102.0":
-  version: 7.102.0
-  resolution: "@eclipse-che/che-devworkspace-generator@npm:7.102.0"
+"@eclipse-che/che-devworkspace-generator@npm:7.103.0-next-4e46cbe":
+  version: 7.103.0-next-4e46cbe
+  resolution: "@eclipse-che/che-devworkspace-generator@npm:7.103.0-next-4e46cbe"
   dependencies:
-    "@devfile/api": "npm:2.3.0-1741179368"
+    "@devfile/api": "npm:2.3.0-1746644330"
     axios: "npm:^1.8.3"
     fs-extra: "npm:^11.2.0"
     inversify: "npm:^7.1.0"
@@ -541,7 +527,7 @@ __metadata:
     reflect-metadata: "npm:^0.2.2"
   bin:
     che-devworkspace-generator: lib/entrypoint.js
-  checksum: 10/cdcfba1b37c210ff3dc0f38714446831741b30e500506f788dbcf24d55d4192c35bc980ea048be19e745690b43600093c976138796954b4a9729fdaf64755b33
+  checksum: 10/e8febe6421405e4ce7eba4a4d4f695b1930337f36c002b04691ce12c1857a9e33ee396aea308d434e85b0fa796f8a6874fc88d3dc647a8b7cd407334afba175f
   languageName: node
   linkType: hard
 
@@ -549,7 +535,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eclipse-che/common@workspace:packages/common"
   dependencies:
-    "@devfile/api": "npm:2.3.0-1738854228"
+    "@devfile/api": "npm:2.3.0-1746644330"
     "@kubernetes/client-node": "npm:^0.22.1"
     "@types/jest": "npm:^29.5.3"
     "@typescript-eslint/eslint-plugin": "npm:^6.3.0"
@@ -572,8 +558,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eclipse-che/dashboard-backend@workspace:packages/dashboard-backend"
   dependencies:
-    "@devfile/api": "npm:2.3.0-1738854228"
-    "@eclipse-che/che-devworkspace-generator": "npm:7.102.0"
+    "@devfile/api": "npm:2.3.0-1746644330"
+    "@eclipse-che/che-devworkspace-generator": "npm:7.103.0-next-4e46cbe"
     "@fastify/cors": "npm:^9.0.1"
     "@fastify/error": "npm:^3.4.1"
     "@fastify/http-proxy": "npm:^9.5.0"
@@ -632,7 +618,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eclipse-che/dashboard-frontend@workspace:packages/dashboard-frontend"
   dependencies:
-    "@devfile/api": "npm:2.3.0-1738854228"
+    "@devfile/api": "npm:2.3.0-1746644330"
     "@eclipse-che/api": "npm:^7.86.0"
     "@kubernetes/client-node": "npm:^0.22.1"
     "@lezer/highlight": "npm:^1.2.1"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes `getStorageType` and `selectDefaultDevfile` methods.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1345 and https://github.com/eclipse-che/che-dashboard/pull/1346 to the 7.102.x branch
