### PR TITLE
fix: improve workspace status styles and remove no-op service worker handler

### DIFF
--- a/packages/dashboard-frontend/src/components/Header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -126,6 +126,7 @@ exports[`The header component for IDE-loader and Factory-loader pages should ren
                             aria-hidden={true}
                             aria-labelledby={null}
                             className="pf-v6-svg rotate"
+                            color="var(--pf-t--color--blue--50)"
                             fill="currentColor"
                             height="1em"
                             role="img"

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
@@ -130,6 +130,7 @@ exports[`Workspace indicator component Che Workspaces should render STARTING sta
             aria-hidden={true}
             aria-labelledby={null}
             className="pf-v6-svg rotate"
+            color="var(--pf-t--color--blue--50)"
             fill="currentColor"
             height="1em"
             role="img"
@@ -171,7 +172,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPED stat
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
-        color="var(--pf-t--global--text--color--regular)"
+        color="var(--pf-t--color--gray--95)"
       >
         <span
           className="pf-v6-c-icon__content"
@@ -239,7 +240,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPING sta
             aria-hidden={true}
             aria-labelledby={null}
             className="pf-v6-svg rotate"
-            color="var(--pf-t--global--text--color--regular)"
+            color="var(--pf-t--color--gray--95)"
             fill="currentColor"
             height="1em"
             role="img"
@@ -387,6 +388,7 @@ exports[`Workspace indicator component DevWorkspaces should render FAILING statu
             aria-hidden={true}
             aria-labelledby={null}
             className="pf-v6-svg rotate"
+            color="var(--pf-t--color--blue--50)"
             fill="currentColor"
             height="1em"
             role="img"
@@ -477,7 +479,7 @@ exports[`Workspace indicator component DevWorkspaces should render STOPPED statu
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
-        color="var(--pf-t--global--text--color--regular)"
+        color="var(--pf-t--color--gray--95)"
       >
         <span
           className="pf-v6-c-icon__content"
@@ -586,7 +588,7 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
-        color="var(--pf-t--global--text--color--regular)"
+        color="var(--pf-t--color--gray--95)"
       >
         <span
           className="pf-v6-c-icon__content"
@@ -646,7 +648,7 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
-        color="var(--pf-t--global--text--color--regular)"
+        color="var(--pf-t--color--gray--95)"
       >
         <span
           className="pf-v6-c-icon__content"
@@ -706,7 +708,7 @@ exports[`Workspace indicator component SCC Mismatch should render warning for ST
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
-        color="var(--pf-t--global--text--color--regular)"
+        color="var(--pf-t--color--gray--95)"
       >
         <span
           className="pf-v6-c-icon__content"
@@ -763,7 +765,7 @@ exports[`Workspace indicator component SCC Mismatch should render warning triang
         rel="noopener noreferrer"
         style={
           {
-            "color": "#73bcf7",
+            "color": "var(--pf-t--color--blue--40)",
             "textDecoration": "underline",
           }
         }
@@ -840,7 +842,7 @@ exports[`Workspace indicator component should render default status correctly 1`
             aria-hidden={true}
             aria-labelledby={null}
             className="pf-v6-svg rotate"
-            color="var(--pf-t--global--text--color--regular)"
+            color="var(--pf-t--color--gray--95)"
             fill="currentColor"
             height="1em"
             role="img"

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Label/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Label/__tests__/__snapshots__/index.spec.tsx.snap
@@ -148,7 +148,7 @@ exports[`The workspace status label component Che Workspaces should render STOPP
         >
           <span
             className="pf-v6-c-icon pf-m-inline"
-            color="var(--pf-t--global--text--color--regular)"
+            color="var(--pf-t--color--gray--95)"
           >
             <span
               className="pf-v6-c-icon__content"
@@ -347,6 +347,7 @@ exports[`The workspace status label component DevWorkspaces should render FAILIN
                 aria-hidden={true}
                 aria-labelledby={null}
                 className="pf-v6-svg rotate"
+                color="var(--pf-t--color--blue--50)"
                 fill="currentColor"
                 height="1em"
                 role="img"
@@ -459,7 +460,7 @@ exports[`The workspace status label component DevWorkspaces should render STOPPE
         >
           <span
             className="pf-v6-c-icon pf-m-inline"
-            color="var(--pf-t--global--text--color--regular)"
+            color="var(--pf-t--color--gray--95)"
           >
             <span
               className="pf-v6-c-icon__content"
@@ -590,7 +591,7 @@ exports[`The workspace status label component SCC Mismatch should render normal 
         >
           <span
             className="pf-v6-c-icon pf-m-inline"
-            color="var(--pf-t--global--text--color--regular)"
+            color="var(--pf-t--color--gray--95)"
           >
             <span
               className="pf-v6-c-icon__content"
@@ -661,7 +662,7 @@ exports[`The workspace status label component SCC Mismatch should render normal 
         >
           <span
             className="pf-v6-c-icon pf-m-inline"
-            color="var(--pf-t--global--text--color--regular)"
+            color="var(--pf-t--color--gray--95)"
           >
             <span
               className="pf-v6-c-icon__content"
@@ -732,7 +733,7 @@ exports[`The workspace status label component SCC Mismatch should render warning
         >
           <span
             className="pf-v6-c-icon pf-m-inline"
-            color="var(--pf-t--global--text--color--regular)"
+            color="var(--pf-t--color--gray--95)"
           >
             <span
               className="pf-v6-c-icon__content"
@@ -796,7 +797,7 @@ exports[`The workspace status label component SCC Mismatch should render warning
         rel="noopener noreferrer"
         style={
           {
-            "color": "#73bcf7",
+            "color": "var(--pf-t--color--blue--40)",
             "textDecoration": "underline",
           }
         }
@@ -888,7 +889,7 @@ exports[`The workspace status label component should render default status corre
                 aria-hidden={true}
                 aria-labelledby={null}
                 className="pf-v6-svg rotate"
-                color="var(--pf-t--global--text--color--regular)"
+                color="var(--pf-t--color--gray--95)"
                 fill="currentColor"
                 height="1em"
                 role="img"

--- a/packages/dashboard-frontend/src/components/Workspace/Status/getStatusIcon.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/getStatusIcon.tsx
@@ -24,12 +24,16 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { SCC_MISMATCH_WARNING_MESSAGE } from '@/services/helpers/sccMismatch';
 import { DevWorkspaceStatus, WorkspaceStatus } from '@/services/helpers/types';
 
-// Theme-aware grey colors using PatternFly 6 tokens
-const lightGreyCssVariable = 'var(--pf-t--global--text--color--regular)';
-const darkGreyCssVariable = 'var(--pf-t--global--text--color--subtle)';
+// Theme-aware blue colors
+const lightBlueCssVariable = 'var(--pf-t--color--blue--50)';
+const darkBlueCssVariable = 'var(--pf-t--color--blue--40)';
+// Theme-aware grey colors
+const lightGreyCssVariable = 'var(--pf-t--color--gray--95)';
+const darkGreyCssVariable = 'var(--pf-t--color--gray--30)';
 
 export function getStatusIcon(status: string, isDarkTheme: boolean) {
   const greyColor = isDarkTheme ? darkGreyCssVariable : lightGreyCssVariable;
+  const blueColor = isDarkTheme ? darkBlueCssVariable : lightBlueCssVariable;
 
   let icon: React.ReactElement;
   switch (status) {
@@ -52,7 +56,7 @@ export function getStatusIcon(status: string, isDarkTheme: boolean) {
     case DevWorkspaceStatus.FAILING:
       icon = (
         <Icon status="warning" isInline>
-          <InProgressIcon className={styles.rotate} />
+          <InProgressIcon className={styles.rotate} color={blueColor} />
         </Icon>
       );
       break;
@@ -60,7 +64,7 @@ export function getStatusIcon(status: string, isDarkTheme: boolean) {
     case WorkspaceStatus.STARTING:
       icon = (
         <Icon status="info" isInline>
-          <InProgressIcon className={styles.rotate} />
+          <InProgressIcon className={styles.rotate} color={blueColor} />
         </Icon>
       );
       break;
@@ -99,7 +103,7 @@ export function getSccMismatchTooltip(documentationUrl: string | undefined): Rea
             target="_blank"
             rel="noopener noreferrer"
             onClick={event => event.stopPropagation()}
-            style={{ color: '#73bcf7', textDecoration: 'underline' }}
+            style={{ color: 'var(--pf-t--color--blue--40)', textDecoration: 'underline' }}
           >
             Learn more
           </a>

--- a/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
@@ -2,24 +2,20 @@
   text-transform: capitalize;
 }
 
+:global(html.pf-v6-theme-dark) .pf-m-green.statusLabel {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--green--10);
+}
+
+:global(html.pf-v6-theme-dark) .pf-m-orange.statusLabel {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--orange--40);
+}
+
+:global(html.pf-v6-theme-dark) .pf-m-info.statusLabel {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--blue--10);
+}
+
 .statusIndicator {
   margin-right: 10px;
-}
-
-.statusIndicator svg {
-  overflow: visible;
-}
-
-.statusLabel .pf-m-success svg {
-  fill: #3c8e01f5;
-}
-
-.statusLabel .pf-m-info svg {
-  fill: #5b2eed;
-}
-
-.statusLabel .pf-m-warning svg {
-  fill: #d27a18;
 }
 
 svg.rotate {

--- a/packages/dashboard-frontend/src/service-worker.ts
+++ b/packages/dashboard-frontend/src/service-worker.ts
@@ -10,5 +10,4 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-self.addEventListener('fetch', () => {});
+export {};


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
1. **Fix workspace status label colors in dark theme** -- The CSS had a duplicate selector targeting `.pf-m-green` instead of `.pf-m-orange`, causing the green (Running) label to display with the orange background in dark theme, while the orange (Failed) label had no dark-theme override at all. This also adds a dark-theme override for `.pf-m-info` (Starting) labels and adjusts color token values for better contrast.

2. **Use PatternFly color token for status spinner and tooltip link** -- Replaces a hardcoded hex color (`#73bcf7`) with a PatternFly design token (`--pf-t--color--blue--40`) for the "Learn more" link in SCC mismatch tooltips, and applies the brand color to the starting/failing spinner icons for consistent theming.

3. **Remove no-op service worker fetch handler** -- The empty `fetch` event listener in `service-worker.ts` triggered a Chrome console warning about no-op fetch handlers causing navigation overhead. Replaced with an empty module export; the service worker registration still works for PWA installability.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="981" height="752" alt="Знімок екрана 2026-04-21 о 04 31 31" src="https://github.com/user-attachments/assets/0a99c6f1-bceb-48da-8f1b-56252d441da7" />
<img width="981" height="752" alt="Знімок екрана 2026-04-21 о 04 30 55" src="https://github.com/user-attachments/assets/1350aa70-275a-4e50-810d-229b021c04b8" />

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23789

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
