### PR TITLE
[cherry-pick] fix: sanitize OAuth parameters

### DIFF
--- a/packages/common/src/helpers/__tests__/sanitize.spec.ts
+++ b/packages/common/src/helpers/__tests__/sanitize.spec.ts
@@ -25,7 +25,7 @@ describe('sanitize', () => {
     it('sanitizeLocation', () => {
       const location = {
         search:
-          'url=https%3A%2F%2Fgithub.com%2Ftest-samples&storageType=persistent',
+          'url=https%3A%2F%2Fgithub.com%2Ftest-samples&&iss=456789&storageType=persistent',
         pathname: '/f',
       };
 
@@ -44,7 +44,7 @@ describe('sanitize', () => {
   describe('sanitizeSearchParams', () => {
     it('should return sanitized value of location.search if it is without encoding)', () => {
       const search =
-        'url=https://github.com/test-samples&state=9284564475&session=98765&session_state=45645654567&code=9844646765&storageType=persistent&new';
+        'url=https://github.com/test-samples&state=9284564475&iss=456789&session=98765&session_state=45645654567&code=9844646765&storageType=persistent&new';
 
       const searchParams = new URLSearchParams(search);
       const sanitizedSearchParams = sanitizeSearchParams(searchParams);

--- a/packages/common/src/helpers/sanitize.ts
+++ b/packages/common/src/helpers/sanitize.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-const oauthParams = ['state', 'session', 'session_state', 'code'];
+const oauthParams = ['state', 'session', 'session_state', 'code', 'iss'];
 
 /**
  * Remove oauth params.


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This pull request adds `iss` to sanitize OAuth parameters.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1366 to the 7.107.x branch

