### PR TITLE
fix(a11y): add inert to collapsed sidebar to remove focusable elements

### DIFF
--- a/packages/dashboard-frontend/src/Layout/Sidebar/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/Layout/Sidebar/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,6 +1,23 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Sidebar snapshot 1`] = `
+exports[`Sidebar snapshot - closed 1`] = `
+<div
+  aria-hidden={false}
+  className="pf-v6-c-page__sidebar pf-m-expanded"
+  id="page-sidebar"
+  inert=""
+>
+  <div
+    className="pf-v6-c-page__sidebar-body"
+  >
+    <div>
+      Mock Navigation component
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Sidebar snapshot - open 1`] = `
 <div
   aria-hidden={false}
   className="pf-v6-c-page__sidebar pf-m-expanded"

--- a/packages/dashboard-frontend/src/Layout/Sidebar/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/Layout/Sidebar/__tests__/index.spec.tsx
@@ -10,6 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { PageContext, pageContextDefaults, PageContextProps } from '@patternfly/react-core';
+import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 
@@ -21,12 +23,35 @@ jest.mock('@/Layout/Navigation');
 const { createSnapshot } = getComponentRenderer(getComponent);
 
 describe('Sidebar', () => {
-  test('snapshot', () => {
-    expect(createSnapshot().toJSON()).toMatchSnapshot();
+  test('snapshot - open', () => {
+    expect(createSnapshot(true).toJSON()).toMatchSnapshot();
+  });
+
+  test('snapshot - closed', () => {
+    expect(createSnapshot(false).toJSON()).toMatchSnapshot();
+  });
+
+  it('does not have inert attribute when the sidebar is open', () => {
+    const { baseElement } = render(getComponent(true));
+    const sidebar = baseElement.querySelector('#page-sidebar');
+    expect(sidebar).not.toBeNull();
+    expect(sidebar?.hasAttribute('inert')).toBe(false);
+  });
+
+  it('has inert attribute when the sidebar is collapsed', () => {
+    const { baseElement } = render(getComponent(false));
+    const sidebar = baseElement.querySelector('#page-sidebar');
+    expect(sidebar).not.toBeNull();
+    expect(sidebar?.hasAttribute('inert')).toBe(true);
   });
 });
 
-function getComponent(): React.ReactElement {
+function getComponent(isSidebarOpen = true): React.ReactElement {
   const history = createMemoryHistory();
-  return <Sidebar history={history} />;
+  const context: PageContextProps = { ...pageContextDefaults, isSidebarOpen };
+  return (
+    <PageContext.Provider value={context}>
+      <Sidebar history={history} />
+    </PageContext.Provider>
+  );
 }

--- a/packages/dashboard-frontend/src/Layout/Sidebar/index.tsx
+++ b/packages/dashboard-frontend/src/Layout/Sidebar/index.tsx
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { PageSidebar, PageSidebarBody } from '@patternfly/react-core';
+import { PageContext, PageSidebar, PageSidebarBody } from '@patternfly/react-core';
 import { History } from 'history';
 import React from 'react';
 
@@ -20,16 +20,21 @@ export type Props = {
   history: History;
 };
 
-export class Sidebar extends React.PureComponent<Props> {
-  public render(): React.ReactElement {
-    const { history } = this.props;
+export function Sidebar({ history }: Props): React.ReactElement {
+  const { isSidebarOpen } = React.useContext(PageContext);
 
-    return (
-      <PageSidebar>
-        <PageSidebarBody>
-          <Navigation history={history} />
-        </PageSidebarBody>
-      </PageSidebar>
-    );
-  }
+  // When the sidebar is collapsed PatternFly sets aria-hidden="true" on
+  // #page-sidebar but leaves child <a> / <button> elements in the tab order,
+  // violating WCAG 4.1.2.  Adding the HTML `inert` attribute when closed
+  // removes the entire subtree from keyboard navigation and the accessibility
+  // tree without unmounting it, which is the correct fix.
+  const inertProp = isSidebarOpen ? {} : ({ inert: '' } as React.HTMLAttributes<HTMLDivElement>);
+
+  return (
+    <PageSidebar {...inertProp}>
+      <PageSidebarBody>
+        <Navigation history={history} />
+      </PageSidebarBody>
+    </PageSidebar>
+  );
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes a WCAG 4.1.2 (Name, Role, Value — Level A) violation where the collapsed
left sidebar (`#page-sidebar`) was marked `aria-hidden="true"` by PatternFly but
still contained fully focusable `<a>` elements (e.g. Recent Workspaces links).

Screen reader users could silently tab into invisible interactive elements,
receiving no feedback from their assistive technology — a broken and confusing
navigation experience.

### Root Cause

PatternFly v6's `PageSidebar` sets `aria-hidden={!isSidebarOpen}` on its root
`<div>` when collapsed, but does not prevent child elements from remaining in the
keyboard tab order.  The ARIA spec requires that elements with `aria-hidden="true"`
are not focusable or reachable via keyboard; PatternFly delegates this
responsibility to the application.

### Fix

The `Sidebar` component now reads `isSidebarOpen` from PatternFly's `PageContext`
(which is provided by the parent `Page` component) and conditionally spreads the
HTML `inert` attribute onto `PageSidebar` when the sidebar is collapsed:

```tsx
const { isSidebarOpen } = React.useContext(PageContext);
const inertProp = isSidebarOpen ? {} : ({ inert: '' } as React.HTMLAttributes<HTMLDivElement>);

return (
  <PageSidebar {...inertProp}>
    <PageSidebarBody>
      <Navigation history={history} />
    </PageSidebarBody>
  </PageSidebar>
);
```

The HTML `inert` attribute removes the **entire subtree** from:
- Keyboard navigation (tab order)
- Pointer events
- The accessibility tree

This satisfies both remediation options from the bug report:
- **Option 1** — interactive children are removed from the tab order when collapsed
- **Option 2** — effectively equivalent to a proper CSS hide for AT purposes,
  without unmounting the component

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-10739


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Open the dashboard.
3. Click the hamburger button (top-left) to collapse the left sidebar.
4. Press `Tab` repeatedly — verify that focus never enters the collapsed sidebar
   (no Recent Workspaces links receive focus while the sidebar is hidden).
5. Expand the sidebar again — verify all navigation links are reachable with `Tab`
   as expected.
