### PR TITLE
fix: add arrow key navigation to User Preferences tabs

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/__snapshots__/index.spec.tsx.snap
@@ -49,6 +49,7 @@ exports[`UserPreferences snapshot 1`] = `
                 data-ouia-safe="true"
                 id="pf-tab-ContainerRegistries-user-preferences-tabs"
                 role="tab"
+                tabindex="0"
                 type="button"
               >
                 Container Registries
@@ -65,6 +66,7 @@ exports[`UserPreferences snapshot 1`] = `
                 data-ouia-safe="true"
                 id="pf-tab-GitServices-user-preferences-tabs"
                 role="tab"
+                tabindex="-1"
                 type="button"
               >
                 Git Services
@@ -81,6 +83,7 @@ exports[`UserPreferences snapshot 1`] = `
                 data-ouia-safe="true"
                 id="pf-tab-PersonalAccessTokens-user-preferences-tabs"
                 role="tab"
+                tabindex="-1"
                 type="button"
               >
                 Personal Access Tokens
@@ -97,6 +100,7 @@ exports[`UserPreferences snapshot 1`] = `
                 data-ouia-safe="true"
                 id="pf-tab-Gitconfig-user-preferences-tabs"
                 role="tab"
+                tabindex="-1"
                 type="button"
               >
                 Gitconfig
