### PR TITLE
fix(a11y): fix invalid list structures in navigation and alert group (WCAG 1.3.1)

### DIFF
--- a/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
+++ b/packages/dashboard-frontend/src/Layout/Navigation/RecentList.tsx
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { NavGroup, NavList } from '@patternfly/react-core';
+import { NavGroup } from '@patternfly/react-core';
 import React from 'react';
 
 import { NavigationRecentItem } from '@/Layout/Navigation/RecentItem';
@@ -51,11 +51,9 @@ function NavigationRecentList(props: {
     );
   });
   return (
-    <NavList>
-      <NavGroup title="RECENT WORKSPACES" style={{ marginTop: '25px' }}>
-        {recentWorkspaceItems}
-      </NavGroup>
-    </NavList>
+    <NavGroup title="RECENT WORKSPACES" style={{ marginTop: '25px' }}>
+      {recentWorkspaceItems}
+    </NavGroup>
   );
 }
 NavigationRecentList.displayName = 'NavigationRecentListComponent';

--- a/packages/dashboard-frontend/src/components/AppAlertGroup/index.tsx
+++ b/packages/dashboard-frontend/src/components/AppAlertGroup/index.tsx
@@ -92,7 +92,11 @@ class AppAlertGroup extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactElement {
-    return <AlertGroup isToast>{this.state.alerts.map(alert => this.getAlert(alert))}</AlertGroup>;
+    const { alerts } = this.state;
+    if (alerts.length === 0) {
+      return <></>;
+    }
+    return <AlertGroup isToast>{alerts.map(alert => this.getAlert(alert))}</AlertGroup>;
   }
 }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fixes two violations of [WCAG 2.2 criterion 1.3.1 Info and Relationships (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html).

WCAG 1.3.1 requires that information conveyed through visual presentation (including list structure) is also available programmatically. When `<ul>` or `<ol>` elements contain children that are not `<li>`, `<script>`, or `<template>`, screen readers cannot correctly announce list context or item count, breaking the programmatic relationship for assistive technology users.

#### Fix 1 — Navigation sidebar: `NavGroup` nested inside `NavList`

**File:** `src/Layout/Navigation/RecentList.tsx`

The "Recent Workspaces" section wrapped a `NavGroup` (which PatternFly renders as `<section class="pf-v6-c-nav__section">`) inside a `NavList` (which renders as `<ul class="pf-v6-c-nav__list" role="list">`). This produced the invalid structure:

```html
<!-- Before (invalid) -->
<ul class="pf-v6-c-nav__list" role="list">
  <section class="pf-v6-c-nav__section">  <!-- <section> not allowed directly in <ul> -->
    <ul>
      <li>...</li>
    </ul>
  </section>
</ul>
```

`NavGroup` already creates its own internal `<ul>` for its `NavItem` children — the outer `NavList` wrapper was redundant and structurally invalid.

**Fix:** remove the `NavList` wrapper from `NavigationRecentList`. `NavGroup` now sits directly inside the `Nav` element alongside `NavigationMainList`, producing valid HTML:

```html
<!-- After (valid) -->
<nav aria-label="Navigation">
  <ul class="pf-v6-c-nav__list">       <!-- NavigationMainList -->
    <li>Create Workspace</li>
    <li>Workspaces (N)</li>
  </ul>
  <section class="pf-v6-c-nav__section">  <!-- NavigationRecentList (NavGroup) -->
    <h2>RECENT WORKSPACES</h2>
    <ul>
      <li>workspace-name</li>
    </ul>
  </section>
</nav>
```

```diff
-import { NavGroup, NavList } from '@patternfly/react-core';
+import { NavGroup } from '@patternfly/react-core';

-  return (
-    <NavList>
-      <NavGroup title="RECENT WORKSPACES" style={{ marginTop: '25px' }}>
-        {recentWorkspaceItems}
-      </NavGroup>
-    </NavList>
-  );
+  return (
+    <NavGroup title="RECENT WORKSPACES" style={{ marginTop: '25px' }}>
+      {recentWorkspaceItems}
+    </NavGroup>
+  );
```

#### Fix 2 — Toast alert group: empty `<ul role="list">`

**File:** `src/components/AppAlertGroup/index.tsx`

`AppAlertGroup` unconditionally rendered `<AlertGroup isToast>`, which PatternFly renders as `<ul role="list" class="pf-v6-c-alert-group pf-m-toast">`. When there are no active alerts the list is empty — a `role="list"` element with no `role="listitem"` children violates 1.3.1.

**Fix:** return an empty fragment when there are no alerts (consistent with the existing guard in `WorkspaceProgress/Alert/index.tsx`):

```diff
 public render(): React.ReactElement {
-  return <AlertGroup isToast>{this.state.alerts.map(alert => this.getAlert(alert))}</AlertGroup>;
+  const { alerts } = this.state;
+  if (alerts.length === 0) {
+    return <></>;
+  }
+  return <AlertGroup isToast>{alerts.map(alert => this.getAlert(alert))}</AlertGroup>;
 }
```

---
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1486" height="848" alt="Знімок екрана 2026-05-13 о 00 04 31" src="https://github.com/user-attachments/assets/571fe0d0-af45-4ca9-84b6-0818b6eabaf1" />


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10232

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
- Verified with browser DevTools Accessibility panel that `<ul>` elements contain only valid `<li>` children.
- Manually verified with macOS VoiceOver on Chrome that the navigation sidebar now announces correct list structure and item count.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
