### PR TITLE
fix: correct editor binary detection and always create new Empty Workspace

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/helpers.spec.ts
@@ -11,7 +11,7 @@
  */
 
 import {
-  EDITORS_WITH_BINARIES,
+  EDITORS_WITHOUT_BINARIES,
   hasDownloadBinaries,
 } from '@/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/helpers';
 import { DEVWORKSPACE_CHE_EDITOR } from '@/services/devfileApi/devWorkspace/metadata';
@@ -86,63 +86,15 @@ describe('hasDownloadBinaries', () => {
         workspaceName: name,
       }),
     ).toEqual(false);
-
-    const editorDevfileV2Content = 'schemaVersion: 2.2.0';
-    const workspaceWithEditorDevfileV2Content = constructWorkspace(
-      devWorkspaceBuilder
-        .withMetadata({
-          name,
-          namespace,
-          annotations: {
-            [DEVWORKSPACE_CHE_EDITOR]: editorDevfileV2Content,
-          },
-        })
-        .build(),
-    );
-    // skip if editor annotation contains the V2 devfile content
-    expect(
-      hasDownloadBinaries([workspaceWithEditorDevfileV2Content], {
-        namespace,
-        workspaceName: name,
-      }),
-    ).toEqual(false);
-
-    const editorDevfileV1Content = 'apiVersion: 1.0.0';
-    const workspaceWithEditorDevfileV1Content = constructWorkspace(
-      devWorkspaceBuilder
-        .withMetadata({
-          name,
-          namespace,
-          annotations: {
-            [DEVWORKSPACE_CHE_EDITOR]: editorDevfileV1Content,
-          },
-        })
-        .build(),
-    );
-    // skip if editor annotation contains the V1 devfile content
-    expect(
-      hasDownloadBinaries([workspaceWithEditorDevfileV1Content], {
-        namespace,
-        workspaceName: name,
-      }),
-    ).toEqual(false);
   });
 
