### PR TITLE
fix: navigate to backups list after restore is initiated

### DIFF
--- a/packages/dashboard-frontend/src/pages/RestoreFromBackup/index.tsx
+++ b/packages/dashboard-frontend/src/pages/RestoreFromBackup/index.tsx
@@ -139,6 +139,9 @@ export const RestoreFromBackupPage: React.FC<Props> = props => {
 
       const location = buildIdeLoaderLocation({ namespace, name: workspaceName } as Workspace);
       window.open(toHref(location), '_blank');
+
+      // Navigate current tab back to the backups list — the restore form is now stale.
+      navigate('/workspaces?view=backups');
     } catch (e: unknown) {
       const errorMessage = e instanceof Error ? e.message : 'Failed to initiate restore.';
       setIsSubmitting(false);


### PR DESCRIPTION

### What does this PR do?

After clicking "Restore", the workspace startup loader opens in a new tab, but the current tab stays on the stale restore form. This navigates the current tab back to the backups list after the restore is initiated.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

**No fix**

https://github.com/user-attachments/assets/35669652-5aa7-49b4-991d-740985938fcc



**Fixed**


https://github.com/user-attachments/assets/060c1f79-0d8e-40f2-8fc4-2245b546446d


### What issues does this PR fix or reference?

N/A

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
