### PR TITLE
fix: checkForTemplatesUpdate method

### DIFF
--- a/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/yamlResolverApi.ts
@@ -11,7 +11,7 @@
  */
 
 import { helpers } from '@eclipse-che/common';
-import * as yaml from 'js-yaml';
+import { load } from 'js-yaml';
 
 import devfileApi from '@/services/devfileApi';
 import { FactoryResolver } from '@/services/helpers/types';
@@ -23,7 +23,7 @@ export async function getYamlResolver(location: string): Promise<FactoryResolver
 
     return {
       v: 'yaml-resolver',
-      devfile: yaml.load(data) as devfileApi.Devfile,
+      devfile: load(data) as devfileApi.Devfile,
       location,
       links: [],
     };

--- a/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/__tests__/helpers.spec.ts
@@ -14,6 +14,7 @@ import devfileApi from '@/services/devfileApi';
 import {
   getErrorMessage,
   hasLoginPage,
+  isCheEditorYamlPath,
   isForbidden,
   isInternalServerError,
   isUnauthorized,
@@ -325,6 +326,32 @@ describe('Workspace-client helpers', () => {
       expect(normalisedDevWorkspace).toEqual({
         ...devWorkspace,
         spec: { started: false, template: {} },
+      });
+    });
+  });
+
+  describe('checks isCheEditorYamlPath method', () => {
+    it('should return the false', () => {
+      const editors = [
+        'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/insider',
+        'https://dummy-host/che-plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml',
+      ];
+
+      editors.forEach(editor => {
+        const hasCheEditorYamlPath = isCheEditorYamlPath(editor);
+        expect(hasCheEditorYamlPath).toBeFalsy();
+      });
+    });
+
+    it('should return the true', () => {
+      const editors = [
+        'http://dummy-host/api/scm/resolve?repository=https%3A%2F%2Fdummy-repo%2Freference-editor.git&file=.che%2Fche-editor.yaml',
+        'http://dummy-host/api/scm/resolve?repository=https://dummy-repo/dashboard&file=.che/che-editor.yaml',
+      ];
+
+      editors.forEach(editor => {
+        const hasCheEditorYamlPath = isCheEditorYamlPath(editor);
+        expect(hasCheEditorYamlPath).toBeTruthy();
       });
     });
   });

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceEditor.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceEditor.spec.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { dump } from 'js-yaml';
+
+import devfileApi from '@/services/devfileApi';
+import { fetchEditor } from '@/services/workspace-client/devworkspace/devWorkspaceEditor';
+
+// mute console warn
+console.warn = jest.fn();
+
+const mockFetchData = jest.fn();
+
+describe('Fetch editor by url', () => {
+  let editorUrl: string;
+  let editor: devfileApi.Devfile;
+
+  beforeEach(() => {
+    editorUrl = 'http://dummy-repo';
+    editor = buildEditor();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return undefined if the fetchData callback throws an error', async () => {
+    mockFetchData.mockRejectedValueOnce(new Error('unexpected error'));
+
+    const customEditor = await fetchEditor(editorUrl, mockFetchData);
+
+    expect(mockFetchData).toBeCalledTimes(1);
+    expect(mockFetchData).toBeCalledWith(editorUrl);
+    expect(customEditor).toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(`Failed to fetch editor yaml by URL: ${editorUrl}.`);
+  });
+
+  describe('request callback returns object', () => {
+    it('should return undefined if it is not a Devfile', async () => {
+      delete (editor as Partial<devfileApi.Devfile>).schemaVersion;
+
+      mockFetchData.mockResolvedValueOnce(editor);
+
+      const customEditor = await fetchEditor(editorUrl, mockFetchData);
+
+      expect(mockFetchData).toBeCalledTimes(1);
+      expect(mockFetchData).toBeCalledWith(editorUrl);
+      expect(customEditor).toBeUndefined();
+    });
+    it('should return the same object if it is a Devfile', async () => {
+      mockFetchData.mockResolvedValueOnce(editor);
+
+      const customEditor = await fetchEditor(editorUrl, mockFetchData);
+
+      expect(mockFetchData).toBeCalledTimes(1);
+      expect(mockFetchData).toBeCalledWith(editorUrl);
+      expect(customEditor).toEqual(editor);
+    });
+  });
+
+  describe('request callback returns string', () => {
+    it('should return the editor object if the request callback returns it', async () => {
+      const editorStr = dump(editor);
+      mockFetchData.mockResolvedValueOnce(editorStr);
+
+      const customEditor = await fetchEditor(editorUrl, mockFetchData, false);
+
+      expect(mockFetchData).toBeCalledTimes(1);
+      expect(mockFetchData).toBeCalledWith(editorUrl);
+      expect(customEditor).toEqual(editor);
+    });
+    describe('inlined editor', () => {
+      it('should return inlined editor without changes', async () => {
+        const cheEditorYamlFile = dump({ inline: editor });
+        mockFetchData.mockResolvedValueOnce(cheEditorYamlFile);
+
+        const customEditor = await fetchEditor(editorUrl, mockFetchData, true);
+
+        expect(mockFetchData).toBeCalledTimes(1);
+        expect(mockFetchData).toBeCalledWith(editorUrl);
+        expect(customEditor).toEqual(editor);
+      });
+
+      it('should return an overridden devfile', async () => {
+        const cheEditorYamlFile = dump({
+          inline: editor,
+          override: {
+            containers: [
+              {
+                name: 'eclipse-ide',
+                memoryLimit: '12345Mi',
+              },
+            ],
+          },
+        });
+        mockFetchData.mockResolvedValueOnce(cheEditorYamlFile);
+
+        const customEditor = await fetchEditor(editorUrl, mockFetchData, true);
+
+        expect(mockFetchData).toBeCalledTimes(1);
+        expect(mockFetchData.mock.calls).toEqual([['http://dummy-repo']]);
+        expect(customEditor).toEqual(
+          expect.objectContaining({
+            components: expect.arrayContaining([
+              {
+                name: 'eclipse-ide',
+                container: expect.objectContaining({ memoryLimit: '12345Mi' }),
+              },
+            ]),
+          }),
+        );
+      });
+    });
+    describe('get editor by id ', () => {
+      describe('from the default registry', () => {
+        it('should return an editor without changes if the editor fetch callback returns object', async () => {
+          const cheEditorYamlFile = dump({
+            id: 'che-incubator/che-idea/next',
+          });
+          mockFetchData.mockResolvedValueOnce(cheEditorYamlFile);
+          mockFetchData.mockResolvedValueOnce(editor);
+
+          const customEditor = await fetchEditor(editorUrl, mockFetchData, true);
+
+          expect(mockFetchData).toBeCalledTimes(2);
+          expect(mockFetchData.mock.calls).toEqual([
+            ['http://dummy-repo'],
+            [
+              'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-idea/next',
+            ],
+          ]);
+          expect(customEditor).toEqual(editor);
+        });
+
+        it('should return an editor without changes if the editor fetch callback returns string', async () => {
+          const cheEditorYamlFile = dump({
+            id: 'che-incubator/che-idea/next',
+          });
+          mockFetchData.mockResolvedValueOnce(cheEditorYamlFile);
+          mockFetchData.mockResolvedValueOnce(dump(editor));
+
+          const customEditor = await fetchEditor(editorUrl, mockFetchData, true);
+
+          expect(mockFetchData).toBeCalledTimes(2);
+          expect(mockFetchData.mock.calls).toEqual([
+            ['http://dummy-repo'],
+            [
+              'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-idea/next',
+            ],
+          ]);
+          expect(customEditor).toEqual(editor);
+        });
+
+        it('should return an overridden devfile', async () => {
+          const cheEditorYamlFile = dump({
+            id: 'che-incubator/che-idea/next',
+            override: {
+              containers: [
+                {
+                  name: 'eclipse-ide',
+                  memoryLimit: '6789Mi',
+                },
+              ],
+            },
+          });
+          mockFetchData.mockResolvedValueOnce(cheEditorYamlFile);
+
+          mockFetchData.mockResolvedValueOnce(dump(editor));
+
+          const customEditor = await fetchEditor(editorUrl, mockFetchData, true);
+
+          expect(mockFetchData).toBeCalledTimes(2);
+          expect(mockFetchData.mock.calls).toEqual([
+            ['http://dummy-repo'],
+            [
+              'http://127.0.0.1:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-idea/next',
+            ],
+          ]);
+          expect(customEditor).toEqual(
+            expect.objectContaining({
+              components: expect.arrayContaining([
+                {
+                  name: 'eclipse-ide',
+                  container: expect.objectContaining({ memoryLimit: '6789Mi' }),
+                },
+              ]),
+            }),
+          );
+        });
+      });
+
+      describe('from the custom registry', () => {
+        it('should return an editor without changes', async () => {
+          const cheEditorYamlFile = dump({
+            id: 'che-incubator/che-idea/next',
+            registryUrl: 'https://dummy/che-plugin-registry/main/v3',
+          });
+          mockFetchData.mockResolvedValueOnce(cheEditorYamlFile);
+          mockFetchData.mockResolvedValueOnce(dump(editor));
+
+          const customEditor = await fetchEditor(editorUrl, mockFetchData, true);
+
+          expect(mockFetchData).toBeCalledTimes(2);
+          expect(mockFetchData.mock.calls).toEqual([
+            ['http://dummy-repo'],
+            [
+              'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',
+            ],
+          ]);
+          expect(customEditor).toEqual(editor);
+        });
+
+        it('should return an overridden devfile', async () => {
+          const cheEditorYamlFile = dump({
+            id: 'che-incubator/che-idea/next',
+            registryUrl: 'https://dummy/che-plugin-registry/main/v3',
+            override: {
+              containers: [
+                {
+                  name: 'eclipse-ide',
+                  memoryLimit: '4321Mi',
+                },
+              ],
+            },
+          });
+          mockFetchData.mockResolvedValueOnce(cheEditorYamlFile);
+          mockFetchData.mockResolvedValueOnce(dump(editor));
+
+          const customEditor = await fetchEditor(editorUrl, mockFetchData, true);
+
+          expect(mockFetchData).toBeCalledTimes(2);
+          expect(mockFetchData.mock.calls).toEqual([
+            ['http://dummy-repo'],
+            [
+              'https://dummy/che-plugin-registry/main/v3/plugins/che-incubator/che-idea/next/devfile.yaml',
+            ],
+          ]);
+          expect(customEditor).toEqual(
+            expect.objectContaining({
+              components: expect.arrayContaining([
+                {
+                  name: 'eclipse-ide',
+                  container: expect.objectContaining({ memoryLimit: '4321Mi' }),
+                },
+              ]),
+            }),
+          );
+        });
+      });
+    });
+  });
+});
+
+function buildEditor(): devfileApi.Devfile {
+  return {
+    schemaVersion: '2.1.0',
+    metadata: {
+      name: 'che-idea',
+      namespace: 'che',
+      attributes: {
+        publisher: 'che-incubator',
+        version: 'next',
+      },
+    },
+    components: [
+      {
+        name: 'eclipse-ide',
+        container: {
+          image: 'docker.io/wsskeleton/eclipse-broadway',
+          mountSources: true,
+          memoryLimit: '2048M',
+        },
+      },
+    ],
+  };
+}

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceEditor.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceEditor.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { load } from 'js-yaml';
+
+import devfileApi, { isDevfileV2 } from '@/services/devfileApi';
+import { ICheEditorYaml } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+import { EDITOR_DEVFILE_API_QUERY } from '@/store/DevfileRegistries/const';
+
+export async function fetchEditor(
+  url: string,
+  requestCallback: <T>(location: string) => Promise<T>,
+  isCheEditorYamlFile?: boolean,
+): Promise<devfileApi.Devfile | undefined> {
+  let editor: devfileApi.Devfile | undefined = undefined;
+  let editorContent: string | devfileApi.Devfile | undefined = undefined;
+  try {
+    editorContent = await requestCallback<string | devfileApi.Devfile>(url);
+  } catch (e) {
+    console.warn(`Failed to fetch editor yaml by URL: ${url}.`);
+  }
+  if (typeof editorContent === 'string') {
+    if (isCheEditorYamlFile) {
+      const cheEditorYaml = load(editorContent) as ICheEditorYaml;
+      let repositoryEditorYaml: devfileApi.Devfile | undefined;
+      let editorReference: string | undefined;
+      if (cheEditorYaml?.inline) {
+        repositoryEditorYaml = cheEditorYaml.inline;
+      } else if (cheEditorYaml?.id) {
+        if (cheEditorYaml?.registryUrl) {
+          editorReference = `${cheEditorYaml.registryUrl}/plugins/${cheEditorYaml.id}/devfile.yaml`;
+        } else {
+          editorReference = `${EDITOR_DEVFILE_API_QUERY}${cheEditorYaml?.id}`;
+        }
+      } else if (cheEditorYaml?.reference) {
+        editorReference = cheEditorYaml.reference;
+      }
+      if (editorReference) {
+        try {
+          const devfileContent = await requestCallback<string>(editorReference);
+          const devfile =
+            typeof devfileContent === 'string' ? load(devfileContent) : devfileContent;
+          repositoryEditorYaml = isDevfileV2(devfile) ? devfile : undefined;
+        } catch (e) {
+          console.warn(`Failed to fetch a devfile from URL: ${url}, reason: ` + e);
+        }
+      }
+      if (cheEditorYaml?.override) {
+        cheEditorYaml.override.containers?.forEach(container => {
+          const matchingComponent = repositoryEditorYaml?.components
+            ? repositoryEditorYaml.components.find(component => component.name === container.name)
+            : undefined;
+          if (matchingComponent?.container) {
+            Object.keys(container).forEach(property => {
+              if (matchingComponent.container?.[property] && property !== 'name') {
+                matchingComponent.container[property] = container[property];
+              }
+            });
+          }
+        });
+      }
+      editor = isDevfileV2(repositoryEditorYaml) ? repositoryEditorYaml : undefined;
+    } else {
+      const devfile = load(editorContent);
+      editor = isDevfileV2(devfile) ? devfile : undefined;
+    }
+  } else if (typeof editorContent === 'object') {
+    editor = isDevfileV2(editorContent) ? editorContent : undefined;
+  }
+
+  return editor;
+}

