### PR TITLE
feat: add warning callback to workspace progress steps

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CommonSteps/CheckRunningWorkspacesLimit/__tests__/index.spec.tsx
@@ -74,6 +74,7 @@ jest.mock('@/store/DevWorkspacesCluster', () => {
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const mockNavigate = jest.fn();
@@ -643,6 +644,7 @@ function getComponent(store: Store, localState?: Partial<State>): React.ReactEle
       onNextStep={mockOnNextStep}
       onRestart={mockOnRestart}
       onError={mockOnError}
+      onWarning={mockOnWarning}
       onHideError={mockOnHideError}
     />
   );

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/__tests__/index.spec.tsx
@@ -71,6 +71,7 @@ let location: Location;
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const factoryUrl = 'https://factory-url';
@@ -995,6 +996,7 @@ function getComponent(
       onNextStep={mockOnNextStep}
       onRestart={mockOnRestart}
       onError={mockOnError}
+      onWarning={mockOnWarning}
       onHideError={mockOnHideError}
     />
   );

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/__tests__/index.spec.tsx
@@ -66,6 +66,7 @@ const mockTabManagerRename = jest.fn();
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const resourcesUrl = 'https://resources-url';
@@ -491,6 +492,7 @@ function getComponent(store: Store, searchParams: URLSearchParams): React.ReactE
       onNextStep={mockOnNextStep}
       onRestart={mockOnRestart}
       onError={mockOnError}
+      onWarning={mockOnWarning}
       onHideError={mockOnHideError}
     />
   );

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
@@ -50,6 +50,7 @@ const mockTabManagerReplace = jest.fn();
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const resourcesUrl = 'https://resources-url';
@@ -774,6 +775,7 @@ function getComponent(store: Store, searchParams: URLSearchParams): React.ReactE
       onNextStep={mockOnNextStep}
       onRestart={mockOnRestart}
       onError={mockOnError}
+      onWarning={mockOnWarning}
       onHideError={mockOnHideError}
     />
   );

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CreateWorkspace/__tests__/index.spec.tsx
@@ -27,6 +27,7 @@ const { renderComponent } = getComponentRenderer(getComponent);
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const searchParams = new URLSearchParams();
@@ -68,6 +69,7 @@ function getComponent(store: Store, searchParams: URLSearchParams): React.ReactE
         onNextStep={mockOnNextStep}
         onRestart={mockOnRestart}
         onError={mockOnError}
+        onWarning={mockOnWarning}
         onHideError={mockOnHideError}
       />
     </Provider>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/__tests__/index.spec.tsx
