### PR TITLE
Add git branch to devfile when creating a workspace from SSH url

### DIFF
--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/__tests__/index.spec.tsx
@@ -44,20 +44,6 @@ describe('GitRepoOptions', () => {
     expect(snapshot.toJSON()).toMatchSnapshot();
   });
 
-  it('should remove "Git Branch" component when it is not supported', () => {
-    const { reRenderComponent } = renderComponent(
-      'test-git-branch',
-      [{ name: 'test', url: 'http://test' }],
-      'test-devfile-path',
-    );
-
-    expect(screen.queryByTestId('git-branch-component')).not.toBeNull();
-
-    reRenderComponent(undefined, undefined, undefined, false);
-
-    expect(screen.queryByTestId('git-branch-component')).toBeNull();
-  });
-
   test('update Git Branch', async () => {
     renderComponent('test-git-branch');
 

--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/index.tsx
@@ -87,16 +87,13 @@ export class GitRepoOptions extends React.PureComponent<Props, State> {
     this.props.onChange(gitBranch, remotes, devfilePath, isValid);
   }
   public render() {
-    const { hasSupportedGitService } = this.props;
     const { gitBranch, remotes, devfilePath } = this.state;
     return (
       <Form isHorizontal={true} onSubmit={e => e.preventDefault()}>
-        {hasSupportedGitService && (
-          <GitBranchField
-            onChange={gitBranch => this.handleGitBranch(gitBranch)}
-            gitBranch={gitBranch}
-          />
-        )}
+        <GitBranchField
+          onChange={gitBranch => this.handleGitBranch(gitBranch)}
+          gitBranch={gitBranch}
+        />
         <AdditionalGitRemotes
           onChange={(remotes: GitRemote[] | undefined, isValid: boolean) =>
             this.handleRemotes(remotes, isValid)

--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/__tests__/index.spec.tsx
@@ -77,6 +77,7 @@ describe('RepoOptionsAccordion', () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       'https://testlocation?image=newContainerImage&storageType=ephemeral&policies.create=perclick&memoryLimit=1Gi&cpuLimit=1',
       undefined,
+      undefined,
     );
   });
 
@@ -109,6 +110,7 @@ describe('RepoOptionsAccordion', () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       'https://testlocation?remotes={{test-updated,http://test}}&devfilePath=newDevfilePath',
       'success',
+      'newBranch',
     );
   });
 
@@ -141,6 +143,7 @@ describe('RepoOptionsAccordion', () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       'https://github.com/testlocation/undefined/tree/newBranch?remotes={{test-updated,http://test}}&devfilePath=newDevfilePath',
       'success',
+      'newBranch',
     );
   });
 });

--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/index.tsx
@@ -40,7 +40,11 @@ type AccordionId = 'git-repo-options' | 'advanced-options';
 
 export type Props = MappedProps & {
   location: string;
-  onChange: (location: string, remotesValidated: ValidatedOptions) => void;
+  onChange: (
+    location: string,
+    remotesValidated: ValidatedOptions,
+    gitBranch: string | undefined,
+  ) => void;
 };
 export type State = {
   location: string;
@@ -141,7 +145,7 @@ class RepoOptionsAccordion extends React.PureComponent<Props, State> {
     ) as State;
     state.remotesValidated = isValid ? ValidatedOptions.success : ValidatedOptions.error;
     this.setState(state);
-    this.props.onChange(state.location, state.remotesValidated);
+    this.props.onChange(state.location, state.remotesValidated, gitBranch);
   }
 
   private handleAdvancedOptionsOptionsChange(
@@ -170,7 +174,7 @@ class RepoOptionsAccordion extends React.PureComponent<Props, State> {
     ) as State;
 
     this.setState(state);
-    this.props.onChange(state.location, state.remotesValidated);
+    this.props.onChange(state.location, state.remotesValidated, this.state.gitBranch);
   }
 
   public render() {

--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
@@ -273,6 +273,17 @@ describe('helpers', () => {
         }
       });
     });
