### PR TITLE
fix(deps): bump fast-uri to 3.1.2 to address path traversal CVE

### DIFF
--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -502,7 +502,6 @@
 | `fast-glob@3.3.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-glob/3.3.3) |
 | `fast-json-stable-stringify@2.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-json-stable-stringify/2.1.0) |
 | `fast-levenshtein@2.0.6` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-levenshtein/2.0.6) |
-| `fast-uri@3.1.0` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/3.1.0) |
 | `fastest-levenshtein@1.0.16` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastest-levenshtein/1.0.16) |
 | `fastq@1.15.0` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastq/1.15.0) |
 | `fb-watchman@2.0.2` | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fb-watchman/2.0.2) |

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "svgo": "^3.3.3",
     "follow-redirects": "^1.16.0",
     "@fastify/static": "^9.1.1",
-    "brace-expansion": "^1.1.13"
+    "brace-expansion": "^1.1.13",
+    "fast-uri": "^3.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6754,10 +6754,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.0, fast-uri@npm:^3.0.1, fast-uri@npm:^3.0.5":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10/818b2c96dc913bcf8511d844c3d2420e2c70b325c0653633f51821e4e29013c2015387944435cd0ef5322c36c9beecc31e44f71b257aeb8e0b333c1d62bb17c2
+"fast-uri@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10/1dff04865b2a38d3e0659deadfbf72efdf83a776bfbf9667e4aa9e5a3ec31bc341cda9622136b32b7652a857c8ba11896794186e8f876f8b2b72731fce8622f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Bumps the transitive dependency `fast-uri` from `3.1.0` to `3.1.2` to address a path traversal vulnerability.

`fast-uri` versions `<= 3.1.0` decoded percent-encoded path separators (`%2F`) and dot segments (`%2E`) before applying dot-segment normalization in its `normalize()` and `equal()` functions. This means that an attacker-controlled URI like:

```
/allowed/%2E%2E/secret
```

would normalize to `/secret`, bypassing any path-prefix policy that checked the raw string. Applications that compare or normalize untrusted URLs to enforce access control were affected.

`3.1.1` introduced the fix; `3.1.2` is the latest patched release.

A resolution pin `"fast-uri": "^3.1.1"` is added to the root `package.json` to force all transitive dependents (e.g. `@fastify/ajv-compiler`, `fast-json-stringify`, `ajv`) to use the patched version.

---

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A — dependency bump only.

### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10862

