### PR TITLE
feat(ui): add validation error messages to Git Config name and email fields

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/__tests__/index.spec.tsx
@@ -93,6 +93,43 @@ describe('GitConfigUserEmail', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith('user@che.orga', true);
   });
+
+  it('should show "Email is required" error message when value is empty', async () => {
+    renderComponent('user@che.org', false);
+
+    const textInput = screen.getByRole('textbox');
+    await userEvent.clear(textInput);
+
+    expect(screen.getByText('Email is required')).toBeInTheDocument();
+  });
+
+  it('should show "Email must not exceed 128 characters" error message when value is too long', async () => {
+    renderComponent('user@che.org', false);
+
+    const textInput = screen.getByRole('textbox');
+    await userEvent.clear(textInput);
+    await userEvent.paste('a'.repeat(129));
+
+    expect(screen.getByText('Email must not exceed 128 characters')).toBeInTheDocument();
+  });
+
+  it('should show "Email must be a valid email address" error message when email format is invalid', async () => {
+    renderComponent('user@che.org', false);
+
+    const textInput = screen.getByRole('textbox');
+    await userEvent.clear(textInput);
+    await userEvent.paste('invalid-email');
+
+    expect(screen.getByText('Email must be a valid email address')).toBeInTheDocument();
+  });
+
+  it('should not show error message when value is valid', () => {
+    renderComponent('user@che.org', false);
+
+    expect(screen.queryByText('Email is required')).not.toBeInTheDocument();
+    expect(screen.queryByText('Email must not exceed 128 characters')).not.toBeInTheDocument();
+    expect(screen.queryByText('Email must be a valid email address')).not.toBeInTheDocument();
+  });
 });
 
 function getComponent(

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Email/index.tsx
@@ -10,7 +10,15 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 import { InputGroupExtended } from '@/components/InputGroupExtended';
@@ -49,27 +57,45 @@ export class GitConfigUserEmail extends React.PureComponent<Props, State> {
   }
 
   private handleChange(value: string): void {
-    const validate = this.validate(value);
-    const isValid = validate === ValidatedOptions.success;
+    const result = this.validateAndSanitize(value);
+    const isValid = result.validated === ValidatedOptions.success;
 
     this.setState({
       value,
-      validated: validate,
+      validated: result.validated,
     });
     this.props.onChange(value, isValid);
   }
 
-  private validate(value: string): ValidatedOptions {
-    if (value.length === 0) {
-      return ValidatedOptions.error;
+  private validateAndSanitize(value: string): {
+    validated: ValidatedOptions;
+    sanitized: string;
+  } {
+    const trimmed = value.trim().toLowerCase();
+
+    if (trimmed.length === 0) {
+      return {
+        validated: ValidatedOptions.error,
+        sanitized: 'Email is required',
+      };
     }
-    if (value.length > MAX_LENGTH) {
-      return ValidatedOptions.error;
+    if (trimmed.length > MAX_LENGTH) {
+      return {
+        validated: ValidatedOptions.error,
+        sanitized: `Email must not exceed ${MAX_LENGTH} characters`,
+      };
     }
-    if (!REGEX.test(value)) {
-      return ValidatedOptions.error;
+    if (!REGEX.test(trimmed)) {
+      return {
+        validated: ValidatedOptions.error,
+        sanitized: 'Email must be a valid email address',
+      };
     }
-    return ValidatedOptions.success;
+
+    return {
+      validated: ValidatedOptions.success,
+      sanitized: trimmed,
+    };
   }
 
   public render(): React.ReactElement {
@@ -77,6 +103,7 @@ export class GitConfigUserEmail extends React.PureComponent<Props, State> {
     const { value = '', validated } = this.state;
 
     const fieldId = 'gitconfig-user-email';
+    const result = this.validateAndSanitize(value);
 
     return (
       <FormGroup label="email" fieldId={fieldId} isRequired>
@@ -97,6 +124,15 @@ export class GitConfigUserEmail extends React.PureComponent<Props, State> {
             onChange={(_event, value) => this.handleChange(value)}
           />
         </InputGroupExtended>
+        {validated === ValidatedOptions.error && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+                {result.sanitized}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
     );
   }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Name/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Name/__tests__/index.spec.tsx
@@ -83,6 +83,32 @@ describe('GitConfigUserName', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith('user one two', true);
   });
+
+  it('should show "Name is required" error message when value is empty', async () => {
+    renderComponent('user one', false);
+
+    const textInput = screen.getByRole('textbox');
+    await userEvent.clear(textInput);
+
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+  });
+
+  it('should show "Name must not exceed 128 characters" error message when value is too long', async () => {
+    renderComponent('user one', false);
+
+    const textInput = screen.getByRole('textbox');
+    await userEvent.clear(textInput);
+    await userEvent.paste('a'.repeat(129));
+
+    expect(screen.getByText('Name must not exceed 128 characters')).toBeInTheDocument();
+  });
+
+  it('should not show error message when value is valid', () => {
+    renderComponent('user one', false);
+
+    expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+    expect(screen.queryByText('Name must not exceed 128 characters')).not.toBeInTheDocument();
+  });
 });
 
 function getComponent(

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Name/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/Name/index.tsx
@@ -10,7 +10,15 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 import { InputGroupExtended } from '@/components/InputGroupExtended';
@@ -48,25 +56,39 @@ export class GitConfigUserName extends React.PureComponent<Props, State> {
   }
 
   private handleChange(value: string): void {
-    const validated = this.validate(value);
-    const isValid = validated === ValidatedOptions.success;
+    const result = this.validateAndSanitize(value);
+    const isValid = result.validated === ValidatedOptions.success;
 
     this.setState({
       value,
-      validated,
+      validated: result.validated,
     });
     this.props.onChange(value, isValid);
   }
 
-  private validate(value: string): ValidatedOptions {
-    if (value.length === 0) {
-      return ValidatedOptions.error;
+  private validateAndSanitize(value: string): {
+    validated: ValidatedOptions;
+    sanitized: string;
+  } {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return {
+        validated: ValidatedOptions.error,
+        sanitized: 'Name is required',
+      };
     }
-    if (value.length > MAX_LENGTH) {
-      return ValidatedOptions.error;
+    if (trimmed.length > MAX_LENGTH) {
+      return {
+        validated: ValidatedOptions.error,
+        sanitized: `Name must not exceed ${MAX_LENGTH} characters`,
+      };
     }
 
-    return ValidatedOptions.success;
+    return {
+      validated: ValidatedOptions.success,
+      sanitized: trimmed,
+    };
   }
 
   public render(): React.ReactElement {
@@ -74,6 +96,7 @@ export class GitConfigUserName extends React.PureComponent<Props, State> {
     const { value = '', validated } = this.state;
 
     const fieldId = 'gitconfig-user-name';
+    const result = this.validateAndSanitize(value);
 
     return (
       <FormGroup label="name" fieldId={fieldId} isRequired>
@@ -94,6 +117,15 @@ export class GitConfigUserName extends React.PureComponent<Props, State> {
             onChange={(_event, value) => this.handleChange(value)}
           />
         </InputGroupExtended>
+        {validated === ValidatedOptions.error && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+                {result.sanitized}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
     );
   }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/__tests__/index.spec.tsx
@@ -70,8 +70,7 @@ describe('SshPrivateKey', () => {
       await userEvent.clear(input);
 
       expect(mockOnChange).toHaveBeenCalledWith(sshPrivateKey, false);
-      // SshPrivateKey component validates but doesn't render error messages
-      // expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeTruthy();
+      expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeTruthy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
     });
@@ -90,8 +89,7 @@ describe('SshPrivateKey', () => {
       const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
 
       expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, false);
-      // SshPrivateKey component validates but doesn't render error messages
-      // expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
+      expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
     });
@@ -136,10 +134,8 @@ describe('SshPrivateKey', () => {
       await userEvent.clear(input);
 
       expect(mockOnChange).toHaveBeenCalledWith('', false);
-      // SshPrivateKey component validates but doesn't render error messages
-      // expect(screen.queryByText(REQUIRED_ERROR)).toBeTruthy();
-
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
+      expect(screen.queryByText(REQUIRED_ERROR)).toBeTruthy();
       expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
     });
 
@@ -158,9 +154,7 @@ describe('SshPrivateKey', () => {
       const expectedSshPrivateKey = btoa(sshPrivateKey.trim() + '\n');
 
       expect(mockOnChange).toHaveBeenCalledWith(expectedSshPrivateKey, false);
-      // SshPrivateKey component validates but doesn't render error messages in text area mode
-      expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeFalsy();
-
+      expect(screen.queryByText(MAX_LENGTH_ERROR)).toBeTruthy();
       expect(screen.queryByText(WRONG_TYPE_ERROR)).toBeFalsy();
       expect(screen.queryByText(REQUIRED_ERROR)).toBeFalsy();
     });

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
@@ -10,7 +10,14 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 import { TextFileUpload } from '@/components/TextFileUpload';
@@ -86,7 +93,9 @@ export class SshPrivateKey extends React.Component<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { validated } = this.state;
+    const { validated, privateKey, isUpload } = this.state;
+
+    const errorMessage = this.getErrorMessage(privateKey, isUpload);
 
     return (
       <FormGroup fieldId="ssh-private-key" label="Private Key" isRequired={true}>
@@ -97,6 +106,15 @@ export class SshPrivateKey extends React.Component<Props, State> {
           validated={validated}
           onChange={(key, isUpload) => this.onChange(key, isUpload)}
         />
+        {validated === ValidatedOptions.error && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
+                {errorMessage}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
     );
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
- Added helper text widgets with specific error messages for validation failures
- Refactored validation logic to use validateAndSanitize pattern (similar to GitProviderEndpoint)
- Error messages display for required field, max length, and invalid email format
- Added comprehensive test coverage for all error message scenarios

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23799

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to `User Preferences` -> `GitConfig` tab.
2. See: no helper text is revealed if the input fields are empty:
<img width="686" height="382" alt="image" src="https://github.com/user-attachments/assets/4c9d2843-ee76-4957-925f-427b89b87526" />

3. Enter some data to the `Name` field, see: the data is validated correctly:
<img width="645" height="105" alt="image" src="https://github.com/user-attachments/assets/13313f06-ace4-4842-9859-9a95a6b750b3" />

4. Clear the `Name` field, see the corresponding error:
<img width="649" height="113" alt="image" src="https://github.com/user-attachments/assets/b9f5c3b2-a012-47f2-8029-97fb5874933b" />

5. Enter a long text to the `Name` field (more than 128 characters), see the error:
<img width="646" height="116" alt="image" src="https://github.com/user-attachments/assets/5474b29e-d746-46c6-9e8f-23eeb542f9f7" />

6. Enter a valid email to the `Email` field, see: the email is validated correctly:
<img width="653" height="136" alt="image" src="https://github.com/user-attachments/assets/cc08ccb5-6cf4-4717-80b7-a6b4f974fa18" />

7. Enter an invalid email to the `Email` field, see: error is revealed:
<img width="649" height="152" alt="image" src="https://github.com/user-attachments/assets/ca0c373d-8785-4526-9d92-50fd8e5096fa" />

8. Clear the `Email` field, see: error is revealed:
<img width="656" height="145" alt="image" src="https://github.com/user-attachments/assets/935e53f7-3a72-4c24-9c84-d9d26bb5e77c" />


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
