### PR TITLE
align Search field accessible name and layout on Backups tab

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,4 +7,5 @@
     "**/node_modules": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
 }

--- a/packages/dashboard-frontend/src/containers/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/containers/WorkspacesList/index.tsx
@@ -18,7 +18,11 @@ import Fallback from '@/components/Fallback';
 import WorkspacesList from '@/pages/WorkspacesList';
 import { RootState } from '@/store';
 import { fetchBackupConfig, fetchWorkspaceBackupStatus } from '@/store/Backups/actions';
-import { selectAllBackupsByWorkspace, selectBackupConfig } from '@/store/Backups/selectors';
+import {
+  selectAllBackupsByWorkspace,
+  selectBackupConfig,
+  selectBackupSchedule,
+} from '@/store/Backups/selectors';
 import { selectBranding } from '@/store/Branding/selectors';
 import { selectCmEditors } from '@/store/Plugins/devWorkspacePlugins/selectors';
 import { workspacesActionCreators } from '@/store/Workspaces';
@@ -56,7 +60,7 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
   }
 
   private fetchBackupStatuses() {
-    const { allWorkspaces, backupConfig, backupsByWorkspace } = this.props;
+    const { allWorkspaces, backupConfig, backupsByWorkspace: backupsByWorkspace } = this.props;
     if (!backupConfig?.registry) {
       return;
     }
@@ -73,10 +77,11 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
 
   render() {
     const {
-      backupConfig,
-      branding,
       allWorkspaces,
+      backupConfig,
       backupsByWorkspace,
+      backupSchedule,
+      branding,
       editors,
       isLoading,
       location,
@@ -90,12 +95,13 @@ export class WorkspacesListContainer extends React.PureComponent<Props> {
     return (
       <WorkspacesList
         backupConfig={backupConfig}
+        backupsByWorkspace={backupsByWorkspace}
+        backupSchedule={backupSchedule}
         branding={branding}
         editors={editors}
         location={location}
         navigate={navigate}
         workspaces={allWorkspaces}
-        backupsByWorkspace={backupsByWorkspace}
       />
     );
   }
@@ -110,10 +116,11 @@ function ContainerWrapper(props: MappedProps) {
 
 const mapStateToProps = (state: RootState) => {
   return {
-    backupConfig: selectBackupConfig(state),
-    branding: selectBranding(state),
     allWorkspaces: selectAllWorkspaces(state),
+    backupConfig: selectBackupConfig(state),
     backupsByWorkspace: selectAllBackupsByWorkspace(state),
+    backupSchedule: selectBackupSchedule(state),
+    branding: selectBranding(state),
     editors: selectCmEditors(state),
     isLoading: selectIsLoading(state),
   };

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/BackupsTable/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/BackupsTable/index.tsx
@@ -50,6 +50,7 @@ export class BackupsTable extends React.PureComponent<Props> {
         <Table aria-label="Backups List Table" variant="compact" data-testid="backups-table">
           <Thead>
             <Tr>
+              <Th screenReaderText="Select backup" />
               {columns.map((col, colIndex) => (
                 <Th
                   key={colIndex}
@@ -74,6 +75,15 @@ export class BackupsTable extends React.PureComponent<Props> {
           <Tbody>
             {rows.map((row, rowIndex) => (
               <Tr key={rowIndex}>
+                <Td
+                  style={{ visibility: 'hidden' }}
+                  select={{
+                    rowIndex,
+                    onSelect: () => {},
+                    isSelected: false,
+                    isDisabled: true,
+                  }}
+                />
                 {row.cells.map((cell, cellIndex) => (
                   <Td key={cell.key} dataLabel={columns[cellIndex]?.dataLabel}>
                     {cell.title}

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/BackupsTableView/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/BackupsTableView/__tests__/index.spec.tsx
@@ -23,11 +23,6 @@ jest.mock('@/services/helpers/dates', () => ({
   formatRelativeDate: jest.fn(() => '2 hours ago'),
 }));
 
-jest.mock('cronstrue', () => ({
-  __esModule: true,
-  default: { toString: jest.fn(() => 'At 01:00 AM') },
-}));
-
 jest.mock('@/components/BackupStatusBadge', () => ({
   BackupStatusBadge: (props: {
     status: string;
@@ -73,15 +68,10 @@ const mockBackups: BackupItem[] = [
   },
 ];
 
-function renderComponent(backups: BackupItem[] = mockBackups, backupSchedule?: string) {
+function renderComponent(backups: BackupItem[] = mockBackups) {
   return render(
     <MemoryRouter>
-      <BackupsTableView
-        backups={backups}
-        namespace="test-namespace"
-        navigate={mockNavigate}
-        backupSchedule={backupSchedule}
-      />
+      <BackupsTableView backups={backups} namespace="test-namespace" navigate={mockNavigate} />
     </MemoryRouter>,
   );
 }
@@ -427,29 +417,6 @@ describe('BackupsTableView', () => {
 
       const size = screen.getByTestId('backup-size');
       expect(size).toHaveTextContent('1.0 MB');
-    });
-  });
-
-  describe('toolbar', () => {
-    test('should render toolbar', () => {
-      renderComponent();
-
-      expect(screen.getByTestId('backups-view-toolbar')).toBeTruthy();
-    });
-
-    test('should show "No backup schedule configured" when backupSchedule is undefined', () => {
-      renderComponent(mockBackups, undefined);
-
-      expect(screen.getByTestId('next-scheduled-backup')).toHaveTextContent(
-        'No backup schedule configured',
-      );
-    });
-
-    test('should display human-readable backup schedule', () => {
-      renderComponent(mockBackups, '0 1 * * *');
-
-      const el = screen.getByTestId('next-scheduled-backup');
-      expect(el).toHaveTextContent('Backup schedule: At 01:00 AM');
     });
   });
 });

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/BackupsTableView/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/BackupsTableView/index.tsx
@@ -34,7 +34,6 @@ type Props = {
   backups: BackupItem[];
   namespace: string;
   navigate: (location: ReturnType<typeof buildRestoreFromBackupLocation>) => void;
-  backupSchedule: string | undefined;
 };
 
 type State = {
@@ -125,7 +124,7 @@ export class BackupsTableView extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { backups, namespace, backupSchedule } = this.props;
+    const { backups, namespace } = this.props;
     const { sortBy, filterValue, expandedDropdowns } = this.state;
 
     const filtered = this.getFilteredBackups();
@@ -141,7 +140,6 @@ export class BackupsTableView extends React.PureComponent<Props, State> {
     const toolbar = (
       <BackupsListToolbar
         filterValue={filterValue}
-        backupSchedule={backupSchedule}
         onFilterChange={value => this.handleFilterChange(value)}
         onFilterApply={() => this.handleFilterApply()}
         onFilterClear={() => this.handleFilterClear()}

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/__tests__/index.spec.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { BackupsListToolbar } from '..';
+
+const mockOnFilterChange = jest.fn();
+const mockOnFilterApply = jest.fn();
+const mockOnFilterClear = jest.fn();
+const mockOnRestoreClick = jest.fn();
+
+describe('Backups List Toolbar', () => {
+  function renderComponent(
+    propsOverrides: Partial<React.ComponentProps<typeof BackupsListToolbar>> = {},
+  ) {
+    const defaultProps: React.ComponentProps<typeof BackupsListToolbar> = {
+      filterValue: '',
+      onFilterChange: mockOnFilterChange,
+      onFilterApply: mockOnFilterApply,
+      onFilterClear: mockOnFilterClear,
+      onRestoreClick: mockOnRestoreClick,
+    };
+    return render(<BackupsListToolbar {...defaultProps} {...propsOverrides} />);
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly', () => {
+    renderComponent();
+
+    expect(screen.queryByRole('searchbox')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /search backups/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /restore from backup/i })).toBeTruthy();
+  });
+
+  it('should call onFilterChange when typing in search', async () => {
+    renderComponent();
+
+    const searchbox = screen.getByRole('searchbox');
+    await userEvent.type(searchbox, 'a');
+
+    expect(mockOnFilterChange).toHaveBeenCalledWith('a');
+  });
+
+  it('should call onFilterApply when clicking search button', async () => {
+    renderComponent();
+
+    const searchButton = screen.getByRole('button', { name: /search backups/i });
+    await userEvent.click(searchButton);
+
+    expect(mockOnFilterApply).toHaveBeenCalled();
+  });
+
+  it('should call onFilterApply when pressing Enter', async () => {
+    renderComponent();
+
+    const searchbox = screen.getByRole('searchbox');
+    await userEvent.type(searchbox, '{Enter}');
+
+    expect(mockOnFilterApply).toHaveBeenCalled();
+  });
+
+  it('should call onFilterClear when pressing Escape', async () => {
+    renderComponent();
+
+    const searchbox = screen.getByRole('searchbox');
+    await userEvent.type(searchbox, '{Escape}');
+
+    expect(mockOnFilterClear).toHaveBeenCalled();
+  });
+
+  it('should call onRestoreClick when clicking Restore Workspace', async () => {
+    renderComponent();
+
+    const restoreButton = screen.getByRole('button', { name: /restore from backup/i });
+    await userEvent.click(restoreButton);
+
+    expect(mockOnRestoreClick).toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.module.css
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/* NOTE: this hidden checkbox is needed to alignt the backup toolbar items in same way as the active workspaces toolbar items. */
+.toolbarCheckbox {
+  margin-top: 6px;
+  margin-left: 26px;
+  visibility: hidden;
+}

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/index.tsx
@@ -15,8 +15,7 @@
 import {
   Button,
   ButtonVariant,
-  Content,
-  ContentVariants,
+  Checkbox,
   InputGroup,
   TextInput,
   Toolbar,
@@ -25,12 +24,12 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { EllipsisVIcon, RedoIcon, SearchIcon } from '@patternfly/react-icons';
-import cronstrue from 'cronstrue';
 import React from 'react';
+
+import styles from '@/pages/WorkspacesList/BackupsView/Toolbar/index.module.css';
 
 type Props = {
   filterValue: string;
-  backupSchedule: string | undefined;
   onFilterChange: (value: string) => void;
   onFilterApply: () => void;
   onFilterClear: () => void;
@@ -50,30 +49,31 @@ export class BackupsListToolbar extends React.PureComponent<Props> {
   }
 
   public render(): React.ReactElement {
-    const { filterValue, backupSchedule, onFilterChange, onFilterApply, onRestoreClick } =
-      this.props;
-
-    let scheduleLabel: string;
-    if (backupSchedule) {
-      try {
-        scheduleLabel = `Backup schedule: ${cronstrue.toString(backupSchedule)}`;
-      } catch {
-        scheduleLabel = `Backup schedule: ${backupSchedule}`;
-      }
-    } else {
-      scheduleLabel = 'No backup schedule configured';
-    }
+    const { filterValue, onFilterChange, onFilterApply, onRestoreClick } = this.props;
 
     return (
-      <Toolbar id="backups-view-toolbar" data-testid="backups-view-toolbar">
+      <Toolbar
+        id="backups-view-toolbar"
+        data-testid="backups-view-toolbar"
+        style={{ paddingBlockStart: '1rem' }}
+      >
         <ToolbarContent>
+          <ToolbarItem className={styles.toolbarCheckbox}>
+            {/* NOTE: this hidden checkbox is needed to align the backup toolbar items in the same way as the active workspaces toolbar items. */}
+            <Checkbox
+              isChecked={false}
+              isDisabled={true}
+              id="backups-select-all-placeholder"
+              name="backups-select-all-placeholder"
+            />
+          </ToolbarItem>
           <ToolbarItem>
             <InputGroup>
               <TextInput
                 name="backups-filter-input"
                 id="backups-filter-input"
                 type="search"
-                aria-label="Filter backups"
+                aria-label="Search backups"
                 placeholder="Search"
                 value={filterValue}
                 onChange={(_event, value) => onFilterChange(value)}
@@ -82,7 +82,7 @@ export class BackupsListToolbar extends React.PureComponent<Props> {
               />
               <Button
                 variant="control"
-                aria-label="Filter backups"
+                aria-label="Search backups"
                 onClick={() => onFilterApply()}
                 data-testid="backups-filter-button"
               >
@@ -116,17 +116,6 @@ export class BackupsListToolbar extends React.PureComponent<Props> {
               </Button>
             </ToolbarItem>
           </ToolbarToggleGroup>
-        </ToolbarContent>
-        <ToolbarContent data-testid="next-backup-info">
-          <ToolbarItem align={{ default: 'alignEnd' }}>
-            <Content
-              id="next-scheduled-backup-label"
-              component={ContentVariants.small}
-              data-testid="next-scheduled-backup"
-            >
-              {scheduleLabel}
-            </Content>
-          </ToolbarItem>
         </ToolbarContent>
       </Toolbar>
     );

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/__tests__/index.spec.tsx
@@ -135,12 +135,11 @@ describe('BackupsView', () => {
   });
 
   describe('lifecycle', () => {
-    test('should fetch backup list on mount with force', () => {
+    test('should fetch backup list on mount', () => {
       renderComponent({ namespace: 'test-namespace' });
 
       expect(mockFetchBackupList).toHaveBeenCalledWith({
         namespace: 'test-namespace',
-        force: true,
       });
     });
 
@@ -169,7 +168,7 @@ describe('BackupsView', () => {
         />,
       );
 
-      expect(mockFetchBackupList).toHaveBeenCalledWith({ namespace: 'namespace-1', force: true });
+      expect(mockFetchBackupList).toHaveBeenCalledWith({ namespace: 'namespace-1' });
       mockFetchBackupList.mockClear();
 
       rerender(
@@ -183,7 +182,7 @@ describe('BackupsView', () => {
         </MemoryRouter>,
       );
 
-      expect(mockFetchBackupList).toHaveBeenCalledWith({ namespace: 'namespace-2', force: true });
+      expect(mockFetchBackupList).toHaveBeenCalledWith({ namespace: 'namespace-2' });
     });
 
     test('should not re-fetch when namespace stays the same', () => {

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/index.tsx
@@ -31,7 +31,6 @@ import {
 import { RootState } from '@/store';
 import { fetchBackupConfig, fetchBackupList } from '@/store/Backups/actions';
 import {
-  selectBackupSchedule,
   selectBackupsError,
   selectHasEverFetchedBackupList,
   selectIsUpdatingBackups,
@@ -49,7 +48,7 @@ export class BackupsView extends React.PureComponent<Props> {
   public componentDidMount(): void {
     const { namespace } = this.props;
     if (namespace) {
-      this.props.fetchBackupList({ namespace, force: true });
+      this.props.fetchBackupList({ namespace });
       this.props.fetchBackupConfig({ namespace });
     }
   }
@@ -57,7 +56,7 @@ export class BackupsView extends React.PureComponent<Props> {
   public componentDidUpdate(prevProps: Props): void {
     const { namespace } = this.props;
     if (namespace && namespace !== prevProps.namespace) {
-      this.props.fetchBackupList({ namespace, force: true });
+      this.props.fetchBackupList({ namespace });
       this.props.fetchBackupConfig({ namespace });
     }
   }
@@ -75,8 +74,7 @@ export class BackupsView extends React.PureComponent<Props> {
   }
 
   public render(): React.ReactElement {
-    const { isLoading, hasEverFetched, error, backups, namespace, navigate, backupSchedule } =
-      this.props;
+    const { isLoading, hasEverFetched, error, backups, namespace, navigate } = this.props;
 
     if (isLoading || !hasEverFetched) {
       return this.renderLoading();
@@ -104,12 +102,7 @@ export class BackupsView extends React.PureComponent<Props> {
             </Alert>
           </PageSection>
         )}
-        <BackupsTableView
-          backups={backups}
-          namespace={namespace}
-          navigate={navigate}
-          backupSchedule={backupSchedule}
-        />
+        <BackupsTableView backups={backups} namespace={namespace} navigate={navigate} />
       </div>
     );
   }
@@ -124,7 +117,6 @@ const mapStateToProps = (state: RootState) => {
     isLoading: selectIsUpdatingBackups(state),
     hasEverFetched: selectHasEverFetchedBackupList(state),
     error: selectBackupsError(state),
-    backupSchedule: selectBackupSchedule(state),
   };
 };
 

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/__tests__/index.spec.tsx
@@ -204,6 +204,7 @@ function getComponent(_workspaces = workspaces): React.ReactElement {
   return (
     <MemoryRouter>
       <WorkspacesList
+        backupSchedule={undefined}
         backupsByWorkspace={{}}
         branding={brandingData}
         editors={[]}

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/index.tsx
@@ -15,12 +15,16 @@ import 'reflect-metadata';
 import { BackupConfig, BackupInfo } from '@eclipse-che/common';
 import {
   Content,
+  ContentVariants,
+  Level,
+  LevelItem,
   PageSection,
   PageSectionVariants,
   ToggleGroup,
   ToggleGroupItem,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import cronstrue from 'cronstrue';
 import React from 'react';
 import { Location, NavigateFunction } from 'react-router-dom';
 
@@ -33,6 +37,7 @@ import { Workspace } from '@/services/workspace-adapter';
 
 type Props = {
   backupConfig?: BackupConfig;
+  backupSchedule: string | undefined;
   backupsByWorkspace: Record<string, BackupInfo>;
   branding: BrandingData;
   editors: devfileApi.Devfile[];
@@ -82,10 +87,28 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactElement {
-    const { backupConfig, backupsByWorkspace, branding, editors, navigate, workspaces } =
-      this.props;
+    const {
+      backupConfig,
+      backupsByWorkspace,
+      backupSchedule,
+      branding,
+      editors,
+      navigate,
+      workspaces,
+    } = this.props;
     const { workspace: workspacesDocsLink } = branding.docs;
     const { viewMode } = this.state;
+
+    let scheduleLabel: string;
+    if (backupSchedule) {
+      try {
+        scheduleLabel = `Backup schedule: ${cronstrue.toString(backupSchedule)}`;
+      } catch {
+        scheduleLabel = `Backup schedule: ${backupSchedule}`;
+      }
+    } else {
+      scheduleLabel = 'No backup schedule configured';
+    }
 
     return (
       <React.Fragment>
@@ -104,20 +127,33 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
           </Content>
         </PageSection>
         <PageSection variant={PageSectionVariants.default}>
-          <ToggleGroup aria-label="View toggle">
-            <ToggleGroupItem
-              text="Active Workspaces"
-              buttonId="view-workspaces"
-              isSelected={viewMode === 'workspaces'}
-              onChange={() => this.handleViewModeChange('workspaces')}
-            />
-            <ToggleGroupItem
-              text="Backups"
-              buttonId="view-backups"
-              isSelected={viewMode === 'backups'}
-              onChange={() => this.handleViewModeChange('backups')}
-            />
-          </ToggleGroup>
+          <Level>
+            <LevelItem>
+              <ToggleGroup aria-label="View toggle">
+                <ToggleGroupItem
+                  text="Active Workspaces"
+                  buttonId="view-workspaces"
+                  isSelected={viewMode === 'workspaces'}
+                  onChange={() => this.handleViewModeChange('workspaces')}
+                />
+                <ToggleGroupItem
+                  text="Backups"
+                  buttonId="view-backups"
+                  isSelected={viewMode === 'backups'}
+                  onChange={() => this.handleViewModeChange('backups')}
+                />
+              </ToggleGroup>
+            </LevelItem>
+            <LevelItem>
+              <Content
+                id="next-scheduled-backup-label"
+                component={ContentVariants.small}
+                data-testid="next-scheduled-backup"
+              >
+                {scheduleLabel}
+              </Content>
+            </LevelItem>
+          </Level>
         </PageSection>
         {viewMode === 'backups' ? (
           <BackupsView navigate={navigate} />


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Renames the Search field aria-label from "Filter backups" to "Search backups" on the Backups tab, aligning the accessible name with the visible "Search" placeholder. Aligns the Backups toolbar and table layout with the Active Workspaces tab by adding hidden checkbox elements that match the same DOM structure. Moves the backup schedule label to the page-level header and removes forced refetching on tab switch.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<img width="1002" height="563" alt="Screenshots" src="https://github.com/user-attachments/assets/122866fa-e24c-431a-b792-e73848fe59d2" />

<br/>
<br/>

https://github.com/user-attachments/assets/03c17535-7823-4419-9446-b0765ad0ec73


### What issues does this PR fix or reference?

Fixes https://issues.redhat.com/browse/CRW-10718

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->

Fixed an accessibility issue where the Search field on the Backups tab had a mismatched accessible name, preventing speech recognition users from activating it by saying "Search".

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
