### PR TITLE
[cherry-pick] fix: buildFactoryLoaderPath method 

### DIFF
--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
@@ -106,7 +106,7 @@ describe('GitRepoLocationInput', () => {
 
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
-          'http://localhost/#http://test-location/',
+          'http://localhost/f?url=http%253A%252F%252Ftest-location%252F',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
@@ -135,7 +135,7 @@ describe('GitRepoLocationInput', () => {
 
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
-          'http://localhost/#http://test-location/',
+          'http://localhost/f?url=http%253A%252F%252Ftest-location%252F',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
@@ -164,7 +164,7 @@ describe('GitRepoLocationInput', () => {
 
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
-          'http://localhost/#http://test-location/?che-editor=che-incubator%2Fche-code%2Finsiders',
+          'http://localhost/f?che-editor=che-incubator%2Fche-code%2Finsiders&url=http%253A%252F%252Ftest-location%252F',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
@@ -193,7 +193,7 @@ describe('GitRepoLocationInput', () => {
 
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
-          'http://localhost/#http://test-location/?editor-image=custom-editor-image',
+          'http://localhost/f?editor-image=custom-editor-image&url=http%253A%252F%252Ftest-location%252F',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
@@ -222,7 +222,7 @@ describe('GitRepoLocationInput', () => {
 
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
-          'http://localhost/#http://test-location/?che-editor=che-incubator%2Fche-code%2Finsiders&editor-image=custom-editor-image',
+          'http://localhost/f?che-editor=che-incubator%2Fche-code%2Finsiders&editor-image=custom-editor-image&url=http%253A%252F%252Ftest-location%252F',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
@@ -253,7 +253,7 @@ describe('GitRepoLocationInput', () => {
 
         // the selected editor ID should NOT be added to the URL, as the URL parameter has higher priority
         expect(window.open).toHaveBeenLastCalledWith(
-          'http://localhost/#http://test-location/?che-editor=other-editor-id',
+          'http://localhost/f?che-editor=other-editor-id&url=http%253A%252F%252Ftest-location%252F',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
@@ -282,7 +282,7 @@ describe('GitRepoLocationInput', () => {
 
         // the selected editor ID should be added to the URL
         expect(window.open).toHaveBeenLastCalledWith(
-          'http://localhost/#http://test-location/?editor-image=custom-editor-image',
+          'http://localhost/f?editor-image=custom-editor-image&url=http%253A%252F%252Ftest-location%252F',
           '_blank',
         );
         expect(window.open).toHaveBeenCalledTimes(1);
@@ -347,7 +347,7 @@ describe('GitRepoLocationInput', () => {
 
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(window.open).toHaveBeenLastCalledWith(
-        'http://localhost/#git@github.com:user/repo.git?che-editor=che-incubator%2Fche-code%2Finsiders&editor-image=custom-editor-image',
+        'http://localhost/f?che-editor=che-incubator%2Fche-code%2Finsiders&editor-image=custom-editor-image&url=git%2540github.com%253Auser%252Frepo.git',
         '_blank',
       );
     });
@@ -381,7 +381,7 @@ describe('GitRepoLocationInput', () => {
 
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(window.open).toHaveBeenLastCalledWith(
-        'http://localhost/#git@github.com:user/repo.git?che-editor=other-editor-id',
+        'http://localhost/f?che-editor=other-editor-id&url=git%2540github.com%253Auser%252Frepo.git',
         '_blank',
       );
     });
@@ -418,7 +418,7 @@ describe('GitRepoLocationInput', () => {
 
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(window.open).toHaveBeenLastCalledWith(
-        'http://localhost/#git@github.com:user/repo.git?revision=test',
+        'http://localhost/f?url=git%2540github.com%253Auser%252Frepo.git%25253Frevision%25253Dtest',
         '_blank',
       );
     });

--- a/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
@@ -34,6 +34,7 @@ import { NavigateFunction } from 'react-router-dom';
 import { validateLocation } from '@/components/ImportFromGit/helpers';
 import RepoOptionsAccordion from '@/components/ImportFromGit/RepoOptionsAccordion';
 import UntrustedSourceModal from '@/components/UntrustedSourceModal';
+import { buildFactoryLoaderPath } from '@/preload/main';
 import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 import {
   EDITOR_ATTR,
@@ -123,8 +124,9 @@ class ImportFromGit extends React.PureComponent<Props, State> {
       factory.searchParams.set(REVISION_ATTR, this.state.gitBranch);
     }
 
+    const factoryLoaderPath = buildFactoryLoaderPath(factory.toString());
     // open a new page to handle that
-    window.open(`${window.location.origin}/#${factory.toString()}`, '_blank');
+    window.open(`${window.location.origin}${factoryLoaderPath}`, '_blank');
   }
 
   private handleChange(location: string): void {

--- a/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
+++ b/packages/dashboard-frontend/src/preload/__tests__/main.spec.ts
@@ -15,11 +15,21 @@ import { REMOTES_ATTR } from '@/services/helpers/factoryFlow/buildFactoryParams'
 import SessionStorageService, { SessionStorageKey } from '@/services/session-storage';
 
 describe('test buildFactoryLoaderPath()', () => {
+  describe('URL', () => {
+    test('unsupported parameter', () => {
+      const result = buildFactoryLoaderPath(
+        'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?unsupportedParameter=foo',
+      );
+      expect(result).toEqual(
+        '/f?url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2%25253FunsupportedParameter%25253Dfoo',
+      );
+    });
+  });
   describe('SSHLocation', () => {
     test('new policy', () => {
       const result = buildFactoryLoaderPath('git@github.com:eclipse-che/che-dashboard.git?new=');
       expect(result).toEqual(
-        '/f?policies.create=perclick&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+        '/f?policies.create=perclick&url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git',
       );
     });
 
@@ -28,7 +38,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'git@github.com:eclipse-che/che-dashboard.git?che-editor=che-incubator/checode/insiders',
       );
       expect(result).toEqual(
-        '/f?che-editor=che-incubator%2Fchecode%2Finsiders&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+        '/f?che-editor=che-incubator%2Fchecode%2Finsiders&url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git',
       );
     });
 
@@ -37,7 +47,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'git@github.com:eclipse-che/che-dashboard.git?editor-image=quay.io/mloriedo/che-code:copilot-builtin',
       );
       expect(result).toEqual(
-        '/f?editor-image=quay.io%2Fmloriedo%2Fche-code%3Acopilot-builtin&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+        '/f?editor-image=quay.io%2Fmloriedo%2Fche-code%3Acopilot-builtin&url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git',
       );
     });
 
@@ -46,7 +56,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'git@github.com:eclipse-che/che-dashboard.git?devfilePath=devfilev2.yaml',
       );
       expect(result).toEqual(
-        '/f?override.devfileFilename=devfilev2.yaml&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+        '/f?override.devfileFilename=devfilev2.yaml&url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git',
       );
     });
 
@@ -55,7 +65,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'git@github.com:eclipse-che/che-dashboard.git?devWorkspace=/devfiles/devworkspace-che-theia-latest.yaml',
       );
       expect(result).toEqual(
-        '/f?devWorkspace=%2Fdevfiles%2Fdevworkspace-che-theia-latest.yaml&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+        '/f?devWorkspace=%2Fdevfiles%2Fdevworkspace-che-theia-latest.yaml&url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git',
       );
     });
 
@@ -64,7 +74,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'git@github.com:eclipse-che/che-dashboard.git?storageType=ephemeral',
       );
       expect(result).toEqual(
-        '/f?storageType=ephemeral&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+        '/f?storageType=ephemeral&url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git',
       );
     });
 
@@ -73,7 +83,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'git@github.com:eclipse-che/che-dashboard.git?existing=che-dashboard',
       );
       expect(result).toEqual(
-        '/f?existing=che-dashboard&url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git',
+        '/f?existing=che-dashboard&url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git',
       );
     });
 
@@ -82,7 +92,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'git@github.com:eclipse-che/che-dashboard.git?unsupportedParameter=foo',
       );
       expect(result).toEqual(
-        '/f?url=git%40github.com%3Aeclipse-che%2Fche-dashboard.git%3FunsupportedParameter%3Dfoo',
+        '/f?url=git%2540github.com%253Aeclipse-che%252Fche-dashboard.git%25253FunsupportedParameter%25253Dfoo',
       );
     });
   });
