### PR TITLE
feat(ui): improve form validation UX in personal access tokens

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/__tests__/index.spec.tsx
@@ -150,6 +150,172 @@ describe('GitProviderEndpoint', () => {
       expect(input).toHaveValue(editEndpoint);
     });
   });
+
+  describe('helper text behavior', () => {
+    it('should not show helper text when endpoint is valid', async () => {
+      renderComponent(undefined);
+
+      const input = screen.getByRole('textbox');
+      const validEndpoint = 'https://provider.test/endpoint';
+      await userEvent.click(input);
+      await userEvent.paste(validEndpoint);
+
+      // Helper text should not be present
+      expect(screen.queryByText('Git provider endpoint is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show error helper text when endpoint is empty', async () => {
+      renderComponent('https://provider.test/endpoint');
+
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+
+      // Error helper text should be visible
+      expect(screen.getByText('Git provider endpoint is required.')).toBeInTheDocument();
+    });
+
+    it('should show error helper text when endpoint has invalid protocol', async () => {
+      renderComponent(undefined);
+
+      const input = screen.getByRole('textbox');
+      const invalidEndpoint = 'ftp://provider.test/endpoint';
+      await userEvent.click(input);
+      await userEvent.paste(invalidEndpoint);
+
+      // Error helper text should be visible
+      expect(
+        screen.getByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should show error helper text when endpoint has no protocol', async () => {
+      renderComponent(undefined);
+
+      const input = screen.getByRole('textbox');
+      const invalidEndpoint = 'provider.test/endpoint';
+      await userEvent.click(input);
+      await userEvent.paste(invalidEndpoint);
+
+      // Error helper text should be visible
+      expect(
+        screen.getByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should show error helper text when endpoint has invalid format', async () => {
+      renderComponent(undefined);
+
+      const input = screen.getByRole('textbox');
+      const invalidEndpoint = 'https://';
+      await userEvent.click(input);
+      await userEvent.paste(invalidEndpoint);
+
+      // Error helper text should be visible
+      expect(
+        screen.getByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should hide helper text when correcting an invalid endpoint', async () => {
+      renderComponent(undefined);
+
+      const input = screen.getByRole('textbox');
+
+      // First set an invalid value
+      const invalidEndpoint = 'ftp://provider.test/endpoint';
+      await userEvent.click(input);
+      await userEvent.paste(invalidEndpoint);
+
+      // Error helper text should be visible
+      expect(
+        screen.getByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).toBeInTheDocument();
+
+      // Now correct it
+      await userEvent.clear(input);
+      const validEndpoint = 'https://provider.test/endpoint';
+      await userEvent.click(input);
+      await userEvent.paste(validEndpoint);
+
+      // Helper text should no longer be visible
+      expect(
+        screen.queryByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show helper text on initial render with valid endpoint', () => {
+      renderComponent('https://provider.test/endpoint');
+
+      // No helper text should be visible
+      expect(screen.queryByText('Git provider endpoint is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show helper text on initial render with default endpoint', () => {
+      renderComponent(undefined);
+
+      // No helper text should be visible initially (validation state is 'default')
+      expect(screen.queryByText('Git provider endpoint is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should handle http endpoint correctly', async () => {
+      renderComponent(undefined);
+
+      const input = screen.getByRole('textbox');
+      const httpEndpoint = 'http://provider.test/endpoint';
+      await userEvent.click(input);
+      await userEvent.paste(httpEndpoint);
+
+      // Should be valid, no helper text
+      expect(screen.queryByText('Git provider endpoint is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should handle endpoint with port correctly', async () => {
+      renderComponent(undefined);
+
+      const input = screen.getByRole('textbox');
+      const endpointWithPort = 'https://provider.test:8443/endpoint';
+      await userEvent.click(input);
+      await userEvent.paste(endpointWithPort);
+
+      // Should be valid, no helper text
+      expect(screen.queryByText('Git provider endpoint is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Invalid URL format. Must be a valid URL starting with http:// or https://',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
 });
 
 function getComponent(

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderEndpoint/index.tsx
@@ -10,7 +10,16 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, TextInput, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  TextInputTypes,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 export type Props = {
@@ -96,10 +105,16 @@ export class GitProviderEndpoint extends React.PureComponent<Props, State> {
     validated: ValidatedOptions;
     sanitized: string;
   } {
-    const validationRe =
+    if (providerEndpoint.length === 0) {
+      return {
+        validated: ValidatedOptions.error,
+        sanitized: '',
+      };
+    }
+    const validationRegexp =
       /^https?:\/\/(?:(?:[a-z\d]+(?:-[a-z\d]+)*)\.)+[a-z]{2,}(?::\d{1,5})?(?:\/[^\s]*)?$/i;
 
-    if (validationRe.test(providerEndpoint) === false) {
+    if (!validationRegexp.test(providerEndpoint)) {
       return {
         validated: ValidatedOptions.error,
         sanitized: providerEndpoint,
@@ -121,11 +136,21 @@ export class GitProviderEndpoint extends React.PureComponent<Props, State> {
     }
   }
 
+  private getErrorMessage(providerEndpoint: string): string {
+    if (providerEndpoint.length === 0) {
+      return 'Git provider endpoint is required.';
+    }
+    return 'Invalid URL format. Must be a valid URL starting with http:// or https://';
+  }
+
   public render(): React.ReactElement {
-    const { providerEndpoint = '' } = this.state;
+    const { providerEndpoint = '', validated } = this.state;
+
+    const errorMessage = this.getErrorMessage(providerEndpoint);
+    const hasError = validated === ValidatedOptions.error;
 
     return (
-      <FormGroup fieldId="git-provider-endpoint-label" label="Git Provider Endpoint" isRequired>
+      <FormGroup fieldId="git-provider-endpoint-label" isRequired label="Git Provider Endpoint">
         <TextInput
           aria-describedby="git-provider-endpoint-label"
           aria-label="Git Provider Endpoint"
@@ -134,8 +159,18 @@ export class GitProviderEndpoint extends React.PureComponent<Props, State> {
           placeholder="Enter a Git Provider Endpoint"
           ref={this.textInputRef}
           type={TextInputTypes.url}
+          validated={hasError ? 'error' : 'default'}
           value={providerEndpoint}
         />
+        {hasError && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+                {errorMessage}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
     );
   }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__tests__/__snapshots__/index.spec.tsx.snap
@@ -7,7 +7,6 @@ exports[`TokenName snapshot w/o token name 1`] = `
 >
   <div
     className="pf-v6-c-form__group"
-    helperText="Alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character."
   >
     <div
       className="pf-v6-c-form__group-label"
@@ -54,6 +53,23 @@ exports[`TokenName snapshot w/o token name 1`] = `
           value=""
         />
       </span>
+      <div
+        className="pf-v6-c-form__helper-text"
+      >
+        <div
+          className="pf-v6-c-helper-text"
+        >
+          <div
+            className="pf-v6-c-helper-text__item"
+          >
+            <span
+              className="pf-v6-c-helper-text__item-text"
+            >
+              Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </form>
@@ -113,6 +129,23 @@ exports[`TokenName snapshot with token name 1`] = `
           value="github-token"
         />
       </span>
+      <div
+        className="pf-v6-c-form__helper-text"
+      >
+        <div
+          className="pf-v6-c-helper-text"
+        >
+          <div
+            className="pf-v6-c-helper-text__item"
+          >
+            <span
+              className="pf-v6-c-helper-text__item-text"
+            >
+              Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </form>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/__tests__/index.spec.tsx
@@ -130,6 +130,131 @@ describe('TokenName', () => {
     //   ),
     // ).toBeTruthy();
   });
+
+  describe('helper text behavior', () => {
+    it('should show informational helper text when token name is valid', () => {
+      renderComponent(false);
+
+      const input = screen.getByRole('textbox');
+
+      const validTokenName = 'github-token';
+      fireEvent.change(input, { target: { value: validTokenName } });
+
+      // Informational helper text should be present
+      expect(
+        screen.getByText(
+          'Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.',
+        ),
+      ).toBeInTheDocument();
+      // Error messages should not be present
+      expect(screen.queryByText('Token name is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Token name must be \d+ characters or less./),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show error helper text when token name is empty', () => {
+      renderComponent(false);
+
+      const input = screen.getByRole('textbox');
+
+      // First set a valid value
+      fireEvent.change(input, { target: { value: 'github-token' } });
+
+      // Then clear it to trigger validation
+      fireEvent.change(input, { target: { value: '' } });
+
+      // Error helper text should be visible
+      expect(screen.getByText('Token name is required.')).toBeInTheDocument();
+    });
+
+    it('should show error helper text when token name is too long', () => {
+      renderComponent(false);
+
+      const input = screen.getByRole('textbox');
+
+      // Create a token name that exceeds MAX_LENGTH (255)
+      const tooLongTokenName = 'a'.repeat(256);
+      fireEvent.change(input, { target: { value: tooLongTokenName } });
+
+      // Error helper text should be visible
+      expect(screen.getByText('Token name must be 255 characters or less.')).toBeInTheDocument();
+    });
+
+    it('should show error helper text when token name has invalid format', () => {
+      renderComponent(false);
+
+      const input = screen.getByRole('textbox');
+
+      // Use invalid character (+)
+      const invalidTokenName = 'github+token';
+      fireEvent.change(input, { target: { value: invalidTokenName } });
+
+      // Error helper text should be visible
+      expect(
+        screen.getByText(
+          'Invalid token name format. Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should switch from error to informational helper text when correcting an invalid token name', () => {
+      renderComponent(false);
+
+      const input = screen.getByRole('textbox');
+
+      // First set an invalid value
+      const invalidTokenName = 'github+token';
+      fireEvent.change(input, { target: { value: invalidTokenName } });
+
+      // Error helper text should be visible
+      expect(
+        screen.getByText(
+          'Invalid token name format. Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.',
+        ),
+      ).toBeInTheDocument();
+
+      // Now correct it
+      const validTokenName = 'github-token';
+      fireEvent.change(input, { target: { value: validTokenName } });
+
+      // Informational helper text should now be visible
+      expect(
+        screen.getByText(
+          'Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should show informational helper text on initial render with valid token name', () => {
+      renderComponent(false, 'github-token');
+
+      // Informational helper text should be visible
+      expect(
+        screen.getByText(
+          'Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.',
+        ),
+      ).toBeInTheDocument();
+      // Error messages should not be visible
+      expect(screen.queryByText('Token name is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Token name must be \d+ characters or less./),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show informational helper text on initial render without token name', () => {
+      renderComponent(false);
+
+      // Informational helper text should be visible initially (validation state is 'default')
+      expect(
+        screen.getByText(
+          'Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.',
+        ),
+      ).toBeInTheDocument();
+      // Error message should not be visible
+      expect(screen.queryByText('Token name is required.')).not.toBeInTheDocument();
+    });
+  });
 });
 
 function getComponent(isEdit: boolean, tokenName?: string): React.ReactElement {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenName/index.tsx
@@ -10,13 +10,19 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, TextInput, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  TextInputTypes,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 const MAX_LENGTH = 255;
-const ALLOWED_CHARACTERS =
-  'Alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.';
-
 const REGEXP = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 
 export type Props = {
@@ -54,22 +60,34 @@ export class TokenName extends React.PureComponent<Props, State> {
       return ValidatedOptions.error;
     } else if (tokenName.length === 0) {
       return ValidatedOptions.error;
-    } else if (REGEXP.test(tokenName) === false) {
+    } else if (!REGEXP.test(tokenName)) {
       return ValidatedOptions.error;
     } else {
       return ValidatedOptions.success;
     }
   }
 
+  private getErrorMessage(tokenName: string): string {
+    if (tokenName.length === 0) {
+      return 'Token name is required.';
+    } else if (tokenName.length > MAX_LENGTH) {
+      return `Token name must be ${MAX_LENGTH} characters or less.`;
+    } else if (!REGEXP.test(tokenName)) {
+      return 'Invalid token name format. Must use alphanumeric characters, "-" or ".", starting and ending with an alphanumeric character.';
+    }
+    return '';
+  }
+
   public render(): React.ReactElement {
     const { isEdit } = this.props;
-    const { tokenName = '' } = this.state;
+    const { tokenName = '', validated } = this.state;
 
     const readOnlyAttr = isEdit ? { isReadOnly: true } : {};
-    const helperText = isEdit ? {} : { helperText: ALLOWED_CHARACTERS };
+    const errorMessage = this.getErrorMessage(tokenName);
+    const hasError = validated === ValidatedOptions.error;
 
     return (
-      <FormGroup fieldId="token-name-label" isRequired label="Token Name" {...helperText}>
+      <FormGroup fieldId="token-name-label" isRequired label="Token Name">
         <TextInput
           aria-describedby="token-name-label"
           aria-label="Token Name"
@@ -77,9 +95,24 @@ export class TokenName extends React.PureComponent<Props, State> {
           onChange={(_event, tokenName) => this.onChange(tokenName)}
           placeholder="Enter a Token Name"
           type={TextInputTypes.text}
+          validated={hasError ? 'error' : 'default'}
           value={tokenName}
           {...readOnlyAttr}
         />
+        <FormHelperText>
+          <HelperText>
+            {hasError ? (
+              <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+                {errorMessage}
+              </HelperTextItem>
+            ) : (
+              <HelperTextItem>
+                Must use alphanumeric characters, &quot;-&quot; or &quot;.&quot;, starting and
+                ending with an alphanumeric character.
+              </HelperTextItem>
+            )}
+          </HelperText>
+        </FormHelperText>
       </FormGroup>
     );
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Add helper text elements to the `Token Name` and `Git Provider URL` inputs of the `Add Personal Access Token` popup
* Validate the inputs and reveal error if the input is invalid.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23801

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to `User Preferences` -> `Personal Access Tokens` tab and click the `Add Personal Access Token` link.
2. see: no helper text elements are visible, except the `Token Name` input rules:
<img width="582" height="526" alt="image" src="https://github.com/user-attachments/assets/b0920d61-1569-4563-973b-feb07031d519" />

3. Enter an invalid value e.g `name@` to the `Token Name` field, see:
<img width="598" height="195" alt="image" src="https://github.com/user-attachments/assets/ad35ac9e-0b95-47af-b1cd-fb876cb78677" />

4. Enter an invalid value e.g `url` to the `Git Provider Endpoint` field, see:
<img width="640" height="126" alt="image" src="https://github.com/user-attachments/assets/53e4d091-71d7-480d-90cc-81d285e9b5ec" />

5. Clear the inputs, see: 
<img width="611" height="392" alt="image" src="https://github.com/user-attachments/assets/e5be24f1-ea2f-4cd4-b6b3-432dc4ca4907" />


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->




#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