@@ -113,6 +117,7 @@ exports[`UserPreferences snapshot 1`] = `
                 data-ouia-safe="true"
                 id="pf-tab-SshKeys-user-preferences-tabs"
                 role="tab"
+                tabindex="-1"
                 type="button"
               >
                 SSH Keys

--- a/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -139,6 +140,124 @@ describe('UserPreferences', () => {
       await userEvent.click(tab);
 
       expect(screen.queryByRole('tabpanel', { name: 'SSH Keys' })).toBeTruthy();
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    it('should move to the next tab on ArrowRight', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.CONTAINER_REGISTRIES);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Container Registries' });
+      fireEvent.keyDown(tab, { key: 'ArrowRight' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.GIT_SERVICES}`),
+      );
+    });
+
+    it('should move to the next tab on ArrowDown', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.CONTAINER_REGISTRIES);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Container Registries' });
+      fireEvent.keyDown(tab, { key: 'ArrowDown' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.GIT_SERVICES}`),
+      );
+    });
+
+    it('should move to the previous tab on ArrowLeft', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.GIT_SERVICES);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Git Services' });
+      fireEvent.keyDown(tab, { key: 'ArrowLeft' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.CONTAINER_REGISTRIES}`),
+      );
+    });
+
+    it('should move to the previous tab on ArrowUp', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.GIT_SERVICES);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Git Services' });
+      fireEvent.keyDown(tab, { key: 'ArrowUp' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.CONTAINER_REGISTRIES}`),
+      );
+    });
+
+    it('should wrap around to the first tab on ArrowRight from the last tab', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.SSH_KEYS);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'SSH Keys' });
+      fireEvent.keyDown(tab, { key: 'ArrowRight' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.CONTAINER_REGISTRIES}`),
+      );
+    });
+
+    it('should wrap around to the last tab on ArrowLeft from the first tab', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.CONTAINER_REGISTRIES);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Container Registries' });
+      fireEvent.keyDown(tab, { key: 'ArrowLeft' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.SSH_KEYS}`),
+      );
+    });
+
+    it('should move to the first tab on Home', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.GITCONFIG);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Gitconfig' });
+      fireEvent.keyDown(tab, { key: 'Home' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.CONTAINER_REGISTRIES}`),
+      );
+    });
+
+    it('should move to the last tab on End', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.CONTAINER_REGISTRIES);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Container Registries' });
+      fireEvent.keyDown(tab, { key: 'End' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`tab=${UserPreferencesTab.SSH_KEYS}`),
+      );
+    });
+
+    it('should not navigate on unhandled keys', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.CONTAINER_REGISTRIES);
+      renderComponent(location);
+
+      const tab = screen.getByRole('tab', { name: 'Container Registries' });
+      fireEvent.keyDown(tab, { key: 'Enter' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate when keydown target is not a tab', () => {
+      const location = buildUserPreferencesLocation(UserPreferencesTab.CONTAINER_REGISTRIES);
+      renderComponent(location);
+
+      const tabPanel = screen.getByRole('tabpanel', { name: 'Container Registries' });
+      fireEvent.keyDown(tabPanel, { key: 'ArrowRight' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
@@ -37,6 +37,14 @@ export type State = {
 };
 
 class UserPreferences extends React.PureComponent<Props, State> {
+  private readonly tabOrder: UserPreferencesTab[] = [
+    UserPreferencesTab.CONTAINER_REGISTRIES,
+    UserPreferencesTab.GIT_SERVICES,
+    UserPreferencesTab.PERSONAL_ACCESS_TOKENS,
+    UserPreferencesTab.GITCONFIG,
+    UserPreferencesTab.SSH_KEYS,
+  ];
+
   constructor(props: Props) {
     super(props);
 
@@ -68,17 +76,49 @@ class UserPreferences extends React.PureComponent<Props, State> {
     return UserPreferencesTab.CONTAINER_REGISTRIES;
   }
 
-  private handleTabClick(
+  private handleTabClick = (
     event: React.MouseEvent<HTMLElement, MouseEvent>,
     activeTabKey: string | number,
-  ): void {
+  ): void => {
     event.stopPropagation();
     this.props.navigate(`${ROUTE.USER_PREFERENCES}?tab=${activeTabKey}`);
 
     this.setState({
       activeTabKey: activeTabKey as UserPreferencesTab,
     });
-  }
+  };
+
+  private handleTabKeyDown = (event: React.KeyboardEvent): void => {
+    const target = event.target as HTMLElement;
+    if (target.getAttribute('role') !== 'tab') {
+      return;
+    }
+
+    const { activeTabKey } = this.state;
+    const currentIndex = this.tabOrder.indexOf(activeTabKey);
+    let nextIndex = -1;
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      nextIndex = (currentIndex + 1) % this.tabOrder.length;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      nextIndex = (currentIndex - 1 + this.tabOrder.length) % this.tabOrder.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = this.tabOrder.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    const nextTabKey = this.tabOrder[nextIndex];
+    this.props.navigate(`${ROUTE.USER_PREFERENCES}?tab=${nextTabKey}`);
+    this.setState({ activeTabKey: nextTabKey }, () => {
+      const tabsContainer = document.getElementById('user-preferences-tabs');
+      const buttons = tabsContainer?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+      buttons?.[nextIndex]?.focus();
+    });
+  };
 
   render(): React.ReactNode {
     const { activeTabKey } = this.state;
@@ -94,26 +134,44 @@ class UserPreferences extends React.PureComponent<Props, State> {
             id="user-preferences-tabs"
             style={{ backgroundColor: 'var(--pf-global--BackgroundColor--100)' }}
             activeKey={activeTabKey}
-            onSelect={(event, tabKey) => this.handleTabClick(event, tabKey)}
+            onSelect={this.handleTabClick}
+            onKeyDown={this.handleTabKeyDown}
             mountOnEnter={true}
             unmountOnExit={true}
           >
-            <Tab eventKey={UserPreferencesTab.CONTAINER_REGISTRIES} title="Container Registries">
+            <Tab
+              eventKey={UserPreferencesTab.CONTAINER_REGISTRIES}
+              title="Container Registries"
+              tabIndex={activeTabKey === UserPreferencesTab.CONTAINER_REGISTRIES ? 0 : -1}
+            >
               <ContainerRegistries />
             </Tab>
-            <Tab eventKey={UserPreferencesTab.GIT_SERVICES} title="Git Services">
+            <Tab
+              eventKey={UserPreferencesTab.GIT_SERVICES}
+              title="Git Services"
+              tabIndex={activeTabKey === UserPreferencesTab.GIT_SERVICES ? 0 : -1}
+            >
               <GitServices />
             </Tab>
             <Tab
               eventKey={UserPreferencesTab.PERSONAL_ACCESS_TOKENS}
               title="Personal Access Tokens"
+              tabIndex={activeTabKey === UserPreferencesTab.PERSONAL_ACCESS_TOKENS ? 0 : -1}
             >
               <PersonalAccessTokens />
             </Tab>
-            <Tab eventKey={UserPreferencesTab.GITCONFIG} title="Gitconfig">
+            <Tab
+              eventKey={UserPreferencesTab.GITCONFIG}
+              title="Gitconfig"
+              tabIndex={activeTabKey === UserPreferencesTab.GITCONFIG ? 0 : -1}
+            >
               <GitConfig />
             </Tab>
-            <Tab eventKey={UserPreferencesTab.SSH_KEYS} title="SSH Keys">
+            <Tab
+              eventKey={UserPreferencesTab.SSH_KEYS}
+              title="SSH Keys"
+              tabIndex={activeTabKey === UserPreferencesTab.SSH_KEYS ? 0 : -1}
+            >
               <SshKeys />
             </Tab>
           </Tabs>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
@@ -76,19 +76,19 @@ class UserPreferences extends React.PureComponent<Props, State> {
     return UserPreferencesTab.CONTAINER_REGISTRIES;
   }
 
-  private handleTabClick = (
+  private handleTabClick(
     event: React.MouseEvent<HTMLElement, MouseEvent>,
     activeTabKey: string | number,
-  ): void => {
+  ): void {
     event.stopPropagation();
     this.props.navigate(`${ROUTE.USER_PREFERENCES}?tab=${activeTabKey}`);
 
     this.setState({
       activeTabKey: activeTabKey as UserPreferencesTab,
     });
-  };
+  }
 
-  private handleTabKeyDown = (event: React.KeyboardEvent): void => {
+  private handleTabKeyDown(event: React.KeyboardEvent): void {
     const target = event.target as HTMLElement;
     if (target.getAttribute('role') !== 'tab') {
       return;
@@ -118,7 +118,7 @@ class UserPreferences extends React.PureComponent<Props, State> {
       const buttons = tabsContainer?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
       buttons?.[nextIndex]?.focus();
     });
-  };
+  }
 
   render(): React.ReactNode {
     const { activeTabKey } = this.state;
@@ -134,8 +134,8 @@ class UserPreferences extends React.PureComponent<Props, State> {
             id="user-preferences-tabs"
             style={{ backgroundColor: 'var(--pf-global--BackgroundColor--100)' }}
             activeKey={activeTabKey}
-            onSelect={this.handleTabClick}
-            onKeyDown={this.handleTabKeyDown}
+            onSelect={(event, tabKey) => this.handleTabClick(event, tabKey)}
+            onKeyDown={event => this.handleTabKeyDown(event)}
             mountOnEnter={true}
             unmountOnExit={true}
           >


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The tab list on the User Preferences page (Container Registries, Git Services, Personal Access Tokens, Gitconfig, SSH Keys) did not follow WAI-ARIA keyboard navigation patterns. Arrow keys did not switch between tabs, and pressing Tab moved focus to the next tab header instead of into the active tab's content panel.

PatternFly 5's `Tabs` component does not implement built-in arrow key navigation. This PR adds an `onKeyDown` handler to the `Tabs` component that implements the WAI-ARIA tabs keyboard pattern:
- **Arrow Left / Arrow Right** -- switches focus and activates the previous/next tab (wraps around)
- **Arrow Up / Arrow Down** -- same behavior for vertical navigation
- **Home / End** -- jumps to the first/last tab


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10288

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the image from this PR.
2. Navigate to the **User Preferences** page
3. Use **Tab** to move focus to the first tab header (Container Registries)
4. Press **Arrow Right** -- focus should move to "Git Services" and the tab panel should switch
5. Press **Arrow Right** repeatedly -- focus should cycle through all tabs and wrap around
6. Press **Arrow Left** -- focus should move to the previous tab
7. Press **Home** -- focus should jump to the first tab (Container Registries)
8. Press **End** -- focus should jump to the last tab (SSH Keys)

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
