### PR TITLE
[cherry-pick] fix: bump axios to 1.15.0 to fix SSRF via hostname normalization bypass

### DIFF
--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -99,8 +99,8 @@
 | `atomic-sleep@1.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/atomic-sleep/1.0.0) |
 | `attr-accept@1.1.3` | MIT | CQ22348 |
 | `available-typed-arrays@1.0.7` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/available-typed-arrays/1.0.7) |
-| `avvio@9.2.0` |  | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/avvio/9.2.0) |
-| `axios@1.13.5` | MIT | #25792 |
+| `avvio@9.2.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/avvio/9.2.0) |
+| `axios@1.15.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/axios/1.15.0) |
 | `b4a@1.7.3` | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/b4a/1.7.3) |
 | `bare-events@2.8.2` | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/bare-events/2.8.2) |
 | `bare-fs@4.5.2` | Apache-2.0 | #24516 |

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/runtime": "^7.26.10",
     "@adobe/css-tools": "^4.3.2",
     "@hapi/hoek": "^10.0.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "bn.js": "^5.2.0",
     "braces": "^3.0.3",
     "cipher-base": "^1.0.6",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^29.5.3",
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "@typescript-eslint/parser": "^6.3.0",
-    "axios": "^1.12.0",
+    "axios": "^1.15.0",
     "axios-mock-adapter": "^1.22.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.0.0",

--- a/packages/dashboard-backend/package.json
+++ b/packages/dashboard-backend/package.json
@@ -40,7 +40,7 @@
     "@kubernetes/client-node": "^1.3.0",
     "any-signal": "^4.2.0",
     "args": "^5.0.3",
-    "axios": "^1.12.0",
+    "axios": "^1.15.0",
     "cron-parser": "^5.5.0",
     "fastify": "^5.7.3",
     "fs-extra": "^11.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,7 +854,7 @@ __metadata:
     "@types/jest": "npm:^29.5.3"
     "@typescript-eslint/eslint-plugin": "npm:^6.3.0"
     "@typescript-eslint/parser": "npm:^6.3.0"
-    axios: "npm:^1.12.0"
+    axios: "npm:^1.15.0"
     axios-mock-adapter: "npm:^1.22.0"
     eslint: "npm:^8.57.1"
     eslint-config-prettier: "npm:^9.0.0"
@@ -894,7 +894,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^6.3.0"
     any-signal: "npm:^4.2.0"
     args: "npm:^5.0.3"
-    axios: "npm:^1.12.0"
+    axios: "npm:^1.15.0"
     copy-webpack-plugin: "npm:^11.0.0"
     cron-parser: "npm:^5.5.0"
     eslint: "npm:^8.57.1"
@@ -4012,14 +4012,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.5":
-  version: 1.13.5
-  resolution: "axios@npm:1.13.5"
+"axios@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/db726d09902565ef9a0632893530028310e2ec2b95b727114eca1b101450b00014133dfc3871cffc87983fb922bca7e4874d7e2826d1550a377a157cdf3f05b6
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
   languageName: node
   linkType: hard
 
@@ -11070,10 +11070,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10/f0bb4a87cfd18f77bc2fba23ae49c3b378fb35143af16cc478171c623eebe181678f09439707ad80081d340d1593cd54a33a0113f3ccb3f4bc9451488780ee23
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10/fbbaf4dab2a6231dc9e394903a5f66f20475e36b734335790b46feb9da07c37d6b32e2c02e3e2ea4d4b23774c53d8562e5b7cc73282cb43f4a597b7eacaee2ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?
This PR upgrade **axios** to 1.15.0 to fix an arbitrary code execution vulnerability.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1516 to the 7.115.x branch

### What issues does this PR fix or reference?
fixes issues:
- https://redhat.atlassian.net/browse/CRW-10692
- https://redhat.atlassian.net/browse/CRW-10694
- https://redhat.atlassian.net/browse/CRW-10710
- https://redhat.atlassian.net/browse/CRW-10708
- https://redhat.atlassian.net/browse/CRW-10696