### PR TITLE
feat(ui): add required field validation to Token field in personal access tokens

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/__snapshots__/index.spec.tsx.snap
@@ -20,6 +20,13 @@ exports[`TokenData snapshot w/o token data 1`] = `
         >
           Token
         </span>
+        <span
+          aria-hidden="true"
+          className="pf-v6-c-form__label-required"
+        >
+           
+          *
+        </span>
       </label>
         
     </div>
@@ -41,11 +48,18 @@ exports[`TokenData snapshot w/o token data 1`] = `
           onChange={[Function]}
           onFocus={[Function]}
           placeholder="Enter a Token"
-          required={false}
+          required={true}
           type="password"
           value=""
         />
       </span>
+      <div
+        className="pf-v6-c-form__helper-text"
+      >
+        <div
+          className="pf-v6-c-helper-text"
+        />
+      </div>
     </div>
   </div>
 </form>
@@ -71,6 +85,13 @@ exports[`TokenData snapshot with token data 1`] = `
         >
           Token
         </span>
+        <span
+          aria-hidden="true"
+          className="pf-v6-c-form__label-required"
+        >
+           
+          *
+        </span>
       </label>
         
     </div>
@@ -92,11 +113,18 @@ exports[`TokenData snapshot with token data 1`] = `
           onChange={[Function]}
           onFocus={[Function]}
           placeholder="Replace Token"
-          required={false}
+          required={true}
           type="password"
           value=""
         />
       </span>
+      <div
+        className="pf-v6-c-form__helper-text"
+      >
+        <div
+          className="pf-v6-c-helper-text"
+        />
+      </div>
     </div>
   </div>
 </form>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/__tests__/index.spec.tsx
@@ -59,7 +59,7 @@ describe('TokenData', () => {
     fireEvent.change(input, { target: { value: tokenData } });
 
     expect(mockOnChange).toHaveBeenCalledWith(btoa(tokenData), true);
-    expect(screen.queryByText('This field is required.')).toBeFalsy();
+    expect(screen.queryByText('Token is required.')).toBeFalsy();
   });
 
   it('should handle the empty value', () => {
@@ -79,8 +79,55 @@ describe('TokenData', () => {
     fireEvent.change(input, { target: { value: '' } });
 
     expect(mockOnChange).toHaveBeenCalledWith('', false);
-    // TokenData component validates but doesn't render error messages
-    expect(screen.queryByText('This field is required.')).toBeFalsy();
+    expect(screen.getByText('Token is required.')).toBeTruthy();
+  });
+
+  it('should display validation error when token is empty', () => {
+    renderComponent(false);
+
+    const input = screen.getByPlaceholderText('Enter a Token');
+
+    // Trigger validation by entering and clearing the field
+    fireEvent.change(input, { target: { value: 'test' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    // Verify error message is displayed
+    expect(screen.getByText('Token is required.')).toBeInTheDocument();
+  });
+
+  it('should clear validation error when token is entered', () => {
+    renderComponent(false);
+
+    const input = screen.getByPlaceholderText('Enter a Token');
+
+    // Trigger error by entering and clearing the field
+    fireEvent.change(input, { target: { value: 'test' } });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(screen.getByText('Token is required.')).toBeInTheDocument();
+
+    // Enter a valid token
+    fireEvent.change(input, { target: { value: 'my-token' } });
+
+    // Verify error message is removed
+    expect(screen.queryByText('Token is required.')).not.toBeInTheDocument();
+  });
+
+  it('should show error icon when validation fails', () => {
+    renderComponent(false);
+
+    const input = screen.getByPlaceholderText('Enter a Token');
+
+    // Trigger validation error
+    fireEvent.change(input, { target: { value: 'test' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    // Verify error message with icon is displayed
+    const errorMessage = screen.getByText('Token is required.');
+    expect(errorMessage).toBeInTheDocument();
+
+    // The error should be in a helper text item with error variant
+    const helperTextItem = errorMessage.closest('.pf-v6-c-helper-text__item');
+    expect(helperTextItem).toHaveClass('pf-m-error');
   });
 });
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/TokenData/index.tsx
@@ -10,7 +10,16 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, TextInput, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  TextInputTypes,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 export type Props = {
@@ -53,21 +62,41 @@ export class TokenData extends React.PureComponent<Props, State> {
     }
   }
 
+  private getErrorMessage(tokenData: string): string {
+    if (tokenData.length === 0) {
+      return 'Token is required.';
+    }
+    return '';
+  }
+
   public render(): React.ReactElement {
     const { isEdit } = this.props;
-    const { tokenData = '' } = this.state;
+    const { tokenData = '', validated } = this.state;
     const placeholder = isEdit ? 'Replace Token' : 'Enter a Token';
+    const errorMessage = this.getErrorMessage(tokenData);
+    const hasError = validated === ValidatedOptions.error;
 
     return (
-      <FormGroup fieldId="token-data-label" label="Token">
+      <FormGroup fieldId="token-data-label" isRequired label="Token">
         <TextInput
           aria-describedby="token-data-label"
           aria-label="Token"
+          isRequired
           onChange={(_event, tokenData) => this.onChange(tokenData)}
           placeholder={placeholder}
           type={TextInputTypes.password}
+          validated={hasError ? 'error' : 'default'}
           value={tokenData}
         />
+        <FormHelperText>
+          <HelperText>
+            {hasError && (
+              <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+                {errorMessage}
+              </HelperTextItem>
+            )}
+          </HelperText>
+        </FormHelperText>
       </FormGroup>
     );
   }


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add asterisk indicator and validation error messages to the Token field in the Add Personal Access Token modal. The field now displays "Token is required." error message when left empty, providing consistent validation UX with other required fields in the form.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10215

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to the `User Preferences` -> Personal Access Tokens tab and click the `Add Personal Access Token` button.
2. Enter some random data to the `Token` field and then clear the input, see the helper text error message: 
<img width="632" height="215" alt="image" src="https://github.com/user-attachments/assets/8d741f0c-e294-4596-b39d-99738079fb41" />


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
