### PR TITLE
fix: improve color contrast to meet WCAG 4.5:1 minimum

### DIFF
--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.module.css
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.module.css
@@ -55,7 +55,7 @@
   border-radius: 3px;
 }
 
-.pf-v6-theme-dark .errorMessage {
+:global(.pf-v6-theme-dark) .errorMessage {
   color: var(--pf-t--global--text--color--regular);
   background-color: rgb(185 80 80);
 }

--- a/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.module.css
+++ b/packages/dashboard-frontend/src/Layout/ErrorReporter/Issue/index.module.css
@@ -54,3 +54,8 @@
   background-color: var(--pf-t--global--color--nonstatus--red--default);
   border-radius: 3px;
 }
+
+.pf-v6-theme-dark .errorMessage {
+  color: var(--pf-t--global--text--color--regular);
+  background-color: rgb(185 80 80);
+}

--- a/packages/dashboard-frontend/src/components/BackupStatusBadge/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/BackupStatusBadge/__tests__/__snapshots__/index.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`BackupStatusBadge icon rendering should render CheckCircleIcon for succ
   >
     <span
       aria-label="Backup status: Success"
-      className="pf-v6-c-label pf-m-green pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-green pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span
@@ -93,7 +93,7 @@ exports[`BackupStatusBadge icon rendering should render ExclamationTriangleIcon 
   >
     <span
       aria-label="Backup status: Failed"
-      className="pf-v6-c-label pf-m-orange pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-orange pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span
@@ -164,7 +164,7 @@ exports[`BackupStatusBadge icon rendering should render InfoCircleIcon for never
   >
     <span
       aria-label="Backup status: Never"
-      className="pf-v6-c-label pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span
@@ -232,7 +232,7 @@ exports[`BackupStatusBadge icon rendering should render animated InProgressIcon 
   >
     <span
       aria-label="Backup status: In Progress"
-      className="pf-v6-c-label pf-m-blue pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-blue pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span
@@ -304,7 +304,7 @@ exports[`BackupStatusBadge snapshots failed status 1`] = `
   >
     <span
       aria-label="Backup status: Failed"
-      className="pf-v6-c-label pf-m-orange pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-orange pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span
@@ -372,7 +372,7 @@ exports[`BackupStatusBadge snapshots in-progress status 1`] = `
   >
     <span
       aria-label="Backup status: In Progress"
-      className="pf-v6-c-label pf-m-blue pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-blue pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span
@@ -444,7 +444,7 @@ exports[`BackupStatusBadge snapshots never status 1`] = `
   >
     <span
       aria-label="Backup status: Never"
-      className="pf-v6-c-label pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span
@@ -515,7 +515,7 @@ exports[`BackupStatusBadge snapshots success status 1`] = `
   >
     <span
       aria-label="Backup status: Success"
-      className="pf-v6-c-label pf-m-green pf-m-filled backupStatusBadge size-md"
+      className="pf-v6-c-label pf-m-green pf-m-filled backupStatusBadge"
       data-testid="backup-status-badge"
     >
       <span

--- a/packages/dashboard-frontend/src/components/BackupStatusBadge/index.module.css
+++ b/packages/dashboard-frontend/src/components/BackupStatusBadge/index.module.css
@@ -15,16 +15,6 @@
   text-transform: capitalize;
 }
 
