### PR TITLE
feat(ui): add helper text and validation messages to Git Provider Org…

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/__tests__/index.spec.tsx
@@ -48,8 +48,8 @@ describe('GitProviderOrganization', () => {
     await userEvent.paste(organization);
 
     expect(mockOnChange).toHaveBeenCalledWith(organization, true);
-    expect(screen.queryByText('This field is required.')).toBeFalsy();
-    expect(screen.queryByText(/^The Provider Organization is too long./)).toBeFalsy();
+    expect(screen.queryByText('Git Provider Organization is required.')).toBeFalsy();
+    expect(screen.queryByText(/must be \d+ characters or less/)).toBeFalsy();
   });
 
   it('should handle a too long organization value', async () => {
@@ -64,9 +64,10 @@ describe('GitProviderOrganization', () => {
     await userEvent.paste(organization);
 
     expect(mockOnChange).toHaveBeenCalledWith(organization, false);
-    // GitProviderOrganization component validates but doesn't render error messages
-    expect(screen.queryByText('This field is required.')).toBeFalsy();
-    expect(screen.queryByText(/^The Provider Organization is too long./)).toBeFalsy();
+    expect(screen.queryByText('Git Provider Organization is required.')).toBeFalsy();
+    expect(
+      screen.getByText('Git Provider Organization must be 255 characters or less.'),
+    ).toBeTruthy();
   });
 
   it('should handle an empty value', async () => {
@@ -79,9 +80,98 @@ describe('GitProviderOrganization', () => {
     await userEvent.clear(input);
 
     expect(mockOnChange).toHaveBeenCalledWith('', false);
-    // GitProviderOrganization component validates but doesn't render error messages
-    expect(screen.queryByText('This field is required.')).toBeFalsy();
-    expect(screen.queryByText(/^The Provider Organization is too long./)).toBeFalsy();
+    expect(screen.getByText('Git Provider Organization is required.')).toBeTruthy();
+    expect(screen.queryByText(/must be \d+ characters or less/)).toBeFalsy();
+  });
+
+  describe('helper text behavior', () => {
+    it('should not show helper text when organization is valid', async () => {
+      renderComponent();
+
+      const input = screen.getByRole('textbox');
+
+      const validOrganization = 'user-organization';
+      await userEvent.click(input);
+      await userEvent.paste(validOrganization);
+
+      // Helper text should not be present
+      expect(screen.queryByText('Git Provider Organization is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Git Provider Organization must be \d+ characters or less./),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show error helper text when organization is empty', async () => {
+      renderComponent();
+
+      const input = screen.getByRole('textbox');
+
+      // First set a valid value
+      await userEvent.click(input);
+      await userEvent.paste('user-organization');
+
+      // Then clear it to trigger validation
+      await userEvent.clear(input);
+
+      // Error helper text should be visible
+      expect(screen.getByText('Git Provider Organization is required.')).toBeInTheDocument();
+    });
+
+    it('should show error helper text when organization is too long', async () => {
+      renderComponent();
+
+      const input = screen.getByRole('textbox');
+
+      // Create an organization that exceeds MAX_LENGTH (255)
+      const tooLongOrganization = 'a'.repeat(256);
+      await userEvent.click(input);
+      await userEvent.paste(tooLongOrganization);
+
+      // Error helper text should be visible
+      expect(
+        screen.getByText('Git Provider Organization must be 255 characters or less.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should hide helper text when correcting an invalid organization', async () => {
+      renderComponent('user-organization');
+
+      const input = screen.getByRole('textbox');
+
+      // Clear the input to trigger error
+      await userEvent.clear(input);
+
+      // Error helper text should be visible
+      expect(screen.getByText('Git Provider Organization is required.')).toBeInTheDocument();
+
+      // Now correct it
+      const validOrganization = 'user-organization';
+      await userEvent.click(input);
+      await userEvent.paste(validOrganization);
+
+      // Helper text should no longer be visible
+      expect(screen.queryByText('Git Provider Organization is required.')).not.toBeInTheDocument();
+    });
+
+    it('should not show helper text on initial render with valid organization', () => {
+      renderComponent('user-organization');
+
+      // No helper text should be visible
+      expect(screen.queryByText('Git Provider Organization is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Git Provider Organization must be \d+ characters or less./),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show helper text on initial render without organization', () => {
+      renderComponent();
+
+      // No helper text should be visible initially (validation state is 'default')
+      expect(screen.queryByText('Git Provider Organization is required.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Git Provider Organization must be \d+ characters or less./),
+      ).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/PersonalAccessTokens/AddEditModal/Form/GitProviderOrganization/index.tsx
@@ -10,7 +10,16 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { FormGroup, TextInput, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  TextInputTypes,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 const MAX_LENGTH = 255;
@@ -54,8 +63,20 @@ export class GitProviderOrganization extends React.PureComponent<Props, State> {
     }
   }
 
+  private getErrorMessage(providerOrganization: string): string {
+    if (providerOrganization.length === 0) {
+      return 'Git Provider Organization is required.';
+    } else if (providerOrganization.length > MAX_LENGTH) {
+      return `Git Provider Organization must be ${MAX_LENGTH} characters or less.`;
+    }
+    return '';
+  }
+
   public render(): React.ReactElement {
-    const { providerOrganization = '' } = this.state;
+    const { providerOrganization = '', validated } = this.state;
+
+    const errorMessage = this.getErrorMessage(providerOrganization);
+    const hasError = validated === ValidatedOptions.error;
 
     return (
       <FormGroup
@@ -69,8 +90,18 @@ export class GitProviderOrganization extends React.PureComponent<Props, State> {
           placeholder="Enter a Git Provider Organization"
           onChange={(_event, providerOrganization) => this.onChange(providerOrganization)}
           type={TextInputTypes.text}
+          validated={hasError ? 'error' : 'default'}
           value={providerOrganization}
         />
+        {hasError && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+                {errorMessage}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
     );
   }


### PR DESCRIPTION
…anization field

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add informational helper text and validation error messages to improve UX for the Git Provider Organization field in the Personal Access Token modal.

Changes:
- Show validation error when field is empty or exceeds 255 characters
- Add visual error state (red border) to input on validation failure
- Include comprehensive tests for helper text behavior

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10756

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to the `User Preferences` -> `Personal Access Tokens` tab, click the `Add Personal Access Token` button.
2. Select `Microsoft Azure DevOps` in the `Git Provider` dropdown.
3. Enter some data to the `Git Provider Organization` field and clear the data, see the helper text error: 
<img width="596" height="662" alt="image" src="https://github.com/user-attachments/assets/6e11ca40-e8c4-48b1-964e-12435835f8a9" />

4. Enter a random long string (more than 255 characters), see the helper text error: 
<img width="593" height="651" alt="image" src="https://github.com/user-attachments/assets/294cabe7-70b8-4007-b02b-ad8b7a12c8e3" />

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
