### PR TITLE
fix: show required field validation on Restore from Backup form

### DIFF
--- a/packages/dashboard-frontend/src/pages/RestoreFromBackup/ExternalRegistryForm/ImageUrlField/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/RestoreFromBackup/ExternalRegistryForm/ImageUrlField/__tests__/index.spec.tsx
@@ -80,6 +80,22 @@ describe('ImageUrlField', () => {
 
     expect(screen.getByText('Invalid image URL format.')).toBeInTheDocument();
   });
+
+  test('should not show required error on initial render with empty value', () => {
+    renderComponent();
+
+    expect(screen.queryByText('Backup image URL is required.')).not.toBeInTheDocument();
+  });
+
+  test('should show required error after typing and clearing the field', async () => {
+    renderComponent();
+
+    const input = screen.getByLabelText('Backup image URL');
+    await userEvent.type(input, 'a');
+    await userEvent.clear(input);
+
+    expect(screen.getByText('Backup image URL is required.')).toBeInTheDocument();
+  });
 });
 
 type PartialProps = {

--- a/packages/dashboard-frontend/src/pages/RestoreFromBackup/ExternalRegistryForm/ImageUrlField/index.tsx
+++ b/packages/dashboard-frontend/src/pages/RestoreFromBackup/ExternalRegistryForm/ImageUrlField/index.tsx
@@ -21,7 +21,7 @@ import {
   ValidatedOptions,
 } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
-import React from 'react';
+import React, { useState } from 'react';
 
 export type Props = {
   value: string;
@@ -31,15 +31,27 @@ export type Props = {
 };
 
 export const ImageUrlField: React.FC<Props> = ({ value, validated, error, onChange }) => {
+  const [dirty, setDirty] = useState(false);
+
+  const isDirtyEmpty = dirty && !value;
+  const effectiveValidated = isDirtyEmpty ? ValidatedOptions.error : validated;
+
   const getHelperContent = (): React.ReactNode => {
-    if (validated === ValidatedOptions.error) {
+    if (isDirtyEmpty) {
+      return (
+        <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+          Backup image URL is required.
+        </HelperTextItem>
+      );
+    }
+    if (effectiveValidated === ValidatedOptions.error) {
       return (
         <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
           {error}
         </HelperTextItem>
       );
     }
-    if (validated === ValidatedOptions.success) {
+    if (effectiveValidated === ValidatedOptions.success) {
       return (
         <HelperTextItem
           variant="success"
@@ -56,6 +68,11 @@ export const ImageUrlField: React.FC<Props> = ({ value, validated, error, onChan
     );
   };
 
+  const handleChange = (_event: React.FormEvent, val: string) => {
+    setDirty(true);
+    onChange(val);
+  };
+
   return (
     <FormGroup fieldId="restore-image-url" label="Backup image URL" isRequired>
       <TextInput
@@ -64,13 +81,13 @@ export const ImageUrlField: React.FC<Props> = ({ value, validated, error, onChan
         placeholder="registry.example.com/namespace/workspace:latest"
         value={value}
         validated={
-          validated === ValidatedOptions.error
+          effectiveValidated === ValidatedOptions.error
             ? 'error'
-            : validated === ValidatedOptions.success
+            : effectiveValidated === ValidatedOptions.success
               ? 'success'
               : 'default'
         }
-        onChange={(_event, val) => onChange(val)}
+        onChange={handleChange}
       />
       <FormHelperText>
         <HelperText>{getHelperContent()}</HelperText>

--- a/packages/dashboard-frontend/src/pages/RestoreFromBackup/WorkspaceNameField/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/RestoreFromBackup/WorkspaceNameField/__tests__/index.spec.tsx
@@ -76,6 +76,22 @@ describe('WorkspaceNameField', () => {
 
     expect(screen.getByTestId('custom-action')).toBeInTheDocument();
   });
+
+  test('should not show required error on initial render with empty value', () => {
+    renderComponent();
+
+    expect(screen.queryByText('Workspace name is required.')).not.toBeInTheDocument();
+  });
+
+  test('should show required error after typing and clearing the field', async () => {
+    renderComponent();
+
+    const input = screen.getByLabelText('Workspace name');
+    await userEvent.type(input, 'a');
+    await userEvent.clear(input);
+
+    expect(screen.getByText('Workspace name is required.')).toBeInTheDocument();
+  });
 });
 
 function getComponent(

--- a/packages/dashboard-frontend/src/pages/RestoreFromBackup/WorkspaceNameField/index.tsx
+++ b/packages/dashboard-frontend/src/pages/RestoreFromBackup/WorkspaceNameField/index.tsx
@@ -22,7 +22,7 @@ import {
   ValidatedOptions,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
-import React from 'react';
+import React, { useState } from 'react';
 
 export type Props = {
   fieldId: string;
@@ -45,21 +45,36 @@ export const WorkspaceNameField: React.FC<Props> = ({
   onChange,
   actionButton,
 }) => {
+  const [dirty, setDirty] = useState(false);
+
+  const isDirtyEmpty = dirty && !value;
+  const effectiveValidated = isDirtyEmpty ? ValidatedOptions.error : validated;
+
   const helperTextInvalid = error || warning || '';
   const helperTextInvalidIcon =
-    validated === ValidatedOptions.warning ? (
+    effectiveValidated === ValidatedOptions.warning ? (
       <ExclamationTriangleIcon />
     ) : (
       <ExclamationCircleIcon />
     );
   const effectiveHelperText =
-    validated === ValidatedOptions.warning && warning ? warning : helperText;
+    effectiveValidated === ValidatedOptions.warning && warning ? warning : helperText;
 
   const getHelperContent = (): React.ReactNode => {
-    if (validated === ValidatedOptions.error || validated === ValidatedOptions.warning) {
+    if (isDirtyEmpty) {
+      return (
+        <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+          Workspace name is required.
+        </HelperTextItem>
+      );
+    }
+    if (
+      effectiveValidated === ValidatedOptions.error ||
+      effectiveValidated === ValidatedOptions.warning
+    ) {
       return (
         <HelperTextItem
-          variant={validated === ValidatedOptions.error ? 'error' : 'warning'}
+          variant={effectiveValidated === ValidatedOptions.error ? 'error' : 'warning'}
           icon={helperTextInvalidIcon}
         >
           {helperTextInvalid}
@@ -67,6 +82,11 @@ export const WorkspaceNameField: React.FC<Props> = ({
       );
     }
     return <HelperTextItem>{effectiveHelperText}</HelperTextItem>;
+  };
+
+  const handleChange = (_event: React.FormEvent, _value: string) => {
+    setDirty(true);
+    onChange(_value);
   };
 
   return (
@@ -78,13 +98,13 @@ export const WorkspaceNameField: React.FC<Props> = ({
           placeholder="my-workspace"
           value={value}
           validated={
-            validated === ValidatedOptions.error
+            effectiveValidated === ValidatedOptions.error
               ? 'error'
-              : validated === ValidatedOptions.warning
+              : effectiveValidated === ValidatedOptions.warning
                 ? 'warning'
                 : 'default'
           }
-          onChange={(_event, _value: string) => onChange(_value)}
+          onChange={handleChange}
         />
         {actionButton}
       </InputGroup>


### PR DESCRIPTION


### What does this PR do?

This PR improves `ImageUrlField` and `WorkspaceNameField` components on the Restore from Backup page (ExternalRegistry mode), so they now track the dirty state. When a field has been interacted with and left empty, they display a required field error with error status.

### Screenshot/screencast of this PR


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<img width="889" height="298" alt="Screenshot 2026-04-16 at 17 59 30" src="https://github.com/user-attachments/assets/31f0f7e4-06f1-4c9a-ad7a-414d9215028d" />


### What issues does this PR fix or reference?

fixes 

- https://github.com/eclipse-che/che/issues/23802
- https://redhat.atlassian.net/browse/CRW-10716

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