-html.pf-v6-theme-dark .pf-m-green {
-  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--green--10);
-  --pf-v6-c-label--Color: var(--pf-t--color--green--40);
-}
-
-html.pf-v6-theme-dark .pf-m-orange {
-  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--orange--40);
-  --pf-v6-c-label--Color: var(--pf-t--color--orange--10);
-}
-
 .rotate {
   animation-name: spinnerRotate;
   animation-duration: 1s;

--- a/packages/dashboard-frontend/src/components/BackupStatusBadge/index.module.css
+++ b/packages/dashboard-frontend/src/components/BackupStatusBadge/index.module.css
@@ -11,11 +11,18 @@
  */
 
 .backupStatusBadge {
+  font-weight: bold;
   text-transform: capitalize;
 }
 
-.size-md {
-  font-size: var(--pf-v5-global--FontSize--sm);
+html.pf-v6-theme-dark .pf-m-green {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--green--10);
+  --pf-v6-c-label--Color: var(--pf-t--color--green--40);
+}
+
+html.pf-v6-theme-dark .pf-m-orange {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--orange--40);
+  --pf-v6-c-label--Color: var(--pf-t--color--orange--10);
 }
 
 .rotate {

--- a/packages/dashboard-frontend/src/components/BackupStatusBadge/index.tsx
+++ b/packages/dashboard-frontend/src/components/BackupStatusBadge/index.tsx
@@ -122,8 +122,7 @@ export function BackupStatusBadge(props: Props): React.ReactElement {
   const icon = getStatusIcon(status);
   const tooltipContent = getTooltipContent(status, lastBackupTime, backupImageUrl);
 
-  const sizeClassName = styles['size-md'] || '';
-  const className = `${styles.backupStatusBadge} ${sizeClassName}`.trim();
+  const className = styles.backupStatusBadge;
 
   const statusLabel = BACKUP_STATUS_LABELS[status];
 

--- a/packages/dashboard-frontend/src/components/BasicViewer/index.module.css
+++ b/packages/dashboard-frontend/src/components/BasicViewer/index.module.css
@@ -21,7 +21,3 @@
   height: 100%;
   border: 1px solid var(--pf-t--global--border--color--default);
 }
-
-html:not(.pf-v6-theme-dark) .basicViewer > div > div > div > div {
-  opacity: 0.8;
-}

--- a/packages/dashboard-frontend/src/components/DevfileViewer/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/DevfileViewer/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`DevfileViewer snapshot with light theme 1`] = `
+<div
+  className="devfileViewer"
+>
+  <div
+    className="cm-theme-light codeMirror"
+    id="devfile-viewer-id"
+  />
+</div>
+`;

