### PR TITLE
fix(a11y): align Restore Workspace button accessible name with visible label

### DIFF
--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
@@ -108,7 +108,6 @@ export class BackupsListToolbar extends React.PureComponent<Props> {
                 icon={<RedoIcon />}
                 iconPosition="left"
                 variant={ButtonVariant.link}
-                aria-label="Restore from backup"
                 onClick={() => onRestoreClick()}
                 data-testid="restore-from-backup-button"
               >


### PR DESCRIPTION
### What does this PR do?

Removes the mismatched `aria-label` from the "Restore Workspace" button on the Backups tab toolbar.

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?

Fixes https://issues.redhat.com/browse/CRW-10720

### Is it tested? How?


#### Release Notes

Fixed an accessibility issue where the "Restore Workspace" button's accessible name did not match its visible label, preventing speech recognition activation.

#### Docs PR
