### PR TITLE
fix(a11y): add Start/Stop workspace kebab on loader page (CRW-10282)

### DIFF
--- a/packages/dashboard-frontend/src/components/Header/index.tsx
+++ b/packages/dashboard-frontend/src/components/Header/index.tsx
@@ -33,6 +33,7 @@ import {
 // Note: PageSectionVariants.default was removed in PF6
 
 type Props = {
+  actions?: React.ReactNode;
   hideBreadcrumbs?: boolean;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   containerScc: string | undefined;
@@ -46,7 +47,7 @@ class Header extends React.PureComponent<Props> {
   }
 
   public render(): React.ReactElement {
-    const { title, status, containerScc, hideBreadcrumbs } = this.props;
+    const { actions, title, status, containerScc, hideBreadcrumbs } = this.props;
 
     return (
       <PageSection>
@@ -71,6 +72,7 @@ class Header extends React.PureComponent<Props> {
               <FlexItem>
                 <WorkspaceStatusLabel status={status} containerScc={containerScc} />
               </FlexItem>
+              {actions && <FlexItem align={{ default: 'alignRight' }}>{actions}</FlexItem>}
             </Flex>
           </StackItem>
         </Stack>

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
@@ -40,6 +40,10 @@ import { selectAllWorkspaces } from '@/store/Workspaces/selectors';
 
 export type Props = {
   workspaceUID: string | undefined;
+  /** When true (default), hides events and shows an empty state while the
+   * workspace is STOPPED. Set to false on the loader page so startup events
+   * remain visible after the user presses Stop. */
+  hideWhenStopped?: boolean;
 } & MappedProps;
 
 class WorkspaceEvents extends React.PureComponent<Props> {
@@ -69,14 +73,14 @@ class WorkspaceEvents extends React.PureComponent<Props> {
   }
 
   render() {
-    const { workspaceUID, allWorkspaces, startedWorkspaces } = this.props;
+    const { workspaceUID, allWorkspaces, startedWorkspaces, hideWhenStopped = true } = this.props;
 
     const workspace = this.findWorkspace(workspaceUID, allWorkspaces);
 
     if (
       workspaceUID === undefined ||
       workspace === undefined ||
-      workspace.status === DevWorkspaceStatus.STOPPED
+      (hideWhenStopped && workspace.status === DevWorkspaceStatus.STOPPED)
     ) {
       return (
         <EmptyState icon={FileIcon} titleText="No events to show.">

--- a/packages/dashboard-frontend/src/containers/Loader/index.tsx
+++ b/packages/dashboard-frontend/src/containers/Loader/index.tsx
@@ -19,9 +19,10 @@ import { LoaderPage } from '@/pages/Loader';
 import { WorkspaceRouteParams } from '@/Routes';
 import { findTargetWorkspace } from '@/services/helpers/factoryFlow/findTargetWorkspace';
 import { getLoaderMode } from '@/services/helpers/factoryFlow/getLoaderMode';
-import { LoaderTab } from '@/services/helpers/types';
+import { DevWorkspaceStatus, LoaderTab } from '@/services/helpers/types';
 import { Workspace } from '@/services/workspace-adapter';
 import { RootState } from '@/store';
+import { workspacesActionCreators } from '@/store/Workspaces';
 import { selectAllWorkspaces } from '@/store/Workspaces/selectors';
 
 type RouteParams = Partial<WorkspaceRouteParams> | undefined;
@@ -74,11 +75,20 @@ class LoaderContainer extends React.Component<Props, State> {
     this.props.navigate(location);
   }
 
+  private handleStartWorkspace(workspace: Workspace): void {
+    this.props.startWorkspace(workspace);
+  }
+
+  private handleStopWorkspace(workspace: Workspace): void {
+    this.props.stopWorkspace(workspace);
+  }
+
   render(): React.ReactElement {
     const { location, navigate } = this.props;
     const { tabParam, searchParams } = this.state;
 
     const workspace = this.findTargetWorkspace(this.props);
+    const workspaceStatus = (workspace?.status as DevWorkspaceStatus) || DevWorkspaceStatus.STOPPED;
 
     return (
       <LoaderPage
@@ -87,7 +97,10 @@ class LoaderContainer extends React.Component<Props, State> {
         searchParams={searchParams}
         tabParam={tabParam}
         workspace={workspace}
+        workspaceStatus={workspaceStatus}
         onTabChange={tab => this.handleTabChange(tab)}
+        onStartWorkspace={() => workspace && this.handleStartWorkspace(workspace)}
+        onStopWorkspace={() => workspace && this.handleStopWorkspace(workspace)}
       />
     );
   }
@@ -107,7 +120,12 @@ const mapStateToProps = (state: RootState) => ({
   allWorkspaces: selectAllWorkspaces(state),
 });
 
-const connector = connect(mapStateToProps, null, null, {
+const mapDispatchToProps = {
+  startWorkspace: workspacesActionCreators.startWorkspace,
+  stopWorkspace: workspacesActionCreators.stopWorkspace,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps, null, {
   // forwardRef is mandatory for using `@react-mock/state` in unit tests
   forwardRef: true,
 });

--- a/packages/dashboard-frontend/src/pages/Loader/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/__tests__/index.spec.tsx
@@ -19,7 +19,7 @@ import { Store } from 'redux';
 
 import getComponentRenderer from '@/services/__mocks__/getComponentRenderer';
 import devfileApi from '@/services/devfileApi';
-import { LoaderTab } from '@/services/helpers/types';
+import { DevWorkspaceStatus, LoaderTab } from '@/services/helpers/types';
 import { constructWorkspace, Workspace } from '@/services/workspace-adapter';
 import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
@@ -33,6 +33,8 @@ jest.mock('@/components/WorkspaceEvents');
 const { renderComponent } = getComponentRenderer(getComponent);
 
 const mockOnTabChange = jest.fn();
+const mockOnStartWorkspace = jest.fn();
+const mockOnStopWorkspace = jest.fn();
 
 const namespace = 'user-che';
 const workspaceName = 'wksp-test';
@@ -65,6 +67,7 @@ describe('Loader page', () => {
     renderComponent(store, {
       tabParam,
       workspace,
+      workspaceStatus: DevWorkspaceStatus.STARTING,
     });
 
     const tabButtonLogs = screen.getByRole('tab', { name: 'Logs' });
@@ -77,6 +80,7 @@ describe('Loader page', () => {
     renderComponent(store, {
       tabParam: LoaderTab.Logs,
       workspace,
+      workspaceStatus: DevWorkspaceStatus.STARTING,
     });
 
     const tabpanelProgress = screen.queryByRole('tabpanel', { name: 'Progress' });
@@ -93,6 +97,7 @@ describe('Loader page', () => {
     const { reRenderComponent } = renderComponent(store, {
       tabParam,
       workspace: undefined,
+      workspaceStatus: DevWorkspaceStatus.STOPPED,
     });
 
     expect(screen.queryByRole('heading')).toHaveTextContent('Creating a workspace');
@@ -111,15 +116,70 @@ describe('Loader page', () => {
     reRenderComponent(storeReady, {
       tabParam,
       workspace: constructWorkspace(devWorkspaceReady),
+      workspaceStatus: DevWorkspaceStatus.RUNNING,
     });
 
     expect(screen.queryByRole('heading')).toHaveTextContent('Starting workspace');
+  });
+
+  it('should show actions kebab when workspace is defined', () => {
+    renderComponent(store, {
+      tabParam,
+      workspace,
+      workspaceStatus: DevWorkspaceStatus.STARTING,
+    });
+
+    expect(screen.getByRole('button', { name: 'Workspace actions' })).toBeInTheDocument();
+  });
+
+  it('should not show actions kebab when workspace is undefined', () => {
+    renderComponent(store, {
+      tabParam,
+      workspace: undefined,
+      workspaceStatus: DevWorkspaceStatus.STOPPED,
+    });
+
+    expect(screen.queryByRole('button', { name: 'Workspace actions' })).toBeNull();
+  });
+
+  it('should call onStopWorkspace when Stop is clicked in kebab', async () => {
+    renderComponent(store, {
+      tabParam,
+      workspace,
+      workspaceStatus: DevWorkspaceStatus.STARTING,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Workspace actions' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /stop/i }));
+
+    await waitFor(() => expect(mockOnStopWorkspace).toHaveBeenCalledTimes(1));
+  });
+
+  it('should call onStartWorkspace when Start is clicked in kebab (workspace stopped)', async () => {
+    renderComponent(store, {
+      tabParam,
+      workspace,
+      workspaceStatus: DevWorkspaceStatus.STOPPED,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Workspace actions' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /start/i }));
+
+    await waitFor(() => expect(mockOnStartWorkspace).toHaveBeenCalledTimes(1));
   });
 });
 
 function getComponent(
   store: Store,
-  props: Omit<Props, 'onTabChange' | 'searchParams' | 'location' | 'navigate'>,
+  props: Omit<
+    Props,
+    | 'onTabChange'
+    | 'onStartWorkspace'
+    | 'onStopWorkspace'
+    | 'searchParams'
+    | 'location'
+    | 'navigate'
+  >,
 ): React.ReactElement {
   return (
     <Provider store={store}>
@@ -129,7 +189,10 @@ function getComponent(
         tabParam={props.tabParam}
         searchParams={new URLSearchParams()}
         workspace={props.workspace}
+        workspaceStatus={props.workspaceStatus}
         onTabChange={mockOnTabChange}
+        onStartWorkspace={mockOnStartWorkspace}
+        onStopWorkspace={mockOnStopWorkspace}
       />
     </Provider>
   );

--- a/packages/dashboard-frontend/src/pages/Loader/index.tsx
+++ b/packages/dashboard-frontend/src/pages/Loader/index.tsx
@@ -10,7 +10,17 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { PageSection, PageSectionVariants, Tab, Tabs } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  Tabs,
+} from '@patternfly/react-core';
+import { EllipsisVIcon, PlayIcon, StopIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { Location, NavigateFunction } from 'react-router-dom';
 
@@ -34,11 +44,15 @@ export type Props = {
   searchParams: URLSearchParams;
   tabParam: string | undefined;
   workspace: Workspace | undefined;
+  workspaceStatus: DevWorkspaceStatus;
   onTabChange: (tab: LoaderTab) => void;
+  onStartWorkspace: () => void;
+  onStopWorkspace: () => void;
 };
 
 export type State = {
   activeTabKey: LoaderTab;
+  isActionsOpen: boolean;
 };
 
 export class LoaderPage extends React.PureComponent<Props, State> {
@@ -55,13 +69,13 @@ export class LoaderPage extends React.PureComponent<Props, State> {
 
     this.state = {
       activeTabKey,
+      isActionsOpen: false,
     };
 
     this.appliedSafeMode = {};
   }
 
   componentDidMount(): void {
-    // hide top and side bars
     this.context.hideAll();
   }
 
@@ -75,12 +89,23 @@ export class LoaderPage extends React.PureComponent<Props, State> {
     this.props.onTabChange(tab);
   }
 
+  private handleActionsToggle = () => {
+    this.setState(prev => ({ isActionsOpen: !prev.isActionsOpen }));
+  };
+
   render(): React.ReactNode {
-    const { searchParams, workspace, location, navigate } = this.props;
-    const { activeTabKey } = this.state;
+    const {
+      searchParams,
+      workspace,
+      workspaceStatus,
+      location,
+      navigate,
+      onStartWorkspace,
+      onStopWorkspace,
+    } = this.props;
+    const { activeTabKey, isActionsOpen } = this.state;
 
     let pageTitle = workspace ? `Starting workspace ${workspace.name}` : 'Creating a workspace';
-    const workspaceStatus = workspace?.status || DevWorkspaceStatus.STOPPED;
     if (getRestartInSafeModeLocation(location) || this.appliedSafeMode[location.pathname]) {
       pageTitle += ' with default devfile';
       this.appliedSafeMode[location.pathname] = true;
@@ -94,10 +119,63 @@ export class LoaderPage extends React.PureComponent<Props, State> {
 
     const containerScc = workspace ? WorkspaceAdapter.getContainerScc(workspace.ref) : undefined;
 
+    const isWorkspaceActive =
+      workspaceStatus === DevWorkspaceStatus.STARTING ||
+      workspaceStatus === DevWorkspaceStatus.RUNNING;
+
+    const actionsDropdown = workspace ? (
+      <Dropdown
+        isOpen={isActionsOpen}
+        onOpenChange={(open: boolean) => this.setState({ isActionsOpen: open })}
+        toggle={(toggleRef: React.Ref<HTMLButtonElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="plain"
+            onClick={this.handleActionsToggle}
+            isExpanded={isActionsOpen}
+            aria-label="Workspace actions"
+          >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
+        popperProps={{ position: 'right' }}
+      >
+        <DropdownList>
+          <DropdownItem
+            key="start"
+            icon={<PlayIcon />}
+            onClick={() => {
+              this.setState({ isActionsOpen: false });
+              onStartWorkspace();
+            }}
+            isDisabled={isWorkspaceActive}
+          >
+            Start
+          </DropdownItem>
+          <DropdownItem
+            key="stop"
+            icon={<StopIcon />}
+            onClick={() => {
+              this.setState({ isActionsOpen: false });
+              onStopWorkspace();
+            }}
+            isDisabled={!isWorkspaceActive}
+          >
+            Stop
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+    ) : undefined;
+
     return (
       <React.Fragment>
         <Head pageName={pageTitle} />
-        <Header title={pageTitle} status={workspaceStatus} containerScc={containerScc} />
+        <Header
+          title={pageTitle}
+          status={workspaceStatus}
+          containerScc={containerScc}
+          actions={actionsDropdown}
+        />
         <PageSection
           variant={PageSectionVariants.default}
           isFilled={true}
@@ -143,7 +221,7 @@ export class LoaderPage extends React.PureComponent<Props, State> {
               isDisabled={isEventsTabDisabled}
               isAriaDisabled={isEventsTabDisabled}
             >
-              <WorkspaceEvents workspaceUID={workspace?.uid} />
+              <WorkspaceEvents workspaceUID={workspace?.uid} hideWhenStopped={false} />
             </Tab>
           </Tabs>
         </PageSection>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fixes a WCAG 2.2.2 (Pause, Stop, Hide, Level A) violation on the workspace start page, and preserves Events tab visibility after a workspace is stopped.

#### 1. Start/Stop kebab dropdown (WCAG 2.2.2)

WCAG 2.2.2 requires that for any auto-updating content lasting more than 5 seconds, the user must have a mechanism to pause, stop, or hide it. The workspace start/creation page showed a continuous spinner and dynamic progress updates with no stop mechanism.

A **kebab dropdown** (`EllipsisVIcon`) is added to the loader page header with two actions:

- **Start** — enabled when the workspace is `STOPPED` or `FAILED`; calls `startWorkspace()`
- **Stop** — enabled when the workspace is `STARTING` or `RUNNING`; calls `stopWorkspace()`

The dropdown is only shown when a workspace object exists (not during the initial factory-create flow). 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1913" height="1015" alt="Знімок екрана 2026-05-28 о 07 23 47" src="https://github.com/user-attachments/assets/81d074da-5d0e-4ce9-bbc0-12f41f4d3805" />


### What issues does this PR fix or reference?
fixes https://redhat.atlassian.net/browse/CRW-10282

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Eclipse Che with the image from this PR.
2. Start a workspace and verify the kebab (`⋮`) appears in the loader page header with Start and Stop items.
3. Press Stop — confirm the workspace stops and the Events tab still shows the events collected during startup.
4. Press Start from the kebab on a stopped workspace — confirm the workspace starts again.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
