### PR TITLE
fix: enable keyboard navigation for appearance theme selector

### DIFF
--- a/packages/dashboard-frontend/src/Layout/Header/Tools/UserMenu/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Header/Tools/UserMenu/index.tsx
@@ -48,6 +48,25 @@ const UserMenuComponent: React.FC<Props> = ({ history, username, logout }) => {
   const autoThemeRef = React.useRef<HTMLSpanElement>(null);
   const tooltipContainerRef = React.useRef<HTMLDivElement>(null);
 
+  const themeOrder = [ThemePreference.LIGHT, ThemePreference.DARK, ThemePreference.AUTO];
+
+  const handleThemeKeyDown = (event: React.KeyboardEvent): void => {
+    const currentIndex = themeOrder.indexOf(themePreference);
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      event.stopPropagation();
+      const step = event.key === 'ArrowRight' ? 1 : -1;
+      const nextIndex = (currentIndex + step + themeOrder.length) % themeOrder.length;
+      setThemePreference(themeOrder[nextIndex]);
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      event.stopPropagation();
+      const nextIndex = (currentIndex + 1) % themeOrder.length;
+      setThemePreference(themeOrder[nextIndex]);
+    }
+  };
+
   const onUsernameSelect = (
     _event?: React.MouseEvent<Element, MouseEvent>,
     itemId?: string | number,
@@ -84,7 +103,7 @@ const UserMenuComponent: React.FC<Props> = ({ history, username, logout }) => {
       <DropdownGroup label="Appearance">
         <DropdownList>
           <DropdownItem itemId="theme-selector" key="theme-selector" component="div">
-            <div ref={tooltipContainerRef}>
+            <div ref={tooltipContainerRef} onKeyDown={handleThemeKeyDown}>
               <ToggleGroup id="theme-toggle" aria-label="Theme toggle group">
                 {/* Span wrappers give triggerRef a real bounding rect (display:contents has none) */}
                 <span ref={lightThemeRef}>


### PR DESCRIPTION
Add onKeyDown handler to the theme toggle group in the user menu so Arrow Left/Right cycles between themes and Enter/Space advances to the next theme, fixing keyboard accessibility.

Resolves: https://redhat.atlassian.net/browse/CRW-10661
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The appearance theme toggle (Light / Dark / Auto) in the user menu dropdown was not accessible via keyboard. The `ToggleGroupItem` buttons inside the `DropdownItem` could not receive focus because PatternFly's Dropdown manages focus at the menu item level, not within nested components.

This PR adds an `onKeyDown` handler to the theme selector wrapper that enables keyboard control:
- **Arrow Left / Arrow Right** -- cycles between Light, Dark, and Auto themes
- **Enter / Space** -- advances to the next theme

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10661

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the image from this PR.
2. Click the username in the top-right corner to open the user menu
3. Use **Arrow Down** to navigate to the "Appearance" theme selector item
4. Press **Arrow Right** or **Arrow Left** -- the active theme should change (Light -> Dark -> Auto -> Light)
5. Press **Enter** or **Space** -- the theme should advance to the next option
6. Verify the page appearance updates immediately when the theme changes

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
