### PR TITLE
Enable che-dashboard build support on s390x architecture

### DIFF
--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -29,10 +29,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64,arm64]
+        arch: [amd64,arm64,s390x]
     outputs:
       amd64: ${{ steps.result.outputs.amd64 }}
       arm64: ${{ steps.result.outputs.arm64 }}
+      s390x: ${{ steps.result.outputs.s390x }}
     steps:
       -
         name: "Checkout Che Dashboard source code"
@@ -89,6 +90,10 @@ jobs:
           ARM64_VERSION="${{ needs['build-images'].outputs.arm64 }}"
           if [ -n "$ARM64_VERSION" ]; then
             AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
+          fi
+          S390X_VERSION="${{ needs['build-images'].outputs.s390x }}"
+          if [ -n "$S390X_VERSION" ]; then
+            AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
           fi
           if [ -z "$AMEND" ]; then
             echo "[!] The job 'build-images' didn't provide any outputs. Can't create the manifest list."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,7 +102,7 @@ jobs:
         name: "Set up QEMU"
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
       -
         name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
@@ -126,14 +126,14 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       -
-        name: "Build and push multi-arch image (linux/amd64, linux/arm64)"
+        name: "Build and push multi-arch image (linux/amd64, linux/arm64, linux/s390x)"
         uses: docker/build-push-action@v5
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           context: ./${{ env.DIR_DASHBOARD }}
           file: ./${{ env.DIR_DASHBOARD }}/build/dockerfiles/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           provenance: false
           tags: ${{ env.ORGANIZATION }}/che-dashboard:${{ env.IMAGE_VERSION }}
@@ -146,7 +146,7 @@ jobs:
             const dashboardImage = "${{ env.ORGANIZATION }}/che-dashboard:${{ env.IMAGE_VERSION }}";
             const patchCommand = `kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p="[{\"op\": \"replace\", \"path\": \"/spec/components/dashboard/deployment\", \"value\": {containers: [{image: \"${dashboardImage}\", name: che-dashboard}]}}]"`;
             const text = `
-            Docker image build succeeded: **${dashboardImage}** (linux/amd64, linux/arm64)
+            Docker image build succeeded: **${dashboardImage}** (linux/amd64, linux/arm64, linux/s390x)
             <details>
             <summary>kubectl patch command</summary>
             

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,7 @@ jobs:
           S390X_VERSION="${{ needs['build-images'].outputs.s390x }}"
 
           if [[ -z "$AMD64_VERSION" || \
-               -z "$ARM64_VERSION" || \
-               -z "$S390X_VERSION" ]]; then
+               -z "$ARM64_VERSION" ]]; then
             echo "[!] The job 'build-images' fails on some of the architectures. Can't create complete manifest.";
             exit 1;
           fi
@@ -154,8 +153,9 @@ jobs:
           AMEND=""
           AMEND+=" --amend ${{ env.IMAGE }}:$AMD64_VERSION";
           AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
-          AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
-
+          if [ -n "$S390X_VERSION" ]; then
+              AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
+          fi
           docker manifest create ${{ env.IMAGE }}:${{ github.event.inputs.version }} $AMEND
           docker manifest push ${{ env.IMAGE }}:${{ github.event.inputs.version }}
       -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64,arm64]
+        arch: [amd64,arm64,s390x]
     outputs:
       amd64: ${{ steps.result.outputs.amd64 }}
       arm64: ${{ steps.result.outputs.arm64 }}
+      s390x: ${{ steps.result.outputs.s390x }}
     steps:
       -
         name: "Checkout Che Dashboard source code"
@@ -141,9 +142,11 @@ jobs:
         run: |
           AMD64_VERSION="${{ needs['build-images'].outputs.amd64 }}"
           ARM64_VERSION="${{ needs['build-images'].outputs.arm64 }}"
+          S390X_VERSION="${{ needs['build-images'].outputs.s390x }}"
 
           if [[ -z "$AMD64_VERSION" || \
-               -z "$ARM64_VERSION" ]]; then
+               -z "$ARM64_VERSION" || \
+               -z "$S390X_VERSION" ]]; then
             echo "[!] The job 'build-images' fails on some of the architectures. Can't create complete manifest.";
             exit 1;
           fi
@@ -151,6 +154,7 @@ jobs:
           AMEND=""
           AMEND+=" --amend ${{ env.IMAGE }}:$AMD64_VERSION";
           AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
+          AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
 
           docker manifest create ${{ env.IMAGE }}:${{ github.event.inputs.version }} $AMEND
           docker manifest push ${{ env.IMAGE }}:${{ github.event.inputs.version }}

--- a/run/MULTIARCH_BUILD.md
+++ b/run/MULTIARCH_BUILD.md
@@ -4,6 +4,9 @@
 
 The `build-multiarch.sh` script builds Docker images for multiple architectures (AMD64, ARM64, and s390x) and pushes them to a container registry.
 
+**Note**:
+The `linux/s390x` platform support is maintained by IBM. For s390x-specific build failures, or investigations, contact: Swapnil Singh([swapnilsingh-ibm](https://github.com/swapnilsingh-ibm)) or Sudharshan Muralidharan([sudharshanibm](https://github.com/sudharshanibm)).
+
 ## Prerequisites
 
 ### For Docker:

--- a/run/MULTIARCH_BUILD.md
+++ b/run/MULTIARCH_BUILD.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `build-multiarch.sh` script builds Docker images for multiple architectures (AMD64 and ARM64) and pushes them to a container registry.
+The `build-multiarch.sh` script builds Docker images for multiple architectures (AMD64, ARM64, and s390x) and pushes them to a container registry.
 
 ## Prerequisites
 
@@ -26,7 +26,7 @@ The `build-multiarch.sh` script builds Docker images for multiple architectures 
 
 ### Multi-Architecture Build (Default)
 
-Build for both AMD64 and ARM64:
+Build for AMD64 and ARM64 (default):
 
 ```bash
 export IMAGE_REGISTRY_HOST=quay.io
