### PR TITLE
[cherry-pick] fix(a11y): announce workspace status and progress steps to screen readers

### DIFF
--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/__tests__/__snapshots__/Indicator.spec.tsx.snap
@@ -45,6 +45,13 @@ exports[`Workspace indicator component Che Workspaces should render ERROR status
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is ERROR
+      </span>
     </span>
   </div>
 </div>
@@ -94,6 +101,13 @@ exports[`Workspace indicator component Che Workspaces should render RUNNING stat
             />
           </svg>
         </span>
+      </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is RUNNING
       </span>
     </span>
   </div>
@@ -145,6 +159,13 @@ exports[`Workspace indicator component Che Workspaces should render STARTING sta
             />
           </svg>
         </span>
+      </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is STARTING
       </span>
     </span>
   </div>
@@ -207,6 +228,13 @@ exports[`Workspace indicator component Che Workspaces should render STOPPED stat
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is STOPPED
+      </span>
     </span>
   </div>
 </div>
@@ -258,6 +286,13 @@ exports[`Workspace indicator component Che Workspaces should render STOPPING sta
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is STOPPING
+      </span>
     </span>
   </div>
 </div>
@@ -308,6 +343,13 @@ exports[`Workspace indicator component Deprecated workspaces should render "Depr
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Deprecated
+      </span>
     </span>
   </div>
 </div>
@@ -357,6 +399,13 @@ exports[`Workspace indicator component DevWorkspaces should render FAILED status
             />
           </svg>
         </span>
+      </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Failed
       </span>
     </span>
   </div>
@@ -409,6 +458,13 @@ exports[`Workspace indicator component DevWorkspaces should render FAILING statu
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Failing
+      </span>
     </span>
   </div>
 </div>
@@ -458,6 +514,13 @@ exports[`Workspace indicator component DevWorkspaces should render RUNNING statu
             />
           </svg>
         </span>
+      </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Running
       </span>
     </span>
   </div>
@@ -520,6 +583,13 @@ exports[`Workspace indicator component DevWorkspaces should render STOPPED statu
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Stopped
+      </span>
     </span>
   </div>
 </div>
@@ -569,6 +639,13 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
             />
           </svg>
         </span>
+      </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Running
       </span>
     </span>
   </div>
@@ -631,6 +708,13 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Stopped
+      </span>
     </span>
   </div>
 </div>
@@ -692,6 +776,13 @@ exports[`Workspace indicator component SCC Mismatch should render normal status 
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Stopped
+      </span>
     </span>
   </div>
 </div>
@@ -752,6 +843,13 @@ exports[`Workspace indicator component SCC Mismatch should render warning for ST
             />
           </svg>
         </span>
+      </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is Stopped
       </span>
     </span>
   </div>
@@ -820,6 +918,13 @@ exports[`Workspace indicator component SCC Mismatch should render warning triang
           </svg>
         </span>
       </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status has SCC mismatch warning
+      </span>
     </span>
   </div>
 </div>
@@ -870,6 +975,13 @@ exports[`Workspace indicator component should render default status correctly 1`
             />
           </svg>
         </span>
+      </span>
+      <span
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        role="status"
+      >
+        Workspace status is STOPPING
       </span>
     </span>
   </div>

--- a/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
+++ b/packages/dashboard-frontend/src/components/Workspace/Status/Indicator/index.tsx
@@ -51,19 +51,23 @@ const WorkspaceStatusIndicatorComponent: React.FC<Props> = ({
       ? 'Deprecated workspace'
       : status.toLocaleUpperCase();
 
+  const statusAriaLabel = sccMismatch
+    ? 'Workspace status has SCC mismatch warning'
+    : `Workspace status is ${status}`;
+
   return (
     <CheTooltip content={tooltip}>
       <span
         role="img"
         className={styles.statusIndicator}
         data-testid="workspace-status-indicator"
-        aria-label={
-          sccMismatch
-            ? 'Workspace status has SCC mismatch warning'
-            : `Workspace status is ${status}`
-        }
+        aria-label={statusAriaLabel}
       >
         {icon}
+        {/* Live region: announces status changes to screen readers without requiring user focus */}
+        <span role="status" aria-atomic="true" className="pf-v6-screen-reader">
+          {statusAriaLabel}
+        </span>
       </span>
     </CheTooltip>
   );

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Devfile/index.tsx
@@ -483,6 +483,7 @@ class CreatingStepApplyDevfile extends ProgressStep<Props, State> {
           hasChildren={hasChildren}
           isError={isError}
           isWarning={isWarning}
+          parentStepName="Creating a workspace"
         >
           {name}
         </ProgressStepTitle>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Apply/Resources/index.tsx
@@ -288,6 +288,7 @@ class CreatingStepApplyResources extends ProgressStep<Props, State> {
           hasChildren={hasChildren}
           isError={isError}
           isWarning={isWarning}
+          parentStepName="Creating a workspace"
         >
           {name}
         </ProgressStepTitle>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
@@ -306,6 +306,7 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
           hasChildren={hasChildren}
           isError={isError}
           isWarning={isWarning}
+          parentStepName="Creating a workspace"
         >
           {name}
         </ProgressStepTitle>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Devfile/index.tsx
@@ -385,6 +385,7 @@ class CreatingStepFetchDevfile extends ProgressStep<Props, State> {
           hasChildren={hasChildren}
           isError={isError}
           isWarning={isWarning}
+          parentStepName="Creating a workspace"
         >
           {name}
         </ProgressStepTitle>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/Fetch/Resources/index.tsx
@@ -189,6 +189,7 @@ class CreatingStepFetchResources extends ProgressStep<Props, State> {
           hasChildren={hasChildren}
           isError={isError}
           isWarning={isWarning}
+          parentStepName="Creating a workspace"
         >
           {name}
         </ProgressStepTitle>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/index.tsx
@@ -176,6 +176,7 @@ class StartingStepWorkspaceConditions extends ProgressStep<Props, State> {
           hasChildren={hasChildren}
           isError={isError}
           isWarning={isWarning}
+          parentStepName="Waiting for workspace to start"
         >
           {this.name}
           <PureSubCondition distance={distance} title={subConditionTitle} />

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/__snapshots__/index.spec.tsx.snap
@@ -23,14 +23,6 @@ exports[`ProgressStepTitle snapshot - active step 1`] = `
   >
     Step 1
   </span>,
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    className="pf-v6-screen-reader"
-    role="status"
-  >
-    Step: Step 1
-  </span>,
 ]
 `;
 
@@ -57,34 +49,16 @@ exports[`ProgressStepTitle snapshot - active step failed 1`] = `
   >
     Step 1
   </span>,
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    className="pf-v6-screen-reader"
-    role="status"
-  >
-    Step: Step 1
-  </span>,
 ]
 `;
 
 exports[`ProgressStepTitle snapshot - active step has children 1`] = `
-[
-  <span
-    className="progress"
-    data-testid="step-title"
-  >
-    Step 1
-  </span>,
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    className="pf-v6-screen-reader"
-    role="status"
-  >
-    Step: Step 1
-  </span>,
-]
+<span
+  className="progress"
+  data-testid="step-title"
+>
+  Step 1
+</span>
 `;
 
 exports[`ProgressStepTitle snapshot - active step warning 1`] = `
@@ -110,30 +84,40 @@ exports[`ProgressStepTitle snapshot - active step warning 1`] = `
   >
     Step 1
   </span>,
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    className="pf-v6-screen-reader"
-    role="status"
-  >
-    Step: Step 1
-  </span>,
 ]
 `;
 
-exports[`ProgressStepTitle snapshot - non-active step 1`] = `
+exports[`ProgressStepTitle snapshot - already-done step 1`] = `
 [
+  <svg
+    aria-hidden={true}
+    aria-labelledby={null}
+    className="pf-v6-svg successIcon stepIcon"
+    data-testid="step-done-icon"
+    fill="currentColor"
+    height="1em"
+    role="img"
+    viewBox="0 0 512 512"
+    width="1em"
+  >
+    <path
+      d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+    />
+  </svg>,
   <span
     className="ready"
     data-testid="step-title"
   >
     Step 1
   </span>,
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    className="pf-v6-screen-reader"
-    role="status"
-  />,
 ]
+`;
+
+exports[`ProgressStepTitle snapshot - non-active step 1`] = `
+<span
+  className="ready"
+  data-testid="step-title"
+>
+  Step 1
+</span>
 `;

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/__snapshots__/index.spec.tsx.snap
@@ -23,6 +23,14 @@ exports[`ProgressStepTitle snapshot - active step 1`] = `
   >
     Step 1
   </span>,
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    className="pf-v6-screen-reader"
+    role="status"
+  >
+    Step: Step 1
+  </span>,
 ]
 `;
 
@@ -49,16 +57,34 @@ exports[`ProgressStepTitle snapshot - active step failed 1`] = `
   >
     Step 1
   </span>,
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    className="pf-v6-screen-reader"
+    role="status"
+  >
+    Step: Step 1
+  </span>,
 ]
 `;
 
 exports[`ProgressStepTitle snapshot - active step has children 1`] = `
-<span
-  className="progress"
-  data-testid="step-title"
->
-  Step 1
-</span>
+[
+  <span
+    className="progress"
+    data-testid="step-title"
+  >
+    Step 1
+  </span>,
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    className="pf-v6-screen-reader"
+    role="status"
+  >
+    Step: Step 1
+  </span>,
+]
 `;
 
 exports[`ProgressStepTitle snapshot - active step warning 1`] = `
@@ -84,14 +110,30 @@ exports[`ProgressStepTitle snapshot - active step warning 1`] = `
   >
     Step 1
   </span>,
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    className="pf-v6-screen-reader"
+    role="status"
+  >
+    Step: Step 1
+  </span>,
 ]
 `;
 
 exports[`ProgressStepTitle snapshot - non-active step 1`] = `
-<span
-  className="ready"
-  data-testid="step-title"
->
-  Step 1
-</span>
+[
+  <span
+    className="ready"
+    data-testid="step-title"
+  >
+    Step 1
+  </span>,
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    className="pf-v6-screen-reader"
+    role="status"
+  />,
+]
 `;

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
@@ -85,12 +85,28 @@ describe('ProgressStepTitle', () => {
       expect(mockEnqueueAnnouncement).toHaveBeenCalledWith('Step: Step 1');
     });
 
-    it('queues announcement when active step completes (distance 0→1)', () => {
+    it('does not re-announce when step completes with unchanged text (distance 0→1)', () => {
       const { reRenderComponent } = renderComponent(0, {});
       expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
 
       reRenderComponent(1, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+    });
+
+    it('announces when step completes with changed text (distance 0→1)', () => {
+      const { reRenderComponent } = renderComponent(0, {
+        parentStepName: 'Waiting for workspace to start',
+      });
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+
+      reRenderComponent(1, {
+        parentStepName: 'Waiting for workspace to start',
+        children: 'StorageReady',
+      });
       expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(2);
+      expect(mockEnqueueAnnouncement).toHaveBeenLastCalledWith(
+        'Step: Waiting for workspace to start / StorageReady',
+      );
     });
 
     it('does not re-queue when already-active step re-renders without distance change', () => {
@@ -120,11 +136,18 @@ describe('ProgressStepTitle', () => {
 function getComponent(
   distance: -1 | 0 | 1 | undefined,
   {
+    children = 'Step 1',
     hasChildren = false,
     isError = false,
     isWarning = false,
     parentStepName,
-  }: { isError?: boolean; isWarning?: boolean; hasChildren?: boolean; parentStepName?: string },
+  }: {
+    children?: string;
+    isError?: boolean;
+    isWarning?: boolean;
+    hasChildren?: boolean;
+    parentStepName?: string;
+  },
 ) {
   return (
     <ProgressStepTitle
@@ -134,7 +157,7 @@ function getComponent(
       isWarning={isWarning}
       parentStepName={parentStepName}
     >
-      Step 1
+      {children}
     </ProgressStepTitle>
   );
 }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
@@ -12,6 +12,12 @@
 
 import React from 'react';
 
+// react-test-renderer does not support ReactDOM.createPortal; render portals inline.
+jest.mock('react-dom', () => ({
+  ...jest.requireActual<typeof import('react-dom')>('react-dom'),
+  createPortal: (children: React.ReactNode) => children,
+}));
+
 import getComponentRenderer from '@/services/__mocks__/getComponentRenderer';
 
 import { ProgressStepTitle } from '..';

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
@@ -12,19 +12,22 @@
 
 import React from 'react';
 
-// react-test-renderer does not support ReactDOM.createPortal; render portals inline.
-jest.mock('react-dom', () => ({
-  ...jest.requireActual<typeof import('react-dom')>('react-dom'),
-  createPortal: (children: React.ReactNode) => children,
+const mockEnqueueAnnouncement = jest.fn();
+jest.mock('@/components/WorkspaceProgress/StepTitle/announceQueue', () => ({
+  enqueueAnnouncement: mockEnqueueAnnouncement,
 }));
 
 import getComponentRenderer from '@/services/__mocks__/getComponentRenderer';
 
 import { ProgressStepTitle } from '..';
 
-const { createSnapshot } = getComponentRenderer(getComponent);
+const { createSnapshot, renderComponent } = getComponentRenderer(getComponent);
 
 describe('ProgressStepTitle', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('snapshot - non-active step', () => {
     const snapshot = createSnapshot(-1, {});
     expect(snapshot).toMatchSnapshot();
@@ -49,6 +52,61 @@ describe('ProgressStepTitle', () => {
     const snapshot = createSnapshot(0, { hasChildren: true });
     expect(snapshot).toMatchSnapshot();
   });
+
+  test('snapshot - already-done step', () => {
+    const snapshot = createSnapshot(1, {});
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  describe('screen-reader announcements', () => {
+    it('does not queue announcement for a not-yet-started step (distance=-1)', () => {
+      renderComponent(-1, {});
+      expect(mockEnqueueAnnouncement).not.toHaveBeenCalled();
+    });
+
+    it('queues announcement when step mounts as active (distance=0)', () => {
+      renderComponent(0, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledWith('Step: Step 1');
+    });
+
+    it('queues announcement when step mounts already done (distance=1)', () => {
+      renderComponent(1, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledWith('Step: Step 1');
+    });
+
+    it('queues announcement when step transitions to active (distance→0)', () => {
+      const { reRenderComponent } = renderComponent(-1, {});
+      expect(mockEnqueueAnnouncement).not.toHaveBeenCalled();
+
+      reRenderComponent(0, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledWith('Step: Step 1');
+    });
+
+    it('does not re-queue when already-active step re-renders without distance change', () => {
+      const { reRenderComponent } = renderComponent(0, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+
+      reRenderComponent(0, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes parent step name in the queued announcement for a sub-step', () => {
+      renderComponent(1, { parentStepName: 'Waiting for workspace to start' });
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledWith(
+        'Step: Waiting for workspace to start / Step 1',
+      );
+    });
+
+    it('queues each already-done sub-step independently', () => {
+      renderComponent(1, { parentStepName: 'Waiting for workspace to start' });
+      renderComponent(1, { parentStepName: 'Waiting for workspace to start' });
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(2);
+    });
+  });
 });
 
 function getComponent(
@@ -57,7 +115,8 @@ function getComponent(
     hasChildren = false,
     isError = false,
     isWarning = false,
-  }: { isError?: boolean; isWarning?: boolean; hasChildren?: boolean },
+    parentStepName,
+  }: { isError?: boolean; isWarning?: boolean; hasChildren?: boolean; parentStepName?: string },
 ) {
   return (
     <ProgressStepTitle
@@ -65,6 +124,7 @@ function getComponent(
       hasChildren={hasChildren}
       isError={isError}
       isWarning={isWarning}
+      parentStepName={parentStepName}
     >
       Step 1
     </ProgressStepTitle>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/__tests__/index.spec.tsx
@@ -85,6 +85,14 @@ describe('ProgressStepTitle', () => {
       expect(mockEnqueueAnnouncement).toHaveBeenCalledWith('Step: Step 1');
     });
 
+    it('queues announcement when active step completes (distance 0→1)', () => {
+      const { reRenderComponent } = renderComponent(0, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);
+
+      reRenderComponent(1, {});
+      expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(2);
+    });
+
     it('does not re-queue when already-active step re-renders without distance change', () => {
       const { reRenderComponent } = renderComponent(0, {});
       expect(mockEnqueueAnnouncement).toHaveBeenCalledTimes(1);

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/announceQueue.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/announceQueue.ts
@@ -10,8 +10,10 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-// How long each message is held in the live region before clearing.
-export const ANNOUNCE_HOLD_MS = 900;
+// Minimum hold time and per-character rate for computing how long each message
+// stays in the live region before clearing.
+export const ANNOUNCE_MIN_HOLD_MS = 1500;
+export const ANNOUNCE_MS_PER_CHAR = 60;
 // Gap between clearing one message and showing the next.
 export const ANNOUNCE_GAP_MS = 150;
 
@@ -37,11 +39,12 @@ function drainQueue(): void {
     return;
   }
   const text = queue.shift()!;
+  const holdMs = Math.max(ANNOUNCE_MIN_HOLD_MS, text.length * ANNOUNCE_MS_PER_CHAR);
   getLiveNode().textContent = text;
   timer = setTimeout(() => {
     getLiveNode().textContent = '';
     timer = setTimeout(drainQueue, ANNOUNCE_GAP_MS);
-  }, ANNOUNCE_HOLD_MS);
+  }, holdMs);
 }
 
 export function enqueueAnnouncement(text: string): void {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/announceQueue.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/announceQueue.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+// How long each message is held in the live region before clearing.
+export const ANNOUNCE_HOLD_MS = 900;
+// Gap between clearing one message and showing the next.
+export const ANNOUNCE_GAP_MS = 150;
+
+const queue: string[] = [];
+let timer: ReturnType<typeof setTimeout> | null = null;
+let node: HTMLElement | null = null;
+
+function getLiveNode(): HTMLElement {
+  if (!node || !document.body.contains(node)) {
+    node = document.createElement('span');
+    node.setAttribute('role', 'status');
+    node.setAttribute('aria-live', 'polite');
+    node.setAttribute('aria-atomic', 'true');
+    node.className = 'pf-v6-screen-reader';
+    document.body.appendChild(node);
+  }
+  return node;
+}
+
+function drainQueue(): void {
+  if (queue.length === 0) {
+    timer = null;
+    return;
+  }
+  const text = queue.shift()!;
+  getLiveNode().textContent = text;
+  timer = setTimeout(() => {
+    getLiveNode().textContent = '';
+    timer = setTimeout(drainQueue, ANNOUNCE_GAP_MS);
+  }, ANNOUNCE_HOLD_MS);
+}
+
+export function enqueueAnnouncement(text: string): void {
+  queue.push(text);
+  if (timer === null) {
+    drainQueue();
+  }
+}
+
+export function _resetQueueForTests(): void {
+  queue.length = 0;
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  if (node && document.body.contains(node)) {
+    document.body.removeChild(node);
+  }
+  node = null;
+}

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
@@ -69,6 +69,9 @@ export class ProgressStepTitle extends React.Component<Props> {
     if (prevProps.distance !== 0 && this.props.distance === 0) {
       this.announce();
     }
+    if (prevProps.distance === 0 && this.props.distance === 1) {
+      this.announce();
+    }
   }
 
   render(): React.ReactElement {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
@@ -11,6 +11,7 @@
  */
 
 import React, { PropsWithChildren } from 'react';
+import ReactDOM from 'react-dom';
 
 import { ProgressStepTitleIcon } from '@/components/WorkspaceProgress/StepTitle/Icon';
 import styles from '@/components/WorkspaceProgress/StepTitle/index.module.css';
@@ -21,11 +22,29 @@ export type Props = PropsWithChildren<{
   hasChildren?: boolean;
   isError?: boolean;
   isWarning?: boolean;
+  /** When set, the live-region announcement reads "Step: {parentStepName} / {step text}".
+   *  Use for condition sub-steps so screen readers hear the full context. */
+  parentStepName?: string;
 }>;
+
+/** Recursively extracts plain-text content from any ReactNode. */
+function extractText(node: React.ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractText).join('');
+  }
+  if (React.isValidElement(node) && node.props.children) {
+    return extractText(node.props.children as React.ReactNode);
+  }
+  return '';
+}
 
 export class ProgressStepTitle extends React.Component<Props> {
   render(): React.ReactElement {
-    const { children, className, hasChildren, distance, isError, isWarning } = this.props;
+    const { children, className, hasChildren, distance, isError, isWarning, parentStepName } =
+      this.props;
 
     let readiness = styles.ready;
     if (distance === 0) {
@@ -49,15 +68,23 @@ export class ProgressStepTitle extends React.Component<Props> {
         <span data-testid="step-title" className={fullClassName}>
           {children}
         </span>
-        {/* Live region: announces the active step to screen readers when it becomes active.
-            The region is always present so screen readers register it on page load;
-            content is only set when the step is active (distance === 0) so the
-            announcement fires exactly once per step transition.
-            The "Step: " prefix ensures the live region text differs from the visible
-            step title, preventing ambiguous matches in DOM queries. */}
-        <span role="status" aria-live="polite" aria-atomic="true" className="pf-v6-screen-reader">
-          {distance === 0 && typeof children === 'string' ? `Step: ${children}` : ''}
-        </span>
+        {/* Live region: rendered via portal so it sits outside the wizard nav button DOM
+            tree, preventing its text from leaking into the button's accessible name
+            (dom-accessibility-api includes role="status" text in name computation despite
+            the ARIA spec's nameFrom:author rule). The portal still announces changes to
+            screen readers because live regions work document-wide regardless of DOM
+            position. Content is only set when the step is active (distance === 0). */}
+        {ReactDOM.createPortal(
+          <span role="status" aria-live="polite" aria-atomic="true" className="pf-v6-screen-reader">
+            {(() => {
+              if (distance !== 0) return '';
+              const stepText = extractText(children);
+              if (!stepText) return '';
+              return parentStepName ? `Step: ${parentStepName} / ${stepText}` : `Step: ${stepText}`;
+            })()}
+          </span>,
+          document.body,
+        )}
       </>
     );
   }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
@@ -42,6 +42,8 @@ function extractText(node: React.ReactNode): string {
 }
 
 export class ProgressStepTitle extends React.Component<Props> {
+  private lastAnnouncedText = '';
+
   private buildAnnouncementText(): string {
     const { children, parentStepName } = this.props;
     const stepText = extractText(children);
@@ -51,15 +53,13 @@ export class ProgressStepTitle extends React.Component<Props> {
 
   private announce(): void {
     const text = this.buildAnnouncementText();
-    if (text) {
+    if (text && text !== this.lastAnnouncedText) {
+      this.lastAnnouncedText = text;
       enqueueAnnouncement(text);
     }
   }
 
   componentDidMount(): void {
-    // All announcements go through the single persistent queue node so screen
-    // readers hear a real content change. Newly-created aria-live nodes that
-    // already have content on mount are silently ignored by most screen readers.
     if (this.props.distance === 0 || this.props.distance === 1) {
       this.announce();
     }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
@@ -11,8 +11,8 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import ReactDOM from 'react-dom';
 
+import { enqueueAnnouncement } from '@/components/WorkspaceProgress/StepTitle/announceQueue';
 import { ProgressStepTitleIcon } from '@/components/WorkspaceProgress/StepTitle/Icon';
 import styles from '@/components/WorkspaceProgress/StepTitle/index.module.css';
 
@@ -42,9 +42,37 @@ function extractText(node: React.ReactNode): string {
 }
 
 export class ProgressStepTitle extends React.Component<Props> {
+  private buildAnnouncementText(): string {
+    const { children, parentStepName } = this.props;
+    const stepText = extractText(children);
+    if (!stepText) return '';
+    return parentStepName ? `Step: ${parentStepName} / ${stepText}` : `Step: ${stepText}`;
+  }
+
+  private announce(): void {
+    const text = this.buildAnnouncementText();
+    if (text) {
+      enqueueAnnouncement(text);
+    }
+  }
+
+  componentDidMount(): void {
+    // All announcements go through the single persistent queue node so screen
+    // readers hear a real content change. Newly-created aria-live nodes that
+    // already have content on mount are silently ignored by most screen readers.
+    if (this.props.distance === 0 || this.props.distance === 1) {
+      this.announce();
+    }
+  }
+
+  componentDidUpdate(prevProps: Props): void {
+    if (prevProps.distance !== 0 && this.props.distance === 0) {
+      this.announce();
+    }
+  }
+
   render(): React.ReactElement {
-    const { children, className, hasChildren, distance, isError, isWarning, parentStepName } =
-      this.props;
+    const { children, className, hasChildren, distance, isError, isWarning } = this.props;
 
     let readiness = styles.ready;
     if (distance === 0) {
@@ -68,23 +96,6 @@ export class ProgressStepTitle extends React.Component<Props> {
         <span data-testid="step-title" className={fullClassName}>
           {children}
         </span>
-        {/* Live region: rendered via portal so it sits outside the wizard nav button DOM
-            tree, preventing its text from leaking into the button's accessible name
-            (dom-accessibility-api includes role="status" text in name computation despite
-            the ARIA spec's nameFrom:author rule). The portal still announces changes to
-            screen readers because live regions work document-wide regardless of DOM
-            position. Content is only set when the step is active (distance === 0). */}
-        {ReactDOM.createPortal(
-          <span role="status" aria-live="polite" aria-atomic="true" className="pf-v6-screen-reader">
-            {(() => {
-              if (distance !== 0) return '';
-              const stepText = extractText(children);
-              if (!stepText) return '';
-              return parentStepName ? `Step: ${parentStepName} / ${stepText}` : `Step: ${stepText}`;
-            })()}
-          </span>,
-          document.body,
-        )}
       </>
     );
   }

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StepTitle/index.tsx
@@ -49,6 +49,15 @@ export class ProgressStepTitle extends React.Component<Props> {
         <span data-testid="step-title" className={fullClassName}>
           {children}
         </span>
+        {/* Live region: announces the active step to screen readers when it becomes active.
+            The region is always present so screen readers register it on page load;
+            content is only set when the step is active (distance === 0) so the
+            announcement fires exactly once per step transition.
+            The "Step: " prefix ensures the live region text differs from the visible
+            step title, preventing ambiguous matches in DOM queries. */}
+        <span role="status" aria-live="polite" aria-atomic="true" className="pf-v6-screen-reader">
+          {distance === 0 && typeof children === 'string' ? `Step: ${children}` : ''}
+        </span>
       </>
     );
   }

--- a/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspacesList/BackupsView/Toolbar/__tests__/index.spec.tsx
@@ -44,7 +44,7 @@ describe('Backups List Toolbar', () => {
 
     expect(screen.queryByRole('searchbox')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /search backups/i })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /restore workspace/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /restore from backup/i })).toBeTruthy();
   });
 
   it('should call onFilterChange when typing in search', async () => {
@@ -86,7 +86,7 @@ describe('Backups List Toolbar', () => {
   it('should call onRestoreClick when clicking Restore Workspace', async () => {
     renderComponent();
 
-    const restoreButton = screen.getByRole('button', { name: /restore workspace/i });
+    const restoreButton = screen.getByRole('button', { name: /restore from backup/i });
     await userEvent.click(restoreButton);
 
     expect(mockOnRestoreClick).toHaveBeenCalled();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What issues does this PR fix or reference?
This PR fixes implementation of progress page for announce workspace status and progress steps to screen readers.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1562 to the 7.117.x branch

### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10313