### PR TITLE
feat(a11y): add aria-label support for upload buttons in SSH keys forms

### DIFF
--- a/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,293 +1,297 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TextFileUpload snapshot, validation is in the default state 1`] = `
-<div
-  className="pf-v6-c-file-upload"
-  data-testid="text-file-upload-id"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onDragEnter={[Function]}
-  onDragLeave={[Function]}
-  onDragOver={[Function]}
-  onDrop={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  role="presentation"
-  tabIndex={null}
->
+<div>
   <div
-    className="pf-v6-c-file-upload__file-select"
+    className="pf-v6-c-file-upload"
+    data-testid="text-file-upload-id"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragEnter={[Function]}
+    onDragLeave={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    role="presentation"
+    tabIndex={null}
   >
     <div
-      className="pf-v6-c-input-group"
+      className="pf-v6-c-file-upload__file-select"
     >
       <div
-        className="pf-v6-c-input-group__item pf-m-fill"
+        className="pf-v6-c-input-group"
       >
-        <span
-          className="pf-v6-c-form-control pf-m-readonly"
+        <div
+          className="pf-v6-c-input-group__item pf-m-fill"
         >
-          <input
-            aria-invalid={false}
-            aria-label="Drag end drop file here"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-1"
-            data-ouia-component-type="PF6/TextInput"
+          <span
+            className="pf-v6-c-form-control pf-m-readonly"
+          >
+            <input
+              aria-invalid={false}
+              aria-label="Drag end drop file here"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+              data-ouia-component-type="PF6/TextInput"
+              data-ouia-safe={true}
+              disabled={false}
+              id="text-file-upload-id-filename"
+              name="text-file-upload-id-filename"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="Drag end drop file here"
+              readOnly={true}
+              required={false}
+              type="text"
+              value=""
+            />
+          </span>
+        </div>
+        <div
+          className="pf-v6-c-input-group__item"
+        >
+          <button
+            aria-label={null}
+            className="pf-v6-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-1"
+            data-ouia-component-type="PF6/Button"
             data-ouia-safe={true}
             disabled={false}
-            id="text-file-upload-id-filename"
-            name="text-file-upload-id-filename"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="Drag end drop file here"
-            readOnly={true}
-            required={false}
-            type="text"
-            value=""
-          />
-        </span>
-      </div>
-      <div
-        className="pf-v6-c-input-group__item"
-      >
-        <button
-          aria-label={null}
-          className="pf-v6-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-1"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          <span
-            className="pf-v6-c-button__text"
+            onClick={[Function]}
+            type="button"
           >
-            Upload
-          </span>
-        </button>
-      </div>
-      <div
-        className="pf-v6-c-input-group__item"
-      >
-        <button
-          aria-label={null}
-          className="pf-v6-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-2"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe={true}
-          disabled={true}
-          onClick={[Function]}
-          tabIndex={null}
-          type="button"
+            <span
+              className="pf-v6-c-button__text"
+            >
+              Upload
+            </span>
+          </button>
+        </div>
+        <div
+          className="pf-v6-c-input-group__item"
         >
-          <span
-            className="pf-v6-c-button__text"
+          <button
+            aria-label={null}
+            className="pf-v6-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-2"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            tabIndex={null}
+            type="button"
           >
-            Clear
-          </span>
-        </button>
+            <span
+              className="pf-v6-c-button__text"
+            >
+              Clear
+            </span>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
-  <div
-    className="pf-v6-c-file-upload__file-details"
-  >
-    <span
-      className="pf-v6-c-form-control pf-m-textarea pf-m-resize-vertical"
+    <div
+      className="pf-v6-c-file-upload__file-details"
     >
-      <textarea
-        aria-invalid={false}
-        aria-label="File upload"
-        disabled={false}
-        id="text-file-upload-id"
-        onChange={[Function]}
-        onClick={[Function]}
-        placeholder="Paste your content here"
-        readOnly={false}
-        required={true}
-        value=""
-      />
-    </span>
-  </div>
-  <input
-    hidden={true}
-    multiple={false}
-    onChange={[Function]}
-    onClick={[Function]}
-    style={
-      {
-        "border": 0,
-        "clip": "rect(0, 0, 0, 0)",
-        "clipPath": "inset(50%)",
-        "height": "1px",
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+      <span
+        className="pf-v6-c-form-control pf-m-textarea pf-m-resize-vertical"
+      >
+        <textarea
+          aria-invalid={false}
+          aria-label="File upload"
+          disabled={false}
+          id="text-file-upload-id"
+          onChange={[Function]}
+          onClick={[Function]}
+          placeholder="Paste your content here"
+          readOnly={false}
+          required={true}
+          value=""
+        />
+      </span>
+    </div>
+    <input
+      hidden={true}
+      multiple={false}
+      onChange={[Function]}
+      onClick={[Function]}
+      style={
+        {
+          "border": 0,
+          "clip": "rect(0, 0, 0, 0)",
+          "clipPath": "inset(50%)",
+          "height": "1px",
+          "margin": "0 -1px -1px 0",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    tabIndex={-1}
-    type="file"
-  />
+      tabIndex={-1}
+      type="file"
+    />
+  </div>
 </div>
 `;
 
 exports[`TextFileUpload snapshot, validation is in the error state 1`] = `
-<div
-  className="pf-v6-c-file-upload"
-  data-testid="text-file-upload-id"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onDragEnter={[Function]}
-  onDragLeave={[Function]}
-  onDragOver={[Function]}
-  onDrop={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  role="presentation"
-  tabIndex={null}
->
+<div>
   <div
-    className="pf-v6-c-file-upload__file-select"
+    className="pf-v6-c-file-upload"
+    data-testid="text-file-upload-id"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragEnter={[Function]}
+    onDragLeave={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    role="presentation"
+    tabIndex={null}
   >
     <div
-      className="pf-v6-c-input-group"
+      className="pf-v6-c-file-upload__file-select"
     >
       <div
-        className="pf-v6-c-input-group__item pf-m-fill"
+        className="pf-v6-c-input-group"
       >
-        <span
-          className="pf-v6-c-form-control pf-m-readonly"
+        <div
+          className="pf-v6-c-input-group__item pf-m-fill"
         >
-          <input
-            aria-invalid={false}
-            aria-label="Drag end drop file here"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-2"
-            data-ouia-component-type="PF6/TextInput"
+          <span
+            className="pf-v6-c-form-control pf-m-readonly"
+          >
+            <input
+              aria-invalid={false}
+              aria-label="Drag end drop file here"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+              data-ouia-component-type="PF6/TextInput"
+              data-ouia-safe={true}
+              disabled={false}
+              id="text-file-upload-id-filename"
+              name="text-file-upload-id-filename"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="Drag end drop file here"
+              readOnly={true}
+              required={false}
+              type="text"
+              value=""
+            />
+          </span>
+        </div>
+        <div
+          className="pf-v6-c-input-group__item"
+        >
+          <button
+            aria-label={null}
+            className="pf-v6-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-3"
+            data-ouia-component-type="PF6/Button"
             data-ouia-safe={true}
             disabled={false}
-            id="text-file-upload-id-filename"
-            name="text-file-upload-id-filename"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="Drag end drop file here"
-            readOnly={true}
-            required={false}
-            type="text"
-            value=""
-          />
-        </span>
-      </div>
-      <div
-        className="pf-v6-c-input-group__item"
-      >
-        <button
-          aria-label={null}
-          className="pf-v6-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-3"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          <span
-            className="pf-v6-c-button__text"
+            onClick={[Function]}
+            type="button"
           >
-            Upload
-          </span>
-        </button>
-      </div>
-      <div
-        className="pf-v6-c-input-group__item"
-      >
-        <button
-          aria-label={null}
-          className="pf-v6-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-4"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe={true}
-          disabled={true}
-          onClick={[Function]}
-          tabIndex={null}
-          type="button"
+            <span
+              className="pf-v6-c-button__text"
+            >
+              Upload
+            </span>
+          </button>
+        </div>
+        <div
+          className="pf-v6-c-input-group__item"
         >
-          <span
-            className="pf-v6-c-button__text"
+          <button
+            aria-label={null}
+            className="pf-v6-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-4"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            tabIndex={null}
+            type="button"
           >
-            Clear
-          </span>
-        </button>
+            <span
+              className="pf-v6-c-button__text"
+            >
+              Clear
+            </span>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
-  <div
-    className="pf-v6-c-file-upload__file-details"
-  >
-    <span
-      className="pf-v6-c-form-control pf-m-textarea pf-m-resize-vertical pf-m-error"
+    <div
+      className="pf-v6-c-file-upload__file-details"
     >
-      <textarea
-        aria-invalid={true}
-        aria-label="File upload"
-        disabled={false}
-        id="text-file-upload-id"
-        onChange={[Function]}
-        onClick={[Function]}
-        placeholder="Paste your content here"
-        readOnly={false}
-        required={true}
-        value=""
-      />
       <span
-        className="pf-v6-c-form-control__utilities"
+        className="pf-v6-c-form-control pf-m-textarea pf-m-resize-vertical pf-m-error"
       >
+        <textarea
+          aria-invalid={true}
+          aria-label="File upload"
+          disabled={false}
+          id="text-file-upload-id"
+          onChange={[Function]}
+          onClick={[Function]}
+          placeholder="Paste your content here"
+          readOnly={false}
+          required={true}
+          value=""
+        />
         <span
-          className="pf-v6-c-form-control__icon pf-m-status"
+          className="pf-v6-c-form-control__utilities"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-v6-svg"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            viewBox="0 0 512 512"
-            width="1em"
+          <span
+            className="pf-v6-c-form-control__icon pf-m-status"
           >
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-            />
-          </svg>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              className="pf-v6-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              />
+            </svg>
+          </span>
         </span>
       </span>
-    </span>
-  </div>
-  <input
-    hidden={true}
-    multiple={false}
-    onChange={[Function]}
-    onClick={[Function]}
-    style={
-      {
-        "border": 0,
-        "clip": "rect(0, 0, 0, 0)",
-        "clipPath": "inset(50%)",
-        "height": "1px",
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+    </div>
+    <input
+      hidden={true}
+      multiple={false}
+      onChange={[Function]}
+      onClick={[Function]}
+      style={
+        {
+          "border": 0,
+          "clip": "rect(0, 0, 0, 0)",
+          "clipPath": "inset(50%)",
+          "height": "1px",
+          "margin": "0 -1px -1px 0",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    tabIndex={-1}
-    type="file"
-  />
+      tabIndex={-1}
+      type="file"
+    />
+  </div>
 </div>
 `;

--- a/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/__tests__/index.spec.tsx
@@ -76,6 +76,19 @@ describe('TextFileUpload', () => {
     expect(contentInput).toBeEnabled();
   });
 
+  test('Upload button aria-label', async () => {
+    const ariaLabel = 'Upload test file';
+    renderComponent(ValidatedOptions.default, ariaLabel);
+
+    // Find the Upload button by its role and name
+    const uploadButton = screen.getByRole('button', { name: /Upload/i });
+    expect(uploadButton).not.toBeNull();
+
+    await waitFor(() => {
+      expect(uploadButton.getAttribute('aria-label')).toBe(ariaLabel);
+    });
+  });
+
   describe('Upload file', () => {
     test('should handle a valid file', async () => {
       renderComponent(ValidatedOptions.default);
@@ -147,12 +160,16 @@ describe('TextFileUpload', () => {
   });
 });
 
-function getComponent(validated: ValidatedOptions): React.ReactElement {
+function getComponent(
+  validated: ValidatedOptions,
+  uploadButtonAriaLabel?: string,
+): React.ReactElement {
   return (
     <TextFileUpload
       fieldId={fieldId}
       fileNamePlaceholder={fileNamePlaceholder}
       textAreaPlaceholder={textAreaPlaceholder}
+      uploadButtonAriaLabel={uploadButtonAriaLabel}
       validated={validated}
       onChange={mockOnChange}
     />

--- a/packages/dashboard-frontend/src/components/TextFileUpload/index.tsx
+++ b/packages/dashboard-frontend/src/components/TextFileUpload/index.tsx
@@ -19,6 +19,7 @@ export type Props = {
   fieldId: string;
   fileNamePlaceholder?: string;
   textAreaPlaceholder?: string;
+  uploadButtonAriaLabel?: string;
   validated: ValidatedOptions;
   onChange: (content: string, isUpload: boolean) => void;
 };
@@ -34,6 +35,8 @@ export type State = {
  * A component that allows the user to upload a text file.
  */
 export class TextFileUpload extends React.PureComponent<Props, State> {
+  private containerRef = React.createRef<HTMLDivElement>();
+
   constructor(props: Props) {
     super(props);
 
@@ -43,6 +46,29 @@ export class TextFileUpload extends React.PureComponent<Props, State> {
       file: undefined,
       isLoading: false,
     };
+  }
+
+  public componentDidMount(): void {
+    this.updateUploadButtonAriaLabel();
+  }
+
+  public componentDidUpdate(): void {
+    this.updateUploadButtonAriaLabel();
+  }
+
+  private updateUploadButtonAriaLabel(): void {
+    const { uploadButtonAriaLabel } = this.props;
+    if (!uploadButtonAriaLabel || !this.containerRef.current) {
+      return;
+    }
+
+    // Find the upload button within the FileUpload component
+    const buttons = this.containerRef.current.querySelectorAll('button');
+    buttons.forEach(button => {
+      if (button.textContent?.includes('Upload')) {
+        button.setAttribute('aria-label', uploadButtonAriaLabel);
+      }
+    });
   }
 
   private handleFileInputChange(file: File): void {
@@ -87,31 +113,33 @@ export class TextFileUpload extends React.PureComponent<Props, State> {
     const hideDefaultPreview = filename !== undefined;
 
     return (
-      <FileUpload
-        id={fieldId}
-        data-testid={fieldId}
-        value={content}
-        filename={filename}
-        filenamePlaceholder={fileNamePlaceholder}
-        onFileInputChange={(_event, file) => this.handleFileInputChange(file)}
-        onClearClick={() => this.handleClearClick()}
-        onDataChange={(_event, data) => this.handleDataChange(data)}
-        onTextChange={(_event, text) => this.handleTextChange(text)}
-        browseButtonText="Upload"
-        isLoading={isLoading}
-        isRequired={true}
-        isReadOnly={isReadOnly}
-        validated={fileUploadValidated}
-        type="text"
-        onReadStarted={() => this.setState({ isLoading: true })}
-        onReadFinished={() => this.setState({ isLoading: false })}
-        onReadFailed={() => this.setState({ isLoading: false })}
-        textAreaPlaceholder={textAreaPlaceholder}
-        allowEditingUploadedText={allowEditingUploadedText}
-        hideDefaultPreview={hideDefaultPreview}
-      >
-        {filename && <TextFileUploadPreview file={file} />}
-      </FileUpload>
+      <div ref={this.containerRef}>
+        <FileUpload
+          id={fieldId}
+          data-testid={fieldId}
+          value={content}
+          filename={filename}
+          filenamePlaceholder={fileNamePlaceholder}
+          onFileInputChange={(_event, file) => this.handleFileInputChange(file)}
+          onClearClick={() => this.handleClearClick()}
+          onDataChange={(_event, data) => this.handleDataChange(data)}
+          onTextChange={(_event, text) => this.handleTextChange(text)}
+          browseButtonText="Upload"
+          isLoading={isLoading}
+          isRequired={true}
+          isReadOnly={isReadOnly}
+          validated={fileUploadValidated}
+          type="text"
+          onReadStarted={() => this.setState({ isLoading: true })}
+          onReadFinished={() => this.setState({ isLoading: false })}
+          onReadFailed={() => this.setState({ isLoading: false })}
+          textAreaPlaceholder={textAreaPlaceholder}
+          allowEditingUploadedText={allowEditingUploadedText}
+          hideDefaultPreview={hideDefaultPreview}
+        >
+          {filename && <TextFileUploadPreview file={file} />}
+        </FileUpload>
+      </div>
     );
   }
 }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPrivateKey/index.tsx
@@ -94,6 +94,7 @@ export class SshPrivateKey extends React.Component<Props, State> {
           fieldId="ssh-private-key"
           fileNamePlaceholder="Upload the PRIVATE key"
           textAreaPlaceholder="Or paste the PRIVATE key"
+          uploadButtonAriaLabel="Upload private key file"
           validated={validated}
           onChange={(key, isUpload) => this.onChange(key, isUpload)}
         />

--- a/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/SshKeys/AddModal/Form/SshPublicKey/index.tsx
@@ -103,6 +103,7 @@ export class SshPublicKey extends React.Component<Props, State> {
           fieldId="ssh-public-key"
           fileNamePlaceholder="Upload the PUBLIC key"
           textAreaPlaceholder="Or paste the PUBLIC key"
+          uploadButtonAriaLabel="Upload public key file"
           validated={validated}
           onChange={(key, isUpload) => this.onChange(key, isUpload)}
         />


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add optional `uploadButtonAriaLabel` prop to `TextFileUpload` component to improve screen reader accessibility. The component now allows consumers to set descriptive `aria-labels` on upload buttons, making it clearer what file type is being uploaded.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10286

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Check the html attribute of the `Upload` buttons.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