@@ -34,14 +34,25 @@ export IMAGE_REGISTRY_USER_NAME=your-username
 ./run/build-multiarch.sh
 ```
 
-### Custom Platforms
+### Build with s390x Support
 
-Specify custom platforms:
+Include s390x architecture:
 
 ```bash
 export IMAGE_REGISTRY_HOST=quay.io
 export IMAGE_REGISTRY_USER_NAME=your-username
-export PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le
+export PLATFORMS=linux/amd64,linux/arm64,linux/s390x
+./run/build-multiarch.sh
+```
+
+### Custom Platforms
+
+Specify any combination of supported platforms:
+
+```bash
+export IMAGE_REGISTRY_HOST=quay.io
+export IMAGE_REGISTRY_USER_NAME=your-username
+export PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 ./run/build-multiarch.sh
 ```
 
@@ -86,6 +97,8 @@ export CHE_DASHBOARD_IMAGE=quay.io/your-username/che-dashboard:TAG
 | `IMAGE_REGISTRY_USER_NAME` | Registry username/namespace | - | Yes |
 | `PLATFORMS` | Comma-separated list of platforms | `linux/amd64,linux/arm64` | No |
 | `IMAGE_TAG` | Custom image tag | `branch_timestamp` | No |
+
+**Note**: Official CI/CD builds include s390x. For local development, the default is `linux/amd64,linux/arm64` for faster builds. To include s390x locally, set `PLATFORMS=linux/amd64,linux/arm64,linux/s390x`.
 
 ## How It Works
 
@@ -187,7 +200,7 @@ jobs:
         env:
           IMAGE_REGISTRY_HOST: ${{ secrets.REGISTRY_HOST }}
           IMAGE_REGISTRY_USER_NAME: ${{ secrets.REGISTRY_USER }}
-          PLATFORMS: linux/amd64,linux/arm64
+          PLATFORMS: linux/amd64,linux/arm64,linux/s390x
         run: ./run/build-multiarch.sh
 ```
 

--- a/run/README.md
+++ b/run/README.md
@@ -4,6 +4,8 @@
 
 This directory contains scripts for building, testing, and deploying the Eclipse Che dashboard.
 
+**Supported Architectures**: AMD64, ARM64, s390x
+
 ## Scripts
 
 ### `patch.sh` - Build and Deploy Dashboard Image
@@ -38,9 +40,9 @@ export CHE_DASHBOARD_IMAGE=quay.io/username/che-dashboard:tag
 
 ### `build-multiarch.sh` - Multi-Architecture Build
 
-Builds and pushes multi-architecture images (AMD64 + ARM64).
+Builds and pushes multi-architecture images (AMD64, ARM64, and optionally s390x).
 
-**Quick Start:**
+**Quick Start (AMD64 + ARM64):**
 
 ```bash
 export IMAGE_REGISTRY_HOST=quay.io
@@ -48,10 +50,19 @@ export IMAGE_REGISTRY_USER_NAME=your-username
 ./run/build-multiarch.sh
 ```
 
-**Build for specific platforms:**
+**Build with s390x support:**
 
 ```bash
-export PLATFORMS=linux/amd64,linux/arm64
+export IMAGE_REGISTRY_HOST=quay.io
+export IMAGE_REGISTRY_USER_NAME=your-username
+export PLATFORMS=linux/amd64,linux/arm64,linux/s390x
+./run/build-multiarch.sh
+```
+
+**Build for a specific platform only:**
+
+```bash
+export PLATFORMS=linux/amd64
 ./run/build-multiarch.sh
 ```
 