@@ -93,7 +103,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?new=',
       );
       expect(result).toEqual(
-        '/f?policies.create=perclick&url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2',
+        '/f?policies.create=perclick&url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2',
       );
     });
 
@@ -102,7 +112,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=che-incubator/checode/insiders',
       );
       expect(result).toEqual(
-        '/f?che-editor=che-incubator%2Fchecode%2Finsiders&url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2',
+        '/f?che-editor=che-incubator%2Fchecode%2Finsiders&url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2',
       );
     });
 
@@ -111,7 +121,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?devfilePath=devfilev2.yaml',
       );
       expect(result).toEqual(
-        '/f?override.devfileFilename=devfilev2.yaml&url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2',
+        '/f?override.devfileFilename=devfilev2.yaml&url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2',
       );
     });
 
@@ -120,7 +130,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?devWorkspace=/devfiles/devworkspace-che-theia-latest.yaml',
       );
       expect(result).toEqual(
-        '/f?devWorkspace=%2Fdevfiles%2Fdevworkspace-che-theia-latest.yaml&url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2',
+        '/f?devWorkspace=%2Fdevfiles%2Fdevworkspace-che-theia-latest.yaml&url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2',
       );
     });
 
@@ -129,7 +139,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?storageType=ephemeral',
       );
       expect(result).toEqual(
-        '/f?storageType=ephemeral&url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2',
+        '/f?storageType=ephemeral&url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2',
       );
     });
 
