### PR TITLE
fix: remove devfile content from attributes for SSH

### DIFF
--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/__tests__/__snapshots__/index.spec.tsx.snap
@@ -76,7 +76,7 @@ exports[`DevfileEditorTab component snapshot without devfile content 1`] = `
           data-ouia-component-type="PF4/Title"
           data-ouia-safe={true}
         >
-          No Data Found
+          Devfile content is not available
         </h4>
       </div>
     </div>

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/DevfileEditorTab/index.tsx
@@ -76,7 +76,7 @@ export default class DevfileEditorTab extends React.PureComponent<Props, State> 
             <EmptyState isFullHeight={true} variant={EmptyStateVariant.small}>
               <EmptyStateIcon icon={CogIcon} />
               <Title headingLevel="h4" size="lg">
-                No Data Found
+                Devfile content is not available
               </Title>
             </EmptyState>
           )}

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/helpers.spec.ts
@@ -17,16 +17,22 @@ import devfileApi, * as devfileApiService from '@/services/devfileApi';
 import { devWorkspaceKind } from '@/services/devfileApi/devWorkspace';
 import { compareStringsAsNumbers } from '@/services/helpers/resourceVersion';
 import {
+  COMPONENT_UPDATE_POLICY,
+  DEVWORKSPACE_DEVFILE,
   DEVWORKSPACE_NEXT_START_ANNOTATION,
   DevWorkspaceClient,
+  REGISTRY_URL,
 } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
 import { RootState } from '@/store';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 import { selectRunningWorkspacesLimit } from '@/store/ClusterConfig/selectors';
 import { RunningWorkspacesExceededError } from '@/store/Workspaces/devWorkspaces';
 import {
   checkDevWorkspaceNextStartAnnotation,
   checkRunningWorkspacesLimit,
   getDevWorkspaceClient,
+  getDevWorkspaceFromResources,
+  getDevWorkspaceTemplateFromResources,
   getWarningFromResponse,
   shouldUpdateDevWorkspace,
 } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers';
@@ -251,6 +257,244 @@ describe('devWorkspaces, helpers', () => {
       const result = shouldUpdateDevWorkspace(prevDevWorkspace, devWorkspace);
       expect(result).toBe(false);
       expect(compareStringsAsNumbers).toHaveBeenCalledWith('2', '2');
+    });
+  });
+
+  describe('getDevWorkspaceFromResources', () => {
+    it('should return DevWorkspace resource from resources', () => {
+      const resources = [
+        {
+          kind: 'DevWorkspace',
+          metadata: {
+            name: 'test-workspace',
+          },
+        },
+        {
+          kind: 'OtherResource',
+          metadata: { name: 'other-resource' },
+        },
+      ] as devfileApi.DevWorkspace[];
+
+      const params = { sourceUrl: 'https://example.com/repo.git' };
+      const result = getDevWorkspaceFromResources(resources, params);
+
+      expect(result).toBeDefined();
+      expect(result.kind).toBe('DevWorkspace');
+      expect(result.metadata.name).toBe('test-workspace');
+    });
+    describe('Devfile resolution supported by che-server', () => {
+      it('should return DevWorkspace with original devfile recourse for URL location', () => {
+        const devWorkspace = new DevWorkspaceBuilder()
+          .withMetadata({
+            name: 'test-workspace',
+            annotations: {
+              'che.eclipse.org/devfile': `schemaVersion: 2.2.0\nmetadata:\n name: test-workspace\n`,
+            },
+          })
+          .build();
+        const resources = [
+          devWorkspace,
+          {
+            kind: 'OtherResource',
+            metadata: { name: 'other-resource' },
+          },
+        ] as devfileApi.DevWorkspace[];
+
+        const params = { sourceUrl: 'http://example.com/repo.git' };
+        const result = getDevWorkspaceFromResources(resources, params);
+
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toBeDefined();
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toContain(
+          'schemaVersion: 2.2.0',
+        );
+      });
+
+      it('should return DevWorkspace wit original devfile recourse for SSH location', () => {
+        const devWorkspace = new DevWorkspaceBuilder()
+          .withMetadata({
+            name: 'test-workspace',
+            annotations: {
+              'che.eclipse.org/devfile': `schemaVersion: 2.2.0\nmetadata:\n name: test-workspace\n`,
+            },
+          })
+          .build();
+        const resources = [
+          devWorkspace,
+          {
+            kind: 'OtherResource',
+            metadata: { name: 'other-resource' },
+          },
+        ] as devfileApi.DevWorkspace[];
+
+        const params = { sourceUrl: 'ssh://example.com/repo.git' };
+        const result = getDevWorkspaceFromResources(resources, params);
+
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toBeDefined();
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toContain(
+          'schemaVersion: 2.2.0',
+        );
+      });
+    });
+    describe('Devfile resolution is not supported by che-server', () => {
+      it('should return DevWorkspace with original devfile recourse for URL location', () => {
+        const devWorkspace = new DevWorkspaceBuilder()
+          .withMetadata({
+            name: 'test-workspace',
+            annotations: {
+              'che.eclipse.org/devfile': `schemaVersion: 2.2.0\nmetadata:\n name: test-workspace\n`,
+            },
+          })
+          .withTemplateAttributes({
+            'controller.devfile.io/bootstrap-devworkspace': true,
+          })
+          .build();
+        const resources = [
+          devWorkspace,
+          {
+            kind: 'OtherResource',
+            metadata: { name: 'other-resource' },
+          },
+        ] as devfileApi.DevWorkspace[];
+
+        const params = { sourceUrl: 'http://example.com/repo.git' };
+        const result = getDevWorkspaceFromResources(resources, params);
+
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toBeDefined();
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toContain(
+          'schemaVersion: 2.2.0',
+        );
+      });
+
+      it('should return DevWorkspace without original devfile recourse for SSH location', () => {
+        const devWorkspace = new DevWorkspaceBuilder()
+          .withMetadata({
+            name: 'test-workspace',
+            annotations: {
+              'che.eclipse.org/devfile': `schemaVersion: 2.2.0\nmetadata:\n name: test-workspace\n`,
+            },
+          })
+          .withTemplateAttributes({
+            'controller.devfile.io/bootstrap-devworkspace': true,
+          })
+          .build();
+        const resources = [
+          devWorkspace,
+          {
+            kind: 'OtherResource',
+            metadata: { name: 'other-resource' },
+          },
+        ] as devfileApi.DevWorkspace[];
+
+        const params = { sourceUrl: 'ssh://example.com/repo.git' };
+        const result = getDevWorkspaceFromResources(resources, params);
+
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toBeDefined();
+        expect(result.metadata.annotations![DEVWORKSPACE_DEVFILE]).toEqual('');
+      });
+    });
+
+    it('should throw error if no DevWorkspace resource found', () => {
+      const resources = [
+        {
+          kind: 'OtherResource',
+          metadata: { name: 'other-resource' },
+        },
+      ] as devfileApi.DevWorkspace[];
+
+      expect(() => getDevWorkspaceFromResources(resources, {})).toThrow(
+        'Failed to find a DevWorkspace in the fetched resources.',
+      );
+    });
+
+    it('should throw error if fetched resource is not a valid DevWorkspace', () => {
+      const resources = [
+        {
+          kind: 'DevWorkspace',
+        },
+      ] as devfileApi.DevWorkspace[]; // invalid DevWorkspace without metadata
+
+      expect(() => getDevWorkspaceFromResources(resources, {})).toThrow(
+        'Fetched resource includes not a valid DevWorkspace.',
+      );
+    });
+  });
+
+  describe('getDevWorkspaceTemplateFromResources', () => {
+    describe('with EditorYamlUrl', () => {
+      it('should return DevWorkspaceTemplate resource from resources', () => {
+        const resources = [
+          {
+            kind: 'DevWorkspaceTemplate',
+            metadata: {
+              name: 'test-template',
+            },
+          },
+          {
+            kind: 'OtherResource',
+            metadata: { name: 'other-resource' },
+          },
+        ] as devfileApi.DevWorkspaceTemplate[];
+
+        const result = getDevWorkspaceTemplateFromResources(
+          resources,
+          'https://dummy-editor-url.com',
+        );
+
+        expect(result).toBeDefined();
+        expect(result.kind).toBe('DevWorkspaceTemplate');
+        expect(result.metadata.name).toBe('test-template');
+        expect(result.metadata.annotations).toBeDefined();
+        expect(result.metadata.annotations![COMPONENT_UPDATE_POLICY]).toBe('managed');
+        expect(result.metadata.annotations![REGISTRY_URL]).toBe('https://dummy-editor-url.com');
+      });
+    });
+    describe('without EditorYamlUrl', () => {
+      it('should return DevWorkspaceTemplate resource from resources', () => {
+        const resources = [
+          {
+            kind: 'DevWorkspaceTemplate',
+            metadata: {
+              name: 'test-template',
+            },
+          },
+          {
+            kind: 'OtherResource',
+            metadata: { name: 'other-resource' },
+          },
+        ] as devfileApi.DevWorkspaceTemplate[];
+
+        const result = getDevWorkspaceTemplateFromResources(resources, undefined);
+
+        expect(result).toBeDefined();
+        expect(result.kind).toBe('DevWorkspaceTemplate');
+        expect(result.metadata.name).toBe('test-template');
+        expect(result.metadata.annotations).toBeUndefined();
+      });
+    });
+
+    it('should throw error if no DevWorkspaceTemplate resource found', () => {
+      const resources = [
+        {
+          kind: 'OtherResource',
+          metadata: { name: 'other-resource' },
+        },
+      ] as devfileApi.DevWorkspaceTemplate[];
+
+      expect(() => getDevWorkspaceTemplateFromResources(resources, undefined)).toThrow(
+        'Failed to find a DevWorkspaceTemplate in the fetched resources.',
+      );
+    });
+
+    it('should throw error if fetched resource is not a valid DevWorkspaceTemplate', () => {
+      const resources = [
+        {
+          kind: 'DevWorkspaceTemplate',
+        },
+      ] as devfileApi.DevWorkspaceTemplate[]; // invalid DevWorkspaceTemplate without metadata
+
+      expect(() => getDevWorkspaceTemplateFromResources(resources, undefined)).toThrow(
+        'Failed to find a DevWorkspaceTemplate in the fetched resources.',
+      );
     });
   });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/createWorkspaceFromDevfile.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/createWorkspaceFromDevfile.ts
@@ -17,14 +17,14 @@ import { fetchResources } from '@/services/backend-client/devworkspaceResourcesA
 import devfileApi from '@/services/devfileApi';
 import { FactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { loadResourcesContent } from '@/services/registry/resources';
-import {
-  COMPONENT_UPDATE_POLICY,
-  REGISTRY_URL,
-} from '@/services/workspace-client/devworkspace/devWorkspaceClient';
 import { AppThunk } from '@/store';
 import { getEditor } from '@/store/DevfileRegistries/getEditor';
 import { verifyAuthorized } from '@/store/SanityCheck';
 import { actionCreators } from '@/store/Workspaces/devWorkspaces/actions';
+import {
+  getDevWorkspaceFromResources,
+  getDevWorkspaceTemplateFromResources,
+} from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers';
 import { updateEditorDevfile } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/editorImage';
 import { getCustomEditor } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor';
 import {
@@ -95,30 +95,8 @@ export const createWorkspaceFromDevfile =
         editorContent: editorContent,
       });
       const resources = loadResourcesContent(resourcesContent);
-      devWorkspaceResource = resources.find(
-        resource => resource.kind === 'DevWorkspace',
-      ) as devfileApi.DevWorkspace;
-      if (devWorkspaceResource === undefined) {
-        throw new Error('Failed to find a DevWorkspace in the fetched resources.');
-      }
-      if (devWorkspaceResource.metadata) {
-        if (!devWorkspaceResource.metadata.annotations) {
-          devWorkspaceResource.metadata.annotations = {};
-        }
-      }
-      devWorkspaceTemplateResource = resources.find(
-        resource => resource.kind === 'DevWorkspaceTemplate',
-      ) as devfileApi.DevWorkspaceTemplate;
-      if (devWorkspaceTemplateResource === undefined) {
-        throw new Error('Failed to find a DevWorkspaceTemplate in the fetched resources.');
-      }
-      if (editorYamlUrl && devWorkspaceTemplateResource.metadata) {
-        if (!devWorkspaceTemplateResource.metadata.annotations) {
-          devWorkspaceTemplateResource.metadata.annotations = {};
-        }
-        devWorkspaceTemplateResource.metadata.annotations[COMPONENT_UPDATE_POLICY] = 'managed';
-        devWorkspaceTemplateResource.metadata.annotations[REGISTRY_URL] = editorYamlUrl;
-      }
+      devWorkspaceResource = getDevWorkspaceFromResources(resources, params);
+      devWorkspaceTemplateResource = getDevWorkspaceTemplateFromResources(resources, editorYamlUrl);
     } catch (e) {
       const errorMessage = common.helpers.errors.getMessage(e);
       dispatch(devWorkspacesErrorAction(errorMessage));


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove devfile content from the target devworkspace attributes when using SSH URL for private repositories.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Знімок екрана 2025-06-05 о 04 52 31](https://github.com/user-attachments/assets/bae15d41-c104-422f-8771-0520ee098930)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23301

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR.
2. Create a private repo on GitHub.com using https://github.com/crw-qe/quarkus-api-example-public
3. Make sure you have SSH keys added to your account on GitHub.com and to the User Dashboard in Eclipse Che.
4. Create a new workspace using SSH URL.
5. Go to "_User Dashboard > Workspaces > (new workspace) > Devfile_" tab. The message **_Devfile content is not available_** should be shown.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
