### PR TITLE
feat(ui): add validation error messages to SSH Private Key field

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
@@ -70,8 +70,7 @@ describe('SshPrivateKey', () => {
       await userEvent.clear(input);
 
       expect(mockOnChange).toHaveBeenCalledWith(sshPrivateKey, false);
-      // SshPrivateKey component validates but doesn't render error messages
-      // expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeTruthy();
+      expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeTruthy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
     });
@@ -90,8 +89,7 @@ describe('SshPrivateKey', () => {
       const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
 
       expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, false);
-      // SshPrivateKey component validates but doesn't render error messages
-      // expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
+      expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
     });
@@ -136,10 +134,8 @@ describe('SshPrivateKey', () => {
       await userEvent.clear(input);
 
       expect(mockOnChange).toHaveBeenCalledWith('', false);
-      // SshPrivateKey component validates but doesn't render error messages
-      // expect(screen.queryByText(REQUIRED_ERROR)).toBeTruthy();
-
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
+      expect(screen.queryByText(REQUIRED_ERROR)).toBeTruthy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
     });
 
@@ -158,9 +154,7 @@ describe('SshPrivateKey', () => {
       const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
 
       expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, false);
-      // SshPrivateKey component validates but doesn't render error messages in text area mode
-      expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
-
+      expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
     });

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
@@ -10,7 +10,14 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 import { TextFileUpload } from '@/components/TextFileUpload';
@@ -86,7 +93,9 @@ export class SshPrivateKey extends React.Component<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { validated } = this.state;
+    const { validated, privateKey, isUpload } = this.state;
+
+    const errorMessage = this.getErrorMessage(privateKey, isUpload);
 
     return (
       <FormGroup fieldId="ssh-private-key" label="Private Key" isRequired={true}>
@@ -97,6 +106,15 @@ export class SshPrivateKey extends React.Component<Props, State> {
           validated={validated}
           onChange={(key, isUpload) => this.onChange(key, isUpload)}
         />
+        {validated === ValidatedOptions.error && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
+                {errorMessage}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
     );
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Display helper text with error messages when SSH Private Key validation fails, matching the behavior of the SSH Public Key field for consistency and better user experience.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23800

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to `User Preferences` -> `SSH Keys` tab and click the `Add SSH Key` button.
2. Enter some random data to the `Private Key` input.
3. Clear the input, see the error helper text:
<img width="593" height="339" alt="image" src="https://github.com/user-attachments/assets/3d77fccc-9c9a-4608-90ea-5f1ca82e825d" />


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
