### PR TITLE
chore: Set HOST_USERS env var

### DIFF
--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.manageContainerSccAttribute.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.manageContainerSccAttribute.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.manageContainerSccAttribute.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/__tests__/devWorkspaceClient.manageContainerSccAttribute.spec.ts
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import mockAxios from 'axios';
+
+import { container } from '@/inversify.config';
+import * as DwApi from '@/services/backend-client/devWorkspaceApi';
+import devfileApi from '@/services/devfileApi';
+import { DevWorkspaceClient } from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+
+describe('DevWorkspace client', () => {
+  let client: DevWorkspaceClient;
+  let spyPatchWorkspace: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockAxios.get = jest.fn();
+    client = container.get(DevWorkspaceClient);
+
+    spyPatchWorkspace = jest
+      .spyOn(DwApi, 'patchWorkspace')
+      .mockResolvedValue({ devWorkspace: {} as devfileApi.DevWorkspace, headers: {} });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('Add attribute, add env var[s]', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: false,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {},
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'add',
+        path: '/spec/template/attributes/controller.devfile.io~1scc',
+        value: 'container-run',
+      },
+      {
+        op: 'add',
+        path: '/spec/template/components/0/container/env',
+        value: [{ name: 'HOST_USERS', value: 'false' }],
+      },
+    ]);
+  });
+
+  it('Add attribute[s], add env var[s]', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: false,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'add',
+        path: '/spec/template/attributes',
+        value: { 'controller.devfile.io/scc': 'container-run' },
+      },
+      {
+        op: 'add',
+        path: '/spec/template/components/0/container/env',
+        value: [{ name: 'HOST_USERS', value: 'false' }],
+      },
+    ]);
+  });
+
+  it('Keep attribute, keep env var', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: false,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {
+          'controller.devfile.io/scc': 'container-run',
+        },
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+              env: [{ name: 'HOST_USERS', value: 'false' }],
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('Keep attribute, keep env var because scc does not match', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: false,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {
+          'controller.devfile.io/scc': 'unknown-scc',
+        },
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+              env: [{ name: 'HOST_USERS', value: 'unknown-host-users' }],
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('Keep attribute, add env var', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: false,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {
+          'controller.devfile.io/scc': 'container-run',
+        },
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+              env: [],
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'add',
+        path: '/spec/template/components/0/container/env/-',
+        value: { name: 'HOST_USERS', value: 'false' },
+      },
+    ]);
+  });
+
+  it('Keep attribute, add env var[s]', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: false,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {
+          'controller.devfile.io/scc': 'container-run',
+        },
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'add',
+        path: '/spec/template/components/0/container/env',
+        value: [{ name: 'HOST_USERS', value: 'false' }],
+      },
+    ]);
+  });
+
+  it('Keep attribute, replace env var', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: false,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {
+          'controller.devfile.io/scc': 'container-run',
+        },
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+              env: [{ name: 'HOST_USERS', value: 'true' }],
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'replace',
+        path: '/spec/template/components/0/container/env/0',
+        value: { name: 'HOST_USERS', value: 'false' },
+      },
+    ]);
+  });
+
+  it('Switch from run capabilities to build capabilities', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: true,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+      containerBuild: {
+        disableContainerBuildCapabilities: false,
+        containerBuildConfiguration: { openShiftSecurityContextConstraint: 'container-build' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {
+          'controller.devfile.io/scc': 'container-run',
+        },
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+              env: [{ name: 'HOST_USERS', value: 'false' }],
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('Delete attribute, delete env var', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: true,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+      containerBuild: {
+        disableContainerBuildCapabilities: true,
+        containerBuildConfiguration: { openShiftSecurityContextConstraint: 'container-build' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        attributes: {
+          'controller.devfile.io/scc': 'container-run',
+        },
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+              env: [{ name: 'HOST_USERS', value: 'false' }],
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).toHaveBeenCalledWith(namespace, name, [
+      {
+        op: 'remove',
+        path: '/spec/template/attributes/controller.devfile.io~1scc',
+      },
+      {
+        op: 'remove',
+        path: '/spec/template/components/0/container/env/0',
+      },
+    ]);
+  });
+
+  it('Attribute already deleted, env var already deleted', async () => {
+    const config = {
+      containerRun: {
+        disableContainerRunCapabilities: true,
+        containerRunConfiguration: { openShiftSecurityContextConstraint: 'container-run' },
+      },
+      containerBuild: {
+        disableContainerBuildCapabilities: true,
+        containerBuildConfiguration: { openShiftSecurityContextConstraint: 'container-build' },
+      },
+    } as api.IServerConfig;
+
+    const namespace = 'test';
+    const name = 'wksp-test';
+    const workspace = new DevWorkspaceBuilder()
+      .withName(name)
+      .withNamespace(namespace)
+      .withTemplate({
+        components: [
+          {
+            name: 'universal-developer-image',
+            container: {
+              image: 'quay.io/devfile/universal-developer-image:ubi8-latest',
+            },
+          },
+        ],
+      })
+      .build();
+
+    await client.manageContainerSccAttribute(workspace, config);
+    expect(spyPatchWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 Red Hat, Inc.
+ * Copyright (c) 2018-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
+++ b/packages/dashboard-frontend/src/services/workspace-client/devworkspace/devWorkspaceClient.ts
@@ -644,7 +644,7 @@ export class DevWorkspaceClient {
       const envIndex = container.env.findIndex(value => value.name === this.hostUsersEnvName);
       if (envIndex >= 0) {
         const env = container.env[envIndex];
-        // If value is different, that replace it
+        // If value is different, then replace it
         if (env.value !== hostUsers.toString()) {
           const path = `/spec/template/components/${cmpIndex}/container/env/${envIndex}`;
           patch.push({ op: 'replace', path, value });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Set HOST_USERS env var depending on enabled container capabilities

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-8320

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
All cases on OpenShift cluster

#### Release Notes
<!-- markdown to be included in marketing announcement -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A