### PR TITLE
check for number of running workspaces when restore a backup

### DIFF
--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/restoreWorkspaceFromBackup.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/restoreWorkspaceFromBackup.spec.ts
@@ -237,6 +237,23 @@ describe('restoreWorkspaceFromBackup', () => {
     expect(fetchCall.devfileContent).toContain('universal-developer-image');
   });
 
+  test('should create workspace with started set to false', async () => {
+    await store.dispatch(
+      restoreWorkspaceFromBackup(
+        'user-ns',
+        'my-ws',
+        'quay.io/user-ns/my-ws:latest',
+        'che-incubator/che-code/latest',
+      ),
+    );
+
+    expect(DwApi.createWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({ started: false }),
+      }),
+    );
+  });
+
   test('should include default components without resource limits when not specified', async () => {
     await store.dispatch(
       restoreWorkspaceFromBackup(

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/restoreWorkspaceFromBackup.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/restoreWorkspaceFromBackup.ts
@@ -166,6 +166,10 @@ export const restoreWorkspaceFromBackup =
       }
       devWorkspaceTemplateResource.metadata.namespace = namespace;
 
+      // Create with started=false so the IDE loader's CheckRunningWorkspacesLimit step
+      // enforces maxNumberOfRunningWorkspacesPerUser before starting the workspace.
+      devWorkspaceResource.spec.started = false;
+
       // Create the DevWorkspaceTemplate first, then set ownerReference once we have the DW uid
       const createdTemplate = await DwtApi.createTemplate(devWorkspaceTemplateResource);
 


### PR DESCRIPTION


### What does this PR do?

The restored DevWorkspace has `spec.started = false`, so the workspace startup flow enforces the number of running workspaces check before start. Previously the workspace started immediately on creation, bypassing the limit. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/user-attachments/assets/5f04e2a2-f3c0-48a9-8c5d-41b82a8d35ee



### What issues does this PR fix or reference?

[CRW-10552](https://redhat.atlassian.net/browse/CRW-10552)

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

see the screencast for steps to test.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
