### PR TITLE
fix(a11y): replace nested anchor in button with onClick handler

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/__tests__/__snapshots__/index.spec.tsx.snap
@@ -68,37 +68,27 @@ exports[`Registry Url Input should correctly render the component 1`] = `
           data-ouia-component-type="PF6/Button"
           data-ouia-safe={true}
           disabled={true}
+          onClick={[Function]}
           tabIndex={null}
           type="button"
         >
           <span
             className="pf-v6-c-button__text"
           >
-            <a
-              href="https://ttt"
-              rel="noreferrer"
-              style={
-                {
-                  "color": "inherit",
-                }
-              }
-              target="_blank"
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              className="pf-v6-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 512 512"
+              width="1em"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-v6-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 512 512"
-                width="1em"
-              >
-                <path
-                  d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                />
-              </svg>
-            </a>
+              <path
+                d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              />
+            </svg>
           </span>
         </button>
       </div>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/ContainerRegistriesTab/RegistryUrl/index.tsx
@@ -109,10 +109,13 @@ export class RegistryUrlFormGroup extends React.PureComponent<Props, State> {
             validated={valid}
             onChange={(_event, _url) => this.onChange(_url)}
           />
-          <Button variant="link" isDisabled={!url || !isUrl} aria-label="open registry">
-            <a href={url} style={{ color: 'inherit' }} target="_blank" rel="noreferrer">
-              <ExternalLinkAltIcon />
-            </a>
+          <Button
+            variant="link"
+            isDisabled={!url || !isUrl}
+            aria-label="open registry"
+            onClick={() => window.open(url, '_blank')}
+          >
+            <ExternalLinkAltIcon />
           </Button>
         </InputGroup>
         {valid === ValidatedOptions.error && errorMessage && (


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add the `onClick` handler to the `open registry` button instead of the anchor element in order to get rid of the nested `<a>` element.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10317

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Navigate the browser's element selector to the `Open Registry` icon.
2. See: no nested `<a>` element is present in the button structure:
<img width="1266" height="880" alt="image" src="https://github.com/user-attachments/assets/aedcfd44-90ad-4e73-a1e8-e743fd67cb1d" />


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
