### PR TITLE
fix: preserve docker config when creating secret on update fallback

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/dockerConfigApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/dockerConfigApi.spec.ts
@@ -36,10 +36,14 @@ describe('Docker Config API Service', () => {
     replaceNamespacedSecret: (_params: { name: string; namespace: string; body: V1Secret }) => {
       return Promise.resolve(buildSecret(namespace, updatedConfig).body);
     },
+    createNamespacedSecret: (_params: { namespace: string; body: V1Secret }) => {
+      return Promise.resolve(buildSecret(namespace, updatedConfig).body);
+    },
   } as unknown as CoreV1Api;
 
   const spyReadNamespacedSecret = jest.spyOn(stubCoreV1Api, 'readNamespacedSecret');
   const spyReplaceNamespacedSecret = jest.spyOn(stubCoreV1Api, 'replaceNamespacedSecret');
+  const spyCreateNamespacedSecret = jest.spyOn(stubCoreV1Api, 'createNamespacedSecret');
 
   beforeEach(() => {
     const { KubeConfig } = mockClient;
@@ -65,6 +69,38 @@ describe('Docker Config API Service', () => {
     expect(dockerconfig).toEqual(updatedConfig);
     expect(spyReplaceNamespacedSecret).toHaveBeenCalledWith({
       name: SECRET_NAME,
+      namespace,
+      body: expect.objectContaining({
+        data: {
+          [SECRET_KEY]: updatedConfig,
+        },
+      }),
+    });
+  });
+
+  test('updating dockerconfig should create secret with provided config when secret does not exist', async () => {
+    // Mock replaceNamespacedSecret to throw a 404 error (KubeClient error format)
+    const notFoundError = new Error('Not Found');
+    Object.assign(notFoundError, {
+      code: 404,
+      headers: {},
+      body: { message: 'Not Found' },
+    });
+    spyReplaceNamespacedSecret.mockRejectedValueOnce(notFoundError);
+
+    const dockerconfig = await dockerConfigService.update(namespace, updatedConfig);
+
+    expect(dockerconfig).toEqual(updatedConfig);
+    expect(spyReplaceNamespacedSecret).toHaveBeenCalledWith({
+      name: SECRET_NAME,
+      namespace,
+      body: expect.objectContaining({
+        data: {
+          [SECRET_KEY]: updatedConfig,
+        },
+      }),
+    });
+    expect(spyCreateNamespacedSecret).toHaveBeenCalledWith({
       namespace,
       body: expect.objectContaining({
         data: {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/dockerConfigApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/dockerConfigApi.ts
@@ -64,7 +64,7 @@ export class DockerConfigApiService implements IDockerConfigApi {
       return this.getDockerConfig(body);
     } catch (error) {
       if (helpers.errors.isKubeClientError(error) && error.code === 404) {
-        return this.createNamespacedSecret(namespace);
+        return this.createNamespacedSecret(namespace, dockerCfg);
       }
       const additionalMessage = `Unable to update dockerConfig in the specified namespace "${namespace}"`;
       throw createError(error, DOCKER_CONFIG_API_ERROR_LABEL, additionalMessage);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When updating a docker config secret fails with 404, the service falls back to creating a new secret. Previously, the `dockerCfg` parameter was not passed to `createNamespacedSecret`, causing it to create an empty config instead of preserving the provided configuration.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10854

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Go to `User Preferences` -> `Container Registries` tab and click the `Add Container Registry` button, see: new registry item is created. 
2. Switch to another tab and then go back to the `Container Registries` tab, see: the registry item is still present in the list.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
