### PR TITLE
fix: UntrustedSourceModal location

### DIFF
--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
@@ -20,6 +20,19 @@ describe('helpers', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+  describe('getRepoLocation', () => {
+    test('with parameters', () => {
+      const location = helpers.getRepoLocation('https://dummy-repo.git?policies.create=perclick');
+
+      expect(location).toEqual('https://dummy-repo.git');
+    });
+
+    test('without parameters', () => {
+      const location = helpers.getRepoLocation('https://dummy-repo.git');
+
+      expect(location).toEqual('https://dummy-repo.git');
+    });
+  });
 
   describe('validateLocation', () => {
     describe('has SSH key', () => {

--- a/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
@@ -342,6 +342,10 @@ export function getAdvancedOptionsFromLocation(location: string): {
   };
 }
 
+export function getRepoLocation(factoryLocation: string): string {
+  return factoryLocation.split('?')[0];
+}
+
 export interface IGitRepoOptions {
   location?: string;
   gitBranch?: string | undefined;

--- a/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/index.tsx
@@ -31,7 +31,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { NavigateFunction } from 'react-router-dom';
 
-import { validateLocation } from '@/components/ImportFromGit/helpers';
+import { getRepoLocation, validateLocation } from '@/components/ImportFromGit/helpers';
 import RepoOptionsAccordion from '@/components/ImportFromGit/RepoOptionsAccordion';
 import UntrustedSourceModal from '@/components/UntrustedSourceModal';
 import { buildFactoryLoaderPath } from '@/preload/main';
@@ -223,10 +223,11 @@ class ImportFromGit extends React.PureComponent<Props, State> {
 
   public render() {
     const { isConfirmationOpen, location, locationValidated } = this.state;
+    const repoLocation = getRepoLocation(location) || location;
     return (
       <>
         <UntrustedSourceModal
-          location={location}
+          location={repoLocation}
           isOpen={isConfirmationOpen}
           onContinue={() => this.handleConfirmationOnContinue()}
           onClose={() => this.handleConfirmationOnClose()}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes **UntrustedSourceModal** location to prevent show **Trust the Authors** popup twice.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<img width="1183" height="437" alt="Знімок екрана 2025-10-08 о 08 50 27" src="https://github.com/user-attachments/assets/ed4cb880-cd32-4f7c-a030-56bde3bc3834" />

### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-9514

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