@@ -138,7 +148,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?image=quay.io/devfile/universal-developer-image:latest',
       );
       expect(result).toEqual(
-        '/f?image=quay.io%2Fdevfile%2Funiversal-developer-image%3Alatest&url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2',
+        '/f?image=quay.io%2Fdevfile%2Funiversal-developer-image%3Alatest&url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2',
       );
     });
 
@@ -147,7 +157,7 @@ describe('test buildFactoryLoaderPath()', () => {
         'https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?unsupportedParameter=foo',
       );
       expect(result).toEqual(
-        '/f?url=https%3A%2F%2Fgithub.com%2Fche-samples%2Fjava-spring-petclinic%2Ftree%2Fdevfilev2%3FunsupportedParameter%3Dfoo',
+        '/f?url=https%253A%252F%252Fgithub.com%252Fche-samples%252Fjava-spring-petclinic%252Ftree%252Fdevfilev2%25253FunsupportedParameter%25253Dfoo',
       );
     });
   });
@@ -201,7 +211,9 @@ describe('test redirectToDashboard()', () => {
 
       redirectToDashboard();
       expect(spyWindowLocation).toHaveBeenCalledWith(
-        origin + '/dashboard/f?policies.create=perclick&url=' + encodeURIComponent(repoUrl),
+        origin +
+          '/dashboard/f?policies.create=perclick&url=' +
+          encodeURIComponent(encodeURIComponent(repoUrl)),
       );
     });
 
@@ -214,7 +226,7 @@ describe('test redirectToDashboard()', () => {
       expect(spyWindowLocation).toHaveBeenCalledWith(
         origin +
           '/dashboard/f?override.devfileFilename=my-devfile.yaml&url=' +
-          encodeURIComponent(repoUrl),
+          encodeURIComponent(encodeURIComponent(repoUrl)),
       );
     });
   });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes `buildFactoryLoaderPath` method by encoding parameters of target request.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1385 to the 7.109.x branch