### PR TITLE
fix(a11y): fix contrast of event meta-text in Events tab (CRW-10318)

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
@@ -12,4 +12,11 @@
 
 .header {
   display: block;
+
+  /* Override PatternFly's subtle color for <small> meta-text in the event card
+     header. The default --pf-t--global--text--color--subtle produces a contrast
+     ratio of ~3.65:1 against the card background, which fails WCAG 1.4.3
+     (Contrast Minimum, Level AA). Setting --pf-v6-c-content--small--Color to
+     the regular text token achieves ≥4.5:1. (CRW-10318) */
+  --pf-v6-c-content--small--Color: var(--pf-t--global--text--color--regular);
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fixes a WCAG 1.4.3 Contrast (Minimum, Level AA) violation in the Events tab on both the Workspace Details page and the Start Workspace progress page.

#### Fix

One CSS custom property override in `WorkspaceEvents/Item/index.module.css`:

```css
.header {
  --pf-v6-c-content--small--Color: var(--pf-t--global--text--color--regular);
}
```

No HTML structure changes — the fix is CSS-only and scoped to the event card header.

---

### Screenshot/screencast of this PR

_After:_ meta text at ≥ 4.5:1 — no contrast violation.
<img width="1909" height="1032" alt="Знімок екрана 2026-05-28 о 03 45 41" src="https://github.com/user-attachments/assets/cfe073f8-7668-43ce-b9fe-ff25222c4520" />

---

### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10318

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
