### PR TITLE
feat(ci): auto-regenerate license files on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-license.yml
+++ b/.github/workflows/dependabot-license.yml
@@ -1,0 +1,110 @@
+#
+# Copyright (c) 2018-2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Dependabot License Update
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  update-licenses:
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Use Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Regenerate licenses
+        run: |
+          # Build a ClearlyDefined URL for a package identifier (name@version).
+          # Scoped:   @scope/name@ver -> npm/npmjs/@scope/name/ver
+          # Unscoped: name@ver        -> npm/npmjs/-/name/ver
+          pkg_to_cd_url() {
+            local pkg="$1"
+            local version="${pkg##*@}"
+            local name="${pkg%@*}"
+            if [[ "$name" == @* ]]; then
+              local scope="${name%%/*}"
+              local pkgname="${name#*/}"
+              echo "https://clearlydefined.io/definitions/npm/npmjs/${scope}/${pkgname}/${version}"
+            else
+              echo "https://clearlydefined.io/definitions/npm/npmjs/-/${name}/${version}"
+            fi
+          }
+
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "=== Attempt $attempt of $MAX_ATTEMPTS ==="
+
+            if yarn license:generate --harvest; then
+              echo "License generation succeeded."
+              break
+            fi
+
+            if [ ! -f .deps/problems.md ]; then
+              echo "::error::License generation failed but no problems.md found."
+              exit 1
+            fi
+
+            SECTION=""
+            while IFS= read -r line; do
+              if echo "$line" | grep -q "## UNRESOLVED Production dependencies"; then
+                SECTION="prod"
+              elif echo "$line" | grep -q "## UNRESOLVED Development dependencies"; then
+                SECTION="dev"
+              fi
+
+              PKG=$(echo "$line" | grep -oP '`\K[^`]+' || true)
+              if [ -z "$PKG" ] || [ -z "$SECTION" ]; then
+                continue
+              fi
+
+              EXCLUDED_FILE=".deps/EXCLUDED/${SECTION}.md"
+              if grep -qF "\`${PKG}\`" "$EXCLUDED_FILE" 2>/dev/null; then
+                echo "Already excluded: $PKG"
+                continue
+              fi
+
+              CD_URL=$(pkg_to_cd_url "$PKG")
+              echo "| \`${PKG}\` | [clearlydefined](${CD_URL}) |" >> "$EXCLUDED_FILE"
+              echo "Added $PKG to $EXCLUDED_FILE"
+            done < .deps/problems.md
+
+            if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+              echo "::error::Failed to resolve all dependencies after $MAX_ATTEMPTS attempts."
+              exit 1
+            fi
+          done
+
+      - name: Commit and push changes
+        run: |
+          git diff --quiet .deps/ && exit 0
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .deps/
+          git commit -s -m "chore(deps): regenerate license dependency files"
+          git push

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
 
   dash-licenses:
     runs-on: ubuntu-22.04
-    if: ${{ github.base_ref == 'main' }}
+    if: ${{ github.base_ref == 'main' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       -
         name: "Checkout Che Dashboard source code"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

> Inspired by [devfile/devworkspace-generator#387](https://github.com/devfile/devworkspace-generator/pull/387), which introduced the same pattern for the devworkspace-generator project.

Adds `.github/workflows/dependabot-license.yml` — a GitHub Actions workflow that automatically regenerates license dependency files whenever Dependabot opens or updates a PR against `main`.

Previously, every Dependabot bump required a manual follow-up commit to re-run `yarn license:generate` and update `.deps/prod.md`, `.deps/dev.md`, and the EXCLUDED files. This workflow eliminates that manual step.

#### How it works

The workflow runs only on PRs authored by `dependabot[bot]` targeting `main`:

1. **Runs `yarn license:generate`** (`license-tool --harvest`) — requests ClearlyDefined to harvest any packages it does not yet know about, and classifies transitive unresolved deps automatically.
2. **If unresolved deps remain** (exit code ≠ 0 and `.deps/problems.md` exists):
   - Parses `problems.md` to identify each unresolved package and whether it belongs to the production or development section.
   - Constructs the ClearlyDefined URL for each package:
     - Scoped (`@scope/name@ver`) → `https://clearlydefined.io/definitions/npm/npmjs/@scope/name/ver`
     - Unscoped (`name@ver`) → `https://clearlydefined.io/definitions/npm/npmjs/-/name/ver`
   - Appends the entry to `.deps/EXCLUDED/prod.md` or `.deps/EXCLUDED/dev.md` (skipping duplicates):
     ```
     | `@isaacs/brace-expansion@5.0.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@isaacs/brace-expansion/5.0.1) |
     | `cronstrue@3.13.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cronstrue/3.13.0) |
     ```
3. **Retries** `yarn license:generate` — up to 3 attempts total.
4. **Commits and pushes** the updated `.deps/` files back to the Dependabot branch (`chore(deps): regenerate license dependency files`). If `.deps/` is unchanged the commit step is skipped.

---

### Screenshot/screencast of this PR

_N/A — CI-only change._

---

### What issues does this PR fix or reference?

- Eliminates the manual `yarn license:generate` follow-up commit required after every Dependabot dependency bump.
- Ensures `.deps/prod.md`, `.deps/dev.md`, and the EXCLUDED files are always up to date before the `dash-licenses` check in `pr.yml` runs.
- Inspired by [devfile/devworkspace-generator#387](https://github.com/devfile/devworkspace-generator/pull/387).

---

### Is it tested? How?

1. Workflow syntax validated with `actionlint` (no errors).
2. The `pkg_to_cd_url` bash function was tested locally against the known-good examples from the existing EXCLUDED files:
   - `@isaacs/brace-expansion@5.0.1` → `https://clearlydefined.io/definitions/npm/npmjs/@isaacs/brace-expansion/5.0.1` ✓
   - `cronstrue@3.13.0` → `https://clearlydefined.io/definitions/npm/npmjs/-/cronstrue/3.13.0` ✓
3. End-to-end: trigger by opening a test Dependabot PR against `main` and confirm the workflow commits the updated `.deps/` files.

---
