### PR TITLE
fix(a11y): ensure Skip to Content works on all pages

### DIFF
--- a/packages/dashboard-frontend/src/Layout/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/Layout/__tests__/__snapshots__/index.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`Layout component snapshot of the default page 1`] = `
 >
   <div
     className="pf-v6-c-skip-to-content"
+    onClick={[Function]}
   >
     <a
       aria-label={null}

--- a/packages/dashboard-frontend/src/Layout/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/index.tsx
@@ -153,7 +153,17 @@ const LayoutComponent: React.FC<Props> = props => {
         masthead={masthead}
         sidebar={sidebar}
         isManagedSidebar={isSidebarVisible}
-        skipToContent={<SkipToContent href="#main-content">Skip to content</SkipToContent>}
+        skipToContent={
+          <SkipToContent
+            href="#main-content"
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              document.getElementById('main-content')?.focus();
+            }}
+          >
+            Skip to content
+          </SkipToContent>
+        }
         mainContainerId="main-content"
       >
         <ErrorBoundary onError={error => testBackends(error)}>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes the "Skip to content" accessibility link so it works on **every page** in the Dashboard, not just the Create Workspace page.

#### Problem

The PatternFly `<SkipToContent>` component renders a standard `<a href="#main-content">` anchor link. When the user presses **Tab** on page load, the link appears; pressing **Enter** should jump focus past the sidebar navigation to the main content area.

However, browsers do not reliably move focus to hash-anchor targets that use `tabIndex="-1"` (the attribute PatternFly sets on the `<main>` element). In practice this meant:

- **Create Workspace page** — skip appeared to work because the first focusable element (the URL input) naturally received focus.
- **All other pages** (Workspaces, User Preferences, Workspace Details, etc.) — focus did **not** move past the navigation menu.

#### Fix

Added an explicit `onClick` handler to `<SkipToContent>` in `Layout/index.tsx`:

```tsx
<SkipToContent
  href="#main-content"
  onClick={(e: React.MouseEvent) => {
    e.preventDefault();
    document.getElementById('main-content')?.focus();
  }}
>
  Skip to content
</SkipToContent>
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1894" height="868" alt="Знімок екрана 2026-04-28 о 16 19 56" src="https://github.com/user-attachments/assets/f8109c87-6ccf-4199-9a6d-4e23d854affa" />


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10284

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the image from this PR
2. Open any Dashboard page (e.g. Workspaces list).
3. Press **Tab**(Shift + Tab keyboard shortcut to move backward) — the "Skip to content" link appears at the top.
4. Press **Enter** — focus jumps to the main content area, bypassing the sidebar.
5. Press **Tab** again — the first interactive element inside the main content receives focus.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