-  it('should return false for editors without binaries', () => {
+  it('should return false for che-code editors', () => {
     const name = 'test';
     const namespace = 'che-user';
 
-    const editorsWithoutBinaries = [
-      'che-incubator/che-code/latest',
-      'che-incubator/che-code/insiders',
-      'che-incubator/che-code-server/latest',
-      'che-incubator/che-code-sshd/latest',
-      'che-incubator/che-web-terminal/latest',
-      'che-incubator/che-kiro-sshd/latest',
-      'che-incubator/jetbrains-sshd/next',
-    ];
+    const cheCodeEditors = ['che-incubator/che-code/latest', 'che-incubator/che-code/insiders'];
 
-    for (const editorId of editorsWithoutBinaries) {
+    for (const editorId of cheCodeEditors) {
       const workspace = constructWorkspace(
         devWorkspaceBuilder
           .withMetadata({
@@ -162,19 +114,12 @@ describe('hasDownloadBinaries', () => {
     const name = 'test';
     const namespace = 'che-user';
 
-    expect(EDITORS_WITH_BINARIES).toEqual([
-      'che-idea-server',
-      'che-clion-server',
-      'che-phpstorm-server',
-      'che-pycharm-server',
-      'che-rider-server',
-      'che-rubymine-server',
-      'che-webstorm-server',
-      'che-goland-server',
-    ]);
+    const editorsWithBinaries = [
+      'che-incubator/che-idea-server/latest',
+      'che-incubator/che-pycharm-server/latest',
+    ];
 
-    for (const editorName of EDITORS_WITH_BINARIES) {
-      const editorId = `che-incubator/${editorName}/latest`;
+    for (const editorId of editorsWithBinaries) {
       const workspace = constructWorkspace(
         devWorkspaceBuilder
           .withMetadata({
@@ -188,5 +133,67 @@ describe('hasDownloadBinaries', () => {
       );
       expect(hasDownloadBinaries([workspace], { namespace, workspaceName: name })).toEqual(true);
     }
+  });
+
+  it('should return false when annotation contains devfile content with che-code editor name', () => {
+    const name = 'test';
+    const namespace = 'che-user';
+
+    expect(EDITORS_WITHOUT_BINARIES).toEqual(['che-code']);
+
+    const editorDevfileContent = [
+      'commands:',
+      '  - apply:',
+      '      component: che-code-injector',
+      '    id: init-container-command',
+      'metadata:',
+      '  name: che-code',
+      '  publisher: che-incubator',
+      'schemaVersion: 2.3.0',
+    ].join('\n');
+
+    const workspace = constructWorkspace(
+      devWorkspaceBuilder
+        .withMetadata({
+          name,
+          namespace,
+          annotations: {
+            [DEVWORKSPACE_CHE_EDITOR]: editorDevfileContent,
+          },
+        })
+        .build(),
+    );
+
+    expect(hasDownloadBinaries([workspace], { namespace, workspaceName: name })).toEqual(false);
+  });
+
+  it('should return true when annotation contains devfile content with JetBrains editor name', () => {
+    const name = 'test';
+    const namespace = 'che-user';
+
+    const editorDevfileContent = [
+      'commands:',
+      '  - apply:',
+      '      component: idea-injector',
+      '    id: init-container-command',
+      'metadata:',
+      '  name: che-idea-server',
+      '  publisher: che-incubator',
+      'schemaVersion: 2.3.0',
+    ].join('\n');
+
+    const workspace = constructWorkspace(
+      devWorkspaceBuilder
+        .withMetadata({
+          name,
+          namespace,
+          annotations: {
+            [DEVWORKSPACE_CHE_EDITOR]: editorDevfileContent,
+          },
+        })
+        .build(),
+    );
+
+    expect(hasDownloadBinaries([workspace], { namespace, workspaceName: name })).toEqual(true);
   });
 });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/helpers.spec.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/helpers.spec.ts
@@ -11,7 +11,7 @@
  */
 
 import {
-  EDITORS_WITHOUT_BINARIES,
+  EDITORS_WITH_BINARIES,
   hasDownloadBinaries,
 } from '@/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/helpers';
 import { DEVWORKSPACE_CHE_EDITOR } from '@/services/devfileApi/devWorkspace/metadata';
@@ -128,24 +128,65 @@ describe('hasDownloadBinaries', () => {
     ).toEqual(false);
   });
 
-  it('should return true', () => {
+  it('should return false for editors without binaries', () => {
     const name = 'test';
     const namespace = 'che-user';
-    const editorId = 'che-incubator/che-idea-server/latest';
-    const workspace = constructWorkspace(
-      devWorkspaceBuilder
-        .withMetadata({
-          name,
-          namespace,
-          annotations: {
-            [DEVWORKSPACE_CHE_EDITOR]: editorId,
-          },
-        })
-        .build(),
-    );
-    // verify the list of editors without binaries
-    expect(EDITORS_WITHOUT_BINARIES).toEqual(['che-code']);
-    // if editor name is not in the list of editors without binaries
-    expect(hasDownloadBinaries([workspace], { namespace, workspaceName: name })).toEqual(true);
+
+    const editorsWithoutBinaries = [
+      'che-incubator/che-code/latest',
+      'che-incubator/che-code/insiders',
+      'che-incubator/che-code-server/latest',
+      'che-incubator/che-code-sshd/latest',
+      'che-incubator/che-web-terminal/latest',
+      'che-incubator/che-kiro-sshd/latest',
+      'che-incubator/jetbrains-sshd/next',
+    ];
+
+    for (const editorId of editorsWithoutBinaries) {
+      const workspace = constructWorkspace(
+        devWorkspaceBuilder
+          .withMetadata({
+            name,
+            namespace,
+            annotations: {
+              [DEVWORKSPACE_CHE_EDITOR]: editorId,
+            },
+          })
+          .build(),
+      );
+      expect(hasDownloadBinaries([workspace], { namespace, workspaceName: name })).toEqual(false);
+    }
+  });
+
+  it('should return true for editors with binaries', () => {
+    const name = 'test';
+    const namespace = 'che-user';
+
+    expect(EDITORS_WITH_BINARIES).toEqual([
+      'che-idea-server',
+      'che-clion-server',
+      'che-phpstorm-server',
+      'che-pycharm-server',
+      'che-rider-server',
+      'che-rubymine-server',
+      'che-webstorm-server',
+      'che-goland-server',
+    ]);
+
+    for (const editorName of EDITORS_WITH_BINARIES) {
+      const editorId = `che-incubator/${editorName}/latest`;
+      const workspace = constructWorkspace(
+        devWorkspaceBuilder
+          .withMetadata({
+            name,
+            namespace,
+            annotations: {
+              [DEVWORKSPACE_CHE_EDITOR]: editorId,
+            },
+          })
+          .build(),
+      );
+      expect(hasDownloadBinaries([workspace], { namespace, workspaceName: name })).toEqual(true);
+    }
   });
 });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/helpers.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/helpers.ts
@@ -10,20 +10,25 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { load } from 'js-yaml';
+
 import { WorkspaceRouteParams } from '@/Routes';
 import { DEVWORKSPACE_CHE_EDITOR } from '@/services/devfileApi/devWorkspace/metadata';
 import { Workspace } from '@/services/workspace-adapter';
 
-export const EDITORS_WITH_BINARIES = [
-  'che-idea-server',
-  'che-clion-server',
-  'che-phpstorm-server',
-  'che-pycharm-server',
-  'che-rider-server',
-  'che-rubymine-server',
-  'che-webstorm-server',
-  'che-goland-server',
-];
+export const EDITORS_WITHOUT_BINARIES = ['che-code'];
+
+function getEditorName(cheEditor: string): string | undefined {
+  if (cheEditor.includes('\n')) {
+    try {
+      const parsed = load(cheEditor) as { metadata?: { name?: string } };
+      return parsed?.metadata?.name;
+    } catch {
+      return undefined;
+    }
+  }
+  return cheEditor.split('/')[1];
+}
 
 export function hasDownloadBinaries(
   allWorkspaces: Workspace[],
@@ -40,9 +45,12 @@ export function hasDownloadBinaries(
     return false;
   }
   const cheEditor = targetWorkspace.ref.metadata.annotations?.[DEVWORKSPACE_CHE_EDITOR];
-  if (!cheEditor || cheEditor.startsWith('apiVersion') || cheEditor.startsWith('schemaVersion')) {
+  if (!cheEditor) {
     return false;
   }
-  const name = cheEditor.split('/')[1];
-  return EDITORS_WITH_BINARIES.includes(name);
+  const name = getEditorName(cheEditor);
+  if (!name) {
+    return false;
+  }
+  return !EDITORS_WITHOUT_BINARIES.includes(name);
 }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/helpers.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/helpers.ts
@@ -14,32 +14,35 @@ import { WorkspaceRouteParams } from '@/Routes';
 import { DEVWORKSPACE_CHE_EDITOR } from '@/services/devfileApi/devWorkspace/metadata';
 import { Workspace } from '@/services/workspace-adapter';
 
-export const EDITORS_WITHOUT_BINARIES = ['che-code'];
+export const EDITORS_WITH_BINARIES = [
+  'che-idea-server',
+  'che-clion-server',
+  'che-phpstorm-server',
+  'che-pycharm-server',
+  'che-rider-server',
+  'che-rubymine-server',
+  'che-webstorm-server',
+  'che-goland-server',
+];
 
 export function hasDownloadBinaries(
   allWorkspaces: Workspace[],
   matchParams: WorkspaceRouteParams,
 ): boolean {
   const { namespace: targetNamespace, workspaceName: targetWorkspaceName } = matchParams;
-  // skip if target namespace or workspace name is empty or workspaces list is empty
   if (!targetNamespace || !targetWorkspaceName || allWorkspaces.length === 0) {
     return false;
   }
-  // find target workspace
   const targetWorkspace = allWorkspaces.find(
     w => w.name === targetWorkspaceName && w.namespace === targetNamespace,
   );
-  // skip if no target workspace found
   if (!targetWorkspace) {
     return false;
   }
   const cheEditor = targetWorkspace.ref.metadata.annotations?.[DEVWORKSPACE_CHE_EDITOR];
-  // skip if editor annotation empty or contains the devfile content
   if (!cheEditor || cheEditor.startsWith('apiVersion') || cheEditor.startsWith('schemaVersion')) {
     return false;
   }
-  // extract editor name from annotation
   const name = cheEditor.split('/')[1];
-  // check if editor is in the list of editors without binaries
-  return !EDITORS_WITHOUT_BINARIES.includes(name);
+  return EDITORS_WITH_BINARIES.includes(name);
 }

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/__tests__/index.spec.tsx
@@ -240,6 +240,50 @@ describe('Samples List', () => {
     });
   });
 
+  describe('Empty Workspace', () => {
+    const preferredPvcStrategy = 'per-workspace';
+
+    test('should force perclick policy for Empty Workspace', async () => {
+      const store = new MockStoreBuilder()
+        .withBranding({
+          docs: {
+            storageTypes: 'storage-types-docs',
+          },
+        } as BrandingData)
+        .withDwServerConfig({
+          defaults: {
+            pvcStrategy: preferredPvcStrategy,
+          } as api.IServerConfig['defaults'],
+        })
+        .withDevfileRegistries({
+          registries: {
+            ['registry-url']: {
+              metadata: [
+                {
+                  displayName: 'Empty Workspace',
+                  description: 'Start an empty workspace',
+                  tags: ['Empty'],
+                  icon: '/images/empty.svg',
+                  links: {
+                    v2: `${origin}/dashboard/devfile-registry/devfiles/empty.yaml`,
+                  },
+                },
+              ],
+            },
+          },
+        })
+        .build();
+
+      renderComponent(store, editorDefinition, editorImage);
+
+      const sampleCardButton = screen.getByRole('button', { name: 'Select Sample' });
+      await userEvent.click(sampleCardButton);
+
+      const calledUrl = mockWindowOpen.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('policies.create=perclick');
+    });
+  });
+
   describe('SSH URL handling', () => {
     const preferredPvcStrategy = 'per-workspace';
 

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/index.tsx
@@ -127,8 +127,8 @@ class SamplesList extends React.PureComponent<Props, State> {
       factoryParams[EDITOR_IMAGE_ATTR] = editorImage;
     }
 
-    const policiesCreate = this.getPoliciesCreate();
-    // This is to avoid sending the default value in the URL('peruser' is the default value)
+    const isEmptyWorkspace = metadata.tags?.some(tag => tag.toLowerCase() === 'empty') === true;
+    const policiesCreate = isEmptyWorkspace ? 'perclick' : this.getPoliciesCreate();
     if (policiesCreate !== 'peruser') {
       factoryParams[POLICIES_CREATE_ATTR] = policiesCreate;
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR contains two fixes:

1. **Use allow-list for editors with binary downloads** — The "Downloading IDE binaries" step was incorrectly shown for Che-Code and other editors that do not download binaries. The previous implementation used a deny-list (`EDITORS_WITHOUT_BINARIES`) that only excluded `che-code`, causing false positives for any new editor not explicitly listed. This is replaced with an allow-list (`EDITORS_WITH_BINARIES`) that explicitly enumerates the JetBrains-based editors that actually download binaries: `che-idea-server`, `che-clion-server`, `che-phpstorm-server`, `che-pycharm-server`, `che-rider-server`, `che-rubymine-server`, `che-webstorm-server`, `che-goland-server`.

2. **Always create new workspace for Empty Workspace sample** — When clicking "Create Empty Workspace", the dashboard would reuse an existing workspace if one had been created from the same empty devfile (due to the default `policies.create=peruser` deduplication). This fix forces `policies.create=perclick` for any sample tagged `"Empty"`, ensuring a new workspace is always created.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<!-- N/A — no UI changes, behavior-only fixes -->

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23798
fixes https://redhat.atlassian.net/browse/CRW-10546

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

**Editor binary detection:**
1. Deploy Eclipse Che with the image from this PR.
2. Start a workspace using **Che-Code** editor (e.g., `che-incubator/che-code/latest`).
3. Verify that the "Downloading IDE binaries" step is **not** shown during workspace startup.
4. Start a workspace using a **JetBrains** editor (e.g., `che-incubator/che-idea-server/latest`).
5. Verify that the "**Downloading IDE binaries**" step **is** shown during workspace startup.

**Empty Workspace creation:**
1. Deploy Eclipse Che with the image from this PR.
2. Unselect "Create New" button (default is "on").
3. Click "**Create Empty Workspace**" from the Get Started page.
4. Wait for the workspace to start.
5. Click "**Create Empty Workspace**" again.
6. Verify that a **new** workspace is created (not redirected to the existing one).


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