--- a/packages/dashboard-frontend/src/components/DevfileViewer/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/DevfileViewer/__tests__/index.spec.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+
+import { DevfileViewer } from '@/components/DevfileViewer';
+import { useTheme } from '@/contexts/ThemeContext';
+import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: jest.fn(),
+}));
+
+const mockUseTheme = useTheme as jest.Mock;
+
+const { createSnapshot, renderComponent } = getComponentRenderer(getComponent);
+
+const sampleDevfile = 'schemaVersion: 2.2.0\nmetadata:\n  name: test-workspace';
+
+describe('DevfileViewer', () => {
+  beforeEach(() => {
+    mockUseTheme.mockReturnValue({
+      themePreference: 'LIGHT',
+      isDarkTheme: false,
+      setThemePreference: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('snapshot with light theme', () => {
+    const snapshot = createSnapshot(sampleDevfile);
+    expect(snapshot.toJSON()).toMatchSnapshot();
+  });
+
+  test('renders content in light theme', () => {
+    renderComponent(sampleDevfile);
+
+    const textbox = screen.getByRole('textbox');
+    expect(textbox).toHaveTextContent('schemaVersion');
+  });
+
+  test('renders content in dark theme', () => {
+    mockUseTheme.mockReturnValue({
+      themePreference: 'DARK',
+      isDarkTheme: true,
+      setThemePreference: jest.fn(),
+    });
+
+    renderComponent(sampleDevfile);
+
+    const textbox = screen.getByRole('textbox');
+    expect(textbox).toHaveTextContent('schemaVersion');
+  });
+
+  test('handles content change', () => {
+    const { reRenderComponent } = renderComponent(sampleDevfile);
+
+    const textbox = screen.getByRole('textbox');
+    expect(textbox).toHaveTextContent('test-workspace');
+
+    const updatedDevfile = 'schemaVersion: 2.2.0\nmetadata:\n  name: updated-workspace';
+    reRenderComponent(updatedDevfile);
+
+    expect(textbox).toHaveTextContent('updated-workspace');
+  });
+});
+
+function getComponent(value: string): React.ReactElement {
+  return <DevfileViewer id="devfile-viewer-id" isActive={true} isExpanded={true} value={value} />;
+}

--- a/packages/dashboard-frontend/src/components/DevfileViewer/index.module.css
+++ b/packages/dashboard-frontend/src/components/DevfileViewer/index.module.css
@@ -23,7 +23,3 @@
   height: 100%;
   border: 1px solid var(--pf-t--global--border--color--default);
 }
-
-html:not(.pf-v6-theme-dark) .devfileViewer > div > div > div > div {
-  opacity: 0.8;
-}

--- a/packages/dashboard-frontend/src/components/DevfileViewer/index.tsx
+++ b/packages/dashboard-frontend/src/components/DevfileViewer/index.tsx
@@ -40,7 +40,7 @@ const createLightTheme = () => {
       },
       '.cm-gutters': {
         backgroundColor: '#f7f7f7',
-        color: '#999',
+        color: '#636363',
       },
       '.cm-activeLineGutter': {
         backgroundColor: '#f7f7f7',
@@ -50,10 +50,25 @@ const createLightTheme = () => {
   );
 };
 
+const createDarkGutterTheme = () => {
+  return EditorView.theme(
+    {
+      '.cm-gutters': {
+        backgroundColor: '#161b22',
+        color: '#8b949e',
+      },
+      '.cm-activeLineGutter': {
+        backgroundColor: '#161b22',
+      },
+    },
+    { dark: true },
+  );
+};
+
 const createLightHighlightStyle = () => {
   return HighlightStyle.define([
-    { tag: t.keyword, color: '#5e81ac' },
-    { tag: [t.string], color: '#5e81ac' },
+    { tag: t.keyword, color: '#4c7399' },
+    { tag: [t.string], color: '#4c7399' },
     { tag: [t.variableName], color: '#008080' },
     {
       tag: [t.name, t.deleted, t.character, t.propertyName, t.macroName],
@@ -66,6 +81,7 @@ export const DevfileViewer: React.FC<Props> = ({ value, id }) => {
   const { isDarkTheme } = useTheme();
 
   const lightTheme = useMemo(() => createLightTheme(), []);
+  const darkGutterTheme = useMemo(() => createDarkGutterTheme(), []);
   const lightHighlightStyle = useMemo(() => createLightHighlightStyle(), []);
 
   const extensions = useMemo(() => {
@@ -74,9 +90,9 @@ export const DevfileViewer: React.FC<Props> = ({ value, id }) => {
       yaml(),
     ];
     return isDarkTheme
-      ? baseExtensions
+      ? [darkGutterTheme, ...baseExtensions]
       : [lightTheme, syntaxHighlighting(lightHighlightStyle), ...baseExtensions];
-  }, [isDarkTheme, lightTheme, lightHighlightStyle]);
+  }, [isDarkTheme, darkGutterTheme, lightTheme, lightHighlightStyle]);
 
   return (
     <div className={styles.devfileViewer}>

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/__tests__/__snapshots__/index.spec.tsx.snap
@@ -80,7 +80,7 @@ exports[`Expandable warning items should correctly render the component 1`] = `
             className="pf-v6-c-code-block__code"
           >
             <small
-              className="pf-v6-c-content--small hideOverflow"
+              className="pf-v6-c-content--small hideOverflow errorMessage"
               data-ouia-component-id="OUIA-Generated-Content-4"
               data-ouia-component-type="PF6/Content"
               data-ouia-safe={true}

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/index.module.css
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/index.module.css
@@ -16,6 +16,16 @@
   border-top: 2px solid;
 }
 
+:global(.pf-v6-theme-dark) .error {
+  color: var(--pf-t--global--text--color--regular);
+  background-color: rgb(185 80 80);
+}
+
+:global(.pf-v6-theme-dark) .error .errorMessage {
+  color: var(--pf-t--global--text--color--regular);
+  background-color: transparent;
+}
+
 .error small,
 .error button {
   font-size: small;

--- a/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
+++ b/packages/dashboard-frontend/src/components/ExpandableWarning/index.tsx
@@ -116,7 +116,9 @@ class ExpandableWarning extends React.Component<Props, State> {
     );
 
     const expandableSectionTitle = isExpanded ? 'Show Less' : 'Show More';
-    const messageClassName = isExpanded ? undefined : styles.hideOverflow;
+    const messageClassName = isExpanded
+      ? styles.errorMessage
+      : `${styles.hideOverflow} ${styles.errorMessage}`;
     return (
       <>
         <Content>

--- a/packages/dashboard-frontend/src/components/ResourceIcon/index.module.css
+++ b/packages/dashboard-frontend/src/components/ResourceIcon/index.module.css
@@ -12,7 +12,6 @@
 
 .icon {
   display: inline-block;
-  flex-shrink: 0;
 
   min-width: 18px;
   margin-right: 4px;
@@ -20,10 +19,10 @@
 
   font-size: 14px;
   line-height: 16px;
-  color: var(--pf-t--global--color--nonstatus--gray--100);
+  color: var(--pf-t--global--text--color--nonstatus--on-blue--default);
   text-align: center;
   white-space: nowrap;
 
-  background-color: var(--pf-t--global--color--nonstatus--blue--300);
+  background-color: var(--pf-t--global--color--nonstatus--blue--default);
   border-radius: 20px;
 }

--- a/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
@@ -3,26 +3,6 @@
   text-transform: capitalize;
 }
 
-html.pf-v6-theme-dark .pf-m-green.statusLabel {
-  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--green--10);
-  --pf-v6-c-label--Color: var(--pf-t--color--green--40);
-}
-
-html.pf-v6-theme-dark .pf-m-orange.statusLabel {
-  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--orange--40);
-  --pf-v6-c-label--Color: var(--pf-t--color--orange--10);
-}
-
-html.pf-v6-theme-dark .pf-m-blue.statusLabel {
-  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--blue--10);
-  --pf-v6-c-label--Color: var(--pf-t--color--blue--30);
-}
-
-html.pf-v6-theme-dark .pf-m-info.statusLabel {
-  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--blue--10);
-  --pf-v6-c-label--Color: var(--pf-t--color--blue--30);
-}
-
 .statusIndicator {
   margin-right: 10px;
 }

--- a/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/index.module.css
@@ -1,17 +1,26 @@
 .statusLabel {
+  font-weight: bold;
   text-transform: capitalize;
 }
 
-:global(html.pf-v6-theme-dark) .pf-m-green.statusLabel {
+html.pf-v6-theme-dark .pf-m-green.statusLabel {
   --pf-v6-c-label--BackgroundColor: var(--pf-t--color--green--10);
+  --pf-v6-c-label--Color: var(--pf-t--color--green--40);
 }
 
-:global(html.pf-v6-theme-dark) .pf-m-orange.statusLabel {
+html.pf-v6-theme-dark .pf-m-orange.statusLabel {
   --pf-v6-c-label--BackgroundColor: var(--pf-t--color--orange--40);
+  --pf-v6-c-label--Color: var(--pf-t--color--orange--10);
 }
 
-:global(html.pf-v6-theme-dark) .pf-m-info.statusLabel {
+html.pf-v6-theme-dark .pf-m-blue.statusLabel {
   --pf-v6-c-label--BackgroundColor: var(--pf-t--color--blue--10);
+  --pf-v6-c-label--Color: var(--pf-t--color--blue--30);
+}
+
+html.pf-v6-theme-dark .pf-m-info.statusLabel {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--blue--10);
+  --pf-v6-c-label--Color: var(--pf-t--color--blue--30);
 }
 
 .statusIndicator {

--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -37,8 +37,12 @@ html.pf-v6-theme-dark .outer-fill {
   padding: 0 !important;
 }
 
-span[class*='label-required'] {
-  color: var(--pf-t--global--color--status--danger--default);
+html:not(.pf-v6-theme-dark) span[class*='label-required'] {
+  color: var(--pf-t--color--red-orange--60);
+}
+
+html.pf-v6-theme-dark span[class*='label-required'] {
+  color: var(--pf-t--color--red-orange--30);
 }
 
 /* Panel border override - only for panels inside page main body */

--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -45,6 +45,23 @@ html.pf-v6-theme-dark span[class*='label-required'] {
   color: var(--pf-t--color--red-orange--30);
 }
 
+/* Dark theme label contrast overrides */
+html.pf-v6-theme-dark .pf-m-green {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--green--10);
+  --pf-v6-c-label--Color: var(--pf-t--color--green--40);
+}
+
+html.pf-v6-theme-dark .pf-m-orange {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--orange--40);
+  --pf-v6-c-label--Color: var(--pf-t--color--orange--10);
+}
+
+html.pf-v6-theme-dark .pf-m-blue,
+html.pf-v6-theme-dark .pf-m-info {
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--color--blue--10);
+  --pf-v6-c-label--Color: var(--pf-t--color--blue--30);
+}
+
 /* Panel border override - only for panels inside page main body */
 .pf-v6-c-page__main-body > .pf-v6-c-panel {
   border: var(--pf-v6-c-table__tr--BorderBlockEndWidth) solid


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Several UI elements had insufficient color contrast in dark theme, failing WCAG 2.2 criterion 1.4.3 (Contrast Minimum, Level AA) which requires a 4.5:1 ratio.

This PR fixes two categories of contrast issues:

**1. CodeMirror editor gutter (line numbers / fold icons)**
- **Light theme**: Changed gutter text color from `#999` to `#636363` (contrast improved from 2.65:1 to ~5.48:1 against `#f7f7f7` background)
- **Dark theme**: Added explicit gutter color override (`#8b949e` on `#161b22`, ~5.5:1) since the `githubDark` theme lacks gutter color settings

**2. Required field asterisk (`*`) in form labels**
- **Dark theme**: PatternFly's danger token `#f0561d` has only ~4.2:1 contrast against the `#414141` page section background. Added dark theme override with `#fe9a62` (~4.86:1 against `#414141`, ~5.6:1 against `#383838`, ~7.0:1 against `#292929`)

### Affected pages

**CodeMirror gutter contrast:**
- Workspace Details > Devfile tab

**Required asterisk contrast (dark theme):**
- `/dashboard/#/restore-from-backup` (Backup image URL, Workspace namespace)
- `/dashboard/#/create-workspace` Import from Git (Git repo URL)
- `/dashboard/#/user-preferences?tab=Gitconfig` (name, email)
- `/dashboard/#/user-preferences?tab=SshKeys` Add SSH Keys modal (Private Key, Public Key)
- `/dashboard/#/user-preferences` Add Container Registry modal (Registry, Password)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
**BEFORE** 
<img width="1894" height="777" alt="Знімок екрана 2026-04-28 о 02 07 53" src="https://github.com/user-attachments/assets/044ec70f-f6d6-4650-86fd-4125483498a5" />


**AFTER**
<img width="1894" height="777" alt="Знімок екрана 2026-04-27 о 21 17 18" src="https://github.com/user-attachments/assets/3e9a2e56-035a-473e-999c-3ed6f459d6a2" />


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10320

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the image from this PR
2. Switch to **dark theme** via user menu > Appearance
3. Navigate to each affected page listed above
4. Verify the required asterisk (`*`) is clearly visible with sufficient contrast
5. Navigate to Workspace Details > Devfile tab in both light and dark theme
6. Verify line numbers in the editor gutter are readable
7. Optionally verify contrast ratios using browser DevTools or an accessibility checker (target: >= 4.5:1)


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
