### PR TITLE
fix(deps): upgrade lodash to 4.18.x to fix arbitrary code execution

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -27,6 +27,7 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `file-selector@2.1.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/file-selector/2.1.2) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |
 | `light-my-request@6.6.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/light-my-request/6.6.0) |
+| `lodash@4.18.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/lodash/4.18.1) |
 | `pino@10.3.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pino/10.3.1) |
 | `qs@6.5.5` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/qs/6.5.5) |
 | `real-require@0.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/real-require/0.2.0) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -285,7 +285,7 @@
 | `jsonschema@1.4.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonschema/1.4.1) |
 | `leven@2.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/leven/2.1.0) |
 | `light-my-request@6.6.0` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/light-my-request/6.6.0) |
-| `lodash@4.17.23` | CC0-1.0 AND MIT | #2096 |
+| `lodash@4.18.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/lodash/4.18.1) |
 | `loose-envify@1.4.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/loose-envify/1.4.0) |
 | `lru-cache@10.4.3` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/lru-cache/10.4.3) |
 | `lru-cache@11.2.4` | BlueOak-1.0.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/lru-cache/11.2.4) |

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "glob-parent": "^6.0.2",
     "js-yaml": "^4.1.1",
     "jsonpath-plus": "10.3.0",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.0",
     "micromatch": "^4.0.8",
     "nanoid": "3.3.8",
     "pbkdf2": "^3.1.3",

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -55,7 +55,7 @@
     "inversify-inject-decorators": "^3.1.0",
     "inversify-react": "^1.1.0",
     "js-yaml": "^4.1.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.0",
     "multi-ini": "^2.3.2",
     "process": "^0.11.10",
     "qs": "^6.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,7 +1009,7 @@ __metadata:
     jest-websocket-mock: "npm:2.4.1"
     js-yaml: "npm:^4.1.1"
     loader-utils: "npm:^3.2.1"
-    lodash: "npm:^4.17.23"
+    lodash: "npm:^4.18.0"
     mini-css-extract-plugin: "npm:^2.7.6"
     multi-ini: "npm:^2.3.2"
     prettier: "npm:^3.2.5"
@@ -9469,10 +9469,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
+"lodash@npm:^4.18.0":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Upgrade lodash from 4.17.23 to 4.18.1 to fix an arbitrary code execution vulnerability.

Changes:
- lodash upgraded from 4.17.23 to 4.18.1 (root and dashboard-frontend)
- Resolution in root package.json already pinned to `^4.18.0`
- Updated `.deps/prod.md` and `.deps/EXCLUDED/prod.md` for license tracking


### What issues does this PR fix or reference?
fixes issues:
https://redhat.atlassian.net/browse/CRW-10640
https://redhat.atlassian.net/browse/CRW-10637

