### PR TITLE
fix(a11y): fix Git Services table layout at 400% zoom (WCAG 1.4.10)

### DIFF
--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/__snapshots__/index.spec.tsx.snap
@@ -24,473 +24,372 @@ exports[`GitServicesList snapshot 1`] = `
       Revoke
     </button>
   </div>,
-  <table
+  <ul
     aria-label="Git Services"
-    className="pf-v6-c-table pf-m-grid-md pf-m-compact"
-    data-ouia-component-id="OUIA-Generated-Table-1"
-    data-ouia-component-type="PF6/Table"
-    data-ouia-safe={true}
-    role="grid"
+    className="pf-v6-c-data-list pf-m-grid-md"
+    role="list"
   >
-    <thead
-      className="pf-v6-c-table__thead"
+    <li
+      className="pf-v6-c-data-list__item"
+      data-testid="bitbucket"
+      id=""
     >
-      <tr
-        aria-label=""
-        className="pf-v6-c-table__tr"
-        data-ouia-component-id="OUIA-Generated-TableRow-1"
-        data-ouia-component-type="PF6/TableRow"
-        data-ouia-safe={true}
-        hidden={false}
+      <div
+        className="pf-v6-c-data-list__item-row"
       >
-        <th
-          className="pf-v6-c-table__th"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          scope="col"
-          tabIndex={-1}
-        />
-        <th
-          className="pf-v6-c-table__th"
-          data-label="Git Service Name Column Header"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          scope="col"
-          tabIndex={-1}
+        <div
+          className="pf-v6-c-data-list__item-control"
+          rowid="git-service-name-bitbucket"
         >
-          Name
-        </th>
-        <th
-          className="pf-v6-c-table__th"
-          data-label="Git Service Endpoint URL Column Header"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          scope="col"
-          tabIndex={-1}
-        >
-          Server
-        </th>
-        <th
-          className="pf-v6-c-table__th"
-          data-label="Git Service Authorization Status Column Header"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          scope="col"
-          tabIndex={-1}
-        >
-          Authorization
-        </th>
-        <th
-          className="pf-v6-c-table__th"
-          data-label="Git Service Actions Column Header"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          scope="col"
-          tabIndex={-1}
-        />
-      </tr>
-    </thead>
-    <tbody
-      className="pf-v6-c-table__tbody"
-      role="rowgroup"
-    >
-      <tr
-        aria-label=""
-        className="pf-v6-c-table__tr"
-        data-ouia-component-id="OUIA-Generated-TableRow-2"
-        data-ouia-component-type="PF6/TableRow"
-        data-ouia-safe={true}
-        data-testid="bitbucket"
-        hidden={false}
-      >
-        <td
-          className="pf-v6-c-table__td pf-v6-c-table__check"
-          data-label="Git Service Checkbox"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          <label>
-            <input
-              aria-label="Select row 0"
-              checked={false}
-              disabled={true}
-              name="checkrow0"
-              onChange={[Function]}
-              type="checkbox"
-            />
-          </label>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Name"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          Bitbucket
-           
-          <span
-            data-testid="git-service-tooltip"
+          <div
+            className="pf-v6-c-data-list__item-control"
           >
-            <span>
-              isVisible: 
-              false
-            </span>
-          </span>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Endpoint URL"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
+            <div
+              className="pf-v6-c-data-list__check"
+            >
+              <label
+                className="pf-v6-c-check pf-m-standalone"
+                htmlFor="datalist-check-pf-random-id-0"
+              >
+                <input
+                  aria-invalid={false}
+                  aria-labelledby="git-service-name-bitbucket"
+                  checked={false}
+                  className="pf-v6-c-check__input"
+                  data-ouia-component-id="OUIA-Generated-Checkbox-1"
+                  data-ouia-component-type="PF6/Checkbox"
+                  data-ouia-safe={true}
+                  disabled={true}
+                  id="datalist-check-pf-random-id-0"
+                  name="checkrow0"
+                  onChange={[Function]}
+                  required={false}
+                  type="checkbox"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pf-v6-c-data-list__item-content"
         >
-          <a
-            aria-label={null}
-            className="pf-v6-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-1"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe={true}
-            disabled={null}
-            href="https://bitbucket.com"
-            rel="noreferer"
-            target="_blank"
-            type={null}
+          <div
+            className="pf-v6-c-data-list__cell nameCell"
           >
             <span
-              className="pf-v6-c-button__text"
+              className="serviceName"
+              id="git-service-name-bitbucket"
             >
-              https://bitbucket.com
+              Bitbucket
             </span>
-          </a>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Authorization"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          <span
-            data-testid="git-service-status-icon"
+            <span
+              data-testid="git-service-tooltip"
+            >
+              <span>
+                isVisible: 
+                false
+              </span>
+            </span>
+          </div>
+          <div
+            className="pf-v6-c-data-list__cell serverCell"
           >
-            <span>
-              Authentication Status Icon for 
-              bitbucket
+            <a
+              aria-label={null}
+              className="pf-v6-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-1"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe={true}
+              disabled={null}
+              href="https://bitbucket.com"
+              rel="noreferer"
+              target="_blank"
+              type={null}
+            >
+              <span
+                className="pf-v6-c-button__text"
+              >
+                https://bitbucket.com
+              </span>
+            </a>
+          </div>
+          <div
+            className="pf-v6-c-data-list__cell authCell"
+          >
+            <span
+              data-testid="git-service-status-icon"
+            >
+              <span>
+                Authentication Status Icon for 
+                bitbucket
+              </span>
             </span>
-          </span>
-        </td>
-        <td
-          className="pf-v6-c-table__td pf-v6-c-table__action"
-          data-label="Git Service Actions"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
+          </div>
+        </div>
+        <div
+          className="pf-v6-c-data-list__item-action"
+          rowid="git-service-name-bitbucket"
         >
           <button
-            aria-expanded={false}
-            aria-label="Kebab toggle"
-            className="pf-v6-c-menu-toggle pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
-            data-ouia-component-type="PF6/MenuToggle"
+            aria-label={null}
+            className="pf-v6-c-button pf-m-secondary pf-m-small"
+            data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+            data-ouia-component-type="PF6/Button"
             data-ouia-safe={true}
             disabled={true}
             onClick={[Function]}
+            tabIndex={null}
             type="button"
-          >
-            <span
-              className="pf-v6-c-menu-toggle__icon"
-            >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-v6-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 192 512"
-                width="1em"
-              >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </span>
-          </button>
-        </td>
-      </tr>
-      <tr
-        aria-label=""
-        className="pf-v6-c-table__tr"
-        data-ouia-component-id="OUIA-Generated-TableRow-3"
-        data-ouia-component-type="PF6/TableRow"
-        data-ouia-safe={true}
-        data-testid="github"
-        hidden={false}
-      >
-        <td
-          className="pf-v6-c-table__td pf-v6-c-table__check"
-          data-label="Git Service Checkbox"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          <label>
-            <input
-              aria-label="Select row 1"
-              checked={false}
-              name="checkrow1"
-              onChange={[Function]}
-              type="checkbox"
-            />
-          </label>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Name"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          GitHub
-           
-          <span
-            data-testid="git-service-tooltip"
-          >
-            <span>
-              isVisible: 
-              false
-            </span>
-          </span>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Endpoint URL"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          <a
-            aria-label={null}
-            className="pf-v6-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-2"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe={true}
-            disabled={null}
-            href="https://github.com"
-            rel="noreferer"
-            target="_blank"
-            type={null}
           >
             <span
               className="pf-v6-c-button__text"
             >
-              https://github.com
+              Revoke
             </span>
-          </a>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Authorization"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
+          </button>
+        </div>
+      </div>
+    </li>
+    <li
+      className="pf-v6-c-data-list__item"
+      data-testid="github"
+      id=""
+    >
+      <div
+        className="pf-v6-c-data-list__item-row"
+      >
+        <div
+          className="pf-v6-c-data-list__item-control"
+          rowid="git-service-name-github"
         >
-          <span
-            data-testid="git-service-status-icon"
+          <div
+            className="pf-v6-c-data-list__item-control"
           >
-            <span>
-              Authentication Status Icon for 
-              github
+            <div
+              className="pf-v6-c-data-list__check"
+            >
+              <label
+                className="pf-v6-c-check pf-m-standalone"
+                htmlFor="datalist-check-pf-random-id-1"
+              >
+                <input
+                  aria-invalid={false}
+                  aria-labelledby="git-service-name-github"
+                  checked={false}
+                  className="pf-v6-c-check__input"
+                  data-ouia-component-id="OUIA-Generated-Checkbox-2"
+                  data-ouia-component-type="PF6/Checkbox"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  id="datalist-check-pf-random-id-1"
+                  name="checkrow1"
+                  onChange={[Function]}
+                  required={false}
+                  type="checkbox"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pf-v6-c-data-list__item-content"
+        >
+          <div
+            className="pf-v6-c-data-list__cell nameCell"
+          >
+            <span
+              className="serviceName"
+              id="git-service-name-github"
+            >
+              GitHub
             </span>
-          </span>
-        </td>
-        <td
-          className="pf-v6-c-table__td pf-v6-c-table__action"
-          data-label="Git Service Actions"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
+            <span
+              data-testid="git-service-tooltip"
+            >
+              <span>
+                isVisible: 
+                false
+              </span>
+            </span>
+          </div>
+          <div
+            className="pf-v6-c-data-list__cell serverCell"
+          >
+            <a
+              aria-label={null}
+              className="pf-v6-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-2"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe={true}
+              disabled={null}
+              href="https://github.com"
+              rel="noreferer"
+              target="_blank"
+              type={null}
+            >
+              <span
+                className="pf-v6-c-button__text"
+              >
+                https://github.com
+              </span>
+            </a>
+          </div>
+          <div
+            className="pf-v6-c-data-list__cell authCell"
+          >
+            <span
+              data-testid="git-service-status-icon"
+            >
+              <span>
+                Authentication Status Icon for 
+                github
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          className="pf-v6-c-data-list__item-action"
+          rowid="git-service-name-github"
         >
           <button
-            aria-expanded={false}
-            aria-label="Kebab toggle"
-            className="pf-v6-c-menu-toggle pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-MenuToggle-plain-2"
-            data-ouia-component-type="PF6/MenuToggle"
+            aria-label={null}
+            className="pf-v6-c-button pf-m-secondary pf-m-small"
+            data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+            data-ouia-component-type="PF6/Button"
             data-ouia-safe={true}
             disabled={false}
             onClick={[Function]}
             type="button"
           >
             <span
-              className="pf-v6-c-menu-toggle__icon"
-            >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-v6-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 192 512"
-                width="1em"
-              >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </span>
-          </button>
-        </td>
-      </tr>
-      <tr
-        aria-label=""
-        className="pf-v6-c-table__tr"
-        data-ouia-component-id="OUIA-Generated-TableRow-4"
-        data-ouia-component-type="PF6/TableRow"
-        data-ouia-safe={true}
-        data-testid="gitlab"
-        hidden={false}
-      >
-        <td
-          className="pf-v6-c-table__td pf-v6-c-table__check"
-          data-label="Git Service Checkbox"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          <label>
-            <input
-              aria-label="Select row 2"
-              checked={false}
-              name="checkrow2"
-              onChange={[Function]}
-              type="checkbox"
-            />
-          </label>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Name"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          GitLab
-           
-          <span
-            data-testid="git-service-tooltip"
-          >
-            <span>
-              isVisible: 
-              false
-            </span>
-          </span>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Endpoint URL"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
-        >
-          <a
-            aria-label={null}
-            className="pf-v6-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-3"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe={true}
-            disabled={null}
-            href="https://gitlab.com"
-            rel="noreferer"
-            target="_blank"
-            type={null}
-          >
-            <span
               className="pf-v6-c-button__text"
             >
-              https://gitlab.com
+              Revoke
             </span>
-          </a>
-        </td>
-        <td
-          className="pf-v6-c-table__td"
-          data-label="Git Service Authorization"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
+          </button>
+        </div>
+      </div>
+    </li>
+    <li
+      className="pf-v6-c-data-list__item"
+      data-testid="gitlab"
+      id=""
+    >
+      <div
+        className="pf-v6-c-data-list__item-row"
+      >
+        <div
+          className="pf-v6-c-data-list__item-control"
+          rowid="git-service-name-gitlab"
         >
-          <span
-            data-testid="git-service-status-icon"
+          <div
+            className="pf-v6-c-data-list__item-control"
           >
-            <span>
-              Authentication Status Icon for 
-              gitlab
+            <div
+              className="pf-v6-c-data-list__check"
+            >
+              <label
+                className="pf-v6-c-check pf-m-standalone"
+                htmlFor="datalist-check-pf-random-id-2"
+              >
+                <input
+                  aria-invalid={false}
+                  aria-labelledby="git-service-name-gitlab"
+                  checked={false}
+                  className="pf-v6-c-check__input"
+                  data-ouia-component-id="OUIA-Generated-Checkbox-3"
+                  data-ouia-component-type="PF6/Checkbox"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  id="datalist-check-pf-random-id-2"
+                  name="checkrow2"
+                  onChange={[Function]}
+                  required={false}
+                  type="checkbox"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pf-v6-c-data-list__item-content"
+        >
+          <div
+            className="pf-v6-c-data-list__cell nameCell"
+          >
+            <span
+              className="serviceName"
+              id="git-service-name-gitlab"
+            >
+              GitLab
             </span>
-          </span>
-        </td>
-        <td
-          className="pf-v6-c-table__td pf-v6-c-table__action"
-          data-label="Git Service Actions"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          tabIndex={-1}
+            <span
+              data-testid="git-service-tooltip"
+            >
+              <span>
+                isVisible: 
+                false
+              </span>
+            </span>
+          </div>
+          <div
+            className="pf-v6-c-data-list__cell serverCell"
+          >
+            <a
+              aria-label={null}
+              className="pf-v6-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-3"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe={true}
+              disabled={null}
+              href="https://gitlab.com"
+              rel="noreferer"
+              target="_blank"
+              type={null}
+            >
+              <span
+                className="pf-v6-c-button__text"
+              >
+                https://gitlab.com
+              </span>
+            </a>
+          </div>
+          <div
+            className="pf-v6-c-data-list__cell authCell"
+          >
+            <span
+              data-testid="git-service-status-icon"
+            >
+              <span>
+                Authentication Status Icon for 
+                gitlab
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          className="pf-v6-c-data-list__item-action"
+          rowid="git-service-name-gitlab"
         >
           <button
-            aria-expanded={false}
-            aria-label="Kebab toggle"
-            className="pf-v6-c-menu-toggle pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-MenuToggle-plain-3"
-            data-ouia-component-type="PF6/MenuToggle"
+            aria-label={null}
+            className="pf-v6-c-button pf-m-secondary pf-m-small"
+            data-ouia-component-id="OUIA-Generated-Button-secondary-3"
+            data-ouia-component-type="PF6/Button"
             data-ouia-safe={true}
             disabled={false}
             onClick={[Function]}
             type="button"
           >
             <span
-              className="pf-v6-c-menu-toggle__icon"
+              className="pf-v6-c-button__text"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-v6-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 192 512"
-                width="1em"
-              >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
+              Revoke
             </span>
           </button>
-        </td>
-      </tr>
-    </tbody>
-  </table>,
+        </div>
+      </div>
+    </li>
+  </ul>,
 ]
 `;

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/__tests__/index.spec.tsx
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -29,18 +28,9 @@ describe('GitServicesList', () => {
   beforeEach(() => {
     props = {
       gitOauth: [
-        {
-          name: 'github',
-          endpointUrl: 'https://github.com',
-        },
-        {
-          name: 'gitlab',
-          endpointUrl: 'https://gitlab.com',
-        },
-        {
-          name: 'bitbucket',
-          endpointUrl: 'https://bitbucket.com',
-        },
+        { name: 'github', endpointUrl: 'https://github.com' },
+        { name: 'gitlab', endpointUrl: 'https://gitlab.com' },
+        { name: 'bitbucket', endpointUrl: 'https://bitbucket.com' },
       ],
       isDisabled: false,
       onRevokeServices: jest.fn(),
@@ -62,139 +52,64 @@ describe('GitServicesList', () => {
   test('initial state', () => {
     renderComponent(props);
 
-    const rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(4);
+    // rows are DataListItems — query by data-testid
+    const bitbucketRow = screen.getByTestId('bitbucket');
+    const githubRow = screen.getByTestId('github');
+    const gitlabRow = screen.getByTestId('gitlab');
 
-    // The very first row in the table is the header, skip it
+    expect(bitbucketRow).toHaveTextContent('https://bitbucket.com');
+    expect(githubRow).toHaveTextContent('https://github.com');
+    expect(gitlabRow).toHaveTextContent('https://gitlab.com');
 
-    // The next row is Bitbucket
-    {
-      const bitbucketRow = rows[1];
-      expect(bitbucketRow).toHaveTextContent('bitbucket');
-      expect(bitbucketRow).toHaveTextContent('https://bitbucket.com');
+    // Bitbucket: no token + not in CAN_REVOKE → checkbox disabled, Revoke disabled
+    expect(within(bitbucketRow).getByRole('checkbox')).toBeDisabled();
+    expect(within(bitbucketRow).getByRole('button', { name: 'Revoke' })).toBeDisabled();
 
-      const checkbox = within(bitbucketRow).getByRole('checkbox');
-      expect(checkbox).toBeDisabled();
-      expect(checkbox).not.toBeChecked();
+    // GitHub: has token + in CAN_REVOKE → checkbox enabled, Revoke enabled
+    expect(within(githubRow).getByRole('checkbox')).toBeEnabled();
+    expect(within(githubRow).getByRole('button', { name: 'Revoke' })).toBeEnabled();
 
-      const kebab = within(bitbucketRow).getByRole('button', { name: 'Kebab toggle' });
-      expect(kebab).toBeDisabled();
-    }
-
-    // The next row is Github
-    {
-      const githubRow = rows[2];
-      expect(githubRow).toHaveTextContent('github');
-      expect(githubRow).toHaveTextContent('https://github.com');
-
-      const checkbox = within(githubRow).getByRole('checkbox');
-      expect(checkbox).toBeEnabled();
-      expect(checkbox).not.toBeChecked();
-
-      const kebab = within(githubRow).getByRole('button', { name: 'Kebab toggle' });
-      expect(kebab).toBeEnabled();
-    }
-
-    // The next row is Gitlab
-    {
-      const gitlabRow = rows[3];
-      expect(gitlabRow).toHaveTextContent('gitlab');
-      expect(gitlabRow).toHaveTextContent('https://gitlab.com');
-
-      const checkbox = within(gitlabRow).getByRole('checkbox');
-      expect(checkbox).toBeEnabled();
-      expect(checkbox).not.toBeChecked();
-
-      const kebab = within(gitlabRow).getByRole('button', { name: 'Kebab toggle' });
-      expect(kebab).toBeEnabled();
-    }
+    // GitLab: has token + in CAN_REVOKE → checkbox enabled, Revoke enabled
+    expect(within(gitlabRow).getByRole('checkbox')).toBeEnabled();
+    expect(within(gitlabRow).getByRole('button', { name: 'Revoke' })).toBeEnabled();
   });
 
   test('service revocable (gitlab)', () => {
     renderComponent(props);
 
-    const rows = screen.getAllByRole('row');
-
-    // get the github row
-    const gitlabRow = rows[3];
-    expect(gitlabRow).toHaveTextContent('gitlab');
-
-    const gitlabCheckbox = within(gitlabRow).getByRole('checkbox');
-    const gitlabKebab = within(gitlabRow).getByRole('button', { name: 'Kebab toggle' });
-
-    expect(gitlabCheckbox).toBeEnabled();
-    expect(gitlabCheckbox).not.toBeChecked();
-
-    expect(gitlabKebab).toBeEnabled();
+    const gitlabRow = screen.getByTestId('gitlab');
+    expect(within(gitlabRow).getByRole('checkbox')).toBeEnabled();
+    expect(within(gitlabRow).getByRole('button', { name: 'Revoke' })).toBeEnabled();
   });
 
   test('service revocable (github)', async () => {
     renderComponent(props);
 
-    const rows = screen.getAllByRole('row');
-
-    // get the github row
-    const githubRow = rows[2];
-    expect(githubRow).toHaveTextContent('github');
-
+    const githubRow = screen.getByTestId('github');
     const githubCheckbox = within(githubRow).getByRole('checkbox');
-    const githubKebab = within(githubRow).getByRole('button', { name: 'Kebab toggle' });
+    const githubRevokeBtn = within(githubRow).getByRole('button', { name: 'Revoke' });
 
-    // the checkbox is enabled and unchecked
     expect(githubCheckbox).toBeEnabled();
     expect(githubCheckbox).not.toBeChecked();
 
-    // check the checkbox
     await userEvent.click(githubCheckbox);
     expect(githubCheckbox).toBeChecked();
 
-    // uncheck the checkbox
     await userEvent.click(githubCheckbox);
     expect(githubCheckbox).not.toBeChecked();
 
-    // the kebab button is enabled
-    expect(githubKebab).toBeEnabled();
-
-    // revoke button is not present
-    {
-      const revokeButton = within(githubRow).queryByRole('menuitem', { name: 'Revoke' });
-      expect(revokeButton).toBeNull();
-    }
-
-    // open kebab menu
-    await userEvent.click(githubKebab);
-
-    // the revoke button is present - wait for menu to appear
-    // ActionsColumn menu items may appear outside the row context
-    const revokeButton = await waitFor(
-      () => {
-        const button = screen.queryByRole('menuitem', { name: 'Revoke' });
-        expect(button).not.toBeNull();
-        return button;
-      },
-      { timeout: 3000 },
-    );
-
-    // click the revoke button
-    await userEvent.click(revokeButton!);
+    expect(githubRevokeBtn).toBeEnabled();
+    await userEvent.click(githubRevokeBtn);
 
     expect(props.onRevokeServices).toHaveBeenCalledTimes(1);
     expect(props.onRevokeServices).toHaveBeenCalledWith([
-      {
-        name: 'github',
-        endpointUrl: 'https://github.com',
-      },
+      { name: 'github', endpointUrl: 'https://github.com' },
     ]);
   });
 
   test('can clear opt-out (github)', async () => {
     props = {
-      gitOauth: [
-        {
-          name: 'github',
-          endpointUrl: 'https://github.com',
-        },
-      ],
+      gitOauth: [{ name: 'github', endpointUrl: 'https://github.com' }],
       isDisabled: false,
       onRevokeServices: jest.fn(),
       onClearService: jest.fn(),
@@ -203,44 +118,14 @@ describe('GitServicesList', () => {
     };
     renderComponent(props);
 
-    const rows = screen.getAllByRole('row');
-
-    // get the github row
-    const githubRow = rows[1];
-    expect(githubRow).toHaveTextContent('github');
-
+    const githubRow = screen.getByTestId('github');
     const githubCheckbox = within(githubRow).getByRole('checkbox');
-    const githubKebab = within(githubRow).getByRole('button', { name: 'Kebab toggle' });
+    const githubClearBtn = within(githubRow).getByRole('button', { name: 'Clear' });
 
-    // the checkbox is disabled and unchecked
     expect(githubCheckbox).toBeDisabled();
-    expect(githubCheckbox).not.toBeChecked();
+    expect(githubClearBtn).toBeEnabled();
 
-    // the kebab button is enabled
-    expect(githubKebab).toBeEnabled();
-
-    // Clear button is not present
-    {
-      const clearButton = within(githubRow).queryByRole('menuitem', { name: 'Clear' });
-      expect(clearButton).toBeNull();
-    }
-
-    // open kebab menu
-    await userEvent.click(githubKebab);
-
-    // the Clear button is present - wait for menu to appear
-    // ActionsColumn menu items may appear outside the row context
-    const clearButton = await waitFor(
-      () => {
-        const button = screen.queryByRole('menuitem', { name: 'Clear' });
-        expect(button).not.toBeNull();
-        return button;
-      },
-      { timeout: 3000 },
-    );
-
-    // click the Clear button
-    await userEvent.click(clearButton!);
+    await userEvent.click(githubClearBtn);
 
     expect(props.onClearService).toHaveBeenCalledTimes(1);
     expect(props.onClearService).toHaveBeenCalledWith('github');
@@ -250,62 +135,41 @@ describe('GitServicesList', () => {
     renderComponent(props);
 
     const selectedItemsCount = screen.getByTestId('selected-items-count');
-
-    // No items selected
     expect(selectedItemsCount).toHaveTextContent('0');
 
-    const rows = screen.getAllByRole('row');
-
-    // check the github row
-    const githubRow = rows[2];
+    const githubRow = screen.getByTestId('github');
     const githubCheckbox = within(githubRow).getByRole('checkbox');
     await userEvent.click(githubCheckbox);
 
-    // One item selected
     expect(selectedItemsCount).toHaveTextContent('1');
 
-    // the revoke button in toolbar
-    const revokeButton = screen.getByRole('button', { name: 'Revoke' });
-    await userEvent.click(revokeButton);
+    const toolbar = screen.getByTestId('git-services-toolbar');
+    const toolbarRevokeButton = within(toolbar).getByRole('button', { name: 'Revoke' });
+    await userEvent.click(toolbarRevokeButton);
 
     expect(props.onRevokeServices).toHaveBeenCalledTimes(1);
     expect(props.onRevokeServices).toHaveBeenCalledWith([
-      {
-        name: 'github',
-        endpointUrl: 'https://github.com',
-      },
+      { name: 'github', endpointUrl: 'https://github.com' },
     ]);
   });
 
   test('disabled list', () => {
-    // initially prop isDisabled is false
     const { reRenderComponent } = renderComponent(props);
 
-    const rows = screen.getAllByRole('row');
-
-    // get the github row
-    const githubRow = rows[2];
-    expect(githubRow).toHaveTextContent('github');
-
-    // get the github row controls
+    const githubRow = screen.getByTestId('github');
     const githubCheckbox = within(githubRow).getByRole('checkbox');
-    const githubKebab = within(githubRow).getByRole('button', { name: 'Kebab toggle' });
+    const githubRevokeBtn = within(githubRow).getByRole('button', { name: 'Revoke' });
 
-    // they are enabled
     expect(githubCheckbox).toBeEnabled();
-    expect(githubKebab).toBeEnabled();
+    expect(githubRevokeBtn).toBeEnabled();
 
-    // toolbar is enabled
     const revokeButtonDisabled = screen.getByTestId('revoke-is-disabled');
     expect(revokeButtonDisabled).toHaveTextContent('false');
 
-    // set isDisabled to be true
     reRenderComponent({ ...props, isDisabled: true });
 
-    // the github row controls are disabled
     expect(githubCheckbox).toBeDisabled();
-
-    // toolbar is disabled
+    expect(githubRevokeBtn).toBeDisabled();
     expect(revokeButtonDisabled).toHaveTextContent('true');
   });
 });

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.module.css
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.module.css
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/* Service name: bold and vertically centred next to the status icon. */
+.serviceName {
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+}
+
+/* Name cell: min-width so short names don't squeeze. */
+.nameCell {
+  min-width: 8rem;
+}
+
+/* Server URL wraps cleanly at path boundaries (WCAG 1.4.10 Reflow). */
+.serverCell {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Authorization cell: stays compact. */
+.authCell {
+  flex: 0 0 auto !important;
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/GitServices/List/index.tsx
@@ -11,22 +11,23 @@
  */
 
 import { api } from '@eclipse-che/common';
-import { Button, ButtonVariant } from '@patternfly/react-core';
 import {
-  ActionsColumn,
-  IAction,
-  Table,
-  TableVariant,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from '@patternfly/react-table';
+  Button,
+  ButtonVariant,
+  DataList,
+  DataListAction,
+  DataListCell,
+  DataListCheck,
+  DataListControl,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+} from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
 
 import { GIT_OAUTH_PROVIDERS } from '@/pages/UserPreferences/const';
+import styles from '@/pages/UserPreferences/GitServices/List/index.module.css';
 import { GitServiceStatusIcon } from '@/pages/UserPreferences/GitServices/List/StatusIcon';
 import { GitServiceTooltip } from '@/pages/UserPreferences/GitServices/List/Tooltip';
 import { GitServicesToolbar } from '@/pages/UserPreferences/GitServices/Toolbar';
@@ -63,139 +64,29 @@ export class GitServicesList extends React.PureComponent<Props, State> {
     };
   }
 
-  /**
-   * Sort by display name
-   */
   private sortServices(gitOauth: IGitOauth[]): IGitOauth[] {
     const services = cloneDeep(gitOauth);
-    return services.sort((serviceA, serviceB) => {
-      return GIT_OAUTH_PROVIDERS[serviceA.name].localeCompare(GIT_OAUTH_PROVIDERS[serviceB.name]);
-    });
-  }
-
-  private buildHeadRow(): React.ReactElement {
-    return (
-      <Tr>
-        <Th />
-        <Th dataLabel="Git Service Name Column Header">Name</Th>
-        <Th dataLabel="Git Service Endpoint URL Column Header">Server</Th>
-        <Th dataLabel="Git Service Authorization Status Column Header">Authorization</Th>
-        <Th dataLabel="Git Service Actions Column Header" />
-      </Tr>
+    return services.sort((serviceA, serviceB) =>
+      GIT_OAUTH_PROVIDERS[serviceA.name].localeCompare(GIT_OAUTH_PROVIDERS[serviceB.name]),
     );
   }
 
-  private handleSelectItem(isSelected: boolean, rowIndex: number): void {
-    const { sortedGitOauth } = this.state;
-
-    /* c8 ignore start */
-    if (rowIndex === -1) {
-      // Select all (header row checked)
-      const selectedItems = isSelected && sortedGitOauth.length > 0 ? sortedGitOauth : [];
-      this.setState({ selectedItems });
-      return;
-    }
-    /* c8 ignore stop */
-
-    // Select single row
-    const selectedItem = sortedGitOauth[rowIndex];
-    this.setState((prevState: State) => {
-      return {
-        selectedItems: isSelected
-          ? [...prevState.selectedItems, selectedItem]
-          : prevState.selectedItems.filter(item => item !== selectedItem),
-      };
-    });
+  private handleSelectItem(isSelected: boolean, service: IGitOauth): void {
+    this.setState((prevState: State) => ({
+      selectedItems: isSelected
+        ? [...prevState.selectedItems, service]
+        : prevState.selectedItems.filter(item => item !== service),
+    }));
   }
 
   private deselectServices(services: IGitOauth[]): void {
-    const { selectedItems } = this.state;
-    this.setState({
-      selectedItems: selectedItems.filter(s => !services.includes(s)),
-    });
-  }
-
-  private buildBody(): React.ReactNode[] {
-    const { sortedGitOauth } = this.state;
-
-    return sortedGitOauth.map((service, rowIndex) => this.buildBodyRow(service, rowIndex));
-  }
-
-  private buildBodyRow(service: IGitOauth, rowIndex: number) {
-    const { isDisabled, providersWithToken, skipOauthProviders } = this.props;
-    const { selectedItems } = this.state;
-
-    const hasWarningMessage =
-      this.isRevokeEnabled(service.name) === false && this.hasOauthToken(service.name) === true;
-
-    const canRevoke = this.isRevokeEnabled(service.name) === true;
-    const canClear = this.hasSkipOauth(service.name) === true;
-    const hasToken = this.hasOauthToken(service.name) === true;
-    const rowDisabled = isDisabled || canRevoke === false || hasToken === false;
-    const kebabDisabled = (isDisabled || !canRevoke || !hasToken) && !canClear;
-
-    const actionItems = this.buildActionItems(service);
-
-    return (
-      <Tr key={service.name} data-testid={service.name}>
-        <Td
-          dataLabel="Git Service Checkbox"
-          select={{
-            rowIndex,
-            onSelect: (_event, isSelected) => this.handleSelectItem(isSelected, rowIndex),
-            isSelected: selectedItems.includes(service),
-            isDisabled: rowDisabled,
-          }}
-        />
-        <Td dataLabel="Git Service Name">
-          {GIT_OAUTH_PROVIDERS[service.name]}{' '}
-          <GitServiceTooltip isVisible={hasWarningMessage} serverURI={service.endpointUrl} />
-        </Td>
-        <Td dataLabel="Git Service Endpoint URL">
-          <Button
-            component="a"
-            variant={ButtonVariant.link}
-            href={service.endpointUrl}
-            isInline={true}
-            target="_blank"
-            rel="noreferer"
-          >
-            {service.endpointUrl}
-          </Button>
-        </Td>
-        <Td dataLabel="Git Service Authorization">
-          <GitServiceStatusIcon
-            gitProvider={service.name}
-            providersWithToken={providersWithToken}
-            skipOauthProviders={skipOauthProviders}
-          />
-        </Td>
-        <Td dataLabel="Git Service Actions" isActionCell={true}>
-          <ActionsColumn isDisabled={kebabDisabled} items={actionItems} />
-        </Td>
-      </Tr>
-    );
-  }
-
-  private buildActionItems(service: IGitOauth): IAction[] {
-    if (this.hasSkipOauth(service.name)) {
-      return [
-        {
-          title: 'Clear',
-          onClick: () => this.handleClearService(service),
-        },
-      ];
-    }
-    return [
-      {
-        title: 'Revoke',
-        onClick: () => this.handleRevokeService(service),
-      },
-    ];
+    this.setState(prev => ({
+      selectedItems: prev.selectedItems.filter(s => !services.includes(s)),
+    }));
   }
 
   private isRevokeEnabled(providerName: api.GitOauthProvider): boolean {
-    return CAN_REVOKE_FROM_DASHBOARD.includes(providerName) === true;
+    return CAN_REVOKE_FROM_DASHBOARD.includes(providerName);
   }
 
   private hasSkipOauth(providerName: api.GitOauthProvider): boolean {
@@ -213,7 +104,7 @@ export class GitServicesList extends React.PureComponent<Props, State> {
 
   private handleClearService(service: IGitOauth): void {
     const serviceToClear = this.props.skipOauthProviders.find(s => s === service.name);
-    if (serviceToClear != undefined) {
+    if (serviceToClear !== undefined) {
       this.props.onClearService(serviceToClear);
       this.deselectServices([service]);
     }
@@ -221,17 +112,92 @@ export class GitServicesList extends React.PureComponent<Props, State> {
 
   private async handleRevokeSelectedServices(): Promise<void> {
     const { selectedItems } = this.state;
-
     this.props.onRevokeServices(selectedItems);
     this.deselectServices(selectedItems);
   }
 
-  render(): React.ReactNode {
-    const { isDisabled } = this.props;
+  private buildItem(service: IGitOauth, rowIndex: number): React.ReactElement {
+    const { isDisabled, providersWithToken, skipOauthProviders } = this.props;
     const { selectedItems } = this.state;
 
-    const headRow = this.buildHeadRow();
-    const bodyRows = this.buildBody();
+    const hasWarningMessage =
+      !this.isRevokeEnabled(service.name) && this.hasOauthToken(service.name);
+    const canRevoke = this.isRevokeEnabled(service.name);
+    const canClear = this.hasSkipOauth(service.name);
+    const hasToken = this.hasOauthToken(service.name);
+    const checkDisabled = isDisabled || !canRevoke || !hasToken;
+    const actionDisabled = (isDisabled || !canRevoke || !hasToken) && !canClear;
+    const actionLabel = canClear ? 'Clear' : 'Revoke';
+    const handleAction = canClear
+      ? () => this.handleClearService(service)
+      : () => this.handleRevokeService(service);
+
+    const nameId = `git-service-name-${service.name}`;
+    const actionId = `git-service-action-${service.name}`;
+
+    return (
+      <DataListItem key={service.name} aria-labelledby={nameId} data-testid={service.name}>
+        <DataListItemRow>
+          <DataListControl>
+            <DataListCheck
+              aria-labelledby={nameId}
+              name={`checkrow${rowIndex}`}
+              isChecked={selectedItems.includes(service)}
+              isDisabled={checkDisabled}
+              onChange={(_event, checked) => this.handleSelectItem(checked, service)}
+            />
+          </DataListControl>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key="name" className={styles.nameCell}>
+                <span id={nameId} className={styles.serviceName}>
+                  {GIT_OAUTH_PROVIDERS[service.name]}
+                </span>
+                <GitServiceTooltip isVisible={hasWarningMessage} serverURI={service.endpointUrl} />
+              </DataListCell>,
+              <DataListCell key="server" className={styles.serverCell}>
+                <Button
+                  component="a"
+                  variant={ButtonVariant.link}
+                  href={service.endpointUrl}
+                  isInline
+                  target="_blank"
+                  rel="noreferer"
+                >
+                  {service.endpointUrl}
+                </Button>
+              </DataListCell>,
+              <DataListCell key="auth" className={styles.authCell}>
+                <GitServiceStatusIcon
+                  gitProvider={service.name}
+                  providersWithToken={providersWithToken}
+                  skipOauthProviders={skipOauthProviders}
+                />
+              </DataListCell>,
+            ]}
+          />
+          <DataListAction
+            id={actionId}
+            aria-labelledby={`${nameId} ${actionId}`}
+            aria-label="Actions"
+          >
+            <Button
+              variant={ButtonVariant.secondary}
+              isDisabled={actionDisabled}
+              onClick={handleAction}
+              size="sm"
+            >
+              {actionLabel}
+            </Button>
+          </DataListAction>
+        </DataListItemRow>
+      </DataListItem>
+    );
+  }
+
+  render(): React.ReactNode {
+    const { isDisabled } = this.props;
+    const { selectedItems, sortedGitOauth } = this.state;
 
     return (
       <React.Fragment>
@@ -240,11 +206,9 @@ export class GitServicesList extends React.PureComponent<Props, State> {
           selectedItems={selectedItems}
           onRevokeButton={async () => await this.handleRevokeSelectedServices()}
         />
-
-        <Table aria-label="Git Services" variant={TableVariant.compact}>
-          <Thead>{headRow}</Thead>
-          <Tbody>{bodyRows}</Tbody>
-        </Table>
+        <DataList aria-label="Git Services">
+          {sortedGitOauth.map((service, rowIndex) => this.buildItem(service, rowIndex))}
+        </DataList>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fixes the **Git Services** table in User Preferences breaking at 400% zoom (WCAG 1.4.10 Reflow, Level AA).

#### Root cause

PatternFly 6 `Table` applies `pf-m-grid-md` by default. This modifier switches the table into a CSS grid card layout when the viewport is ≤768px. At 400% zoom on a 1280px display, the effective viewport is ~320px — well inside that breakpoint — so the grid mode is always active.

The grid-mode layout collapsed the `ActionsColumn` (kebab menu, `pf-v6-c-menu-toggle pf-m-plain`), causing the action cell to break and the table to render unreadably with text stacking character-by-character.

#### Fix

Replace the `Table` with PatternFly **DataList**, which is designed for responsive list layouts and renders correctly at all viewport widths without grid-mode breakage.

Each provider becomes a `DataListItem` with:
- **`DataListCheck`** — row checkbox for bulk revoke
- **`DataListItemCells`** — name (bold), server URL (wraps cleanly), authorization status icon
- **`DataListAction`** — inline `Button` labeled _Revoke_ or _Clear_ (no kebab needed since each row has exactly one action)

The server URL cell uses `overflow-wrap: anywhere` so long URLs wrap at path boundaries (WCAG 1.4.10 Reflow).

---
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
_Before (400% zoom):_ action column collapses, table layout breaks, text stacks character-by-character.
<img width="1909" height="964" alt="Знімок екрана 2026-05-28 о 02 25 35" src="https://github.com/user-attachments/assets/b866dc16-0a7e-4cfa-ae11-6c3e50dbef65" />

_After (400% zoom):_ DataList renders as a clean responsive list; each item stacks vertically with clearly labeled fields and an inline Revoke/Clear button.
<img width="1909" height="964" alt="Знімок екрана 2026-05-28 о 02 26 45" src="https://github.com/user-attachments/assets/bf6ae3ea-b5ff-48c5-97a3-598cb6933a8c" />

### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10230

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
