### PR TITLE
fix(a11y): remove prohibited aria-label from backup schedule element

### DIFF
--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
@@ -122,7 +122,6 @@ export class BackupsListToolbar extends React.PureComponent<Props> {
             <Content
               id="next-scheduled-backup-label"
               component={ContentVariants.small}
-              aria-label="Next scheduled backup time"
               data-testid="next-scheduled-backup"
             >
               {scheduleLabel}


### PR DESCRIPTION
### What does this PR do?

Removes the prohibited `aria-label` attribute from the backup schedule `<small>` element on the Workspaces > Backups page.

### Screenshot/screencast of this PR

### What issues does this PR fix or reference?

Fixes https://issues.redhat.com/browse/CRW-10738

### Is it tested? How?

#### Release Notes

Fixed an accessibility violation where the backup schedule indicator used a prohibited `aria-label` on a generic `<small>` element (WCAG 4.1.2).

#### Docs PR