### PR TITLE
fix: enable keyboard navigation for editor selector cards

### DIFF
--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,12 +2,16 @@
 
 exports[`Editor Selector Entry snapshot 1`] = `
 <div
+  aria-label="Select editor VS Code - Open Source"
   className="pf-v6-c-card pf-m-compact pf-m-selectable pf-m-clickable"
   data-ouia-component-id="OUIA-Generated-Card-1"
   data-ouia-component-type="PF6/Card"
   data-ouia-safe={true}
   id="editor-selector-card-che-incubator/che-code/insiders"
   onClick={[Function]}
+  onKeyDown={[Function]}
+  role="button"
+  tabIndex={0}
 >
   <div
     className="pf-v6-c-card__header"

--- a/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
+++ b/packages/dashboard-frontend/src/components/EditorSelector/Gallery/Entry/index.tsx
@@ -101,6 +101,18 @@ export class EditorSelectorEntry extends React.PureComponent<Props, State> {
     onSelect(activeEditor.id);
   };
 
+  private handleKeyDown(event: React.KeyboardEvent): void {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    const target = event.target as HTMLElement;
+    if (target.tagName === 'BUTTON' || target.closest('[role="menu"]')) {
+      return;
+    }
+    event.preventDefault();
+    this.handleSelectableAction();
+  }
+
   private handleDropdownToggle(event: React.MouseEvent) {
     event.stopPropagation();
 
@@ -184,6 +196,10 @@ export class EditorSelectorEntry extends React.PureComponent<Props, State> {
         isSelectable
         isSelected={isSelectedGroup}
         onClick={this.handleSelectableAction}
+        onKeyDown={(e: React.KeyboardEvent) => this.handleKeyDown(e)}
+        role="button"
+        tabIndex={0}
+        aria-label={`Select editor ${groupName}`}
       >
         <CardHeader
           selectableActions={{


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds keyboard accessibility to the editor `Card` component, matching the existing pattern used by `SampleCard`:
- `tabIndex={0}` -- makes the card focusable via **Tab**
- `role="button"` -- exposes the card as an interactive element to assistive technology
- `aria-label` -- provides a descriptive label for screen readers
- `onKeyDown` handler -- pressing **Enter** or **Space** triggers editor selection, matching the existing `onClick` behavior


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10660

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the image from this PR.
2. Navigate to the "Create Workspace" page
3. Use **Tab** to focus the editor selector cards in the "Choose an Editor" section -- the card should receive visible focus
4. Press **Enter** or **Space** on a focused card -- it should become selected
5. **Tab** to the kebab menu (three-dot icon) and press **Enter** -- the dropdown should open normally

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
