### PR TITLE
fix(a11y): prevent empty alert-group list from appearing in DOM

### DIFF
--- a/packages/dashboard-frontend/src/components/AppAlertGroup/index.tsx
+++ b/packages/dashboard-frontend/src/components/AppAlertGroup/index.tsx
@@ -12,6 +12,7 @@
 
 import { Alert, AlertActionCloseButton, AlertGroup, AlertVariant } from '@patternfly/react-core';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import { lazyInject } from '@/inversify.config';
 import { AppAlerts } from '@/services/alerts/appAlerts';
@@ -96,7 +97,14 @@ class AppAlertGroup extends React.PureComponent<Props, State> {
     if (alerts.length === 0) {
       return <></>;
     }
-    return <AlertGroup isToast>{alerts.map(alert => this.getAlert(alert))}</AlertGroup>;
+    // Use ReactDOM.createPortal directly (synchronous commit-phase cleanup) instead of
+    // AlertGroup isToast (which uses useEffect for portal cleanup, leaving an empty
+    // <ul role="list"> briefly visible between React commit and passive-effect teardown).
+    // The empty list violates WCAG 4.1.2 / aria-required-children (CRW-10740).
+    return ReactDOM.createPortal(
+      <AlertGroup className="pf-m-toast">{alerts.map(alert => this.getAlert(alert))}</AlertGroup>,
+      document.body,
+    );
   }
 }
 

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Alert/index.tsx
@@ -12,6 +12,7 @@
 
 import { Alert, AlertActionLink, AlertGroup } from '@patternfly/react-core';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import { ActionGroupSelector } from '@/components/WorkspaceProgress/Alert/ActionGroupSelector';
 import styles from '@/components/WorkspaceProgress/Alert/index.module.css';
@@ -62,12 +63,25 @@ export class ProgressAlert extends React.PureComponent<Props> {
     const isInline = !isToast;
     const alerts = this.buildAlerts(alertItems, isInline);
 
+    if (isToast) {
+      // Use ReactDOM.createPortal directly (synchronous commit-phase cleanup) instead of
+      // AlertGroup isToast (which uses useEffect for portal cleanup, leaving an empty
+      // <ul role="list"> briefly visible between React commit and passive-effect teardown).
+      // The empty list violates WCAG 4.1.2 / aria-required-children (CRW-10740).
+      return ReactDOM.createPortal(
+        <AlertGroup
+          data-testid="loader-alerts-group"
+          aria-label="Loader Alerts Group"
+          className="pf-m-toast"
+        >
+          {alerts}
+        </AlertGroup>,
+        document.body,
+      );
+    }
+
     return (
-      <AlertGroup
-        data-testid="loader-alerts-group"
-        aria-label="Loader Alerts Group"
-        isToast={isToast}
-      >
+      <AlertGroup data-testid="loader-alerts-group" aria-label="Loader Alerts Group">
         {alerts}
       </AlertGroup>
     );


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?


Fixes a WCAG 4.1.2 (Name, Role, Value — Level A) violation where an empty
`<ul role="list" class="pf-v6-c-alert-group pf-m-toast">` element was briefly
present in the DOM without any `<li>` children, triggering the axe
`aria-required-children` rule.

### Root Cause

PatternFly v6's `AlertGroup` with `isToast={true}` manages its portal container
(a `<div>` appended to `document.body`) via a `useEffect` hook. In React's
execution order:

1. **Commit phase (synchronous, before paint):** React reconciles the component
   tree. When `AlertGroup` is unmounted (e.g. when all alerts are cleared), React
   synchronously removes the React-rendered content from the portal container —
   the `<ul>` is emptied.

2. **Browser paint:** The portal container `<div>` is still in `document.body`
   but its `<ul>` child is now empty (React has cleared it).

3. **Passive effects (after paint):** The `useEffect` cleanup runs and removes
   the portal container from `document.body`.

During the window between steps 1 and 3, an empty
`<ul role="list" class="pf-v6-c-alert-group pf-m-toast">` is in the DOM.
Automated accessibility tools (axe) can catch this window and report
`aria-required-children: list must contain listitem`.

This affected two components:

- **`AppAlertGroup`** — always-present global toast alert container
- **`ProgressAlert`** (WorkspaceProgress/Alert) — per-step toast alerts shown
  when the user is on the Logs or Events tab of the Workspace Creation page

### Fix

Replace `AlertGroup isToast` with `ReactDOM.createPortal` called directly in
`render()`. This change:

- **Eliminates the async gap**: `ReactDOM.createPortal` content is added and
  removed synchronously during React's commit phase (before paint), not via
  `useEffect`. The empty `<ul>` window no longer exists.
- **Preserves visual behaviour**: The `pf-m-toast` class is passed explicitly
  as `className` to `AlertGroup`, giving the `<ul>` the same CSS as before
  (`pf-v6-c-alert-group pf-m-toast`). Toast positioning is unchanged.
- **Preserves the existing guard**: Both components already return `<></>` when
  the alert list is empty, so `AlertGroup` (and its `<ul>`) is only rendered
  when there is at least one alert. The fix makes the guard effective even
  during teardown.

```tsx
// Before — async portal cleanup leaves empty <ul> briefly
return <AlertGroup isToast>{alerts}</AlertGroup>;

// After — synchronous portal management, <ul> never empty
return ReactDOM.createPortal(
  <AlertGroup className="pf-m-toast">{alerts}</AlertGroup>,
  document.body,
);
```

### What issues does this PR fix or reference?

Fixes https://redhat.atlassian.net/browse/CRW-10740
### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the dashboard image from this PR.
2. Start a workspace to open the Workspace Creation page.
3. Navigate to the **Logs** tab.
4. Verify that no `aria-required-children` violation is reported for
   `.pf-v6-c-alert-group.pf-m-toast`.
5. Navigate back to the **Progress** tab and trigger a workspace error (e.g.
   network interruption) so that an alert toast appears.
6. Dismiss the alert and immediately re-run axe — verify no empty list violation
   appears.
7. Confirm that toast alerts still appear in the top-right corner of the
   viewport with the correct PatternFly styling.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
