### PR TITLE
fix: use shared hasSccMismatch helper to prevent false positive SCC warning

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
@@ -34,7 +34,7 @@ import { lazyInject } from '@/inversify.config';
 import { WorkspaceRouteParams } from '@/Routes';
 import { AppAlerts } from '@/services/alerts/appAlerts';
 import { findTargetWorkspace } from '@/services/helpers/factoryFlow/findTargetWorkspace';
-import { SCC_MISMATCH_WARNING_MESSAGE } from '@/services/helpers/sccMismatch';
+import { hasSccMismatch, SCC_MISMATCH_WARNING_MESSAGE } from '@/services/helpers/sccMismatch';
 import { AlertItem, DevWorkspaceStatus, LoaderTab } from '@/services/helpers/types';
 import { Workspace, WorkspaceAdapter } from '@/services/workspace-adapter';
 import { RootState } from '@/store';
@@ -180,15 +180,10 @@ class StartingStepStartWorkspace extends ProgressStep<Props, State> {
     this.handleError(timeoutError);
   }
 
-  /**
-   * Check if there's an SCC mismatch between the workspace and server configuration.
-   * Returns true if server has SCC configured but workspace has different or missing SCC.
-   */
-  private hasSccMismatch(workspace: Workspace): boolean {
+  private checkSccMismatch(workspace: Workspace): boolean {
     const { currentScc } = this.props;
-    // Server has SCC requirement - check if workspace matches
     const containerScc = WorkspaceAdapter.getContainerScc(workspace.ref);
-    return containerScc !== currentScc;
+    return hasSccMismatch(containerScc, currentScc);
   }
 
   /**
@@ -208,8 +203,7 @@ class StartingStepStartWorkspace extends ProgressStep<Props, State> {
       );
     }
 
-    // Check for SCC mismatch - show warning but allow start
-    if (this.hasSccMismatch(workspace)) {
+    if (this.checkSccMismatch(workspace)) {
       const documentationUrl = this.props.branding.docs.containerRunCapabilities;
       this.appAlerts.showAlert({
         key: 'scc-mismatch-warning',

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
@@ -24,6 +24,7 @@ import {
   buildWorkspaceDetailsLocation,
   toHref,
 } from '@/services/helpers/location';
+import { hasSccMismatch } from '@/services/helpers/sccMismatch';
 import { LoaderTab, WorkspaceAction } from '@/services/helpers/types';
 import { TabManager } from '@/services/tabManager';
 import { Workspace, WorkspaceAdapter } from '@/services/workspace-adapter';
@@ -108,19 +109,10 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
     }
   }
 
-  /**
-   * Check if there's an SCC mismatch between the workspace and server configuration.
-   * Returns true if server has SCC configured but workspace has different or missing SCC.
-   */
-  private hasSccMismatch(workspace: Workspace): boolean {
+  private checkSccMismatch(workspace: Workspace): boolean {
     const { currentScc } = this.props;
-    // If server has no SCC requirement, no mismatch
-    if (currentScc === undefined) {
-      return false;
-    }
-    // Server has SCC requirement - check if workspace matches
     const containerScc = WorkspaceAdapter.getContainerScc(workspace.ref);
-    return containerScc !== currentScc;
+    return hasSccMismatch(containerScc, currentScc);
   }
 
   /**
@@ -149,7 +141,7 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
         break;
       }
       case WorkspaceAction.START_DEBUG_AND_OPEN_LOGS: {
-        if (this.hasSccMismatch(workspace)) {
+        if (this.checkSccMismatch(workspace)) {
           console.warn(
             `Workspace "${workspace.name}" has SCC mismatch. The workspace was created with a different container SCC than what is currently configured.`,
           );
@@ -162,7 +154,7 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
       }
       case WorkspaceAction.START_IN_BACKGROUND:
         {
-          if (this.hasSccMismatch(workspace)) {
+          if (this.checkSccMismatch(workspace)) {
             console.warn(
               `Workspace "${workspace.name}" has SCC mismatch. The workspace was created with a different container SCC than what is currently configured.`,
             );


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes positive SCC mismatch warning that appeared when creating workspaces from the "Empty" template

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23817

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
