### PR TITLE
feat(ui): add detailed validation error messages to Git Config import modal

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/AddModal/GitConfigForm/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/AddModal/GitConfigForm/__tests__/__snapshots__/index.spec.tsx.snap
@@ -57,6 +57,46 @@ exports[`GitConfigForm snapshot with predefined git configuration 1`] = `
           onClick={[Function]}
           type="button"
         />
+        <input
+          data-testid="submit-missing-user-section-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-empty-email-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-long-email-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-parse-error-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-max-length-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-only-name-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-only-email-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-both-null-git-config"
+          onClick={[Function]}
+          type="button"
+        />
       </div>
     </div>
   </div>
@@ -113,6 +153,46 @@ exports[`GitConfigForm snapshot without predefined git configuration 1`] = `
         />
         <input
           data-testid="submit-long-name-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-missing-user-section-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-empty-email-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-long-email-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-parse-error-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-max-length-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-only-name-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-only-email-git-config"
+          onClick={[Function]}
+          type="button"
+        />
+        <input
+          data-testid="submit-both-null-git-config"
           onClick={[Function]}
           type="button"
         />

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/AddModal/GitConfigForm/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/AddModal/GitConfigForm/__tests__/index.spec.tsx
@@ -93,6 +93,144 @@ describe('GitConfigForm', () => {
       false,
     );
   });
