### PR TITLE
fix(ui): disable Save button when Gitconfig name or email fields are empty

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/__tests__/index.spec.tsx
@@ -63,7 +63,7 @@ describe('GitConfigSectionUser', () => {
           email: 'user@che',
         },
       },
-      true,
+      false,
     );
   });
 
@@ -88,7 +88,7 @@ describe('GitConfigSectionUser', () => {
           email: 'new-user@che',
         },
       },
-      true,
+      false,
     );
   });
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitConfig/Form/SectionUser/index.tsx
@@ -24,8 +24,8 @@ export type Props = {
 };
 
 export class GitConfigSectionUser extends React.PureComponent<Props> {
-  private isNameValid = true;
-  private isEmailValid = true;
+  private isNameValid = false;
+  private isEmailValid = false;
 
   private handleChange(
     partialConfigUser: Partial<GitConfig['user']>,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Initialize validation state to false instead of true in `GitConfigSectionUser` to ensure the Save button remains disabled when one of the field is empty, preventing users from saving invalid gitconfig data.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10719

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to `User Preferences` GitConfig tab.
2. Enter a valid username to the `Name` field.
3. See: The `Save` button is disabled.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
