### PR TITLE
Add Bitbucket to the list of providers in the Add/Edit PAT window

### DIFF
--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -35,6 +35,7 @@ export type GitOauthProvider =
 export type GitProvider =
   | 'github'
   | 'gitlab'
+  | 'bitbucket'
   | 'bitbucket-server'
   | 'azure-devops';
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/__tests__/index.spec.tsx
@@ -52,6 +52,7 @@ describe('Registry Username Input', () => {
     expect(screen.queryByRole('menuitem', { name: 'GitHub' })).toBeTruthy();
     expect(screen.queryByRole('menuitem', { name: 'GitLab' })).toBeTruthy();
     expect(screen.queryByRole('menuitem', { name: 'Microsoft Azure DevOps' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'Bitbucket' })).not.toBeTruthy();
   });
 
   it('should select a provider', async () => {
@@ -69,11 +70,23 @@ describe('Registry Username Input', () => {
     expect(screen.queryByRole('button', { name: 'Bitbucket Server' })).toBeTruthy();
   });
 
-  it('should handle component update', () => {
+  it('should handle component update Bitbucket Server', () => {
     const { reRenderComponent } = renderComponent('bitbucket-server');
 
-    // expect Bitbucket to be selected by default
+    // expect Bitbucket Server to be selected by default
     expect(screen.queryByRole('button', { name: 'Bitbucket Server' })).toBeTruthy();
+
+    reRenderComponent('gitlab');
+
+    // expect the dropdown button to be updated
+    expect(screen.queryByRole('button', { name: 'GitLab' })).toBeTruthy();
+  });
+
+  it('should handle component update Bitbucket SAAS', () => {
+    const { reRenderComponent } = renderComponent('bitbucket');
+
+    // expect Bitbucket to be selected by default
+    expect(screen.queryByRole('button', { name: 'Bitbucket' })).toBeTruthy();
 
     reRenderComponent('gitlab');
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/index.tsx
@@ -66,6 +66,10 @@ export class GitProviderSelector extends React.PureComponent<Props, State> {
         const providerNameB = providerEntryB[1];
         return providerNameA.localeCompare(providerNameB);
       })
+      .filter(providerEntry => {
+        // Exclude Bitbucket from the list as it does not provide PAT.
+        return providerEntry[0] !== 'bitbucket';
+      })
       .map(providerEntry => {
         const [provider, providerName] = providerEntry as [api.GitProvider, string];
         return (

--- a/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/const.ts
@@ -33,6 +33,7 @@ export const GIT_PROVIDERS: Record<api.GitProvider, string> = {
   'bitbucket-server': 'Bitbucket Server',
   github: 'GitHub',
   gitlab: 'GitLab',
+  bitbucket: 'Bitbucket',
 } as const;
 
 export const DEFAULT_GIT_PROVIDER: api.GitProvider = 'github';
@@ -42,4 +43,5 @@ export const GIT_PROVIDER_ENDPOINTS: Record<api.GitProvider, string> = {
   'bitbucket-server': 'https://bitbucket.org',
   github: 'https://github.com',
   gitlab: 'https://gitlab.com',
+  bitbucket: 'https://bitbucket.org/',
 } as const;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Add Bitbucket to the list of providers in the Add/Edit PAT window. If the PAT is a Bitbucket SAAS oauth 2 token, Bitbucket is selected by default in the provider's dropdown. 
* Exclude the Bitbucket item in the providers dropdown, when creating a new token, because Bitbucket SAAS does not provide PATs. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23537

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Apply the pull request image: `quay.io/eclipse/che-dashboard:pr-`
2. Apply [Bitbucket SAAS oauth configuration](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-the-bitbucket-cloud/)
3. Start a workspace from a Bitbucket Cloud repository with a devfile.
4. Go to the dashboard User Preferences -> Personal Access Tokens tab
5. Click the kebab icon on the token's item -> Edit Token, see: `Bitbucket` is selected in the `Provider Name` dropdown.
6. Close the Edit widget and click the `Add Token` Action.
7. Click the `Provider Name` dropdown, see: the `Bitbucket` item is not included to the list.
#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