--- a/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/helpers.ts
@@ -141,3 +141,10 @@ export function normaliseDevWorkspace(workspace: devfileApi.DevWorkspace): devfi
   }
   return _workspace;
 }
+
+export function isCheEditorYamlPath(path: string): boolean {
+  const regex = new RegExp('file=.che/che-editor.yaml');
+  const decodedPath = decodeURIComponent(path);
+
+  return regex.test(decodedPath);
+}

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/actions.spec.ts
@@ -156,7 +156,9 @@ describe('FactoryResolver, actions', () => {
         const mockFactoryResolver = { devfile: {}, links: [] };
         const mockDefaultComponents = [];
         const mockNormalizedDevfile = {};
-        const mockOptionalFilesContent = { '.che/che-editor.yaml': 'content' };
+        const mockOptionalFilesContent = {
+          '.che/che-editor.yaml': { location: 'location', content: 'content' },
+        };
 
         jest
           .spyOn(infrastructureNamespaces, 'selectDefaultNamespace')
@@ -164,7 +166,7 @@ describe('FactoryResolver, actions', () => {
         (verifyAuthorized as jest.Mock).mockResolvedValue(true);
         (isDevfileRegistryLocation as jest.Mock).mockReturnValue(false);
         (getFactoryResolver as jest.Mock).mockResolvedValue(mockFactoryResolver);
-        (grabLink as jest.Mock).mockResolvedValue('content');
+        (grabLink as jest.Mock).mockResolvedValue({ location: 'location', content: 'content' });
         jest.spyOn(serverConfig, 'selectDefaultComponents').mockReturnValue(mockDefaultComponents);
         (normalizeDevfile as jest.Mock).mockReturnValue(mockNormalizedDevfile);
 

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/helpers.grabLink.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/helpers.grabLink.spec.ts
@@ -45,9 +45,12 @@ describe('grabLink', () => {
     const links = getLinks();
     const link = await grabLink(links, '.che/che-editor.yaml');
 
-    expect(link).toEqual(
-      'inline:\n  schemaVersion: 2.1.0\n  metadata:\n    name: che-code\n    displayName: VS Code - Open Source',
-    );
+    expect(link).toEqual({
+      location:
+        'https://che-host/api/scm/resolve?repository=https%3A%2F%2Fgithub.com%2Fusername%2Fweb-nodejs-sample%2Ftree%2Fubi9-devspaces-editor&file=.che%2Fche-editor.yaml',
+      content:
+        'inline:\n  schemaVersion: 2.1.0\n  metadata:\n    name: che-code\n    displayName: VS Code - Open Source',
+    });
   });
 
   test('link is found but devfile is not found', async () => {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/reducer.spec.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/__tests__/reducer.spec.ts
@@ -41,7 +41,7 @@ describe('FactoryResolver reducer', () => {
   it('should handle factoryResolverReceiveAction', () => {
     const resolver = {
       devfile: {} as devfileApi.Devfile,
-      optionalFilesContent: { 'README.md': 'Content' },
+      optionalFilesContent: { 'README.md': { location: 'location', content: 'Content' } },
     };
     const action = factoryResolverReceiveAction(resolver);
     const expectedState: State = {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/actions.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/actions.ts
@@ -39,7 +39,9 @@ export const actionCreators = {
     (location: string, factoryParams: Partial<FactoryParams> = {}): AppThunk =>
     async (dispatch, getState): Promise<void> => {
       const state = getState();
-      const optionalFilesContent = {};
+      const optionalFilesContent: {
+        [fileName: string]: { location: string; content: string } | undefined;
+      } = {};
 
       const overrideParams = factoryParams
         ? Object.assign({}, factoryParams.overrides, {
@@ -59,10 +61,10 @@ export const actionCreators = {
         } else {
           try {
             data = await getFactoryResolver(location, overrideParams);
-            const cheEditor = await grabLink(data.links || [], CHE_EDITOR_YAML_PATH);
-            if (cheEditor) {
-              optionalFilesContent[CHE_EDITOR_YAML_PATH] = cheEditor;
-            }
+            optionalFilesContent[CHE_EDITOR_YAML_PATH] = await grabLink(
+              data.links,
+              CHE_EDITOR_YAML_PATH,
+            );
           } catch (error) {
             if (location.endsWith('.yaml') || location.endsWith('.yml')) {
               try {

--- a/packages/dashboard-frontend/src/store/FactoryResolver/actions.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/actions.ts
@@ -66,12 +66,10 @@ export const actionCreators = {
               CHE_EDITOR_YAML_PATH,
             );
           } catch (error) {
-            if (location.endsWith('.yaml') || location.endsWith('.yml')) {
-              try {
-                data = await getYamlResolver(location);
-              } catch (e) {
-                console.log(e);
-              }
+            try {
+              data = await getYamlResolver(location);
+            } catch (e) {
+              console.log(e);
             }
             if (!data?.devfile) {
               throw error;

--- a/packages/dashboard-frontend/src/store/FactoryResolver/reducer.ts
+++ b/packages/dashboard-frontend/src/store/FactoryResolver/reducer.ts
@@ -32,9 +32,7 @@ export type OAuthResponse = {
 
 export interface Resolver extends FactoryResolver {
   devfile: devfileApi.Devfile;
-  optionalFilesContent?: {
-    [fileName: string]: string;
-  };
+  optionalFilesContent?: { [fileName: string]: { location: string; content: string } | undefined };
 }
 
 export interface State {

--- a/packages/dashboard-frontend/src/store/Workspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/__tests__/actions.spec.ts
@@ -210,7 +210,9 @@ describe('Workspaces Actions', () => {
     it('should dispatch createWorkspaceFromDevfile action', async () => {
       const mockDevfile = {} as devfileApi.Devfile;
       const mockAttributes = {} as Partial<FactoryParams>;
-      const mockOptionalFilesContent = { 'README.md': 'Content' };
+      const mockOptionalFilesContent = {
+        'README.md': { location: 'location', content: 'Content' },
+      };
 
       const mockCreateWorkspace = jest.fn();
       jest.spyOn(devWorkspacesActionCreators, 'createWorkspaceFromDevfile').mockImplementationOnce(

--- a/packages/dashboard-frontend/src/store/Workspaces/actions.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/actions.ts
@@ -101,7 +101,7 @@ export const actionCreators = {
       devfile: devfileApi.Devfile,
       attributes: Partial<FactoryParams>,
       optionalFilesContent?: {
-        [fileName: string]: string;
+        [fileName: string]: { location: string; content: string } | undefined;
       },
     ): AppThunk =>
     async dispatch => {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/createWorkspaceFromDevfile.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/createWorkspaceFromDevfile.ts
@@ -17,6 +17,7 @@ import { fetchResources } from '@/services/backend-client/devworkspaceResourcesA
 import devfileApi from '@/services/devfileApi';
 import { FactoryParams } from '@/services/helpers/factoryFlow/buildFactoryParams';
 import { loadResourcesContent } from '@/services/registry/resources';
+import { CHE_EDITOR_YAML_PATH } from '@/services/workspace-client/helpers';
 import { AppThunk } from '@/store';
 import { getEditor } from '@/store/DevfileRegistries/getEditor';
 import { verifyAuthorized } from '@/store/SanityCheck';
@@ -37,7 +38,7 @@ export const createWorkspaceFromDevfile =
     devfile: devfileApi.Devfile,
     params: Partial<FactoryParams>,
     optionalFilesContent: {
-      [fileName: string]: string;
+      [fileName: string]: { location: string; content: string } | undefined;
     },
   ): AppThunk =>
   async (dispatch, getState) => {
@@ -60,7 +61,10 @@ export const createWorkspaceFromDevfile =
       // do we have the custom editor in `.che/che-editor.yaml` ?
       try {
         editorContent = await getCustomEditor(optionalFilesContent, dispatch, getState);
-        if (!editorContent) {
+        if (editorContent) {
+          // keep the URL of the editor.yaml for later use
+          editorYamlUrl = optionalFilesContent[CHE_EDITOR_YAML_PATH]?.location;
+        } else {
           console.warn('No custom editor found');
         }
       } catch (e) {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/__tests__/getCustomEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/__tests__/getCustomEditor.spec.ts
@@ -19,7 +19,9 @@ import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
 import { getCustomEditor } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor';
 
 describe('Look for the custom editor', () => {
-  let optionalFilesContent: { [fileName: string]: string };
+  let optionalFilesContent: {
+    [fileName: string]: { location: string; content: string } | undefined;
+  };
   let editor: devfileApi.Devfile;
 
   beforeEach(() => {
@@ -44,7 +46,10 @@ describe('Look for the custom editor', () => {
 
   describe('inlined editor', () => {
     it('should return inlined editor without changes', async () => {
-      optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({ inline: editor });
+      optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+        location: 'location',
+        content: dump({ inline: editor }),
+      };
       const store = new MockStoreBuilder().build();
 
       const customEditor = await getCustomEditor(
@@ -57,17 +62,20 @@ describe('Look for the custom editor', () => {
     });
 
     it('should return an overridden devfile', async () => {
-      optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({
-        inline: editor,
-        override: {
-          containers: [
-            {
-              name: 'eclipse-ide',
-              memoryLimit: '1234Mi',
-            },
-          ],
-        },
-      });
+      optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+        location: 'location',
+        content: dump({
+          inline: editor,
+          override: {
+            containers: [
+              {
+                name: 'eclipse-ide',
+                memoryLimit: '1234Mi',
+              },
+            ],
+          },
+        }),
+      };
       const store = new MockStoreBuilder().build();
 
       const customEditor = await getCustomEditor(
@@ -82,7 +90,10 @@ describe('Look for the custom editor', () => {
     it('should throw the "missing metadata.name" error message', async () => {
       // set an empty value as a name
       editor.metadata.name = '';
-      optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({ inline: editor });
+      optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+        location: 'location',
+        content: dump({ inline: editor }),
+      };
       const store = new MockStoreBuilder().build();
 
       let errorText: string | undefined;
@@ -102,9 +113,12 @@ describe('Look for the custom editor', () => {
   describe('get editor by id ', () => {
     describe('from the default registry', () => {
       it('should return an editor without changes', async () => {
-        optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({
-          id: 'che-incubator/che-idea/next',
-        });
+        optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+          location: 'location',
+          content: dump({
+            id: 'che-incubator/che-idea/next',
+          }),
+        };
 
         const editors = [
           {
@@ -143,17 +157,20 @@ describe('Look for the custom editor', () => {
       });
 
       it('should return an overridden devfile', async () => {
-        optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({
-          id: 'che-incubator/che-idea/next',
-          override: {
-            containers: [
-              {
-                name: 'eclipse-ide',
-                memoryLimit: '1234Mi',
-              },
-            ],
-          },
-        });
+        optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+          location: 'location',
+          content: dump({
+            id: 'che-incubator/che-idea/next',
+            override: {
+              containers: [
+                {
+                  name: 'eclipse-ide',
+                  memoryLimit: '1234Mi',
+                },
+              ],
+            },
+          }),
+        };
 
         const editors = [
           {
@@ -202,9 +219,12 @@ describe('Look for the custom editor', () => {
       it('should failed fetching editor without metadata.name attribute', async () => {
         // set an empty value as a name
         editor.metadata.name = '';
-        optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({
-          id: 'che-incubator/che-idea/next',
-        });
+        optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+          location: 'location',
+          content: dump({
+            id: 'che-incubator/che-idea/next',
+          }),
+        };
 
         const editors = [
           {
@@ -255,10 +275,13 @@ describe('Look for the custom editor', () => {
 
     describe('from the custom registry', () => {
       it('should return an editor without changes', async () => {
-        optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({
-          id: 'che-incubator/che-idea/next',
-          registryUrl: 'https://dummy/che-plugin-registry/main/v3',
-        });
+        optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+          location: 'location',
+          content: dump({
+            id: 'che-incubator/che-idea/next',
+            registryUrl: 'https://dummy/che-plugin-registry/main/v3',
+          }),
+        };
         const store = new MockStoreBuilder()
           .withDevfileRegistries({
             devfiles: {
@@ -280,18 +303,21 @@ describe('Look for the custom editor', () => {
       });
 
       it('should return an overridden devfile', async () => {
-        optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({
-          id: 'che-incubator/che-idea/next',
-          registryUrl: 'https://dummy/che-plugin-registry/main/v3',
-          override: {
-            containers: [
-              {
-                name: 'eclipse-ide',
-                memoryLimit: '1234Mi',
-              },
-            ],
-          },
-        });
+        optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+          location: 'location',
+          content: dump({
+            id: 'che-incubator/che-idea/next',
+            registryUrl: 'https://dummy/che-plugin-registry/main/v3',
+            override: {
+              containers: [
+                {
+                  name: 'eclipse-ide',
+                  memoryLimit: '1234Mi',
+                },
+              ],
+            },
+          }),
+        };
         const store = new MockStoreBuilder()
           .withDevfileRegistries({
             devfiles: {
@@ -315,10 +341,13 @@ describe('Look for the custom editor', () => {
       it('should throw the "missing metadata.name" error message', async () => {
         // set an empty value as a name
         editor.metadata.name = '';
-        optionalFilesContent[CHE_EDITOR_YAML_PATH] = dump({
-          id: 'che-incubator/che-idea/next',
-          registryUrl: 'https://dummy/che-plugin-registry/main/v3',
-        });
+        optionalFilesContent[CHE_EDITOR_YAML_PATH] = {
+          location: 'location',
+          content: dump({
+            id: 'che-incubator/che-idea/next',
+            registryUrl: 'https://dummy/che-plugin-registry/main/v3',
+          }),
+        };
         const store = new MockStoreBuilder()
           .withDevfileRegistries({
             devfiles: {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor.ts
@@ -37,28 +37,18 @@ export async function getCustomEditor(
   if (!cheEditorYaml) {
     return undefined;
   }
-  // check the content of cheEditor file
-  console.debug('Using the repository .che/che-editor.yaml file', cheEditorYaml);
-
   let repositoryEditorYaml: devfileApi.Devfile | undefined;
   let editorReference: string | undefined;
   // it's an inlined editor, use the inline content
   if (cheEditorYaml.inline) {
-    console.debug('Using the inline content of the repository editor');
     repositoryEditorYaml = cheEditorYaml.inline;
   } else if (cheEditorYaml.id) {
-    // load the content of this editor
-    console.debug(`Loading editor from its id ${cheEditorYaml.id}`);
-
-    // registryUrl ?
     if (cheEditorYaml.registryUrl) {
       editorReference = `${cheEditorYaml.registryUrl}/plugins/${cheEditorYaml.id}/devfile.yaml`;
     } else {
       editorReference = cheEditorYaml.id;
     }
   } else if (cheEditorYaml.reference) {
-    // load the content of this editor
-    console.debug(`Loading editor from reference ${cheEditorYaml.reference}`);
     editorReference = cheEditorYaml.reference;
   }
   if (editorReference) {
@@ -73,7 +63,6 @@ export async function getCustomEditor(
 
   // if there are some overrides, apply them
   if (cheEditorYaml.override) {
-    console.debug(`Applying overrides ${JSON.stringify(cheEditorYaml.override)}...`);
     cheEditorYaml.override.containers?.forEach(container => {
       // search matching component
       const matchingComponent = repositoryEditorYaml?.components
@@ -83,9 +72,6 @@ export async function getCustomEditor(
         // apply overrides except the name
         Object.keys(container).forEach(property => {
           if (matchingComponent.container?.[property] && property !== 'name') {
-            console.debug(
-              `Updating property from ${matchingComponent.container[property]} to ${container[property]}`,
-            );
             matchingComponent.container[property] = container[property];
           }
         });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor.ts
@@ -27,8 +27,6 @@ export async function getCustomEditor(
   dispatch: ThunkDispatch<RootState, unknown, UnknownAction>,
   getState: () => RootState,
 ): Promise<string | undefined> {
-  // let editorsDevfile: devfileApi.Devfile | undefined;
-
   // do we have a custom editor specified in the repository ?
   const cheEditorYaml = optionalFilesContent[CHE_EDITOR_YAML_PATH]?.content
     ? (load(optionalFilesContent[CHE_EDITOR_YAML_PATH].content) as ICheEditorYaml)

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/getCustomEditor.ts
@@ -23,91 +23,86 @@ import { getEditor } from '@/store/DevfileRegistries/getEditor';
  * Look for the custom editor in .che/che-editor.yaml
  */
 export async function getCustomEditor(
-  optionalFilesContent: { [fileName: string]: string },
+  optionalFilesContent: { [fileName: string]: { location: string; content: string } | undefined },
   dispatch: ThunkDispatch<RootState, unknown, UnknownAction>,
   getState: () => RootState,
 ): Promise<string | undefined> {
-  let editorsDevfile: devfileApi.Devfile | undefined;
+  // let editorsDevfile: devfileApi.Devfile | undefined;
 
   // do we have a custom editor specified in the repository ?
-  const cheEditorYaml = optionalFilesContent[CHE_EDITOR_YAML_PATH]
-    ? (load(optionalFilesContent[CHE_EDITOR_YAML_PATH]) as ICheEditorYaml)
+  const cheEditorYaml = optionalFilesContent[CHE_EDITOR_YAML_PATH]?.content
+    ? (load(optionalFilesContent[CHE_EDITOR_YAML_PATH].content) as ICheEditorYaml)
     : undefined;
 
-  if (cheEditorYaml) {
-    // check the content of cheEditor file
-    console.debug('Using the repository .che/che-editor.yaml file', cheEditorYaml);
+  if (!cheEditorYaml) {
+    return undefined;
+  }
+  // check the content of cheEditor file
+  console.debug('Using the repository .che/che-editor.yaml file', cheEditorYaml);
 
-    let repositoryEditorYaml: devfileApi.Devfile | undefined;
-    let editorReference: string | undefined;
-    // it's an inlined editor, use the inline content
-    if (cheEditorYaml.inline) {
-      console.debug('Using the inline content of the repository editor');
-      repositoryEditorYaml = cheEditorYaml.inline;
-    } else if (cheEditorYaml.id) {
-      // load the content of this editor
-      console.debug(`Loading editor from its id ${cheEditorYaml.id}`);
+  let repositoryEditorYaml: devfileApi.Devfile | undefined;
+  let editorReference: string | undefined;
+  // it's an inlined editor, use the inline content
+  if (cheEditorYaml.inline) {
+    console.debug('Using the inline content of the repository editor');
+    repositoryEditorYaml = cheEditorYaml.inline;
+  } else if (cheEditorYaml.id) {
+    // load the content of this editor
+    console.debug(`Loading editor from its id ${cheEditorYaml.id}`);
 
-      // registryUrl ?
-      if (cheEditorYaml.registryUrl) {
-        editorReference = `${cheEditorYaml.registryUrl}/plugins/${cheEditorYaml.id}/devfile.yaml`;
-      } else {
-        editorReference = cheEditorYaml.id;
-      }
-    } else if (cheEditorYaml.reference) {
-      // load the content of this editor
-      console.debug(`Loading editor from reference ${cheEditorYaml.reference}`);
-      editorReference = cheEditorYaml.reference;
+    // registryUrl ?
+    if (cheEditorYaml.registryUrl) {
+      editorReference = `${cheEditorYaml.registryUrl}/plugins/${cheEditorYaml.id}/devfile.yaml`;
+    } else {
+      editorReference = cheEditorYaml.id;
     }
-    if (editorReference) {
-      const response = await getEditor(editorReference, dispatch, getState);
-      if (response.content) {
-        const yaml = load(response.content);
-        repositoryEditorYaml = isDevfileV2(yaml) ? yaml : undefined;
-      } else {
-        throw new Error(response.error);
-      }
+  } else if (cheEditorYaml.reference) {
+    // load the content of this editor
+    console.debug(`Loading editor from reference ${cheEditorYaml.reference}`);
+    editorReference = cheEditorYaml.reference;
+  }
+  if (editorReference) {
+    const response = await getEditor(editorReference, dispatch, getState);
+    if (response.content) {
+      const yaml = load(response.content);
+      repositoryEditorYaml = isDevfileV2(yaml) ? yaml : undefined;
+    } else {
+      throw new Error(response.error);
     }
-
-    // if there are some overrides, apply them
-    if (cheEditorYaml.override) {
-      console.debug(`Applying overrides ${JSON.stringify(cheEditorYaml.override)}...`);
-      cheEditorYaml.override.containers?.forEach(container => {
-        // search matching component
-        const matchingComponent = repositoryEditorYaml?.components
-          ? repositoryEditorYaml.components.find(component => component.name === container.name)
-          : undefined;
-        if (matchingComponent?.container) {
-          // apply overrides except the name
-          Object.keys(container).forEach(property => {
-            if (matchingComponent.container?.[property] && property !== 'name') {
-              console.debug(
-                `Updating property from ${matchingComponent.container[property]} to ${container[property]}`,
-              );
-              matchingComponent.container[property] = container[property];
-            }
-          });
-        }
-      });
-    }
-
-    if (!repositoryEditorYaml) {
-      throw new Error(
-        'Failed to analyze the editor devfile inside the repository, reason: Missing id, reference or inline content.',
-      );
-    }
-    // Use the repository defined editor
-    editorsDevfile = repositoryEditorYaml;
   }
 
-  if (editorsDevfile) {
-    if (!editorsDevfile.metadata || !editorsDevfile.metadata.name) {
-      throw new Error(
-        'Failed to analyze the editor devfile, reason: Missing metadata.name attribute in the editor yaml file.',
-      );
-    }
-    return dump(editorsDevfile);
+  // if there are some overrides, apply them
+  if (cheEditorYaml.override) {
+    console.debug(`Applying overrides ${JSON.stringify(cheEditorYaml.override)}...`);
+    cheEditorYaml.override.containers?.forEach(container => {
+      // search matching component
+      const matchingComponent = repositoryEditorYaml?.components
+        ? repositoryEditorYaml.components.find(component => component.name === container.name)
+        : undefined;
+      if (matchingComponent?.container) {
+        // apply overrides except the name
+        Object.keys(container).forEach(property => {
+          if (matchingComponent.container?.[property] && property !== 'name') {
+            console.debug(
+              `Updating property from ${matchingComponent.container[property]} to ${container[property]}`,
+            );
+            matchingComponent.container[property] = container[property];
+          }
+        });
+      }
+    });
   }
 
-  return undefined;
+  if (!repositoryEditorYaml) {
+    throw new Error(
+      'Failed to analyze the editor devfile inside the repository, reason: Missing id, reference or inline content.',
+    );
+  }
+  // Use the repository defined editor
+  if (!repositoryEditorYaml.metadata || !repositoryEditorYaml.metadata.name) {
+    throw new Error(
+      'Failed to analyze the editor devfile, reason: Missing metadata.name attribute in the editor yaml file.',
+    );
+  }
+  return dump(repositoryEditorYaml);
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR updates the `heckForTemplatesUpdate` method to allow custom editor updates from the `.che/che-editor.yaml` file before the next workspace start.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<img width="1339" height="564" alt="Знімок екрана 2025-09-17 о 18 05 11" src="https://github.com/user-attachments/assets/42f897b0-a5c6-484c-b6c0-f5f989fd7c1c" />

<img width="1339" height="564" alt="Знімок екрана 2025-09-17 о 18 11 09" src="https://github.com/user-attachments/assets/af99b8d7-2e9b-4ebb-8094-bbcc03161860" />


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23467

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Apply dashboard pull request image: quay.io/eclipse/che-dashboard:pr-1378-amd64
2. Prepare a git repository with `.che/che-editor.yaml` file with the following content:
```yaml
reference: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
override:
  containers:
    - name: che-code-injector
      memoryLimit: 2048Mi
```
3. Create a new workspace from the target repository.  Check the che-editor memory limit, it should be `2048Mi`.
4. Update `.che/che-editor.yaml` file with the following content:
```yaml
reference: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
override:
  containers:
    - name: che-code-injector
      memoryLimit: 4096Mi
```
5. Restart the target workspace. Check the che-editor memory limit, it should be `4096Mi`.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
