### PR TITLE
[cherry-pick] fix: import from Git

### DIFF
--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/__tests__/index.spec.tsx
@@ -65,7 +65,7 @@ describe('GitRepoOptions', () => {
       [{ name: 'test', url: 'http://test' }],
       'test-devfile-path',
       false,
-      'git@ssh-url',
+      'git@ssh-url:dummy/che.git',
     );
 
     expect(screen.queryByTestId('git-branch-component')).not.toBeNull();

--- a/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/index.tsx
@@ -18,6 +18,7 @@ import { AdditionalGitRemotes } from '@/components/ImportFromGit/RepoOptionsAcco
 import { GitBranchField } from '@/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/GitBranchField';
 import { PathToDevfileField } from '@/components/ImportFromGit/RepoOptionsAccordion/GitRepoOptions/PathToDevfileField';
 import { GitRemote } from '@/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/getGitRemotes';
+import { FactoryLocationAdapter } from '@/services/factory-location-adapter';
 
 export type Props = {
   gitBranch: string | undefined;
@@ -90,10 +91,9 @@ export class GitRepoOptions extends React.PureComponent<Props, State> {
   public render() {
     const { hasSupportedGitService, location } = this.props;
     const { gitBranch, remotes, devfilePath } = this.state;
-    const isSSHUrl = location.startsWith('git@') || location.startsWith('ssh://');
     return (
       <Form isHorizontal={true} onSubmit={e => e.preventDefault()}>
-        {(hasSupportedGitService || isSSHUrl) && (
+        {(hasSupportedGitService || FactoryLocationAdapter.isSshLocation(location)) && (
           <GitBranchField
             onChange={gitBranch => this.handleGitBranch(gitBranch)}
             gitBranch={gitBranch}

--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/index.spec.tsx
@@ -418,7 +418,7 @@ describe('GitRepoLocationInput', () => {
 
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(window.open).toHaveBeenLastCalledWith(
-        'http://localhost/f?url=git%2540github.com%253Auser%252Frepo.git%25253Frevision%25253Dtest',
+        'http://localhost/f?revision=test&url=git%2540github.com%253Auser%252Frepo.git',
         '_blank',
       );
     });

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -27,6 +27,7 @@ export const EDITOR_IMAGE_ATTR = 'editor-image';
 export const USE_DEFAULT_DEVFILE = 'useDefaultDevfile';
 export const DEBUG_WORKSPACE_START = 'debugWorkspaceStart';
 export const EXISTING_WORKSPACE_NAME = 'existing';
+export const REVISION = 'revision';
 export const PROPAGATE_FACTORY_ATTRS = [
   'workspaceDeploymentAnnotations',
   'workspaceDeploymentLabels',
@@ -41,6 +42,7 @@ export const PROPAGATE_FACTORY_ATTRS = [
   MEMORY_LIMIT_ATTR,
   EDITOR_IMAGE_ATTR,
   EXISTING_WORKSPACE_NAME,
+  REVISION,
 ];
 export const OVERRIDE_ATTR_PREFIX = 'override.';
 export const DEFAULT_POLICIES_CREATE = 'peruser';


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This pull request fixes the **Import from Git** widget.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1390 to the 7.109.x branch