### PR TITLE
feat: add 'Restart in Debug mode' workspace action

### DIFF
--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/__tests__/index.spec.tsx
@@ -221,6 +221,34 @@ describe('WorkspaceActionsDropdown', () => {
       );
     });
 
+    test('action: restart in debug mode', async () => {
+      mockHandleAction.mockResolvedValueOnce(undefined);
+
+      workspace.status = DevWorkspaceStatus.RUNNING;
+      renderComponent(workspace, 'kebab-toggle', { isExpanded: true });
+
+      const actionRestartDebug = screen.getByRole('menuitem', {
+        name: 'Action: Restart in Debug mode',
+      });
+
+      expect(actionRestartDebug).not.toBeNull();
+
+      await user.click(actionRestartDebug!);
+
+      await jest.advanceTimersByTimeAsync(1000);
+
+      expect(mockShowConfirmation).not.toHaveBeenCalled();
+      expect(mockHandleAction).toHaveBeenCalledWith(
+        WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
+        workspace.uid,
+      );
+      expect(mockOnAction).toHaveBeenCalledWith(
+        WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
+        workspace.uid,
+        true, // succeeded
+      );
+    });
+
     test('action: stop workspace', async () => {
       mockHandleAction.mockResolvedValueOnce(undefined);
 
@@ -364,6 +392,11 @@ describe('WorkspaceActionsDropdown', () => {
         }),
       ).toBeDisabled();
       expect(
+        screen.getByRole('menuitem', {
+          name: 'Action: ' + WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
+        }),
+      ).toBeDisabled();
+      expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.STOP_WORKSPACE }),
       ).toBeDisabled();
       expect(
@@ -389,6 +422,11 @@ describe('WorkspaceActionsDropdown', () => {
       expect(
         screen.getByRole('menuitem', {
           name: 'Action: ' + WorkspaceAction.RESTART_WORKSPACE,
+        }),
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole('menuitem', {
+          name: 'Action: ' + WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
         }),
       ).not.toBeDisabled();
       expect(
@@ -420,6 +458,11 @@ describe('WorkspaceActionsDropdown', () => {
         }),
       ).not.toBeDisabled();
       expect(
+        screen.getByRole('menuitem', {
+          name: 'Action: ' + WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
+        }),
+      ).not.toBeDisabled();
+      expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.STOP_WORKSPACE }),
       ).not.toBeDisabled();
       expect(
@@ -445,6 +488,11 @@ describe('WorkspaceActionsDropdown', () => {
       expect(
         screen.getByRole('menuitem', {
           name: 'Action: ' + WorkspaceAction.RESTART_WORKSPACE,
+        }),
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole('menuitem', {
+          name: 'Action: ' + WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
         }),
       ).not.toBeDisabled();
       expect(
@@ -476,6 +524,11 @@ describe('WorkspaceActionsDropdown', () => {
         }),
       ).toBeDisabled();
       expect(
+        screen.getByRole('menuitem', {
+          name: 'Action: ' + WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
+        }),
+      ).toBeDisabled();
+      expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.STOP_WORKSPACE }),
       ).toBeDisabled();
       expect(
@@ -504,6 +557,11 @@ describe('WorkspaceActionsDropdown', () => {
         }),
       ).not.toBeDisabled();
       expect(
+        screen.getByRole('menuitem', {
+          name: 'Action: ' + WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
+        }),
+      ).not.toBeDisabled();
+      expect(
         screen.getByRole('menuitem', { name: 'Action: ' + WorkspaceAction.STOP_WORKSPACE }),
       ).not.toBeDisabled();
       expect(
@@ -529,6 +587,11 @@ describe('WorkspaceActionsDropdown', () => {
       expect(
         screen.getByRole('menuitem', {
           name: 'Action: ' + WorkspaceAction.RESTART_WORKSPACE,
+        }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('menuitem', {
+          name: 'Action: ' + WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS,
         }),
       ).toBeDisabled();
       expect(

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/index.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Dropdown/index.tsx
@@ -186,6 +186,7 @@ class WorkspaceActionsDropdownComponent extends React.PureComponent<Props, State
       getItem(WorkspaceAction.START_DEBUG_AND_OPEN_LOGS, isTerminating || !isStopped),
       getItem(WorkspaceAction.START_IN_BACKGROUND, isTerminating || !isStopped),
       getItem(WorkspaceAction.RESTART_WORKSPACE, isTerminating || isStopped),
+      getItem(WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS, isTerminating || isStopped),
       getItem(WorkspaceAction.STOP_WORKSPACE, isTerminating || isStopped),
       getItem(WorkspaceAction.DELETE_WORKSPACE, isTerminating),
     ];

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
@@ -177,6 +177,19 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
           await this.props.restartWorkspace(workspace);
         }
         break;
+      case WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS:
+        {
+          if (this.checkSccMismatch(workspace)) {
+            console.warn(
+              `Workspace "${workspace.name}" has SCC mismatch. The workspace was created with a different container SCC than what is currently configured.`,
+            );
+          }
+          await this.props.restartWorkspace(workspace, {
+            'debug-workspace-start': true,
+          });
+          this.handleLocation(buildIdeLoaderLocation(workspace, LoaderTab.Logs));
+        }
+        break;
       default:
         console.warn(`Unhandled action type: "${action}".`);
     }

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/Provider.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/Provider.spec.tsx
@@ -326,6 +326,28 @@ describe('WorkspaceActionsProvider', () => {
       );
     });
 
+    test('restart debug and open logs', async () => {
+      mockRestartWorkspace.mockResolvedValueOnce(undefined);
+
+      renderComponent(store, WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS, wantDelete[1]);
+
+      const handleActionBtn = screen.getByTestId('test-component-handle-action');
+
+      await user.click(handleActionBtn);
+
+      await jest.advanceTimersByTimeAsync(1000);
+
+      expect(mockRestartWorkspace).toHaveBeenCalledTimes(1);
+      expect(mockRestartWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: wantDelete[1] }),
+        { 'debug-workspace-start': true },
+      );
+
+      expect(mockTabManagerOpen).toHaveBeenCalledWith(
+        'http://localhost/#/ide/user-che/wksp-5678?tab=Logs',
+      );
+    });
+
     describe('SCC mismatch warning', () => {
       let storeWithScc: Store;
 
@@ -407,6 +429,27 @@ describe('WorkspaceActionsProvider', () => {
         // Should still start the workspace
         expect(mockStartWorkspace).toHaveBeenCalledTimes(1);
         expect(mockStartWorkspace).toHaveBeenCalledWith(
+          expect.objectContaining({ uid: wantDelete[0] }),
+          { 'debug-workspace-start': true },
+        );
+      });
+
+      test('restart debug and open logs with SCC mismatch logs warning', async () => {
+        console.warn = jest.fn();
+        mockRestartWorkspace.mockResolvedValueOnce(undefined);
+
+        renderComponent(storeWithScc, WorkspaceAction.RESTART_DEBUG_AND_OPEN_LOGS, wantDelete[0]);
+
+        const handleActionBtn = screen.getByTestId('test-component-handle-action');
+
+        await user.click(handleActionBtn);
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('SCC mismatch'));
+
+        expect(mockRestartWorkspace).toHaveBeenCalledTimes(1);
+        expect(mockRestartWorkspace).toHaveBeenCalledWith(
           expect.objectContaining({ uid: wantDelete[0] }),
           { 'debug-workspace-start': true },
         );

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -116,6 +116,7 @@ export enum WorkspaceAction {
   DELETE_WORKSPACE = 'Delete Workspace',
   OPEN_IDE = 'Open',
   RESTART_WORKSPACE = 'Restart Workspace',
+  RESTART_DEBUG_AND_OPEN_LOGS = 'Restart in Debug mode',
   START_DEBUG_AND_OPEN_LOGS = 'Open in Debug mode',
   START_IN_BACKGROUND = 'Start in background',
   STOP_WORKSPACE = 'Stop Workspace',

--- a/packages/dashboard-frontend/src/store/Workspaces/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/__tests__/actions.spec.ts
@@ -128,7 +128,7 @@ describe('Workspaces Actions', () => {
       const actions = store.getActions();
       expect(actions).toHaveLength(0);
 
-      expect(mockRestartWorkspace).toHaveBeenCalledWith(mockWorkspace.ref);
+      expect(mockRestartWorkspace).toHaveBeenCalledWith(mockWorkspace.ref, undefined);
     });
   });
 

--- a/packages/dashboard-frontend/src/store/Workspaces/actions.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/actions.ts
@@ -53,9 +53,10 @@ export const actionCreators = {
     },
 
   restartWorkspace:
-    (workspace: Workspace): AppThunk =>
+    (workspace: Workspace, params?: ResourceQueryParams): AppThunk =>
     async dispatch => {
-      await dispatch(devWorkspacesActionCreators.restartWorkspace(workspace.ref));
+      const debugWorkspace = params && params['debug-workspace-start'];
+      await dispatch(devWorkspacesActionCreators.restartWorkspace(workspace.ref, debugWorkspace));
     },
 
   stopWorkspace:

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/restartWorkspace.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/restartWorkspace.spec.ts
@@ -66,7 +66,21 @@ describe('devWorkspaces, actions', () => {
 
       store.dispatch(restartWorkspace(mockStoppedWorkspace));
 
-      expect(actionCreators.startWorkspace).toHaveBeenCalled();
+      expect(actionCreators.startWorkspace).toHaveBeenCalledWith(mockStoppedWorkspace, false);
+      expect(actionCreators.stopWorkspace).not.toHaveBeenCalled();
+    });
+
+    it('should call startWorkspace with debugWorkspace=true if the workspace is stopped', async () => {
+      const mockStoppedWorkspace = {
+        ...mockWorkspace,
+        status: {
+          phase: DevWorkspaceStatus.STOPPED,
+        },
+      } as devfileApi.DevWorkspace;
+
+      store.dispatch(restartWorkspace(mockStoppedWorkspace, true));
+
+      expect(actionCreators.startWorkspace).toHaveBeenCalledWith(mockStoppedWorkspace, true);
       expect(actionCreators.stopWorkspace).not.toHaveBeenCalled();
     });
 
@@ -84,7 +98,21 @@ describe('devWorkspaces, actions', () => {
       const handler = onStatusChangeCallbacks.get(WorkspaceAdapter.getUID(mockWorkspace))!;
       handler(DevWorkspaceStatus.STOPPED as string);
 
-      expect(actionCreators.startWorkspace).toHaveBeenCalled();
+      expect(actionCreators.startWorkspace).toHaveBeenCalledWith(mockWorkspace, false);
+    });
+
+    it('should pass debugWorkspace=true through status change callback', async () => {
+      store.dispatch(restartWorkspace(mockWorkspace, true));
+
+      expect(actionCreators.stopWorkspace).toHaveBeenCalled();
+      expect(actionCreators.startWorkspace).not.toHaveBeenCalled();
+
+      expect(onStatusChangeCallbacks.size).toBe(1);
+
+      const handler = onStatusChangeCallbacks.get(WorkspaceAdapter.getUID(mockWorkspace))!;
+      handler(DevWorkspaceStatus.STOPPED as string);
+
+      expect(actionCreators.startWorkspace).toHaveBeenCalledWith(mockWorkspace, true);
     });
 
     it('should handle errors when stopping the workspace', async () => {

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/restartWorkspace.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/restartWorkspace.ts
@@ -19,7 +19,7 @@ import { AppThunk } from '@/store';
 import { actionCreators, onStatusChangeCallbacks } from '@/store/Workspaces/devWorkspaces/actions';
 
 export const restartWorkspace =
-  (workspace: devfileApi.DevWorkspace): AppThunk =>
+  (workspace: devfileApi.DevWorkspace, debugWorkspace = false): AppThunk =>
   async dispatch => {
     const defer: IDeferred<void> = getDefer();
     const toDispose = new DisposableCollection();
@@ -28,7 +28,7 @@ export const restartWorkspace =
       if (status === DevWorkspaceStatus.STOPPED || status === DevWorkspaceStatus.FAILED) {
         toDispose.dispose();
         try {
-          await dispatch(actionCreators.startWorkspace(workspace));
+          await dispatch(actionCreators.startWorkspace(workspace, debugWorkspace));
           defer.resolve();
         } catch (e) {
           defer.reject(


### PR DESCRIPTION
### What does this PR do?

Adds a "Restart in Debug mode" action to the workspace dropdown that restarts a running workspace with `debug-workspace-start: true` and redirects to the Logs tab.

The `restartWorkspace` action creator (`restartWorkspace.ts`) and the mid-level wrapper (`actions.ts`) now accept an optional `debugWorkspace` flag, which is forwarded to `startWorkspace`. Previously, `restartWorkspace` always called `startWorkspace(workspace)` without the debug flag, so `manageDebugMode()` would strip the `controller.devfile.io/debug-start` annotation on every restart — making it impossible to restart a running workspace into debug mode from the dashboard.

**Files changed:**
- `services/helpers/types.ts` — new `RESTART_DEBUG_AND_OPEN_LOGS` enum value
- `store/Workspaces/devWorkspaces/actions/actionCreators/restartWorkspace.ts` — accepts and forwards `debugWorkspace` parameter
- `store/Workspaces/actions.ts` — threads `debug-workspace-start` from `ResourceQueryParams` to `restartWorkspace`
- `contexts/WorkspaceActions/Dropdown/index.tsx` — adds menu item (disabled when stopped/terminating)
- `contexts/WorkspaceActions/Provider.tsx` — handles the new action (SCC mismatch check, restart with debug, navigate to Logs tab)

### Screenshot/screencast of this PR

_Unable to provide a screenshot — no access to a running Eclipse Che instance to deploy and test the dashboard image._

### What issues does this PR fix or reference?

Fixes https://github.com/eclipse-che/che/issues/23863
Related: https://github.com/eclipse-che/che/issues/23864 (docs)

### Is it tested? How?

**Automated tests (all 43 pass across 3 suites):**
- `restartWorkspace.spec.ts` — 2 new tests verifying `debugWorkspace=true` is forwarded to `startWorkspace` in both the immediate-start and callback-after-stop paths
- `Provider.spec.tsx` — 2 new tests: action handler calls `restartWorkspace` with `{ 'debug-workspace-start': true }` and navigates to Logs tab; SCC mismatch variant logs a warning
- `Dropdown/index.spec.tsx` — new test for the menu item click, plus assertions for correct enabled/disabled state across all 7 workspace statuses (FAILED, FAILING, RUNNING, STARTING, STOPPED, STOPPING, TERMINATING)

**Manual verification steps:**
1. Deploy Eclipse Che with the dashboard image from this PR.
2. **Dropdown appearance**: start a workspace and wait for it to reach Running state. Open the workspace actions dropdown (kebab menu). Verify "Restart in Debug mode" appears immediately below "Restart Workspace" and is enabled.
3. **Action**: click "Restart in Debug mode" — verify the workspace begins restarting and the browser navigates to the Logs tab. After it reaches Running state, verify the `controller.devfile.io/debug-start` annotation is set to `"true"` on the DevWorkspace resource.
4. **Stopped workspace — disabled state**: open the dropdown for a stopped workspace. Verify "Restart in Debug mode" is greyed out (same behavior as "Restart Workspace").
5. **Terminating workspace**: trigger a deletion and immediately open the dropdown — verify "Restart in Debug mode" is disabled during termination.
6. **SCC mismatch** (if your cluster setup allows): with a workspace that has an SCC mismatch configured, trigger "Restart in Debug mode" and verify a `console.warn` message containing "SCC mismatch" appears in the browser devtools — the workspace should still restart.

#### Release Notes

Added a "Restart in Debug mode" action to the workspace dropdown menu. This enables users to restart a running workspace with the `controller.devfile.io/debug-start` annotation, keeping containers alive after failure so that `postStart` command issues can be diagnosed.

#### Docs PR

eclipse-che/che-docs#3111

🤖 Generated with [Claude Code](https://claude.com/claude-code)