@@ -13,6 +13,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { FACTORY_LINK_ATTR } from '@eclipse-che/common';
+import { AlertVariant } from '@patternfly/react-core';
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import React from 'react';
@@ -71,6 +72,7 @@ const { renderComponent } = getComponentRenderer(getComponent);
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const factoryUrl = 'https://factory-url';
@@ -348,6 +350,11 @@ describe('Creating steps, fetching a devfile', () => {
   describe('unsupported git provider', () => {
     let emptyStore: Store;
     const rejectReason = 'Failed to fetch devfile';
+    const alertItem = {
+      key: 'Inspecting repo',
+      title: 'Failed to fetch devfile. Workspace will start from the default devfile.',
+      variant: AlertVariant.warning,
+    };
 
     beforeEach(() => {
       emptyStore = new MockStoreBuilder().build();
@@ -360,6 +367,7 @@ describe('Creating steps, fetching a devfile', () => {
       await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
 
       await waitFor(() => expect(mockOnError).not.toHaveBeenCalled());
+      expect(mockOnWarning).toHaveBeenCalledWith(alertItem);
       expect(mockOnNextStep).toHaveBeenCalled();
     });
   });
@@ -710,6 +718,7 @@ function getComponent(
         onNextStep={mockOnNextStep}
         onRestart={mockOnRestart}
         onError={mockOnError}
+        onWarning={mockOnWarning}
         onHideError={mockOnHideError}
       />
     </Provider>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -225,7 +225,7 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
           title: 'Failed to fetch devfile. Workspace will start from the default devfile.',
           variant: AlertVariant.warning,
         };
-        this.props.onWarning(alertItem);
+        this.handleWarning(alertItem);
         return true;
       }
       throw e;

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -220,6 +220,12 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
         errorMessage.startsWith('Could not reach devfile')
       ) {
         this.setState({ useDefaultDevfile: true });
+        const alertItem = {
+          key: this.name,
+          title: 'Failed to fetch devfile. Workspace will start from the default devfile.',
+          variant: AlertVariant.warning,
+        };
+        this.props.onWarning(alertItem);
         return true;
       }
       throw e;

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/__tests__/index.spec.tsx
@@ -53,6 +53,7 @@ const { renderComponent } = getComponentRenderer(getComponent);
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const resourcesUrl = 'https://resources-url';
@@ -262,6 +263,7 @@ function getComponent(store: Store, searchParams: URLSearchParams): React.ReactE
         onNextStep={mockOnNextStep}
         onRestart={mockOnRestart}
         onError={mockOnError}
+        onWarning={mockOnWarning}
         onHideError={mockOnHideError}
       />
     </Provider>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Initialize/__tests__/index.spec.tsx
@@ -34,6 +34,7 @@ const { renderComponent } = getComponentRenderer(getComponent);
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 jest.mock('@/services/helpers/location', () => ({
@@ -464,6 +465,7 @@ function getComponent(store: Store, searchParams: URLSearchParams): React.ReactE
         onNextStep={mockOnNextStep}
         onRestart={mockOnRestart}
         onError={mockOnError}
+        onWarning={mockOnWarning}
         onHideError={mockOnHideError}
       />
     </Provider>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/ProgressStep.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/ProgressStep.tsx
@@ -25,6 +25,7 @@ export type ProgressStepProps = {
   location: Location;
   navigate: NavigateFunction;
   onError: (alertItem: AlertItem) => void;
+  onWarning: (alertItem: AlertItem) => void;
   onHideError: (key: string) => void;
   onNextStep: () => void;
   onRestart: (tabName?: LoaderTab) => void;
@@ -81,6 +82,10 @@ export abstract class ProgressStep<
     });
     const alertItem = this.buildAlertItem(error);
     this.props.onError(alertItem);
+  }
+
+  protected handleWarning(alertItem: AlertItem) {
+    this.props.onWarning(alertItem);
   }
 
   protected clearStepError() {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/Initialize/__tests__/index.spec.tsx
@@ -34,6 +34,7 @@ const { renderComponent } = getComponentRenderer(getComponent);
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const namespace = 'che-user';
@@ -472,6 +473,7 @@ function getComponent(
         onNextStep={mockOnNextStep}
         onRestart={mockOnRestart}
         onError={mockOnError}
+        onWarning={mockOnWarning}
         onHideError={mockOnHideError}
       />
     </Provider>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/OpenWorkspace/__tests__/index.spec.tsx
@@ -41,6 +41,7 @@ const { renderComponent } = getComponentRenderer(getComponent);
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const namespace = 'che-user';
@@ -504,6 +505,7 @@ function getComponent(
         onNextStep={mockOnNextStep}
         onRestart={mockOnRestart}
         onError={mockOnError}
+        onWarning={mockOnWarning}
         onHideError={mockOnHideError}
       />
     </Provider>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/__tests__/index.spec.tsx
@@ -49,6 +49,7 @@ jest.mock('@/store/Workspaces', () => {
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const { renderComponent } = getComponentRenderer(getComponent);
@@ -911,6 +912,7 @@ function getComponent(
         onNextStep={mockOnNextStep}
         onRestart={mockOnRestart}
         onError={mockOnError}
+        onWarning={mockOnWarning}
         onHideError={mockOnHideError}
       />
     </Provider>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/index.spec.tsx
@@ -37,6 +37,7 @@ jest.mock('@/components/WorkspaceProgress/StepTitle');
 const mockOnNextStep = jest.fn();
 const mockOnRestart = jest.fn();
 const mockOnError = jest.fn();
+const mockOnWarning = jest.fn();
 const mockOnHideError = jest.fn();
 
 const { renderComponent, createSnapshot } = getComponentRenderer(getComponent);
@@ -186,6 +187,7 @@ function getComponent(condition: ConditionType, _matchParams = matchParams): Rea
           onNextStep={mockOnNextStep}
           onRestart={mockOnRestart}
           onError={mockOnError}
+          onWarning={mockOnWarning}
           onHideError={mockOnHideError}
         />
       </React.Fragment>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__mocks__/ProgressStep.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__mocks__/ProgressStep.tsx
@@ -20,12 +20,18 @@ export class ProgressStep extends React.Component<ProgressStepProps, ProgressSte
   protected readonly name: string;
 
   public render() {
-    const { distance, onError, onNextStep, onRestart } = this.props;
+    const { distance, onError, onWarning, onNextStep, onRestart } = this.props;
     const alertItem: AlertItem = {
       title: 'Error',
       key: 'error',
       variant: AlertVariant.danger,
       children: `Error in step ${this.name}`,
+    };
+    const warningItem: AlertItem = {
+      title: 'Warning',
+      key: 'warning',
+      variant: AlertVariant.warning,
+      children: `Warning in step ${this.name}`,
     };
     return (
       <div data-testid="progress-step">
@@ -37,6 +43,13 @@ export class ProgressStep extends React.Component<ProgressStepProps, ProgressSte
           name="onError"
           type="button"
           value="onError"
+        />
+        <input
+          onClick={() => onWarning(warningItem)}
+          data-testid="onWarning"
+          name="onWarning"
+          type="button"
+          value="onWarning"
         />
         <input
           onClick={() => onRestart()}

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
@@ -49,6 +49,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                 value="onError"
               />
               <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
+              />
+              <input
                 data-testid="onRestart"
                 name="onRestart"
                 onClick={[Function]}
@@ -103,6 +110,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                 value="onError"
               />
               <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
+              />
+              <input
                 data-testid="onRestart"
                 name="onRestart"
                 onClick={[Function]}
@@ -155,6 +169,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                 onClick={[Function]}
                 type="button"
                 value="onError"
+              />
+              <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
               />
               <input
                 data-testid="onRestart"
@@ -214,6 +235,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                     value="onError"
                   />
                   <input
+                    data-testid="onWarning"
+                    name="onWarning"
+                    onClick={[Function]}
+                    type="button"
+                    value="onWarning"
+                  />
+                  <input
                     data-testid="onRestart"
                     name="onRestart"
                     onClick={[Function]}
@@ -268,6 +296,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                     value="onError"
                   />
                   <input
+                    data-testid="onWarning"
+                    name="onWarning"
+                    onClick={[Function]}
+                    type="button"
+                    value="onWarning"
+                  />
+                  <input
                     data-testid="onRestart"
                     name="onRestart"
                     onClick={[Function]}
@@ -320,6 +355,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                     onClick={[Function]}
                     type="button"
                     value="onError"
+                  />
+                  <input
+                    data-testid="onWarning"
+                    name="onWarning"
+                    onClick={[Function]}
+                    type="button"
+                    value="onWarning"
                   />
                   <input
                     data-testid="onRestart"
@@ -378,6 +420,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                 value="onError"
               />
               <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
+              />
+              <input
                 data-testid="onRestart"
                 name="onRestart"
                 onClick={[Function]}
@@ -432,6 +481,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                 value="onError"
               />
               <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
+              />
+              <input
                 data-testid="onRestart"
                 name="onRestart"
                 onClick={[Function]}
@@ -473,7 +529,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
           aria-current="step"
           aria-disabled={null}
           className="pf-v6-c-wizard__nav-link pf-m-current"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-94"
+          data-ouia-component-id="OUIA-Generated-WizardNavItem-118"
           data-ouia-component-type="PF6/WizardNavItem"
           data-ouia-safe={true}
           disabled={false}
@@ -503,6 +559,13 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
                 value="onError"
               />
               <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
+              />
+              <input
                 data-testid="onRestart"
                 name="onRestart"
                 onClick={[Function]}
@@ -527,7 +590,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
           aria-current={false}
           aria-disabled={null}
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-95"
+          data-ouia-component-id="OUIA-Generated-WizardNavItem-119"
           data-ouia-component-type="PF6/WizardNavItem"
           data-ouia-safe={true}
           disabled={false}
@@ -557,6 +620,13 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
                 value="onError"
               />
               <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
+              />
+              <input
                 data-testid="onRestart"
                 name="onRestart"
                 onClick={[Function]}
@@ -581,7 +651,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
           aria-current={false}
           aria-disabled={null}
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-96"
+          data-ouia-component-id="OUIA-Generated-WizardNavItem-120"
           data-ouia-component-type="PF6/WizardNavItem"
           data-ouia-safe={true}
           disabled={false}
@@ -611,6 +681,13 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
                 value="onError"
               />
               <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
+              />
+              <input
                 data-testid="onRestart"
                 name="onRestart"
                 onClick={[Function]}
@@ -635,7 +712,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
           aria-current={false}
           aria-disabled={null}
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-97"
+          data-ouia-component-id="OUIA-Generated-WizardNavItem-121"
           data-ouia-component-type="PF6/WizardNavItem"
           data-ouia-safe={true}
           disabled={false}
@@ -663,6 +740,13 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
                 onClick={[Function]}
                 type="button"
                 value="onError"
+              />
+              <input
+                data-testid="onWarning"
+                name="onWarning"
+                onClick={[Function]}
+                type="button"
+                value="onWarning"
               />
               <input
                 data-testid="onRestart"

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/index.spec.tsx
@@ -144,7 +144,7 @@ describe('LoaderProgress', () => {
 
       async function triggerStepEvent(
         step: HTMLElement,
-        event: 'onError' | 'onNextStep' | 'onRestart',
+        event: 'onError' | 'onWarning' | 'onNextStep' | 'onRestart',
       ) {
         const errorButton = within(step).getByRole('button', { name: event });
         await user.click(errorButton);
@@ -186,6 +186,76 @@ describe('LoaderProgress', () => {
 
           /* still no alert notifications in the document */
           expect(getAlertGroup()).toBeNull();
+        });
+      });
+
+      describe('onWarning', () => {
+        test('alert notification for the active step', async () => {
+          renderComponent(location, store, searchParams, false);
+
+          /* no alert notification */
+          expect(getAlertGroup()).toBeNull();
+
+          const steps = getSteps();
+
+          // trigger a warning in the first (active) step
+          await triggerStepEvent(steps[0], 'onWarning');
+
+          /* alert notification in document */
+
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const alertGroup = getAlertGroup()!;
+          expect(getAlertGroup).not.toBeNull();
+
+          expect(
+            within(alertGroup).queryByText('Warning in step Creating step: Initialize'),
+          ).not.toBeNull();
+        });
+
+        test('handle warning for an non-active step', async () => {
+          renderComponent(location, store, searchParams, false);
+
+          /* no alert notification */
+          expect(getAlertGroup()).toBeNull();
+
+          const steps = getSteps();
+
+          /* trigger a warning in the second (non-active) step */
+          await triggerStepEvent(steps[1], 'onWarning');
+
+          /* still no alert notifications in the document */
+          expect(getAlertGroup()).toBeNull();
+        });
+
+        test('does not add duplicate warnings', async () => {
+          renderComponent(location, store, searchParams, false);
+
+          /* no alert notification */
+          expect(getAlertGroup()).toBeNull();
+
+          const steps = getSteps();
+
+          // trigger a warning in the first (active) step
+          await triggerStepEvent(steps[0], 'onWarning');
+
+          /* alert notification in document */
+
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          let alertGroup = getAlertGroup()!;
+          expect(getAlertGroup).not.toBeNull();
+
+          const alerts = within(alertGroup).getAllByRole('listitem');
+          expect(alerts).toHaveLength(1);
+
+          // trigger the same warning again
+          await triggerStepEvent(steps[0], 'onWarning');
+
+          /* still only one alert notification in the document */
+
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          alertGroup = getAlertGroup()!;
+          const alertsAfterDuplicate = within(alertGroup).getAllByRole('listitem');
+          expect(alertsAfterDuplicate).toHaveLength(1);
         });
       });
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -258,6 +258,21 @@ class Progress extends React.Component<Props, State> {
     });
   }
 
+  private handleStepsShowWarning(step: StepId, alertItem: AlertItem): void {
+    if (step !== this.state.activeStepId) {
+      return;
+    }
+
+    const { alertItems } = this.state;
+    if (alertItems.some(item => item.key === alertItem.key)) {
+      return;
+    }
+
+    this.setState({
+      alertItems: [...alertItems, alertItem],
+    });
+  }
+
   private handleCloseStepAlert(key: string): void {
     const { alertItems } = this.state;
 
@@ -351,6 +366,7 @@ class Progress extends React.Component<Props, State> {
           navigate={navigate}
           searchParams={searchParams}
           onError={alertItem => this.handleStepsShowAlert(Step.INITIALIZE, alertItem)}
+          onWarning={alertItem => this.handleStepsShowWarning(Step.INITIALIZE, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
           onNextStep={() => this.handleStepsGoToNext(Step.INITIALIZE)}
           onRestart={tab => this.handleStepsRestart(Step.INITIALIZE, tab)}
@@ -376,6 +392,7 @@ class Progress extends React.Component<Props, State> {
           navigate={navigate}
           matchParams={matchParams}
           onError={alertItem => this.handleStepsShowAlert(Step.INITIALIZE, alertItem)}
+          onWarning={alertItem => this.handleStepsShowWarning(Step.INITIALIZE, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
           onNextStep={() => this.handleStepsGoToNext(Step.INITIALIZE)}
           onRestart={tab => this.handleStepsRestart(Step.INITIALIZE, tab)}
@@ -402,6 +419,7 @@ class Progress extends React.Component<Props, State> {
             navigate={navigate}
             matchParams={matchParams}
             onError={alertItem => this.handleStepsShowAlert(Step.LIMIT_CHECK, alertItem)}
+            onWarning={alertItem => this.handleStepsShowWarning(Step.LIMIT_CHECK, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
             onNextStep={() => this.handleStepsGoToNext(Step.LIMIT_CHECK)}
             onRestart={tab => this.handleStepsRestart(Step.LIMIT_CHECK, tab)}
@@ -437,6 +455,7 @@ class Progress extends React.Component<Props, State> {
             navigate={navigate}
             searchParams={searchParams}
             onError={alertItem => this.handleStepsShowAlert(Step.CREATE, alertItem)}
+            onWarning={alertItem => this.handleStepsShowWarning(Step.CREATE, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
             onNextStep={() => this.handleStepsGoToNext(Step.CREATE)}
             onRestart={tab => this.handleStepsRestart(Step.CREATE, tab)}
@@ -463,6 +482,7 @@ class Progress extends React.Component<Props, State> {
           navigate={navigate}
           searchParams={searchParams}
           onError={alertItem => this.handleStepsShowAlert(Step.CONFLICT_CHECK, alertItem)}
+          onWarning={alertItem => this.handleStepsShowWarning(Step.CONFLICT_CHECK, alertItem)}
           onHideError={alertId => this.handleCloseStepAlert(alertId)}
           onNextStep={() => this.handleStepsGoToNext(Step.CONFLICT_CHECK)}
           onRestart={tab => this.handleStepsRestart(Step.CONFLICT_CHECK, tab)}
@@ -487,6 +507,7 @@ class Progress extends React.Component<Props, State> {
           navigate={navigate}
           searchParams={searchParams}
           onError={alertItem => this.handleStepsShowAlert(Step.FETCH, alertItem)}
+          onWarning={alertItem => this.handleStepsShowWarning(Step.FETCH, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
           onNextStep={() => this.handleStepsGoToNext(Step.FETCH)}
           onRestart={tab => this.handleStepsRestart(Step.FETCH, tab)}
@@ -511,6 +532,7 @@ class Progress extends React.Component<Props, State> {
           navigate={navigate}
           searchParams={searchParams}
           onError={alertItem => this.handleStepsShowAlert(Step.APPLY, alertItem)}
+          onWarning={alertItem => this.handleStepsShowWarning(Step.APPLY, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
           onNextStep={() => this.handleStepsGoToNext(Step.APPLY)}
           onRestart={tab => this.handleStepsRestart(Step.APPLY, tab)}
@@ -535,6 +557,7 @@ class Progress extends React.Component<Props, State> {
           navigate={navigate}
           searchParams={searchParams}
           onError={alertItem => this.handleStepsShowAlert(Step.FETCH, alertItem)}
+          onWarning={alertItem => this.handleStepsShowWarning(Step.FETCH, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
           onNextStep={() => this.handleStepsGoToNext(Step.FETCH)}
           onRestart={tab => this.handleStepsRestart(Step.FETCH, tab)}
@@ -559,6 +582,7 @@ class Progress extends React.Component<Props, State> {
           navigate={navigate}
           searchParams={searchParams}
           onError={alertItem => this.handleStepsShowAlert(Step.APPLY, alertItem)}
+          onWarning={alertItem => this.handleStepsShowWarning(Step.APPLY, alertItem)}
           onHideError={key => this.handleCloseStepAlert(key)}
           onNextStep={() => this.handleStepsGoToNext(Step.APPLY)}
           onRestart={tab => this.handleStepsRestart(Step.APPLY, tab)}
@@ -591,6 +615,7 @@ class Progress extends React.Component<Props, State> {
             distance={this.getDistance(Step.START)}
             hasChildren={showChildren}
             onError={alertItem => this.handleStepsShowAlert(Step.START, alertItem)}
+            onWarning={alertItem => this.handleStepsShowWarning(Step.START, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
             onNextStep={() => this.handleStepsGoToNext(Step.START)}
             onRestart={tab => this.handleStepsRestart(Step.START, tab)}
@@ -608,6 +633,7 @@ class Progress extends React.Component<Props, State> {
             distance={this.getDistance(Step.OPEN)}
             hasChildren={false}
             onError={alertItem => this.handleStepsShowAlert(Step.OPEN, alertItem)}
+            onWarning={alertItem => this.handleStepsShowWarning(Step.OPEN, alertItem)}
             onHideError={key => this.handleCloseStepAlert(key)}
             onNextStep={() => this.handleStepsGoToNext(Step.OPEN)}
             onRestart={tab => this.handleStepsRestart(Step.OPEN, tab)}
@@ -662,6 +688,7 @@ class Progress extends React.Component<Props, State> {
               location={location}
               navigate={navigate}
               onError={alertItem => this.handleStepsShowAlert(stepId, alertItem)}
+              onWarning={alertItem => this.handleStepsShowWarning(stepId, alertItem)}
               onHideError={key => this.handleCloseStepAlert(key)}
               onNextStep={() => this.handleStepsGoToNext(stepId)}
               onRestart={tab => this.handleStepsRestart(stepId, tab)}


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.5

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Refactor workspace progress step components to use a dedicated `onWarning` callback instead of directly showing alerts for non-fatal warnings. This provides consistent warning handling across all progress steps and allows the parent component to manage warning display alongside errors.

Changes include:
- Add onWarning prop to ProgressStep base class and all step implementations
- Add warning display when devfile fetch fails and falls back to default devfile
- Update all test files to include mockOnWarning callback

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10219

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Start a workspace from a private repo without necessary credentials
2. See: the Warning appears on `Fetch Devfile` step, workspace starts from the default devfile:
<img width="633" height="668" alt="image" src="https://github.com/user-attachments/assets/09a8968e-71a2-4176-a190-3c905b32ddc1" />


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
