### PR TITLE
fix: enable keyboard selection in git provider dropdown

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderSelector/index.tsx
@@ -62,7 +62,7 @@ export class GitProviderSelector extends React.PureComponent<Props, State> {
     this.props.onSelect(provider);
   }
 
-  private buildDropdownItems(): React.ReactElement[] {
+  private buildDropdownItems(selectedProvider: api.GitProvider): React.ReactElement[] {
     return Object.entries(GIT_PROVIDERS)
       .sort((providerEntryA, providerEntryB) => {
         // compare by values
@@ -77,7 +77,11 @@ export class GitProviderSelector extends React.PureComponent<Props, State> {
       .map(providerEntry => {
         const [provider, providerName] = providerEntry as [api.GitProvider, string];
         return (
-          <DropdownItem key={provider} onClick={() => this.onSelect(provider)}>
+          <DropdownItem
+            key={provider}
+            isSelected={provider === selectedProvider}
+            onClick={() => this.onSelect(provider)}
+          >
             {providerName}
           </DropdownItem>
         );
@@ -88,12 +92,14 @@ export class GitProviderSelector extends React.PureComponent<Props, State> {
     const { isOpen, provider = DEFAULT_GIT_PROVIDER } = this.state;
     const providerName = GIT_PROVIDERS[provider];
 
-    const dropdownItems = this.buildDropdownItems();
+    const dropdownItems = this.buildDropdownItems(provider);
 
     return (
       <FormGroup label="Provider Name" fieldId="provider-name">
         <Dropdown
           onOpenChange={isOpen => this.setState({ isOpen })}
+          shouldFocusFirstItemOnOpen
+          popperProps={{ appendTo: 'inline' }}
           toggle={toggleRef => (
             <MenuToggle
               ref={toggleRef}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The "Provider Name" dropdown in the "Add Personal Access Token" form was not accessible via keyboard. After opening the dropdown with Enter/Space, focus remained on the toggle button and the user could not navigate to or select a git provider using the keyboard.

This PR fixes the issue by:
- Adding `shouldFocusFirstItemOnOpen` to the `Dropdown` so that focus automatically moves to the first menu item when the dropdown opens
- Adding `onSelect` handler to the `Dropdown` component to handle selection triggered by keyboard (Enter/Space on a focused item)
- Adding `value` prop to each `DropdownItem` to identify the selected provider in the `onSelect` callback


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10662

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the image from this PR.
2. Navigate to **User Preferences** > **Personal Access Tokens** tab
3. Click **Add Personal Access Token** to open the form
4. Use **Tab** to focus the "Provider Name" dropdown toggle
5. Press **Enter** or **Space** -- the dropdown should open and focus the first item
6. Use **Arrow Down** / **Arrow Up** to navigate between git providers
7. Press **Enter** or **Space** to select a provider -- the dropdown should close and the selected provider should be displayed


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
