### PR TITLE
fix(a11y): remove nested radio input from sample workspace cards

### DIFF
--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Devfile Metadata Card snapshot 1`] = `
 <div
   aria-label="Create workspace from sample Go"
-  className="pf-v6-c-card pf-m-compact pf-m-selectable pf-m-clickable sample-card"
+  className="pf-v6-c-card pf-m-compact pf-m-clickable sampleCard sample-card"
   data-ouia-component-id="OUIA-Generated-Card-1"
   data-ouia-component-type="PF6/Card"
   data-ouia-safe={true}
@@ -18,35 +18,8 @@ exports[`Devfile Metadata Card snapshot 1`] = `
     className="pf-v6-c-card__header"
   >
     <div
-      className="pf-v6-c-card__actions pf-m-no-offset"
-    >
-      <div
-        className="pf-v6-c-card__selectable-actions"
-      >
-        <div
-          className="pf-v6-c-radio pf-m-standalone"
-        >
-          <input
-            aria-invalid={false}
-            aria-labelledby="sample-card-go"
-            checked={false}
-            className="pf-v6-c-radio__input pf-v6-screen-reader"
-            data-ouia-component-id="OUIA-Generated-Radio-1"
-            data-ouia-component-type="PF6/Radio"
-            data-ouia-safe={true}
-            disabled={false}
-            id="sample-card-go-input"
-            name="sample-card-selector"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="pf-v6-c-radio__label"
-            htmlFor="sample-card-go-input"
-          />
-        </div>
-      </div>
-    </div>
+      className="pf-v6-c-card__actions"
+    />
     <div
       className="pf-v6-c-card__header-main"
     >

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/index.module.css
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/index.module.css
@@ -10,6 +10,10 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+.sampleCard {
+  border: var(--pf-v6-c-card--BorderWidth) var(--pf-v6-c-card--BorderStyle) var(--pf-t--global--border--color--default);
+}
+
 .sampleCardIcon {
   width: 68px;
   height: 68px;

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/index.tsx
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/index.tsx
@@ -89,27 +89,15 @@ export class SampleCard extends React.PureComponent<Props> {
         id={this.cardId}
         isCompact
         isClickable
-        isSelectable
         onClick={this.handleSelectableAction}
         onKeyDown={(e: React.KeyboardEvent) => this.handleKeyDown(e)}
         role="button"
         tabIndex={0}
         aria-label={`Create workspace from sample ${metadata.displayName}`}
-        className={'sample-card'}
+        className={`${styles.sampleCard} sample-card`}
         data-testid="sample-card"
       >
-        <CardHeader
-          selectableActions={{
-            selectableActionId: `${this.cardId}-input`,
-            selectableActionAriaLabelledby: this.cardId,
-            name: 'sample-card-selector',
-            variant: 'single',
-            onChange: this.handleSelectableAction,
-            hasNoOffset: true,
-            isHidden: true,
-          }}
-          actions={{ actions: <>{tags}</> }}
-        >
+        <CardHeader actions={{ actions: <>{tags}</> }}>
           {devfileIcon}
           <CardTitle>{metadata.displayName}</CardTitle>
         </CardHeader>

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
@@ -108,6 +108,7 @@ export class BackupsListToolbar extends React.PureComponent<Props> {
                 icon={<RedoIcon />}
                 iconPosition="left"
                 variant={ButtonVariant.link}
+                aria-label="Restore from backup"
                 onClick={() => onRestoreClick()}
                 data-testid="restore-from-backup-button"
               >


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes an accessibility violation on the "Create Workspace" page where an interactive `<input type="radio">` element was illegally nested inside a card element with `role="button"`.

**Related WCAG 2.2 criterion:** 4.1.2 Name, Role, Value (Level A)

**Root cause:** The PatternFly `Card` component was rendered with both `isSelectable` and `isClickable` props, and `CardHeader` was configured with `selectableActions`. This combination caused PatternFly to inject a hidden radio input (`<input type="radio" class="pf-v6-screen-reader">`) inside the card's DOM — which also carries `role="button"`. Nesting an interactive input inside another interactive element is invalid HTML and breaks screen reader navigation and keyboard behavior.

**Fix:** Removed `isSelectable` from `<Card>` and removed `selectableActions` from `<CardHeader>`. The card retains full click/keyboard interactivity through its existing `onClick`, `onKeyDown`, `role="button"`, `tabIndex={0}`, and `aria-label` attributes.

## Before / After

**Before** (invalid DOM):
```html
<div role="button" id="sample-card-empty-workspace" class="pf-v6-c-card pf-m-selectable pf-m-clickable ...">
  <div class="pf-v6-c-card__header">
    <div class="pf-v6-c-card__selectable-actions">
      <!-- ❌ interactive input nested inside role="button" -->
      <input type="radio" class="pf-v6-c-radio__input pf-v6-screen-reader" />
    </div>
  </div>
</div>
```

**After** (valid DOM):
```html
<div role="button" id="sample-card-empty-workspace" class="pf-v6-c-card pf-m-clickable ...">
  <div class="pf-v6-c-card__header">
    <!-- ✅ no nested interactive elements -->
  </div>
</div>
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://issues.redhat.com/browse/CRW-10737

### Is it tested? How?
1. Deploy Eclipse Che with the dashboard image from this PR.
2. Navigate to the **Create Workspace** page.
3. Inspect the DOM of any sample card (e.g. `#sample-card-empty-workspace`).
4. Confirm there is no `<input type="radio">` inside the card element.
5. Verify clicking and keyboard navigation (Tab, Enter, Space) on the sample cards still works correctly.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
