### PR TITLE
fix(a11y): improve danger button contrast in dark mode

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
@@ -11,12 +11,12 @@
  */
 
 .header {
-  display: block;
-
   /* Override PatternFly's subtle color for <small> meta-text in the event card
      header. The default --pf-t--global--text--color--subtle produces a contrast
      ratio of ~3.65:1 against the card background, which fails WCAG 1.4.3
      (Contrast Minimum, Level AA). Setting --pf-v6-c-content--small--Color to
      the regular text token achieves ≥4.5:1. (CRW-10318) */
   --pf-v6-c-content--small--Color: var(--pf-t--global--text--color--regular);
+
+  display: block;
 }

--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -89,6 +89,23 @@ html.pf-v6-theme-dark .pf-v6-c-page__main-section {
   background-color: #414141;
 }
 
+/* Dark theme danger button contrast override for WCAG 2.2 Level AA compliance - Overrides PF v6 variables */
+html.pf-v6-theme-dark .pf-v6-c-button.pf-m-danger {
+  --pf-v6-c-button--m-danger--BackgroundColor: #e57373;
+  --pf-v6-c-button--m-danger--Color: #1a1a1a;
+  --pf-v6-c-button--m-danger--hover--BackgroundColor: #ef8787;
+  --pf-v6-c-button--m-danger--active--BackgroundColor: #d65f5f;
+  --pf-v6-c-button--m-danger--focus--BackgroundColor: #e57373;
+}
+
+html.pf-v6-theme-dark .pf-v6-c-button.pf-m-danger:disabled {
+  --pf-v6-c-button--disabled--BackgroundColor: #6b3535;
+  --pf-v6-c-button--disabled--Color: rgb(255 255 255 / 40%);
+  --pf-v6-c-button--disabled--BorderColor: #c27a7a;
+
+  border: 1px solid var(--pf-v6-c-button--disabled--BorderColor);
+}
+
 /* Workspace Progress - inherit background for loader tab content */
 /* stylelint-disable-next-line selector-id-pattern */
 #pf-tab-section-Progress-loader-progress-tab .pf-v6-c-page__main-section {

--- a/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/index.module.css
+++ b/packages/dashboard-frontend/src/pages/GetStarted/SamplesList/Gallery/Card/index.module.css
@@ -19,7 +19,9 @@
   display: inline-flex;
   flex-wrap: wrap;
   gap: var(--pf-t--global--spacer--xs);
+
   margin-inline-start: var(--pf-t--global--spacer--sm);
+
   vertical-align: middle;
 }
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.module.css
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.module.css
@@ -22,8 +22,8 @@
 
 /* Server URL wraps cleanly at path boundaries (WCAG 1.4.10 Reflow). */
 .serverCell {
-  overflow-wrap: anywhere;
   word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* Authorization cell: stays compact. */


### PR DESCRIPTION
**What does this PR do?**

Fixes violation of WCAG 2.2 criterion 1.4.11 Non-text Contrast (Level AA). User interface components and graphical objects must have a contrast ratio of at least 3:1 against adjacent colors.

**Issue — Danger buttons have insufficient contrast in dark mode**

Files affected:
- User Preferences → Container Registries: Delete button
- User Preferences → Personal Access Tokens: Delete button
- User Preferences → Git Services: Revoke button

All three buttons use PatternFly's `ButtonVariant.danger` which has a contrast ratio of 2.94:1 in dark mode (below the required 3:1 minimum). Users with low vision or color blindness may have difficulty perceiving these critical destructive action buttons.

**Fix — CSS overrides for danger buttons in dark mode**

File: `packages/dashboard-frontend/src/overrides.css`

Added PatternFly component CSS variable overrides to increase danger button contrast specifically in dark mode:

**Active state:**
- Base, hover, active, and focus states adjusted with new color values
- Applied globally to all danger buttons in dark mode for consistency

**Disabled state:**
- Disabled background color adjusted to `#6b3535` for better visibility
- Border color set to `#c27a7a` with 1px width to ensure 3:1 contrast ratio
- Text color uses 40% opacity white for proper disabled state appearance

This ensures that danger buttons maintain sufficient contrast in all states (active, hover, focus, and disabled), meeting WCAG 2.2 Level AA requirements for users with low vision.

**What issues does this PR fix or reference?**

https://redhat.atlassian.net/browse/CRW-10684

**Is it tested? How?**

- Deploy Eclipse Che with the dashboard image from this PR
- Set dark mode and navigate to User Preferences
- Test both enabled and disabled 'Delete' and 'Revoke' buttons in relevant tabs
- Use a contrast checker tool to measure the ratio
- According to the criterion should be 3:1 or more for both active and disabled states

#### Release Notes
<!-- markdown to be included in marketing announcement -->

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->