@@ -111,11 +122,16 @@ Revert changes made by local development scripts.
 
 ## Multi-Architecture Build
 
-For multi-architecture builds supporting AMD64 and ARM64:
+For multi-architecture builds supporting AMD64, ARM64, and s390x:
 
 ```bash
+# Default: AMD64 + ARM64 (faster for local development)
 export IMAGE_REGISTRY_HOST=quay.io
 export IMAGE_REGISTRY_USER_NAME=your-username
+./run/build-multiarch.sh
+
+# With s390x (matches CI/CD builds)
+export PLATFORMS=linux/amd64,linux/arm64,linux/s390x
 ./run/build-multiarch.sh
 ```
 

--- a/run/build-multiarch.sh
+++ b/run/build-multiarch.sh
@@ -3,7 +3,7 @@
 # Multi-Architecture Build Script for Eclipse Che Dashboard
 #
 # This script builds and pushes multi-architecture Docker images
-# supporting AMD64 and ARM64 platforms.
+# supporting AMD64, ARM64, and s390x platforms.
 #
 # Usage:
 #   export IMAGE_REGISTRY_HOST=quay.io
@@ -13,7 +13,8 @@
 # Environment Variables:
 #   IMAGE_REGISTRY_HOST     - Container registry host (required)
 #   IMAGE_REGISTRY_USER_NAME - Registry username/namespace (required)
-#   PLATFORMS               - Platforms to build (default: linux/amd64,linux/arm64)
+#   PLATFORMS               - Platforms to build (default: linux/amd64,linux/arm64;
+#                             use linux/amd64,linux/arm64,linux/s390x to match CI/CD)
 #   IMAGE_TAG               - Custom image tag (default: branch_timestamp)
 #
 # See run/MULTIARCH_BUILD.md for detailed documentation.


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR enables support for building the Che Dashboard on the s390x architecture.
It updates and refines architecture compatibility logic and ensures successful builds on IBM Z running RHEL 9.2 (s390x).

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1860" height="580" alt="Screenshot 2026-05-29 at 1 31 44 PM" src="https://github.com/user-attachments/assets/67b828ac-f872-4cc9-a705-82d3e9d4fb1e" />
<img width="1860" height="196" alt="Screenshot 2026-05-29 at 1 31 58 PM" src="https://github.com/user-attachments/assets/f82829ec-9903-4ca2-b62d-a383d89988da" />
<img width="1858" height="1220" alt="Screenshot 2026-05-29 at 1 34 11 PM" src="https://github.com/user-attachments/assets/fd995a49-b0ba-42b5-9be4-0544f4b5da82" />
<img width="1862" height="1010" alt="Screenshot 2026-05-29 at 1 34 39 PM" src="https://github.com/user-attachments/assets/f377f4fb-827e-47f8-ad89-358540aa8de5" />
<img width="1868" height="388" alt="Screenshot 2026-05-29 at 1 34 54 PM" src="https://github.com/user-attachments/assets/4259e917-8637-4144-b320-4d8f2c85aa02" />

### What issues does this PR fix or reference?
This is part of internal enablement for Che on s390x (IBM Z).

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
Tested end-to-end on native IBM Z hardware (RHEL 9.2, s390x) and a dedicated s390x OpenShift 4.21 cluster:

  1. Native image build — `podman build -f build/dockerfiles/rhel.Dockerfile` completed successfully on s390x
  2. Architecture verification — `podman inspect` confirms `OS/Arch: linux/s390x`
  3. Full unit test suite — yarn test ran natively inside a ubi9/nodejs-20 container on s390x: `2576 tests passed, 369 suites, 251 snapshots — all green`
  4. Live OpenShift deployment — image deployed to a production-like s390x OpenShift 4.21 cluster (3 masters + 3 workers, all s390x). Dashboard pod ran
  1/1 Running on worker node `qe2-devspaces-s390x-worker-0` with image `quay.io/swasingh/che-dashboard:s390x-test`. Dashboard UI was verified in browser — workspace creation page loaded 
  successfully.
  5. Image published — `quay.io/swasingh/che-dashboard:s390x-test` is publicly available for independent reviewer verification

#### Release Notes
<!-- markdown to be included in marketing announcement -->
The che-dashboard container image now ships as a multi-arch manifest that includes `linux/s390x` (IBM Z) in addition to `linux/amd64` and `linux/arm64`. Users deploying Eclipse Che on IBM Z infrastructure can now pull the standard image without requiring a separate build.

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
Documentation updates are included directly in this PR:
  - `run/README.md` — updated supported architectures and build examples
  - `run/MULTIARCH_BUILD.md` — updated overview and added s390x build instructions
  
  No separate docs repo PR is required as the changes are self-contained to the `run/` directory docs.