+    describe('ssh url', () => {
+      test('should return url with branch', () => {
+        const branch = 'branch';
+        expect(helpers.setBranchToLocation('git@ssh-url.git', branch)).toBe(
+          `git@ssh-url.git?revision=${branch}`,
+        );
+      });
+      test('should return url without branch', () => {
+        expect(helpers.setBranchToLocation('git@ssh-url.git', undefined)).toBe('git@ssh-url.git');
+      });
+    });
   });
   describe('getGitRepoOptionsFromLocation', () => {
     describe('supported Git services', () => {

--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
@@ -10,12 +10,13 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { StateMock } from '@react-mock/state';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
 
-import ImportFromGit from '@/components/ImportFromGit';
+import ImportFromGit, { State } from '@/components/ImportFromGit';
 import getComponentRenderer, { screen, waitFor } from '@/services/__mocks__/getComponentRenderer';
 import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
 
@@ -64,6 +65,26 @@ describe('GitRepoLocationInput', () => {
 
   test('invalid location', async () => {
     renderComponent(store);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeValid();
+
+    await userEvent.click(input);
+    await userEvent.paste('invalid-test-location');
+
+    expect(input).toHaveValue('invalid-test-location');
+    expect(input).toBeInvalid();
+
+    const button = screen.getByRole('button', { name: 'Create & Open' });
+    expect(button).toBeDisabled();
+
+    await userEvent.type(input, '{enter}');
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  test('invalid locccation', async () => {
+    const localState: Partial<State> = { gitBranch: 'branch' };
+    renderComponent(store, undefined, undefined, localState);
 
     const input = screen.getByRole('textbox');
     expect(input).toBeValid();
@@ -385,6 +406,43 @@ describe('GitRepoLocationInput', () => {
         '_blank',
       );
     });
+
+    test('should add revision query parameter to ', async () => {
+      const localState: Partial<State> = { gitBranch: 'branch' };
+      renderComponent(store, undefined, undefined, localState);
+
+      const input = screen.getByRole('textbox');
+      expect(input).toBeValid();
+
+      await userEvent.click(input);
+
+      await userEvent.paste('git@github.com:user/repo.git');
+      expect(input).toHaveValue('git@github.com:user/repo.git');
+
+      expect(input).toBeValid();
+
+      const repoOptions = screen.getByText('Git Repo Options');
+      await userEvent.click(repoOptions);
+
+      const gitBranch = screen.getByRole('textbox', { name: 'Git Branch' });
+      await userEvent.click(gitBranch);
+      await userEvent.paste('test');
+
+      const buttonCreate = screen.getByRole('button', { name: 'Create & Open' });
+      expect(buttonCreate).toBeEnabled();
+
+      await userEvent.click(buttonCreate);
+
+      // trust the resource
+      const continueButton = screen.getByRole('button', { name: 'Continue' });
+      await userEvent.click(continueButton);
+
+      expect(window.open).toHaveBeenCalledTimes(1);
+      expect(window.open).toHaveBeenLastCalledWith(
+        'http://localhost/#git@github.com:user/repo.git?revision=test',
+        '_blank',
+      );
+    });
   });
 });
 
@@ -392,14 +450,22 @@ function getComponent(
   store: Store,
   editorDefinition: string | undefined = undefined,
   editorImage: string | undefined = undefined,
+  localState?: Partial<State>,
 ) {
-  return (
-    <Provider store={store}>
-      <ImportFromGit
-        navigate={mockNavigate}
-        editorDefinition={editorDefinition}
-        editorImage={editorImage}
-      />
-    </Provider>
+  const component = (
+    <ImportFromGit
+      navigate={mockNavigate}
+      editorDefinition={editorDefinition}
+      editorImage={editorImage}
+    />
   );
+  if (localState) {
+    return (
+      <Provider store={store}>
+        <StateMock state={localState}>{component}</StateMock>
+      </Provider>
+    );
+  } else {
+    return <Provider store={store}>{component}</Provider>;
+  }
 }

--- a/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
@@ -139,6 +139,9 @@ function setBranchToAzureDevOpsLocation(location: string, branch: string | undef
 }
 
 export function setBranchToLocation(location: string, branch: string | undefined): string {
+  if (!location.startsWith('http')) {
+    return branch ? `${location}?revision=${branch}` : location;
+  }
   const url = new URL(location);
   const pathname = url.pathname.replace(/^\//, '').replace(/\/$/, '');
 

--- a/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
@@ -35,7 +35,11 @@ import { validateLocation } from '@/components/ImportFromGit/helpers';
 import RepoOptionsAccordion from '@/components/ImportFromGit/RepoOptionsAccordion';
 import UntrustedSourceModal from '@/components/UntrustedSourceModal';
 import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
-import { EDITOR_ATTR, EDITOR_IMAGE_ATTR } from '@/services/helpers/factoryFlow/buildFactoryParams';
+import {
+  EDITOR_ATTR,
+  EDITOR_IMAGE_ATTR,
+  REVISION_ATTR,
+} from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { buildUserPreferencesLocation } from '@/services/helpers/location';
 import { UserPreferencesTab } from '@/services/helpers/types';
 import { RootState } from '@/store';
@@ -56,6 +60,7 @@ export type State = {
   remotesValidated: ValidatedOptions;
   isFocused: boolean;
   isConfirmationOpen: boolean;
+  gitBranch: string | undefined;
 };
 
 class ImportFromGit extends React.PureComponent<Props, State> {
@@ -69,6 +74,7 @@ class ImportFromGit extends React.PureComponent<Props, State> {
       remotesValidated: ValidatedOptions.default,
       isFocused: false,
       isConfirmationOpen: false,
+      gitBranch: undefined,
     };
   }
 
@@ -112,6 +118,9 @@ class ImportFromGit extends React.PureComponent<Props, State> {
       if (editorImage !== undefined) {
         factory.searchParams.set(EDITOR_IMAGE_ATTR, editorImage);
       }
+    }
+    if (this.state.gitBranch && !this.state.location.startsWith('http')) {
+      factory.searchParams.set(REVISION_ATTR, this.state.gitBranch);
     }
 
     // open a new page to handle that
@@ -232,9 +241,13 @@ class ImportFromGit extends React.PureComponent<Props, State> {
               <PanelMainBody>
                 <RepoOptionsAccordion
                   location={location}
-                  onChange={(location: string, remotesValidated: ValidatedOptions) => {
+                  onChange={(
+                    location: string,
+                    remotesValidated: ValidatedOptions,
+                    gitBranch: string | undefined,
+                  ) => {
                     const locationValidated = validateLocation(location, this.state.hasSshKeys);
-                    this.setState({ location, remotesValidated, locationValidated });
+                    this.setState({ location, remotesValidated, locationValidated, gitBranch });
                   }}
                 />
               </PanelMainBody>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/getGitRemotes.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/getGitRemotes.spec.ts
@@ -163,7 +163,7 @@ describe('getGitRemotes functions', () => {
 
     test('remotes configured with urls', () => {
       const remotes = '{http://git-test-1.git,http://git-test-2.git,http://git-test-3.git}';
-      configureProjectRemotes(dashboardDevfile, remotes, false);
+      configureProjectRemotes(dashboardDevfile, remotes, false, 'HEAD');
 
       expect(dashboardDevfile.projects).not.toBe(undefined);
       expect(dashboardDevfile.projects?.length).toBe(1);
@@ -184,7 +184,7 @@ describe('getGitRemotes functions', () => {
     test('remotes configured with urls and names', () => {
       const remotes =
         '{{test1,http://git-test-1.git},{test2,http://git-test-2.git},{test3,http://git-test-3.git}}';
-      configureProjectRemotes(dashboardDevfile, remotes, false);
+      configureProjectRemotes(dashboardDevfile, remotes, false, 'HEAD');
 
       expect(dashboardDevfile.projects).not.toBe(undefined);
       expect(dashboardDevfile.projects?.length).toBe(1);
@@ -206,7 +206,7 @@ describe('getGitRemotes functions', () => {
     test('keep origin remote if origin remote not provided as a parameter', () => {
       const remotes =
         '{{upstream,https://github.com/eclipse-che/che-dashboard.git},{fork,https://github.com/fork/che-dashboard.git}}';
-      configureProjectRemotes(dashboardDevfile, remotes, false);
+      configureProjectRemotes(dashboardDevfile, remotes, false, 'HEAD');
 
       expect(dashboardDevfile.projects).not.toBe(undefined);
       expect(dashboardDevfile.projects?.length).toBe(1);
@@ -240,7 +240,7 @@ describe('getGitRemotes functions', () => {
       ];
       const remotes =
         '{{upstream,https://github.com/eclipse-che/che-dashboard.git},{fork,https://github.com/fork/che-dashboard.git}}';
-      configureProjectRemotes(dashboardDevfile, remotes, false);
+      configureProjectRemotes(dashboardDevfile, remotes, false, 'HEAD');
 
       expect(dashboardDevfile.projects).not.toBe(undefined);
       expect(dashboardDevfile.projects?.length).toBe(1);
@@ -248,7 +248,7 @@ describe('getGitRemotes functions', () => {
         git: {
           checkoutFrom: {
             remote: 'origin',
-            revision: 'branch',
+            revision: 'HEAD',
           },
           remotes: {
             origin: 'https://github.com/user/che-dashboard.git',
@@ -262,7 +262,7 @@ describe('getGitRemotes functions', () => {
     test('use new origin remote if provided as a parameter', () => {
       const remotes =
         '{{origin,https://github.com/other-user/che-dashboard.git},{upstream,https://github.com/eclipse-che/che-dashboard.git},{fork,https://github.com/fork/che-dashboard.git}}';
-      configureProjectRemotes(dashboardDevfile, remotes, false);
+      configureProjectRemotes(dashboardDevfile, remotes, false, 'HEAD');
 
       expect(dashboardDevfile.projects).not.toBe(undefined);
       expect(dashboardDevfile.projects?.length).toBe(1);
@@ -288,7 +288,7 @@ describe('getGitRemotes functions', () => {
         },
       } as devfileApi.Devfile;
       const remotes = '{https://github.com/eclipse-che/che-dashboard.git}';
-      configureProjectRemotes(defaultDevfile, remotes, true);
+      configureProjectRemotes(defaultDevfile, remotes, true, 'HEAD');
 
       const expectedDevfile = {
         schemaVersion: '2.1.0',
@@ -299,7 +299,7 @@ describe('getGitRemotes functions', () => {
         projects: [
           {
             git: {
-              checkoutFrom: { remote: 'origin' },
+              checkoutFrom: { remote: 'origin', revision: 'HEAD' },
               remotes: {
                 origin: 'https://github.com/eclipse-che/che-dashboard.git',
               },

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes.ts
@@ -133,8 +133,9 @@ function parseUrls(remotesArray: unknown[], remotesString: string): GitRemote[] 
 
 export function configureProjectRemotes(
   devfile: devfileApi.Devfile,
-  remotes: string,
+  remotes: string | undefined,
   isDefaultDevfile: boolean,
+  revision: string,
 ): void {
   const parsedRemotes = getGitRemotes(remotes);
 
@@ -156,7 +157,7 @@ export function configureProjectRemotes(
     checkoutRemote = { name: 'origin', url: gitProject.remotes.origin };
   }
   if (gitProject) {
-    addRemotesToProject(gitProject, checkoutRemote, parsedRemotes);
+    addRemotesToProject(gitProject, checkoutRemote, parsedRemotes, revision);
   } else {
     console.warn('Failed to configure the project remotes.');
   }
@@ -195,11 +196,13 @@ function getGitProjectForConfiguringRemotes(projects: V230DevfileProjects[] | un
  * @param gitProject The Git project to add the new remotes to
  * @param checkoutRemote The Git remote to set checkoutFrom.remote to
  * @param newRemotes The array of new Git remotes to add
+ * @param revision Git branch or tag
  */
 function addRemotesToProject(
   gitProject: V230DevfileProjectsItemsGit,
   checkoutRemote: GitRemote,
   newRemotes: GitRemote[],
+  revision: string,
 ): void {
   const gitRemotes = newRemotes.reduce((map, remote) => {
     map[remote.name] = remote.url;
@@ -209,5 +212,6 @@ function addRemotesToProject(
   gitProject.remotes = Object.assign(gitProject.remotes, gitRemotes);
   gitProject.checkoutFrom = Object.assign(gitProject.checkoutFrom || {}, {
     remote: checkoutRemote.name,
+    revision,
   });
 }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -179,7 +179,7 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
   private updateCurrentDevfile(devfile: devfileApi.Devfile): void {
     const { factoryResolver, allWorkspaces, defaultDevfile, preferredStorageType } = this.props;
     const { factoryParams } = this.state;
-    const { factoryId, policiesCreate, sourceUrl, remotes } = factoryParams;
+    const { factoryId, policiesCreate, sourceUrl, remotes, revision } = factoryParams;
 
     // when using the default devfile instead of a user devfile
     if (factoryResolver === undefined && isEqual(devfile, defaultDevfile)) {
@@ -210,8 +210,13 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
       devfile.attributes[DEVWORKSPACE_BOOTSTRAP] = true;
     }
 
-    if (remotes) {
-      configureProjectRemotes(devfile, remotes, isEqual(devfile, defaultDevfile));
+    if (remotes || revision) {
+      configureProjectRemotes(
+        devfile,
+        remotes,
+        isEqual(devfile, defaultDevfile),
+        revision || 'HEAD',
+      );
     }
 
     // test the devfile name to decide if we need to append a suffix to is

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
@@ -26,6 +26,7 @@ import {
   EXISTING_WORKSPACE_NAME,
   FACTORY_URL_ATTR,
   POLICIES_CREATE_ATTR,
+  REVISION_ATTR,
 } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { buildFactoryLocation } from '@/services/helpers/location';
 import { TabManager } from '@/services/tabManager';
@@ -209,6 +210,257 @@ describe('Creating steps, checking existing workspaces', () => {
 
         await waitFor(() =>
           expect(mockTabManagerReplace).toHaveBeenCalledWith(
+            expect.stringContaining(`/ide/user-che/project-1`),
+          ),
+        );
+      });
+
+      it('should open the existing workspace created from the same repo and revision', async () => {
+        searchParams.delete(DEV_WORKSPACE_ATTR);
+        searchParams.set(EXISTING_WORKSPACE_NAME, 'project-1');
+        searchParams.set(FACTORY_URL_ATTR, 'https://github.com/eclipse-che/che-dashboard');
+        searchParams.set(REVISION_ATTR, 'revision');
+
+        const resources: DevWorkspaceResources = [
+          {
+            metadata: {
+              name: workspaceName,
+            },
+          } as devfileApi.DevWorkspace,
+          {} as devfileApi.DevWorkspaceTemplate,
+        ];
+        store = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: 'project-1',
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: 'url=https://github.com/eclipse-che/che-dashboard',
+                      },
+                    }),
+                  },
+                })
+                .withSpec({
+                  template: {
+                    projects: [
+                      {
+                        git: {
+                          remotes: {
+                            origin: 'remote',
+                          },
+                          checkoutFrom: { revision: 'revision' },
+                        },
+                        name: 'project-1',
+                      },
+                    ],
+                  },
+                })
+                .build(),
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: 'project-2',
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: 'url=https://github.com/eclipse-che/che-dashboard',
+                      },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withDevfileRegistries({
+            devWorkspaceResources: {
+              [resourcesUrl]: {
+                resources,
+              },
+            },
+          })
+          .withFactoryResolver({
+            resolver: {
+              location: 'https://github.com/eclipse-che/che-dashboard',
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: {
+                  name: workspaceName,
+                },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(store, searchParams);
+
+        await waitFor(() =>
+          expect(mockTabManagerReplace).toHaveBeenCalledWith(
+            expect.stringContaining(`/ide/user-che/project-1`),
+          ),
+        );
+      });
+
+      it('should not open the existing workspace created from the same repo with revision in workspace', async () => {
+        searchParams.delete(DEV_WORKSPACE_ATTR);
+        searchParams.set(EXISTING_WORKSPACE_NAME, 'project-1');
+        searchParams.set(FACTORY_URL_ATTR, 'https://github.com/eclipse-che/che-dashboard');
+
+        const resources: DevWorkspaceResources = [
+          {
+            metadata: {
+              name: workspaceName,
+            },
+          } as devfileApi.DevWorkspace,
+          {} as devfileApi.DevWorkspaceTemplate,
+        ];
+        store = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: 'project-1',
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: 'url=https://github.com/eclipse-che/che-dashboard',
+                      },
+                    }),
+                  },
+                })
+                .withSpec({
+                  template: {
+                    projects: [
+                      {
+                        git: {
+                          remotes: {
+                            origin: 'remote',
+                          },
+                          checkoutFrom: { revision: 'revision' },
+                        },
+                        name: 'project-1',
+                      },
+                    ],
+                  },
+                })
+                .build(),
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: 'project-2',
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: 'url=https://github.com/eclipse-che/che-dashboard',
+                      },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withDevfileRegistries({
+            devWorkspaceResources: {
+              [resourcesUrl]: {
+                resources,
+              },
+            },
+          })
+          .withFactoryResolver({
+            resolver: {
+              location: 'https://github.com/eclipse-che/che-dashboard',
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: {
+                  name: workspaceName,
+                },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(store, searchParams);
+
+        await waitFor(() =>
+          expect(mockTabManagerReplace).not.toHaveBeenCalledWith(
+            expect.stringContaining(`/ide/user-che/project-1`),
+          ),
+        );
+      });
+
+      it('should not open the existing workspace created from the same repo with revision in parameters', async () => {
+        searchParams.delete(DEV_WORKSPACE_ATTR);
+        searchParams.set(EXISTING_WORKSPACE_NAME, 'project-1');
+        searchParams.set(FACTORY_URL_ATTR, 'https://github.com/eclipse-che/che-dashboard');
+        searchParams.set(REVISION_ATTR, 'revision');
+
+        const resources: DevWorkspaceResources = [
+          {
+            metadata: {
+              name: workspaceName,
+            },
+          } as devfileApi.DevWorkspace,
+          {} as devfileApi.DevWorkspaceTemplate,
+        ];
+        store = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: 'project-1',
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: 'url=https://github.com/eclipse-che/che-dashboard',
+                      },
+                    }),
+                  },
+                })
+                .build(),
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: 'project-2',
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: 'url=https://github.com/eclipse-che/che-dashboard',
+                      },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withDevfileRegistries({
+            devWorkspaceResources: {
+              [resourcesUrl]: {
+                resources,
+              },
+            },
+          })
+          .withFactoryResolver({
+            resolver: {
+              location: 'https://github.com/eclipse-che/che-dashboard',
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: {
+                  name: workspaceName,
+                },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(store, searchParams);
+
+        await waitFor(() =>
+          expect(mockTabManagerReplace).not.toHaveBeenCalledWith(
             expect.stringContaining(`/ide/user-che/project-1`),
           ),
         );

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
@@ -228,7 +228,19 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
     workspaces: Workspace[],
     factoryParams: FactoryParams,
   ): Workspace[] {
-    return workspaces.filter(workspace => workspace.source === factoryParams.sourceUrl);
+    return workspaces.filter(workspace => {
+      let revision: string | undefined;
+      const projects = workspace.ref.spec.template.projects;
+      if (projects && projects.length > 0) {
+        const git = projects[0].git;
+        if (git && git.checkoutFrom && git.checkoutFrom.revision) {
+          if (git.checkoutFrom.revision) {
+            revision = git.checkoutFrom.revision;
+          }
+        }
+      }
+      return workspace.source === factoryParams.sourceUrl && revision === factoryParams.revision;
+    });
   }
 
   protected buildAlertItem(error: Error): AlertItem {

--- a/packages/dashboard-frontend/src/containers/Loader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/index.tsx
@@ -43,7 +43,7 @@ class LoaderContainer extends React.Component<Props, State> {
 
     const dirtyLocation = this.props.location;
     const { search } = helpers.sanitizeLocation(dirtyLocation);
-    const searchParams = new URLSearchParams(search);
+    const searchParams = new URLSearchParams(decodeURIComponent(search).replaceAll('?', '&'));
     const tabParam = searchParams.get('tab') || undefined;
 
     this.state = {
@@ -66,7 +66,9 @@ class LoaderContainer extends React.Component<Props, State> {
     });
 
     const { location } = this.props;
-    const searchParams = new URLSearchParams(location.search);
+    const searchParams = new URLSearchParams(
+      decodeURIComponent(location.search).replaceAll('?', '&'),
+    );
     searchParams.set('tab', LoaderTab[tab]);
     location.search = searchParams.toString();
     this.props.navigate(location);

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -19,6 +19,7 @@ export const FACTORY_URL_ATTR = 'url';
 export const POLICIES_CREATE_ATTR = 'policies.create';
 export const STORAGE_TYPE_ATTR = 'storageType';
 export const REMOTES_ATTR = 'remotes';
+export const REVISION_ATTR = 'revision';
 export const IMAGE_ATTR = 'image';
 export const CPU_LIMIT_ATTR = 'cpuLimit';
 export const MEMORY_LIMIT_ATTR = 'memoryLimit';
@@ -57,6 +58,7 @@ export type FactoryParams = {
   cheEditor: string | undefined;
   editorImage: string | undefined;
   remotes: string | undefined;
+  revision: string | undefined;
   image: string | undefined;
   cpuLimit: string | undefined;
   memoryLimit: string | undefined;
@@ -81,6 +83,7 @@ export function buildFactoryParams(searchParams: URLSearchParams): FactoryParams
     sourceUrl: getSourceUrl(searchParams),
     storageType: getStorageType(searchParams),
     remotes: getRemotes(searchParams),
+    revision: getRevision(searchParams),
     useDevWorkspaceResources: getDevworkspaceResourcesUrl(searchParams) !== undefined,
     image: getImage(searchParams),
     cpuLimit: getCpuLimit(searchParams),
@@ -141,6 +144,10 @@ function getErrorCode(searchParams: URLSearchParams): ErrorCode | undefined {
 
 function getRemotes(searchParams: URLSearchParams): string | undefined {
   return searchParams.get(REMOTES_ATTR) || undefined;
+}
+
+function getRevision(searchParams: URLSearchParams): string | undefined {
+  return searchParams.get(REVISION_ATTR) || undefined;
 }
 
 function buildFactoryId(searchParams: URLSearchParams): string {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/actions.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/actions.ts
@@ -44,6 +44,7 @@ export const actionCreators = {
       const overrideParams = factoryParams
         ? Object.assign({}, factoryParams.overrides, {
             error_code: factoryParams?.errorCode,
+            revision: factoryParams?.revision,
           })
         : undefined;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Do not hide the Git Branch input if an SSH url is entered.
* When creating a workspace from an SSH url, pass the git branch value from the input to the `checkoutFrom` devfile section.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23499

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Apply dashboard pull request image: `quay.io/eclipse/che-dashboard:pr-1373-amd64`
2. Apply che-server pull request image: `quay.io/eclipse/che-server:pr-828`
3. Add SSH key to the user namespace.
4. Prepare a git repository with several branches with devfiles.
5. Enter the SSH url of the repository to the `Create Workspace` -> `Git repo URL` input
6. Open the `Git repo Options` section and fill in the `Git branch` input
7. Click the `Create Workspace` button.

See: Workspace starts from the devfile located in the specified branch. Try the steps above with private and public repositories.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
