### PR TITLE
fix: Preserve the current context from the generated kubeconfig (#1349)

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/fixtures/merged_kubeconfig.yaml
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/fixtures/merged_kubeconfig.yaml
@@ -7,10 +7,18 @@ clusters:
       certificate-authority: ca-file
       insecure-skip-tls-verify: false
 users:
+  - name: guest
+    user:
+      token: guest-token
   - name: dev
     user:
       token: dev-token
 contexts:
+  - name: guest-context
+    context:
+      name: guest-context
+      user: guest
+      cluster: cluster
   - name: dev-context
     context:
       name: dev-context

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/fixtures/mounted_kubeconfig.yaml
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/fixtures/mounted_kubeconfig.yaml
@@ -9,13 +9,20 @@ clusters:
 users:
   - name: dev
     user:
-      token: dev-token
+      token: new-dev-token
+  - name: guest
+    user:
+      token: guest-token
 contexts:
   - name: dev-context
     context:
       name: dev-context
-      user: dev
+      user: new-dev
+      cluster: new-cluster
+  - name: guest-context
+    context:
+      name: guest-context
+      user: guest
       cluster: cluster
-      namespace: user-che
 preferences: {}
-current-context: dev-context
+current-context: guest-context

--- a/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/kubeConfigApi.ts
@@ -251,6 +251,10 @@ export class KubeConfigApiService implements IKubeConfigApi {
         }
         kubeConfig.users.push(user);
       }
+
+      // Preserve the current context from the generated kubeconfig
+      // Ensures that user always has access to the cluster
+      kubeConfig['current-context'] = generatedKubeConfig['current-context'];
       return stringify(kubeConfig);
     } catch (e) {
       logger.error(e, 'Failed to merge kubeconfig, returning source');


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Preserve the current context from the generated kubeconfig
Original PR https://github.com/eclipse-che/che-dashboard/pull/1349

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-8879

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che
2. Update CheCluster CR:
```yaml
spec:
  devEnvironments:
    persistUserHome:
      enabled: true
```
3. Start a workspace
4. Edit `~/.kube/config` file like that:
```yaml
apiVersion: v1
kind: Config
clusters:
  - name: inCluster
    cluster:
      server: https://10.96.0.1:443
      certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
      insecure-skip-tls-verify: false
users:
  - name: admin
    user:
      token: <EXISTED_TOKEN>
  - name: admin-2
    user:
      token: XXXXX
contexts:
  - name: logged-user
    context:
      user: admin
      cluster: inCluster
      name: logged-user
      namespace: admin-che
  - name: logged-user-2
    context:
      user: admin-2
      cluster: inCluster
      name: logged-user
      namespace: admin-che      
preferences: {}
current-context: logged-user-2
```
5.  Try in terminal `oc get secrets`. Command should print an error.
6. Stop the workspace
7. Apply patch
```
kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {containers: [{image: "quay.io/eclipse/che-dashboard:pr-1349", name: che-dashboard}]}}]"
```
8. Restart worskspace
9. Try in terminal `oc get secrets`. Command should print secrets.

#### Release Notes
<!-- markdown to be included in marketing announcement -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A