### PR TITLE
fix: registerAirGapSampleRoute

### DIFF
--- a/packages/dashboard-backend/src/routes/api/airGapSample.ts
+++ b/packages/dashboard-backend/src/routes/api/airGapSample.ts
@@ -26,6 +26,15 @@ const rateLimitConfig = {
     },
   },
 };
+const querystring = {
+  type: 'object',
+  required: ['id'],
+  properties: {
+    id: {
+      type: 'string',
+    },
+  },
+};
 
 export function registerAirGapSampleRoute(instance: FastifyInstance) {
   instance.register(async server => {
@@ -41,7 +50,7 @@ export function registerAirGapSampleRoute(instance: FastifyInstance) {
 
     server.get(
       `${baseApiPath}/airgap-sample/devfile/download`,
-      Object.assign({}, rateLimitConfig, getSchema({ tags })),
+      Object.assign({}, rateLimitConfig, getSchema({ tags, querystring })),
       async function (request: FastifyRequest, reply: FastifyReply) {
         const sampleId = (request.query as { id: string })['id'];
         if (!sampleId) {
@@ -65,7 +74,7 @@ export function registerAirGapSampleRoute(instance: FastifyInstance) {
 
     server.get(
       `${baseApiPath}/airgap-sample/project/download`,
-      Object.assign({}, rateLimitConfig, getSchema({ tags })),
+      Object.assign({}, rateLimitConfig, getSchema({ tags, querystring })),
       async function (request: FastifyRequest, reply: FastifyReply) {
         const sampleId = (request.query as { id: string })['id'];
         if (!sampleId) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR add query properties for swagger data models. This will allow to use swagger to check the Air Gapped sample API.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1428" height="890" alt="Знімок екрана 2025-09-30 о 05 03 34" src="https://github.com/user-attachments/assets/ae28287b-28f2-4a3e-afbe-369bbb5aa6e7" />


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
