### PR TITLE
fix(a11y): add workspace name to kebab menu aria-label

### DIFF
--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`WorkspaceActionsDropdown dropdown toggle snapshot 1`] = `
 <button
   aria-expanded={false}
-  aria-label="Actions"
+  aria-label="Actions for my-workspace"
   className="pf-v6-c-menu-toggle pf-m-primary"
   data-ouia-component-id="OUIA-Generated-MenuToggle-primary-1"
   data-ouia-component-type="PF6/MenuToggle"
@@ -47,7 +47,7 @@ exports[`WorkspaceActionsDropdown dropdown toggle snapshot 1`] = `
 exports[`WorkspaceActionsDropdown kebab toggle snapshot 1`] = `
 <button
   aria-expanded={false}
-  aria-label="Actions"
+  aria-label="Actions for my-workspace"
   className="pf-v6-c-menu-toggle pf-m-plain"
   data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
   data-ouia-component-type="PF6/MenuToggle"

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/index.spec.tsx
@@ -61,7 +61,7 @@ describe('WorkspaceActionsDropdown', () => {
     test('open dropdown', async () => {
       renderComponent(workspace, 'kebab-toggle');
 
-      const toggle = screen.queryByRole('button', { name: 'Actions' });
+      const toggle = screen.queryByRole('button', { name: 'Actions for my-workspace' });
 
       expect(toggle).toBeTruthy();
       expect(toggle).toHaveAttribute('data-testtype', 'kebab-toggle');
@@ -93,7 +93,7 @@ describe('WorkspaceActionsDropdown', () => {
     test('open dropdown', async () => {
       renderComponent(workspace, 'dropdown-toggle');
 
-      const toggle = screen.queryByRole('button', { name: 'Actions' });
+      const toggle = screen.queryByRole('button', { name: 'Actions for my-workspace' });
 
       expect(toggle).not.toBeNull();
       expect(toggle).toHaveAttribute('data-testtype', 'dropdown-toggle');

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/index.tsx
@@ -79,7 +79,7 @@ class WorkspaceActionsDropdownComponent extends React.PureComponent<Props, State
       return (toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
           ref={toggleRef}
-          aria-label="Actions"
+          aria-label={`Actions for ${workspace.name}`}
           data-testid={`${workspace.uid}-action-dropdown`}
           data-testtype="kebab-toggle"
           isDisabled={isDisabled}
@@ -96,7 +96,7 @@ class WorkspaceActionsDropdownComponent extends React.PureComponent<Props, State
     return (toggleRef: React.Ref<MenuToggleElement>) => (
       <MenuToggle
         ref={toggleRef}
-        aria-label="Actions"
+        aria-label={`Actions for ${workspace.name}`}
         data-testid={`${workspace.uid}-action-dropdown`}
         data-testtype="dropdown-toggle"
         isDisabled={isDisabled}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds workspace-specific context to the `aria-label` of kebab action menu buttons in the Workspaces list, so screen reader users can distinguish which workspace each menu belongs to.

#### Problem

Every workspace row's 3-dot kebab menu had an identical `aria-label="Actions"`. When a screen reader user lists all buttons on the page, they hear "Actions, button" repeated for every workspace with no way to tell which workspace each menu controls.

#### Fix

Changed the `aria-label` on both toggle variants (kebab and dropdown) in `WorkspaceActionsDropdown` from the static `"Actions"` to `"Actions for {workspace.name}"`.

**Before:**
```html
<button aria-label="Actions">...</button>
<button aria-label="Actions">...</button>
```

**After:**
```html
<button aria-label="Actions for spring-petclinic">...</button>
<button aria-label="Actions for nodejs-app">...</button>
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10287

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
