### PR TITLE
fix: regex check to allow url to contain port number

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
@@ -40,7 +40,7 @@ describe('GitProviderEndpoint', () => {
   });
 
   it('should handle a correct endpoint', async () => {
-    const endpoint = 'https://provider.test/endpoint';
+    const endpoint = 'https://provider.test:8080/endpoint';
     renderComponent(undefined);
 
     expect(mockOnChange).not.toHaveBeenCalled();

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
@@ -100,7 +100,7 @@ export class GitProviderEndpoint extends React.PureComponent<Props, State> {
     sanitized: string;
   } {
     const validationRe =
-      /^https?:\/\/(?:(?:[a-z\d]+(?:-[a-z\d]+)*)\.)+[a-z]{2,}(?:\/[^\s]*)?(?::\d+)?$/i;
+      /^https?:\/\/(?:(?:[a-z\d]+(?:-[a-z\d]+)*)\.)+[a-z]{2,}(?::\d{1,5})?(?:\/[^\s]*)?$/i;
 
     if (validationRe.test(providerEndpoint) === false) {
       return {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes validation regex for personal access token UI to allow URL parameter contain port number.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1044" height="900" alt="Знімок екрана 2025-09-11 о 20 07 57" src="https://github.com/user-attachments/assets/1e8b83aa-1a2d-4a6a-ad31-4a25807298bb" />


### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-9390

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse-Che with the image from this PR - quay.io/eclipse/che-dashboard:pr-1376-amd64.
2. Open **User Preferences** and try to add
a personal access token for **Bitbucket Server** with a server URL, which contains the port number. 
   _Example:_ `https://your-bitbucket-server-hostname.org:7999/project/repo.git`
3. The server URL, which contains the port number, should be valid in the form.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
