### PR TITLE
chore(deps): bump pbkdf2 from 3.1.2 to 3.1.3

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -2,20 +2,16 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 
 | Packages | Resolved CQs |
 | --- | --- |
-| `@devfile/api@2.3.0-1746644330` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@devfile/api/2.3.0-1746644330) |
 | `@fastify/cors@9.0.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@fastify/cors/9.0.1) |
 | `@hapi/hoek@10.0.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/hoek/10.0.1) |
-| `@inversifyjs/common@1.5.0` | transitive dependency |
-| `@inversifyjs/container@1.9.1` | transitive dependency |
 | `@patternfly/react-core@4.278.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-core/4.278.0) |
 | `@patternfly/react-icons@4.93.7` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-icons/4.93.7) |
 | `@patternfly/react-table@4.113.6` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@patternfly/react-table/4.113.6) |
 | `blueimp-md5@2.19.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/blueimp-md5/2.19.0) |
 | `codemirror@5.65.18` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/codemirror/5.65.18) |
-| `elliptic@6.6.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/elliptic/6.6.1) |
+| `create-hash@1.1.3` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/create-hash/1.1.3) |
 | `fast-uri@2.4.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.4.0) |
 | `fastify@4.28.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify/4.28.1) |
-| `inversify@7.5.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/inversify/7.5.1) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |
 | `light-my-request@5.14.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/light-my-request/5.14.0) |
 | `real-require@0.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/real-require/0.2.0) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -29,7 +29,7 @@
 | [`@babel/template@7.27.0`](https://github.com/babel/babel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@babel/template/7.27.0) |
 | [`@babel/traverse@7.23.2`](https://github.com/babel/babel.git) | MIT | #11520 |
 | [`@babel/types@7.26.10`](https://github.com/babel/babel.git) | MIT | #17734 |
-| [`@babel/types@7.27.0`](https://github.com/babel/babel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@babel/types/7.27.0) |
+| [`@babel/types@7.27.0`](https://github.com/babel/babel.git) | MIT | #21827 |
 | [`@bcoe/v8-coverage@0.2.3`](git://github.com/demurgos/v8-coverage.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@bcoe/v8-coverage/0.2.3) |
 | [`@csstools/css-parser-algorithms@3.0.4`](git+https://github.com/csstools/postcss-plugins.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@csstools/css-parser-algorithms/3.0.4) |
 | [`@csstools/css-tokenizer@3.0.3`](git+https://github.com/csstools/postcss-plugins.git) | MIT | #19008 |
@@ -405,7 +405,6 @@
 | `is-binary-path@2.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-binary-path/2.1.0) |
 | [`is-boolean-object@1.1.2`](git://github.com/inspect-js/is-boolean-object.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-boolean-object/1.1.2) |
 | [`is-buffer@2.0.5`](git://github.com/feross/is-buffer.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-buffer/2.0.5) |
-| [`is-callable@1.2.7`](git://github.com/inspect-js/is-callable.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-callable/1.2.7) |
 | [`is-core-module@2.13.1`](git+https://github.com/inspect-js/is-core-module.git) | MIT | #9885 |
 | [`is-date-object@1.0.5`](git://github.com/inspect-js/is-date-object.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-date-object/1.0.5) |
 | `is-docker@2.2.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-docker/2.2.1) |
@@ -436,7 +435,6 @@
 | [`is-weakref@1.0.2`](git+https://github.com/inspect-js/is-weakref.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-weakref/1.0.2) |
 | [`is-weakset@2.0.2`](git+https://github.com/inspect-js/is-weakset.git) | MIT | #18388 |
 | `is-wsl@2.2.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-wsl/2.2.0) |
-| [`isarray@2.0.5`](git://github.com/juliangruber/isarray.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/isarray/2.0.5) |
 | [`isobject@3.0.1`](https://github.com/jonschlinkert/isobject) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/isobject/3.0.1) |
 | [`istanbul-lib-coverage@3.2.1`](git+ssh://git@github.com/istanbuljs/istanbuljs.git) | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/istanbul-lib-coverage/3.2.1) |
 | [`istanbul-lib-instrument@5.2.1`](git+ssh://git@github.com/istanbuljs/istanbuljs.git) | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/istanbul-lib-instrument/5.2.1) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -28,8 +28,8 @@
 | `@hapi/hoek@10.0.1` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/hoek/10.0.1) |
 | `@hapi/topo@5.1.0` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/topo/5.1.0) |
 | `@hapi/wreck@18.0.1` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/wreck/18.0.1) |
-| [`@inversifyjs/common@1.5.0`](git+https://github.com/inversify/monorepo.git) | MIT | transitive dependency |
-| [`@inversifyjs/container@1.9.1`](git+https://github.com/inversify/monorepo.git) | MIT | transitive dependency |
+| [`@inversifyjs/common@1.5.0`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/common/1.5.0) |
+| [`@inversifyjs/container@1.9.1`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/container/1.9.1) |
 | [`@inversifyjs/core@5.2.0`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/core/5.2.0) |
 | [`@inversifyjs/prototype-utils@0.1.0`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/prototype-utils/0.1.0) |
 | [`@inversifyjs/reflect-metadata-utils@1.1.0`](git+https://github.com/inversify/monorepo.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@inversifyjs/reflect-metadata-utils/1.1.0) |
@@ -81,11 +81,12 @@
 | `argparse@2.0.1` | Python-2.0 | CQ22954 |
 | [`args@5.0.3`](https://github.com/leo/args#readme) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/args/5.0.3) |
 | [`asn1.js@5.4.1`](git@github.com:indutny/asn1.js) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/asn1.js/5.4.1) |
-| [`asn1@0.2.6`](https://github.com/joyent/node-asn1.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/asn1/0.2.6) |
+| [`asn1@0.2.6`](https://github.com/joyent/node-asn1.git) | MIT | #21125 |
 | [`assert-plus@1.0.0`](https://github.com/mcavage/node-assert-plus.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/assert-plus/1.0.0) |
 | [`asynckit@0.4.0`](git+https://github.com/alexindigo/asynckit.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/asynckit/0.4.0) |
 | [`atomic-sleep@1.0.0`](git+https://github.com/davidmarkclements/atomic-sleep.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/atomic-sleep/1.0.0) |
 | [`attr-accept@1.1.3`](https://github.com/okonet/attr-accept.git) | MIT | CQ22348 |
+| [`available-typed-arrays@1.0.7`](git+https://github.com/inspect-js/available-typed-arrays.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/available-typed-arrays/1.0.7) |
 | [`avvio@8.4.0`](git+https://github.com/fastify/avvio.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/avvio/8.4.0) |
 | [`aws-sign2@0.7.0`](https://github.com/mikeal/aws-sign) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/aws-sign2/0.7.0) |
 | `aws4@1.12.0` | MIT | #6221 |
@@ -106,7 +107,10 @@
 | [`buffer@6.0.3`](git://github.com/feross/buffer.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/buffer/6.0.3) |
 | [`byline@5.0.0`](https://github.com/jahewson/node-byline) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/byline/5.0.0) |
 | [`cacache@18.0.4`](git+https://github.com/npm/cacache.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cacache/18.0.4) |
+| [`call-bind-apply-helpers@1.0.2`](git+https://github.com/ljharb/call-bind-apply-helpers.git) | MIT | #17826 |
 | [`call-bind@1.0.7`](git+https://github.com/ljharb/call-bind.git) | MIT | #11092 |
+| [`call-bind@1.0.8`](git+https://github.com/ljharb/call-bind.git) | MIT | #11092 |
+| [`call-bound@1.0.4`](git+https://github.com/ljharb/call-bound.git) | MIT | #17832 |
 | `camelcase@5.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/camelcase/5.0.0) |
 | [`caseless@0.12.0`](https://github.com/mikeal/caseless) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/caseless/0.12.0) |
 | `chalk@2.4.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/chalk/2.4.2) |
@@ -128,6 +132,7 @@
 | [`core-js@2.6.12`](https://github.com/zloirock/core-js.git) | MIT | #2912 |
 | [`core-util-is@1.0.2`](git://github.com/isaacs/core-util-is) | MIT | #5898 |
 | [`create-ecdh@4.0.4`](https://github.com/crypto-browserify/createECDH.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/create-ecdh/4.0.4) |
+| [`create-hash@1.1.3`](git@github.com:crypto-browserify/createHash.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/create-hash/1.1.3) |
 | [`create-hash@1.2.0`](git@github.com:crypto-browserify/createHash.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/create-hash/1.2.0) |
 | [`create-hmac@1.1.7`](https://github.com/crypto-browserify/createHmac.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/create-hmac/1.1.7) |
 | [`cross-spawn@7.0.6`](git@github.com:moxystudio/node-cross-spawn.git) | MIT | #17146 |
@@ -146,19 +151,22 @@
 | [`domelementtype@2.3.0`](git://github.com/fb55/domelementtype.git) | BSD-2-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/domelementtype/2.3.0) |
 | [`domhandler@5.0.3`](git://github.com/fb55/domhandler.git) | BSD-2-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/domhandler/5.0.3) |
 | [`domutils@3.1.0`](git://github.com/fb55/domutils.git) | BSD-2-Clause | #8391 |
+| [`dunder-proto@1.0.1`](git+https://github.com/es-shims/dunder-proto.git) | MIT | #17824 |
 | [`duplexify@4.1.3`](git://github.com/mafintosh/duplexify) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/duplexify/4.1.3) |
 | `eastasianwidth@0.2.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/eastasianwidth/0.2.0) |
 | [`ecc-jsbn@0.1.2`](https://github.com/quartzjer/ecc-jsbn.git) | MIT | #17389 |
-| [`elliptic@6.6.1`](git@github.com:indutny/elliptic) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/elliptic/6.6.1) |
+| [`elliptic@6.6.1`](git@github.com:indutny/elliptic) | MIT | #21533 |
 | [`emoji-regex@8.0.0`](https://github.com/mathiasbynens/emoji-regex.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/emoji-regex/8.0.0) |
 | [`emoji-regex@9.2.2`](https://github.com/mathiasbynens/emoji-regex.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/emoji-regex/9.2.2) |
 | `encoding@0.1.13` | MIT | #1016 |
-| [`end-of-stream@1.4.4`](git://github.com/mafintosh/end-of-stream.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/end-of-stream/1.4.4) |
+| [`end-of-stream@1.4.4`](git://github.com/mafintosh/end-of-stream.git) | MIT | #21942 |
 | [`entities@4.5.0`](git://github.com/fb55/entities.git) | BSD-2-Clause | #7910 |
 | `env-paths@2.2.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/env-paths/2.2.1) |
 | [`err-code@2.0.3`](git://github.com/IndigoUnited/js-err-code.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/err-code/2.0.3) |
 | [`es-define-property@1.0.0`](git+https://github.com/ljharb/es-define-property.git) | MIT | #13222 |
+| [`es-define-property@1.0.1`](git+https://github.com/ljharb/es-define-property.git) | MIT | #13222 |
 | [`es-errors@1.3.0`](git+https://github.com/ljharb/es-errors.git) | MIT | #13162 |
+| [`es-object-atoms@1.1.1`](git+https://github.com/ljharb/es-object-atoms.git) | MIT | #18800 |
 | [`es6-promise@4.2.8`](git://github.com/stefanpenner/es6-promise.git) | MIT | #2898 |
 | `escape-html@1.0.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/escape-html/1.0.3) |
 | `escape-string-regexp@1.0.5` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/escape-string-regexp/1.0.5) |
@@ -189,6 +197,7 @@
 | [`find-my-way@9.0.1`](git+https://github.com/delvedor/find-my-way.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/find-my-way/9.0.1) |
 | [`focus-trap@6.9.2`](git+https://github.com/focus-trap/focus-trap.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/focus-trap/6.9.2) |
 | [`follow-redirects@1.15.6`](git@github.com:follow-redirects/follow-redirects.git) | MIT | #10782 |
+| [`for-each@0.3.5`](https://github.com/Raynos/for-each.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/for-each/0.3.5) |
 | [`foreground-child@3.1.1`](git+https://github.com/tapjs/foreground-child.git) | ISC | #8232 |
 | [`forever-agent@0.6.1`](https://github.com/mikeal/forever-agent) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/forever-agent/0.6.1) |
 | [`form-data@2.3.3`](git://github.com/form-data/form-data.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/form-data/2.3.3) |
@@ -203,10 +212,13 @@
 | [`function-bind@1.1.2`](https://github.com/Raynos/function-bind.git) | MIT | #11063 |
 | [`get-intrinsic@1.2.2`](git+https://github.com/ljharb/get-intrinsic.git) | MIT | #8453 |
 | [`get-intrinsic@1.2.4`](git+https://github.com/ljharb/get-intrinsic.git) | MIT | #8453 |
+| [`get-intrinsic@1.3.0`](git+https://github.com/ljharb/get-intrinsic.git) | MIT | #19525 |
+| [`get-proto@1.0.1`](git+https://github.com/ljharb/get-proto.git) | MIT | #18351 |
 | [`getpass@0.1.7`](https://github.com/arekinath/node-getpass.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/getpass/0.1.7) |
 | [`glob@10.4.5`](git://github.com/isaacs/node-glob.git) | ISC | #15059 |
 | [`glob@8.1.0`](git://github.com/isaacs/node-glob.git) | ISC | #7145 |
 | [`gopd@1.0.1`](git+https://github.com/ljharb/gopd.git) | MIT | #4863 |
+| [`gopd@1.2.0`](git+https://github.com/ljharb/gopd.git) | MIT | #17752 |
 | [`graceful-fs@4.2.11`](https://github.com/isaacs/node-graceful-fs) | ISC | #7413 |
 | `gravatar-url@4.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/gravatar-url/4.0.1) |
 | [`har-schema@2.0.0`](https://github.com/ahmadnassri/har-schema.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/har-schema/2.0.0) |
@@ -215,9 +227,13 @@
 | [`has-property-descriptors@1.0.2`](git+https://github.com/inspect-js/has-property-descriptors.git) | MIT | #11098 |
 | [`has-proto@1.0.1`](git+https://github.com/inspect-js/has-proto.git) | MIT | #6175 |
 | [`has-symbols@1.0.3`](git://github.com/inspect-js/has-symbols.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/has-symbols/1.0.3) |
+| [`has-symbols@1.1.0`](git://github.com/inspect-js/has-symbols.git) | MIT | #17606 |
+| [`has-tostringtag@1.0.2`](git+https://github.com/inspect-js/has-tostringtag.git) | MIT | #13161 |
+| [`hash-base@2.0.2`](https://github.com/crypto-browserify/hash-base.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/hash-base/2.0.2) |
 | [`hash-base@3.1.0`](https://github.com/crypto-browserify/hash-base.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/hash-base/3.1.0) |
 | [`hash.js@1.1.7`](git@github.com:indutny/hash.js) | MIT | #1044 |
 | [`hasown@2.0.0`](git+https://github.com/inspect-js/hasOwn.git) | MIT | #11097 |
+| [`hasown@2.0.2`](git+https://github.com/inspect-js/hasOwn.git) | MIT | #11097 |
 | [`help-me@4.2.0`](https://github.com/mcollina/help-me.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/help-me/4.2.0) |
 | `history@4.10.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/history/4.10.1) |
 | [`hmac-drbg@1.0.1`](git+ssh://git@github.com/indutny/hmac-drbg.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/hmac-drbg/1.0.1) |
@@ -241,10 +257,13 @@
 | [`inversify@7.5.1`](https://github.com/inversify/InversifyJS.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/inversify/7.5.1) |
 | [`ip-address@9.0.5`](git://github.com/beaugunderson/ip-address.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/ip-address/9.0.5) |
 | `ipaddr.js@1.9.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/ipaddr.js/1.9.1) |
+| [`is-callable@1.2.7`](git://github.com/inspect-js/is-callable.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-callable/1.2.7) |
 | `is-fullwidth-code-point@3.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-fullwidth-code-point/3.0.0) |
 | [`is-lambda@1.0.1`](https://github.com/watson/is-lambda.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-lambda/1.0.1) |
 | [`is-plain-object@5.0.0`](https://github.com/jonschlinkert/is-plain-object) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/is-plain-object/5.0.0) |
+| [`is-typed-array@1.1.15`](git://github.com/inspect-js/is-typed-array.git) | MIT | #4853 |
 | [`is-typedarray@1.0.0`](git://github.com/hughsk/is-typedarray.git) | MIT | #2531 |
+| [`isarray@2.0.5`](git://github.com/juliangruber/isarray.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/isarray/2.0.5) |
 | [`isexe@2.0.0`](git+https://github.com/isaacs/isexe.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/isexe/2.0.0) |
 | `isexe@3.1.1` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/isexe/3.1.1) |
 | [`isomorphic-ws@5.0.0`](git+https://github.com/heineiuo/isomorphic-ws.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/isomorphic-ws/5.0.0) |
@@ -277,6 +296,7 @@
 | [`lru-cache@10.4.3`](git://github.com/isaacs/node-lru-cache.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/lru-cache/10.4.3) |
 | `lru-cache@6.0.0` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/lru-cache/6.0.0) |
 | [`make-fetch-happen@13.0.1`](https://github.com/npm/make-fetch-happen.git) | ISC | #11651 |
+| [`math-intrinsics@1.1.0`](git+https://github.com/es-shims/math-intrinsics.git) | MIT | #17964 |
 | `md5-hex@4.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/md5-hex/4.0.0) |
 | [`md5.js@1.3.5`](https://github.com/crypto-browserify/md5.js.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/md5.js/1.3.5) |
 | [`miller-rabin@4.0.1`](git@github.com:indutny/miller-rabin) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/miller-rabin/4.0.1) |
@@ -328,7 +348,7 @@
 | [`parse-srcset@1.0.2`](git+https://github.com/albell/parse-srcset.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/parse-srcset/1.0.2) |
 | `path-key@3.1.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/path-key/3.1.1) |
 | [`path-scurry@1.11.1`](git+https://github.com/isaacs/path-scurry) | BlueOak-1.0.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/path-scurry/1.11.1) |
-| [`pbkdf2@3.1.2`](https://github.com/crypto-browserify/pbkdf2.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pbkdf2/3.1.2) |
+| [`pbkdf2@3.1.3`](https://github.com/crypto-browserify/pbkdf2.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pbkdf2/3.1.3) |
 | [`performance-now@2.1.0`](git://github.com/braveg1rl/performance-now.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/performance-now/2.1.0) |
 | `picocolors@1.1.1` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/picocolors/1.1.1) |
 | [`pino-abstract-transport@1.1.0`](git+https://github.com/pinojs/pino-abstract-transport.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pino-abstract-transport/1.1.0) |
@@ -339,6 +359,7 @@
 | [`pino@8.16.1`](git+https://github.com/pinojs/pino.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pino/8.16.1) |
 | [`pino@9.1.0`](git+https://github.com/pinojs/pino.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pino/9.1.0) |
 | [`popper.js@1.16.1`](git+https://github.com/FezVrasta/popper.js.git) | MIT | CQ22353 |
+| [`possible-typed-array-names@1.1.0`](git+https://github.com/ljharb/possible-typed-array-names.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/possible-typed-array-names/1.1.0) |
 | [`postcss@8.4.49`](https://postcss.org/) | MIT | #3545 |
 | [`proc-log@4.2.0`](https://github.com/npm/proc-log.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/proc-log/4.2.0) |
 | [`process-warning@2.3.0`](git+https://github.com/fastify/process-warning.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/process-warning/2.3.0) |
@@ -351,7 +372,7 @@
 | [`proxy-from-env@1.1.0`](https://github.com/Rob--W/proxy-from-env.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/proxy-from-env/1.1.0) |
 | [`psl@1.9.0`](git@github.com:lupomontero/psl.git) | MIT | #3080 |
 | [`public-encrypt@4.0.3`](https://github.com/crypto-browserify/publicEncrypt.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/public-encrypt/4.0.3) |
-| `pump@3.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pump/3.0.0) |
+| `pump@3.0.0` | MIT | #21946 |
 | [`punycode@2.3.1`](https://github.com/mathiasbynens/punycode.js.git) | MIT | #6373 |
 | [`qs@6.12.1`](https://github.com/ljharb/qs.git) | BSD-3-Clause | #14380 |
 | [`qs@6.5.3`](https://github.com/ljharb/qs.git) | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/qs/6.5.3) |
@@ -379,8 +400,8 @@
 | [`reconnecting-websocket@4.4.0`](git+https://github.com/pladaria/reconnecting-websocket.git) | MIT | #940 |
 | [`redux-thunk@3.1.0`](https://github.com/reduxjs/redux-thunk) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/redux-thunk/3.1.0) |
 | [`redux@5.0.1`](http://redux.js.org) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/redux/5.0.1) |
-| [`reflect-metadata@0.1.13`](https://github.com/rbuckton/reflect-metadata.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/reflect-metadata/0.1.13) |
-| [`reflect-metadata@0.1.14`](https://github.com/rbuckton/reflect-metadata.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/reflect-metadata/0.1.14) |
+| [`reflect-metadata@0.1.13`](https://github.com/rbuckton/reflect-metadata.git) | Apache-2.0 | #21141 |
+| [`reflect-metadata@0.1.14`](https://github.com/rbuckton/reflect-metadata.git) | Apache-2.0 | #21141 |
 | [`reflect-metadata@0.2.2`](https://github.com/rbuckton/reflect-metadata.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/reflect-metadata/0.2.2) |
 | [`regenerator-runtime@0.14.0`](https://github.com/facebook/regenerator/tree/main/packages/runtime) | MIT | #9897 |
 | [`request@2.88.2`](https://github.com/request/request.git) | Apache-2.0 | #997 |
@@ -395,6 +416,7 @@
 | [`rfdc@1.3.0`](git+https://github.com/davidmarkclements/rfdc.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/rfdc/1.3.0) |
 | [`rfdc@1.4.1`](git+https://github.com/davidmarkclements/rfdc.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/rfdc/1.4.1) |
 | `rimraf@5.0.7` | ISC | #10787 |
+| [`ripemd160@2.0.1`](https://github.com/crypto-browserify/ripemd160) | MIT | #1001 |
 | [`ripemd160@2.0.2`](https://github.com/crypto-browserify/ripemd160) | MIT | #1001 |
 | [`safe-buffer@5.2.1`](git://github.com/feross/safe-buffer.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/safe-buffer/5.2.1) |
 | [`safe-regex2@4.0.0`](git://github.com/fastify/safe-regex.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/safe-regex2/4.0.0) |
@@ -442,6 +464,7 @@
 | [`tiny-invariant@1.3.1`](https://github.com/alexreardon/tiny-invariant.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/tiny-invariant/1.3.1) |
 | [`tiny-warning@1.0.3`](https://github.com/alexreardon/tiny-warning.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/tiny-warning/1.0.3) |
 | [`tippy.js@5.1.2`](git+https://github.com/atomiks/tippyjs.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/tippy.js/5.1.2) |
+| [`to-buffer@1.2.1`](https://github.com/browserify/to-buffer.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/to-buffer/1.2.1) |
 | [`toad-cache@3.7.0`](git://github.com/kibertoad/toad-cache.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/toad-cache/3.7.0) |
 | [`toggle-selection@1.0.6`](git+https://github.com/sudodoki/toggle-selection) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/toggle-selection/1.0.6) |
 | `toidentifier@1.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/toidentifier/1.0.1) |
@@ -452,6 +475,7 @@
 | [`tunnel-agent@0.6.0`](https://github.com/mikeal/tunnel-agent) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/tunnel-agent/0.6.0) |
 | [`tweetnacl@0.14.5`](https://github.com/dchest/tweetnacl-js.git) | Unlicense | #1035 |
 | `type-fest@1.4.0` | (MIT OR CC0-1.0) | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/type-fest/1.4.0) |
+| [`typed-array-buffer@1.0.3`](git+https://github.com/inspect-js/typed-array-buffer.git) | MIT | #9658 |
 | [`undici-types@5.26.5`](git+https://github.com/nodejs/undici.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/undici-types/5.26.5) |
 | [`undici-types@6.19.8`](git+https://github.com/nodejs/undici.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/undici-types/6.19.8) |
 | [`undici@5.28.4`](git+https://github.com/nodejs/undici.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/undici/5.28.4) |
@@ -469,6 +493,7 @@
 | [`warning@4.0.3`](https://github.com/BerkeleyTrue/warning.git) | MIT | CQ22359 |
 | `webidl-conversions@3.0.1` | BSD-2-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/webidl-conversions/3.0.1) |
 | `whatwg-url@5.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/whatwg-url/5.0.0) |
+| [`which-typed-array@1.1.19`](git://github.com/inspect-js/which-typed-array.git) | MIT | #4864 |
 | [`which@2.0.2`](git://github.com/isaacs/node-which.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/which/2.0.2) |
 | [`which@4.0.0`](https://github.com/npm/node-which.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/which/4.0.0) |
 | `wrap-ansi@7.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/wrap-ansi/7.0.0) |

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jsonpath-plus": "10.1.0",
     "micromatch": "^4.0.8",
     "nanoid": "3.3.8",
+    "pbkdf2": "^3.1.3",
     "postcss": "^8.4.49",
     "serialize-javascript": "^6.0.2",
     "sha.js": "^2.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,6 +3035,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"available-typed-arrays@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "available-typed-arrays@npm:1.0.7"
+  dependencies:
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 10/6c9da3a66caddd83c875010a1ca8ef11eac02ba15fb592dc9418b2b5e7b77b645fa7729380a92d9835c2f05f2ca1b6251f39b993e0feb3f1517c74fa1af02cab
+  languageName: node
+  linkType: hard
+
 "avvio@npm:^8.3.0":
   version: 8.4.0
   resolution: "avvio@npm:8.4.0"
@@ -3468,6 +3477,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+  checksum: 10/00482c1f6aa7cfb30fb1dbeb13873edf81cfac7c29ed67a5957d60635a56b2a4a480f1016ddbdb3395cc37900d46037fb965043a51c5c789ffeab4fc535d18b5
+  languageName: node
+  linkType: hard
+
 "call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.4, call-bind@npm:^1.0.5":
   version: 1.0.5
   resolution: "call-bind@npm:1.0.5"
@@ -3489,6 +3508,28 @@ __metadata:
     get-intrinsic: "npm:^1.2.4"
     set-function-length: "npm:^1.2.1"
   checksum: 10/cd6fe658e007af80985da5185bff7b55e12ef4c2b6f41829a26ed1eef254b1f1c12e3dfd5b2b068c6ba8b86aba62390842d81752e67dcbaec4f6f76e7113b6b7
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "call-bind@npm:1.0.8"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.2"
+  checksum: 10/659b03c79bbfccf0cde3a79e7d52570724d7290209823e1ca5088f94b52192dc1836b82a324d0144612f816abb2f1734447438e38d9dafe0b3f82c2a1b9e3bce
+  languageName: node
+  linkType: hard
+
+"call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "call-bound@npm:1.0.4"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.3.0"
+  checksum: 10/ef2b96e126ec0e58a7ff694db43f4d0d44f80e641370c21549ed911fecbdbc2df3ebc9bddad918d6bbdefeafb60bb3337902006d5176d72bcd2da74820991af7
   languageName: node
   linkType: hard
 
@@ -3933,7 +3974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-hash@npm:^1.1.0, create-hash@npm:^1.1.2, create-hash@npm:^1.2.0":
+"create-hash@npm:^1.1.0, create-hash@npm:^1.2.0":
   version: 1.2.0
   resolution: "create-hash@npm:1.2.0"
   dependencies:
@@ -3946,7 +3987,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-hmac@npm:^1.1.0, create-hmac@npm:^1.1.4, create-hmac@npm:^1.1.7":
+"create-hash@npm:~1.1.3":
+  version: 1.1.3
+  resolution: "create-hash@npm:1.1.3"
+  dependencies:
+    cipher-base: "npm:^1.0.1"
+    inherits: "npm:^2.0.1"
+    ripemd160: "npm:^2.0.0"
+    sha.js: "npm:^2.4.0"
+  checksum: 10/b9f675719321dd3a3c3540bb46afcbdaf7182366ce93da9265318290e928be881e5edeff8c48a5ee9263c342e5e3f705fad5eb48f2e2cddc5fed1eb54077e076
+  languageName: node
+  linkType: hard
+
+"create-hmac@npm:^1.1.0, create-hmac@npm:^1.1.7":
   version: 1.1.7
   resolution: "create-hmac@npm:1.1.7"
   dependencies:
@@ -4629,6 +4682,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.2.0"
+  checksum: 10/5add88a3d68d42d6e6130a0cac450b7c2edbe73364bbd2fc334564418569bea97c6943a8fcd70e27130bf32afc236f30982fc4905039b703f23e9e0433c29934
+  languageName: node
+  linkType: hard
+
 "duplexer@npm:^0.1.2":
   version: 0.1.2
   resolution: "duplexer@npm:0.1.2"
@@ -4869,6 +4933,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 10/f8dc9e660d90919f11084db0a893128f3592b781ce967e4fccfb8f3106cb83e400a4032c559184ec52ee1dbd4b01e7776c7cd0b3327b1961b1a4a7008920fe78
+  languageName: node
+  linkType: hard
+
 "es-errors@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
@@ -4902,6 +4973,15 @@ __metadata:
   version: 1.3.1
   resolution: "es-module-lexer@npm:1.3.1"
   checksum: 10/c6aa137c5f5865fe1d12b4edbe027ff618d3836684cda9e52ae4dec48bfc2599b25db4f1265a12228d4663e21fd0126addfb79f761d513f1a6708c37989137e3
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10/54fe77de288451dae51c37bfbfe3ec86732dc3778f98f3eb3bdb4bf48063b2c0b8f9c93542656986149d08aa5be3204286e2276053d19582b76753f1a2728867
   languageName: node
   linkType: hard
 
@@ -5733,6 +5813,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"for-each@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "for-each@npm:0.3.5"
+  dependencies:
+    is-callable: "npm:^1.2.7"
+  checksum: 10/330cc2439f85c94f4609de3ee1d32c5693ae15cdd7fe3d112c4fd9efd4ce7143f2c64ef6c2c9e0cfdb0058437f33ef05b5bdae5b98fcc903fb2143fbaf0fea0f
+  languageName: node
+  linkType: hard
+
 "foreground-child@npm:^3.1.0":
   version: 3.1.1
   resolution: "foreground-child@npm:3.1.1"
@@ -5921,10 +6010,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "get-intrinsic@npm:1.3.0"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10/6e9dd920ff054147b6f44cb98104330e87caafae051b6d37b13384a45ba15e71af33c3baeac7cb630a0aaa23142718dcf25b45cfdd86c184c5dcb4e56d953a10
+  languageName: node
+  linkType: hard
+
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: 10/bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: "npm:^1.0.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10/4fc96afdb58ced9a67558698b91433e6b037aaa6f1493af77498d7c85b141382cf223c0e5946f334fb328ee85dfe6edd06d218eaf09556f4bc4ec6005d7f5f7b
   languageName: node
   linkType: hard
 
@@ -6110,6 +6227,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: 10/94e296d69f92dc1c0768fcfeecfb3855582ab59a7c75e969d5f96ce50c3d201fd86d5a2857c22565764d5bb8a816c7b1e58f133ec318cd56274da36c5e3fb1a1
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -6243,12 +6367,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: 10/959385c98696ebbca51e7534e0dc723ada325efa3475350951363cce216d27373e0259b63edb599f72eb94d6cde8577b4b2375f080b303947e560f85692834fa
+  languageName: node
+  linkType: hard
+
 "has-tostringtag@npm:^1.0.0":
   version: 1.0.0
   resolution: "has-tostringtag@npm:1.0.0"
   dependencies:
     has-symbols: "npm:^1.0.2"
   checksum: 10/95546e7132efc895a9ae64a8a7cf52588601fc3d52e0304ed228f336992cdf0baaba6f3519d2655e560467db35a1ed79f6420c286cc91a13aa0647a31ed92570
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: "npm:^1.0.3"
+  checksum: 10/c74c5f5ceee3c8a5b8bc37719840dc3749f5b0306d818974141dda2471a1a2ca6c8e46b9d6ac222c5345df7a901c9b6f350b1e6d62763fec877e26609a401bfe
+  languageName: node
+  linkType: hard
+
+"hash-base@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "hash-base@npm:2.0.2"
+  dependencies:
+    inherits: "npm:^2.0.1"
+  checksum: 10/e39f3f2bb91679ed350bd2eb81035acb1e1e6e9bb86d9f1197fcfdc3cf39a2c56bf82a1870f000fae651477883b4c107fd6ac0c640a18ab06298b87c39939396
   languageName: node
   linkType: hard
 
@@ -6279,6 +6428,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/c330f8d93f9d23fe632c719d4db3d698ef7d7c367d51548b836069e06a90fa9151e868c8e67353cfe98d67865bf7354855db28fa36eb1b18fa5d4a3f4e7f1c90
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
   languageName: node
   linkType: hard
 
@@ -7007,6 +7165,15 @@ __metadata:
   dependencies:
     which-typed-array: "npm:^1.1.11"
   checksum: 10/d953adfd3c41618d5e01b2a10f21817e4cdc9572772fa17211100aebb3811b6e3c2e308a0558cc87d218a30504cb90154b833013437776551bfb70606fb088ca
+  languageName: node
+  linkType: hard
+
+"is-typed-array@npm:^1.1.14":
+  version: 1.1.15
+  resolution: "is-typed-array@npm:1.1.15"
+  dependencies:
+    which-typed-array: "npm:^1.1.16"
+  checksum: 10/e8cf60b9ea85667097a6ad68c209c9722cfe8c8edf04d6218366469e51944c5cc25bae45ffb845c23f811d262e4314d3b0168748eb16711aa34d12724cdf0735
   languageName: node
   linkType: hard
 
@@ -8252,6 +8419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 10/11df2eda46d092a6035479632e1ec865b8134bdfc4bd9e571a656f4191525404f13a283a515938c3a8de934dbfd9c09674d9da9fa831e6eb7e22b50b197d2edd
+  languageName: node
+  linkType: hard
+
 "mathml-tag-names@npm:^2.1.3":
   version: 2.1.3
   resolution: "mathml-tag-names@npm:2.1.3"
@@ -9238,16 +9412,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pbkdf2@npm:^3.0.3":
-  version: 3.1.2
-  resolution: "pbkdf2@npm:3.1.2"
+"pbkdf2@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "pbkdf2@npm:3.1.3"
   dependencies:
-    create-hash: "npm:^1.1.2"
-    create-hmac: "npm:^1.1.4"
-    ripemd160: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
-    sha.js: "npm:^2.4.8"
-  checksum: 10/40bdf30df1c9bb1ae41ec50c11e480cf0d36484b7c7933bf55e4451d1d0e3f09589df70935c56e7fccc5702779a0d7b842d012be8c08a187b44eb24d55bb9460
+    create-hash: "npm:~1.1.3"
+    create-hmac: "npm:^1.1.7"
+    ripemd160: "npm:=2.0.1"
+    safe-buffer: "npm:^5.2.1"
+    sha.js: "npm:^2.4.11"
+    to-buffer: "npm:^1.2.0"
+  checksum: 10/980cf2977aa84ec3166fde195a28464ab494131c0a5778fc8f20b8894410747e502159c19ef2b41842c728bc52ba49ffee6847e3ee61ac0d482689f85d8a1b30
   languageName: node
   linkType: hard
 
@@ -9422,6 +9597,13 @@ __metadata:
   version: 1.16.1
   resolution: "popper.js@npm:1.16.1"
   checksum: 10/71338c86faf9b66ce60c3cdd7fb2ed742944e5d2765a188f269239fee2980aa6223b77b41302d1b6eb7d724e611092f9a2576d0048ac2071b605291abc72c0cf
+  languageName: node
+  linkType: hard
+
+"possible-typed-array-names@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "possible-typed-array-names@npm:1.1.0"
+  checksum: 10/2f44137b8d3dd35f4a7ba7469eec1cd9cfbb46ec164b93a5bc1f4c3d68599c9910ee3b91da1d28b4560e9cc8414c3cd56fedc07259c67e52cc774476270d3302
   languageName: node
   linkType: hard
 
@@ -10705,6 +10887,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ripemd160@npm:=2.0.1":
+  version: 2.0.1
+  resolution: "ripemd160@npm:2.0.1"
+  dependencies:
+    hash-base: "npm:^2.0.0"
+    inherits: "npm:^2.0.1"
+  checksum: 10/f1a20b72b3ef897a981544c72a1fe15c2bd580f6f40e3062f7839af8e81232f746aa860964686e4b81e90929ad086f14823a9864e4e4bed3367e597fe14a0968
+  languageName: node
+  linkType: hard
+
 "ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1":
   version: 2.0.2
   resolution: "ripemd160@npm:2.0.2"
@@ -10905,7 +11097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-function-length@npm:^1.2.1":
+"set-function-length@npm:^1.2.1, set-function-length@npm:^1.2.2":
   version: 1.2.2
   resolution: "set-function-length@npm:1.2.2"
   dependencies:
@@ -11859,6 +12051,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"to-buffer@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "to-buffer@npm:1.2.1"
+  dependencies:
+    isarray: "npm:^2.0.5"
+    safe-buffer: "npm:^5.2.1"
+    typed-array-buffer: "npm:^1.0.3"
+  checksum: 10/f8d03f070b8567d9c949f1b59c8d47c83ed2e59b50b5449258f931df9a1fcb751aa8bb8756a9345adc529b6b1822521157c48e1a7d01779a47185060d7bf96d4
+  languageName: node
+  linkType: hard
+
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
@@ -12078,6 +12281,17 @@ __metadata:
     get-intrinsic: "npm:^1.2.1"
     is-typed-array: "npm:^1.1.10"
   checksum: 10/3e0281c79b2a40cd97fe715db803884301993f4e8c18e8d79d75fd18f796e8cd203310fec8c7fdb5e6c09bedf0af4f6ab8b75eb3d3a85da69328f28a80456bd3
+  languageName: node
+  linkType: hard
+
+"typed-array-buffer@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "typed-array-buffer@npm:1.0.3"
+  dependencies:
+    call-bound: "npm:^1.0.3"
+    es-errors: "npm:^1.3.0"
+    is-typed-array: "npm:^1.1.14"
+  checksum: 10/3fb91f0735fb413b2bbaaca9fabe7b8fc14a3fa5a5a7546bab8a57e755be0e3788d893195ad9c2b842620592de0e68d4c077d4c2c41f04ec25b8b5bb82fa9a80
   languageName: node
   linkType: hard
 
@@ -12651,6 +12865,21 @@ __metadata:
     gopd: "npm:^1.0.1"
     has-tostringtag: "npm:^1.0.0"
   checksum: 10/605e3e10b7118af904a0e79d0d50b95275102f06ec902734024989cd71354929f7acee50de43529d3baf5858e2e4eb32c75e6ebd226c888ad976d8140e4a3e71
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.16":
+  version: 1.1.19
+  resolution: "which-typed-array@npm:1.1.19"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.4"
+    for-each: "npm:^0.3.5"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/12be30fb88567f9863186bee1777f11bea09dd59ed8b3ce4afa7dd5cade75e2f4cc56191a2da165113cc7cf79987ba021dac1e22b5b62aa7e5c56949f2469a68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Bumps [pbkdf2](https://github.com/crypto-browserify/pbkdf2) from 3.1.2 to 3.1.3.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-9159, 
https://issues.redhat.com/browse/CRW-9160, 
https://issues.redhat.com/browse/CRW-9161, 
https://issues.redhat.com/browse/CRW-9162
