### PR TITLE
chore: bump sha.js and cipher-base deps

### DIFF
--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -61,7 +61,7 @@
 | [`@jest/test-sequencer@29.7.0`](https://github.com/jestjs/jest.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@jest/test-sequencer/29.7.0) |
 | [`@jest/transform@29.7.0`](https://github.com/jestjs/jest.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@jest/transform/29.7.0) |
 | [`@jest/types@29.6.3`](https://github.com/jestjs/jest.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@jest/types/29.6.3) |
-| `@jridgewell/gen-mapping@0.3.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@jridgewell/gen-mapping/0.3.3) |
+| `@jridgewell/gen-mapping@0.3.3` | MIT | #22834 |
 | `@jridgewell/resolve-uri@3.1.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@jridgewell/resolve-uri/3.1.1) |
 | `@jridgewell/set-array@1.1.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@jridgewell/set-array/1.1.2) |
 | `@jridgewell/source-map@0.3.5` | MIT | #9304 |
@@ -192,7 +192,7 @@
 | `binary-extensions@2.2.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/binary-extensions/2.2.0) |
 | [`boolbase@1.0.0`](https://github.com/fb55/boolbase) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/boolbase/1.0.0) |
 | [`bplist-parser@0.2.0`](https://github.com/nearinfinity/node-bplist-parser.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/bplist-parser/0.2.0) |
-| [`brace-expansion@1.1.11`](git://github.com/juliangruber/brace-expansion.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/brace-expansion/1.1.11) |
+| [`brace-expansion@1.1.12`](git://github.com/juliangruber/brace-expansion.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/brace-expansion/1.1.12) |
 | [`braces@3.0.3`](https://github.com/micromatch/braces) | MIT | #14866 |
 | `browserslist@4.22.1` | MIT | #10780 |
 | `browserslist@4.23.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/browserslist/4.23.0) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -116,7 +116,7 @@
 | `chalk@2.4.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/chalk/2.4.2) |
 | [`chownr@2.0.0`](git://github.com/isaacs/chownr.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/chownr/2.0.0) |
 | [`chownr@3.0.0`](git://github.com/isaacs/chownr.git) | BlueOak-1.0.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/chownr/3.0.0) |
-| [`cipher-base@1.0.4`](git+https://github.com/crypto-browserify/cipher-base.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cipher-base/1.0.4) |
+| [`cipher-base@1.0.6`](git+https://github.com/crypto-browserify/cipher-base.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cipher-base/1.0.6) |
 | `clean-stack@2.2.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/clean-stack/2.2.0) |
 | [`codemirror@5.65.18`](https://github.com/codemirror/CodeMirror.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/codemirror/5.65.18) |
 | `color-convert@1.9.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/color-convert/1.9.3) |
@@ -429,7 +429,7 @@
 | [`set-cookie-parser@2.7.1`](https://github.com/nfriedly/set-cookie-parser) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/set-cookie-parser/2.7.1) |
 | [`set-function-length@1.2.2`](git+https://github.com/ljharb/set-function-length.git) | MIT | #12772 |
 | [`setprototypeof@1.2.0`](https://github.com/wesleytodd/setprototypeof.git) | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/setprototypeof/1.2.0) |
-| [`sha.js@2.4.11`](git://github.com/crypto-browserify/sha.js.git) | (MIT AND BSD-3-Clause) | #1031 |
+| [`sha.js@2.4.12`](git://github.com/crypto-browserify/sha.js.git) | (MIT AND BSD-3-Clause) | #1031 |
 | `shebang-command@2.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/shebang-command/2.0.0) |
 | `shebang-regex@3.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/shebang-regex/3.0.0) |
 | [`side-channel@1.0.6`](git+https://github.com/ljharb/side-channel.git) | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/side-channel/1.0.6) |

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "pbkdf2": "^3.1.3",
     "postcss": "^8.4.49",
     "serialize-javascript": "^6.0.2",
-    "sha.js": "^2.4.8",
+    "sha.js": "^2.4.12",
+    "cipher-base": "^1.0.6",
     "undici": "^5.28.3",
     "ws": "^8.17.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,13 +3696,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "cipher-base@npm:1.0.4"
+"cipher-base@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "cipher-base@npm:1.0.6"
   dependencies:
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10/3d5d6652ca499c3f7c5d7fdc2932a357ec1e5aa84f2ad766d850efd42e89753c97b795c3a104a8e7ae35b4e293f5363926913de3bf8181af37067d9d541ca0db
+    inherits: "npm:^2.0.4"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10/faf232deff2351448ea23d265eb8723e035ebbb454baca45fb60c1bd71056ede8b153bef1b221e067f13e6b9288ebb83bb6ae2d5dd4cec285411f9fc22ec1f5b
   languageName: node
   linkType: hard
 
@@ -11129,15 +11129,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:^2.4.8":
-  version: 2.4.11
-  resolution: "sha.js@npm:2.4.11"
+"sha.js@npm:^2.4.12":
+  version: 2.4.12
+  resolution: "sha.js@npm:2.4.12"
   dependencies:
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
+    inherits: "npm:^2.0.4"
+    safe-buffer: "npm:^5.2.1"
+    to-buffer: "npm:^1.2.0"
   bin:
-    sha.js: ./bin.js
-  checksum: 10/d833bfa3e0a67579a6ce6e1bc95571f05246e0a441dd8c76e3057972f2a3e098465687a4369b07e83a0375a88703577f71b5b2e966809e67ebc340dbedb478c7
+    sha.js: bin.js
+  checksum: 10/39c0993592c2ab34eb2daae2199a2a1d502713765aecb611fd97c0c4ab7cd53e902d628e1962aaf384bafd28f55951fef46dcc78799069ce41d74b03aa13b5a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Bump sha.js and cipher-base dependencies to fix CVEs