+
+  describe('Error messages', () => {
+    it('should display error message for missing user section', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-missing-user-section-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(
+        screen.getByText('The [user] section with "name" and "email" fields is required.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should display error message for invalid email format', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-invalid-email-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(
+        screen.getByText('User email must be a valid email address (e.g., user@example.com).'),
+      ).toBeInTheDocument();
+    });
+
+    it('should display error message for empty name when email is valid', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-empty-name-git-config');
+      await userEvent.click(gitConfigField);
+
+      // Name is now required
+      expect(screen.getByText('Username is required.')).toBeInTheDocument();
+    });
+
+    it('should display error message for name exceeding max length', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-long-name-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(
+        screen.getByText('User name must be between 1 and 128 characters.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should display error message for empty email when name is valid', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-empty-email-git-config');
+      await userEvent.click(gitConfigField);
+
+      // Email is now required
+      expect(screen.getByText('User email is required.')).toBeInTheDocument();
+    });
+
+    it('should display error message for email exceeding max length', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-long-email-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(
+        screen.getByText('User email must be between 1 and 128 characters.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should display error message for malformed config', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-parse-error-git-config');
+      await userEvent.click(gitConfigField);
+
+      // The multi-ini parser is lenient and may parse malformed content
+      // but it should still fail validation and show an error message
+      expect(
+        screen.getByText('The [user] section with "name" and "email" fields is required.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should display error message for max length exceeded', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-max-length-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(
+        screen.getByText('The value is too long. The maximum length is 4096 characters.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should not display error message for valid input', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-valid-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(
+        screen.queryByText('User email must be a valid email address (e.g., user@example.com).'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('The [user] section with "name" and "email" fields is required.'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Required field validation', () => {
+    it('should reject config with only name (email is required)', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-only-name-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(mockOnChange).toHaveBeenCalledWith({ user: { name: 'User One' } }, false);
+      expect(screen.getByText('User email is required.')).toBeInTheDocument();
+    });
+
+    it('should reject config with only email (name is required)', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-only-email-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(mockOnChange).toHaveBeenCalledWith({ user: { email: 'user@test.com' } }, false);
+      expect(screen.getByText('Username is required.')).toBeInTheDocument();
+    });
+
+    it('should reject config when both name and email are null', async () => {
+      renderComponent();
+
+      const gitConfigField = screen.getByTestId('submit-both-null-git-config');
+      await userEvent.click(gitConfigField);
+
+      expect(mockOnChange).toHaveBeenCalledWith({ user: {} }, false);
+      expect(
+        screen.getByText('The [user] section with "name" and "email" fields is required.'),
+      ).toBeInTheDocument();
+    });
+  });
 });
 
 function getComponent(gitConfig?: GitConfigStore.GitConfig) {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/AddModal/GitConfigForm/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/AddModal/GitConfigForm/index.tsx
@@ -10,17 +10,34 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { Form, FormGroup, ValidatedOptions } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import * as ini from 'multi-ini';
 import React from 'react';
 
 import { GitConfigImport } from '@/pages/UserPreferences/GitConfig/GitConfigImport';
 import * as GitConfigStore from '@/store/GitConfig';
 
-export const REQUIRED_ERROR = 'This field is required.';
 const MAX_LENGTH = 4096;
 export const MAX_LENGTH_ERROR = `The value is too long. The maximum length is ${MAX_LENGTH} characters.`;
 export const WRONG_TYPE_ERROR = 'This file type is not supported.';
+export const PARSE_ERROR =
+  'Unable to parse the Git configuration. Please ensure it is a valid .gitconfig file.';
+export const USER_SECTION_MISSING_ERROR =
+  'The [user] section with "name" and "email" fields is required.';
+export const USER_NAME_REQUIRED_ERROR = 'Username is required.';
+export const USER_NAME_LENGTH_ERROR = `User name must be between 1 and ${128} characters.`;
+export const USER_EMAIL_REQUIRED_ERROR = `User email is required.`;
+export const USER_EMAIL_LENGTH_ERROR = `User email must be between 1 and ${128} characters.`;
+export const USER_EMAIL_FORMAT_ERROR =
+  'User email must be a valid email address (e.g., user@example.com).';
 
 // Validation constants for user fields
 const USER_NAME_MAX_LENGTH = 128;
@@ -37,6 +54,7 @@ export type State = {
   gitConfig: GitConfigStore.GitConfig | undefined;
   gitConfigStr: string | undefined;
   validated: ValidatedOptions;
+  errorMessage: string | undefined;
 };
 
 export class GitConfigForm extends React.Component<Props, State> {
@@ -48,6 +66,7 @@ export class GitConfigForm extends React.Component<Props, State> {
       gitConfig: undefined,
       gitConfigStr: undefined,
       validated: ValidatedOptions.default,
+      errorMessage: undefined,
     };
   }
 
@@ -60,10 +79,18 @@ export class GitConfigForm extends React.Component<Props, State> {
   }
 
   public shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>): boolean {
-    const { gitConfig, validated } = this.state;
-    const { gitConfig: nextGitConfig, validated: nextValidated } = nextState;
+    const { gitConfig, validated, errorMessage } = this.state;
+    const {
+      gitConfig: nextGitConfig,
+      validated: nextValidated,
+      errorMessage: nextErrorMessage,
+    } = nextState;
 
-    return gitConfig !== nextGitConfig || validated !== nextValidated;
+    return (
+      gitConfig !== nextGitConfig ||
+      validated !== nextValidated ||
+      errorMessage !== nextErrorMessage
+    );
   }
 
   private parseGitConfig(gitConfigStr: string): GitConfigStore.GitConfig {
@@ -86,61 +113,93 @@ export class GitConfigForm extends React.Component<Props, State> {
 
   private onChange(gitConfigStr: string, isUpload: boolean): void {
     const { onChange } = this.props;
+
+    // Check for max length first
+    if (gitConfigStr && gitConfigStr.length > MAX_LENGTH) {
+      this.setState({
+        gitConfigStr,
+        validated: ValidatedOptions.error,
+        errorMessage: MAX_LENGTH_ERROR,
+        isUpload,
+      });
+      return;
+    }
+
     try {
       const gitConfig = this.parseGitConfig(gitConfigStr);
-      const validated = this.validate(gitConfig);
+      const { validated, errorMessage } = this.validate(gitConfig);
       const isValid = validated === ValidatedOptions.success;
 
-      this.setState({ gitConfigStr, gitConfig, validated, isUpload });
+      this.setState({ gitConfigStr, gitConfig, validated, errorMessage, isUpload });
       onChange(gitConfig, isValid);
     } catch (error) {
       console.log(error);
-      this.setState({ validated: ValidatedOptions.error, isUpload });
+      this.setState({
+        validated: ValidatedOptions.error,
+        errorMessage: isUpload ? WRONG_TYPE_ERROR : PARSE_ERROR,
+        isUpload,
+      });
     }
   }
 
-  private validate(gitConfig: GitConfigStore.GitConfig): ValidatedOptions {
-    return this.isGitConfig(gitConfig) ? ValidatedOptions.success : ValidatedOptions.error;
-  }
-
-  private isGitConfig(gitConfig: unknown): gitConfig is GitConfigStore.GitConfig {
+  private validate(gitConfig: GitConfigStore.GitConfig): {
+    validated: ValidatedOptions;
+    errorMessage: string | undefined;
+  } {
     const config = gitConfig as GitConfigStore.GitConfig;
 
     // Check if user section exists
-    if (!config.user || !config.user.email || !config.user.name) {
-      return false;
+    if (!config.user || (!config.user.email && !config.user.name)) {
+      return {
+        validated: ValidatedOptions.error,
+        errorMessage: USER_SECTION_MISSING_ERROR,
+      };
     }
 
     // Validate name
     const name = config.user.name;
-    if (name.length === 0 || name.length > USER_NAME_MAX_LENGTH) {
-      return false;
+    if (!name || name.length === 0) {
+      return {
+        validated: ValidatedOptions.error,
+        errorMessage: USER_NAME_REQUIRED_ERROR,
+      };
+    }
+    if (name.length > USER_NAME_MAX_LENGTH) {
+      return {
+        validated: ValidatedOptions.error,
+        errorMessage: USER_NAME_LENGTH_ERROR,
+      };
     }
 
     // Validate email
     const email = config.user.email;
-    if (email.length === 0 || email.length > USER_EMAIL_MAX_LENGTH) {
-      return false;
+    if (!email || email.length === 0) {
+      return {
+        validated: ValidatedOptions.error,
+        errorMessage: USER_EMAIL_REQUIRED_ERROR,
+      };
+    }
+    if (email.length > USER_EMAIL_MAX_LENGTH) {
+      return {
+        validated: ValidatedOptions.error,
+        errorMessage: USER_EMAIL_LENGTH_ERROR,
+      };
     }
     if (!USER_EMAIL_REGEX.test(email)) {
-      return false;
+      return {
+        validated: ValidatedOptions.error,
+        errorMessage: USER_EMAIL_FORMAT_ERROR,
+      };
     }
 
-    return true;
-  }
-
-  private getErrorMessage(gitConfigStr: string | undefined, isUpload: boolean): string | undefined {
-    if (gitConfigStr && gitConfigStr.length > MAX_LENGTH) {
-      return MAX_LENGTH_ERROR;
-    }
-    if (isUpload) {
-      return WRONG_TYPE_ERROR;
-    }
-    return REQUIRED_ERROR;
+    return {
+      validated: ValidatedOptions.success,
+      errorMessage: undefined,
+    };
   }
 
   public render(): React.ReactElement {
-    const { validated } = this.state;
+    const { validated, errorMessage } = this.state;
 
     const content = this.stringifyGitConfig(this.props.gitConfig);
 
@@ -150,8 +209,18 @@ export class GitConfigForm extends React.Component<Props, State> {
           <GitConfigImport
             content={content}
             validated={validated}
+            errorMessage={errorMessage}
             onChange={(gitConfig, isUpload) => this.onChange(gitConfig, isUpload)}
           />
+          {validated === ValidatedOptions.error && errorMessage && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
+                  {errorMessage}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
       </Form>
     );

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/__mocks__/index.tsx
@@ -51,6 +51,53 @@ export class GitConfigImport extends React.PureComponent<Props> {
             onChange(`[user]\n\tname = ${longName}\n\temail = user@test.com\n`, false);
           }}
         />
+        <input
+          data-testid="submit-missing-user-section-git-config"
+          type="button"
+          onClick={() => onChange('[core]\n\teditor = vim\n', false)}
+        />
+        <input
+          data-testid="submit-empty-email-git-config"
+          type="button"
+          onClick={() => onChange('[user]\n\tname = User One\n\temail = \n', false)}
+        />
+        <input
+          data-testid="submit-long-email-git-config"
+          type="button"
+          onClick={() => {
+            const longEmail = 'a'.repeat(120) + '@test.com';
+            onChange(`[user]\n\tname = User One\n\temail = ${longEmail}\n`, false);
+          }}
+        />
+        <input
+          data-testid="submit-parse-error-git-config"
+          type="button"
+          onClick={() => onChange('invalid [[[[ config', false)}
+        />
+        <input
+          data-testid="submit-max-length-git-config"
+          type="button"
+          onClick={() => {
+            const longContent =
+              '[user]\n\tname = User One\n\temail = user@test.com\n' + 'x'.repeat(4100);
+            onChange(longContent, false);
+          }}
+        />
+        <input
+          data-testid="submit-only-name-git-config"
+          type="button"
+          onClick={() => onChange('[user]\n\tname = User One\n', false)}
+        />
+        <input
+          data-testid="submit-only-email-git-config"
+          type="button"
+          onClick={() => onChange('[user]\n\temail = user@test.com\n', false)}
+        />
+        <input
+          data-testid="submit-both-null-git-config"
+          type="button"
+          onClick={() => onChange('[user]\n', false)}
+        />
       </div>
     );
   }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/__tests__/__snapshots__/index.spec.tsx.snap
@@ -137,6 +137,163 @@ exports[`GitConfigUpload snapshot with content, validation is in the default sta
 </div>
 `;
 
+exports[`GitConfigUpload snapshot with error message 1`] = `
+<div
+  className="pf-v6-c-file-upload"
+  data-testid="git-configuration"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onDragEnter={[Function]}
+  onDragLeave={[Function]}
+  onDragOver={[Function]}
+  onDrop={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  role="presentation"
+  tabIndex={null}
+>
+  <div
+    className="pf-v6-c-file-upload__file-select"
+  >
+    <div
+      className="pf-v6-c-input-group"
+    >
+      <div
+        className="pf-v6-c-input-group__item pf-m-fill"
+      >
+        <span
+          className="pf-v6-c-form-control pf-m-readonly"
+        >
+          <input
+            aria-invalid={false}
+            aria-label="Upload the .gitconfig file"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+            data-ouia-component-type="PF6/TextInput"
+            data-ouia-safe={true}
+            disabled={false}
+            id="git-configuration-filename"
+            name="git-configuration-filename"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Upload the .gitconfig file"
+            readOnly={true}
+            required={false}
+            type="text"
+            value=""
+          />
+        </span>
+      </div>
+      <div
+        className="pf-v6-c-input-group__item"
+      >
+        <button
+          aria-label={null}
+          className="pf-v6-c-button pf-m-control"
+          data-ouia-component-id="OUIA-Generated-Button-control-7"
+          data-ouia-component-type="PF6/Button"
+          data-ouia-safe={true}
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            className="pf-v6-c-button__text"
+          >
+            Upload
+          </span>
+        </button>
+      </div>
+      <div
+        className="pf-v6-c-input-group__item"
+      >
+        <button
+          aria-label={null}
+          className="pf-v6-c-button pf-m-control"
+          data-ouia-component-id="OUIA-Generated-Button-control-8"
+          data-ouia-component-type="PF6/Button"
+          data-ouia-safe={true}
+          disabled={true}
+          onClick={[Function]}
+          tabIndex={null}
+          type="button"
+        >
+          <span
+            className="pf-v6-c-button__text"
+          >
+            Clear
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    className="pf-v6-c-file-upload__file-details"
+  >
+    <span
+      className="pf-v6-c-form-control pf-m-textarea pf-m-resize-vertical pf-m-error"
+    >
+      <textarea
+        aria-invalid={true}
+        aria-label="File upload"
+        disabled={false}
+        id="git-configuration"
+        onChange={[Function]}
+        onClick={[Function]}
+        placeholder="Or paste the Git Configuration here"
+        readOnly={false}
+        required={true}
+        value=""
+      />
+      <span
+        className="pf-v6-c-form-control__utilities"
+      >
+        <span
+          className="pf-v6-c-form-control__icon pf-m-status"
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+            />
+          </svg>
+        </span>
+      </span>
+    </span>
+  </div>
+  <input
+    hidden={true}
+    multiple={false}
+    onChange={[Function]}
+    onClick={[Function]}
+    style={
+      {
+        "border": 0,
+        "clip": "rect(0, 0, 0, 0)",
+        "clipPath": "inset(50%)",
+        "height": "1px",
+        "margin": "0 -1px -1px 0",
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "whiteSpace": "nowrap",
+        "width": "1px",
+      }
+    }
+    tabIndex={-1}
+    type="file"
+  />
+</div>
+`;
+
 exports[`GitConfigUpload snapshot without content, validation is in the default state 1`] = `
 <div
   className="pf-v6-c-file-upload"

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/__tests__/index.spec.tsx
@@ -53,6 +53,15 @@ describe('GitConfigUpload', () => {
     expect(snapshot.toJSON()).toMatchSnapshot();
   });
 
+  test('snapshot with error message', () => {
+    const snapshot = createSnapshot(
+      ValidatedOptions.error,
+      undefined,
+      'User email must be a valid email address (e.g., user@example.com).',
+    );
+    expect(snapshot.toJSON()).toMatchSnapshot();
+  });
+
   test('File uploader controls', () => {
     renderComponent(ValidatedOptions.default);
 
@@ -149,6 +158,17 @@ describe('GitConfigUpload', () => {
   });
 });
 
-function getComponent(validated: ValidatedOptions, content?: string): React.ReactElement {
-  return <GitConfigImport content={content} validated={validated} onChange={mockOnChange} />;
+function getComponent(
+  validated: ValidatedOptions,
+  content?: string,
+  errorMessage?: string,
+): React.ReactElement {
+  return (
+    <GitConfigImport
+      content={content}
+      validated={validated}
+      errorMessage={errorMessage}
+      onChange={mockOnChange}
+    />
+  );
 }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/GitConfigImport/index.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 export type Props = {
   content: string | undefined;
   validated: ValidatedOptions;
+  errorMessage: string | undefined;
   onChange: (content: string, isUpload: boolean) => void;
 };
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Display specific error explanations below the file upload field when Git configuration validation fails. Error messages cover missing user section, invalid email format, name/email length violations, parse errors, and content length limits. This helps users quickly understand and fix validation issues.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10297

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to `User Preferences` -> `Git Config` tab, click the `Import Git configuration` button, see: <img width="596" height="422" alt="image" src="https://github.com/user-attachments/assets/733fda12-0615-4e41-8e26-9a651b5a3ddb" />

2. Enter a random string, more than 5000 characters, see the error: <img width="590" height="422" alt="image" src="https://github.com/user-attachments/assets/95b9c551-cc39-47c1-8682-92642bcf71e5" />

3. Enter a random string more than 128 characters to the `user` section, see the error: 
<img width="578" height="422" alt="image" src="https://github.com/user-attachments/assets/002c2719-088b-4066-9f40-3ffb7314dff5" />

4. Enter a random string more than 128 characters to the `email` section, see the error: 
<img width="574" height="412" alt="image" src="https://github.com/user-attachments/assets/93daf434-a9b4-4b82-ad50-c634fed1e427" />

5. Enter an invalid email, see the error: 
<img width="581" height="414" alt="image" src="https://github.com/user-attachments/assets/b019171c-1b3f-4b4e-a969-690534c88528" />

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
