### PR TITLE
fix(a11y): add role="img" to workspace status indicator span (WCAG 4.1.2)

### DIFF
--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
@@ -21,6 +21,7 @@ exports[`Workspace indicator component Che Workspaces should render ERROR status
       aria-label="Workspace status is ERROR"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -70,6 +71,7 @@ exports[`Workspace indicator component Che Workspaces should render RUNNING stat
       aria-label="Workspace status is RUNNING"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -119,6 +121,7 @@ exports[`Workspace indicator component Che Workspaces should render STARTING sta
       aria-label="Workspace status is STARTING"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -169,6 +172,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPED stat
       aria-label="Workspace status is STOPPED"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -229,6 +233,7 @@ exports[`Workspace indicator component Che Workspaces should render STOPPING sta
       aria-label="Workspace status is STOPPING"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -279,6 +284,7 @@ exports[`Workspace indicator component Deprecated workspaces should render "Depr
       aria-label="Workspace status is Deprecated"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -328,6 +334,7 @@ exports[`Workspace indicator component DevWorkspaces should render FAILED status
       aria-label="Workspace status is Failed"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -377,6 +384,7 @@ exports[`Workspace indicator component DevWorkspaces should render FAILING statu
       aria-label="Workspace status is Failing"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -427,6 +435,7 @@ exports[`Workspace indicator component DevWorkspaces should render RUNNING statu
       aria-label="Workspace status is Running"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -476,6 +485,7 @@ exports[`Workspace indicator component DevWorkspaces should render STOPPED statu
       aria-label="Workspace status is Stopped"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -536,6 +546,7 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
       aria-label="Workspace status is Running"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -585,6 +596,7 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
       aria-label="Workspace status is Stopped"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -645,6 +657,7 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
       aria-label="Workspace status is Stopped"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -705,6 +718,7 @@ exports[`Workspace indicator component SCC Mismatch should render warning for ST
       aria-label="Workspace status is Stopped"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -782,6 +796,7 @@ exports[`Workspace indicator component SCC Mismatch should render warning triang
       aria-label="Workspace status has SCC mismatch warning"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"
@@ -831,6 +846,7 @@ exports[`Workspace indicator component should render default status correctly 1`
       aria-label="Workspace status is STOPPING"
       className="statusIndicator"
       data-testid="workspace-status-indicator"
+      role="img"
     >
       <span
         className="pf-v6-c-icon pf-m-inline"

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
@@ -54,6 +54,7 @@ const WorkspaceStatusIndicatorComponent: React.FC<Props> = ({
   return (
     <CheTooltip content={tooltip}>
       <span
+        role="img"
         className={styles.statusIndicator}
         data-testid="workspace-status-indicator"
         aria-label={


### PR DESCRIPTION
### What does this PR do?
Fixes [WCAG 2.2 criterion 4.1.2 Name, Role, Value (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html) for the workspace status indicator icon.

The `WorkspaceStatusIndicator` component renders a `<span>` with an `aria-label` (e.g. `"Workspace status is Running"`) but no semantic role. Per the ARIA specification, naming attributes such as `aria-label` are only honoured by assistive technologies when the element has a valid role. On a generic `<span>`, screen readers silently ignore the label — users who rely on a screen reader receive no information about the workspace status.

This PR adds `role="img"` to the span, declaring it as a named graphic element. The `aria-label` is now correctly exposed to the accessibility API and announced by screen readers when the element receives focus.

**Affected surfaces:** Workspaces list table (status column) and Workspace Details Overview tab.

```diff
 <span
+  role="img"
   className={styles.statusIndicator}
   data-testid="workspace-status-indicator"
   aria-label={`Workspace status is ${status}`}
 >
   {icon}
 </span>
```

The `role="img"` value is the correct choice here: the element contains a purely visual icon that conveys information, and the `aria-label` supplies its accessible text alternative — exactly the pattern described in [ARIA authoring practices for images](https://www.w3.org/WAI/ARIA/apg/patterns/img/).

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10233

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
- 16 snapshots updated in `Indicator.spec.tsx.snap` to include `role="img"`.
- Manually verified with macOS VoiceOver on Chrome: the status label is now announced on focus for both the Workspaces list and the Workspace Details Overview.


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
