### PR TITLE
fix(backup): read registry auth secret from workspace namespace

### DIFF
--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/registryApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/registryApi.spec.ts
@@ -42,17 +42,8 @@ const mockCoreV1Api = {
   readNamespacedSecret: jest.fn(),
 };
 
-const mockSaCoreV1Api = {
-  readNamespacedSecret: jest.fn(),
-};
-
-let prepareCoreV1APICallCount = 0;
 jest.mock('@/devworkspaceClient/services/helpers/prepareCoreV1API', () => ({
-  prepareCoreV1API: jest.fn(() => {
-    prepareCoreV1APICallCount++;
-    // First call is user KubeConfig, second call is SA KubeConfig
-    return prepareCoreV1APICallCount % 2 === 1 ? mockCoreV1Api : mockSaCoreV1Api;
-  }),
+  prepareCoreV1API: jest.fn(() => mockCoreV1Api),
 }));
 
 const mockKubeConfig = {
@@ -83,7 +74,6 @@ describe('RegistryApiService', () => {
   };
 
   beforeEach(() => {
-    prepareCoreV1APICallCount = 0;
     service = new RegistryApiService(mockKubeConfig as any, mockSaKubeConfig as any);
     jest.clearAllMocks();
     // Default: DWOC returns a valid registry path (via SA token)
@@ -655,10 +645,10 @@ describe('RegistryApiService', () => {
       );
     });
 
-    it('should look up the auth secret by its configured name', async () => {
+    it('should look up the auth secret from the workspace namespace using the fixed name', async () => {
       const robotToken = 'my-robot-token';
       const auth = Buffer.from(`my-robot:${robotToken}`).toString('base64');
-      mockSaCoreV1Api.readNamespacedSecret.mockResolvedValue({
+      mockCoreV1Api.readNamespacedSecret.mockResolvedValue({
         data: {
           '.dockerconfigjson': Buffer.from(
             JSON.stringify({ auths: { 'quay.io': { auth } } }),
@@ -669,13 +659,13 @@ describe('RegistryApiService', () => {
 
       await service.listBackupImages(namespace);
 
-      expect(mockSaCoreV1Api.readNamespacedSecret).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'registry-secret' }),
+      expect(mockCoreV1Api.readNamespacedSecret).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'devworkspace-backup-registry-auth', namespace }),
       );
     });
 
     it('should fall back gracefully when auth secret is missing', async () => {
-      mockSaCoreV1Api.readNamespacedSecret.mockRejectedValue(new Error('Secret not found'));
+      mockCoreV1Api.readNamespacedSecret.mockRejectedValue(new Error('Secret not found'));
       mockCustomObjectsApi.listNamespacedCustomObject.mockResolvedValue({ items: [] });
 
       // Should not throw — proceeds as unauthenticated QuayRegistryClient
@@ -684,7 +674,7 @@ describe('RegistryApiService', () => {
 
     it('should use quay-api-token as Bearer when present', async () => {
       const oauthToken = 'my-oauth-token';
-      mockSaCoreV1Api.readNamespacedSecret.mockResolvedValue({
+      mockCoreV1Api.readNamespacedSecret.mockResolvedValue({
         data: {
           'quay-api-token': Buffer.from(oauthToken).toString('base64'),
           '.dockerconfigjson': Buffer.from(
@@ -711,7 +701,7 @@ describe('RegistryApiService', () => {
 
     it('should use Basic auth from .dockerconfigjson when quay-api-token is absent', async () => {
       const rawAuth = Buffer.from('robot:robot-token').toString('base64');
-      mockSaCoreV1Api.readNamespacedSecret.mockResolvedValue({
+      mockCoreV1Api.readNamespacedSecret.mockResolvedValue({
         data: {
           '.dockerconfigjson': Buffer.from(
             JSON.stringify({ auths: { 'quay.io': { auth: rawAuth } } }),
@@ -734,7 +724,7 @@ describe('RegistryApiService', () => {
     });
 
     it('should send no Authorization header when secret has neither quay-api-token nor .dockerconfigjson', async () => {
-      mockSaCoreV1Api.readNamespacedSecret.mockResolvedValue({ data: {} });
+      mockCoreV1Api.readNamespacedSecret.mockResolvedValue({ data: {} });
       mockCustomObjectsApi.listNamespacedCustomObject.mockResolvedValue({ items: [] });
 
       await service.listBackupImages(namespace);
@@ -763,7 +753,7 @@ describe('RegistryApiService', () => {
           },
         },
       });
-      mockSaCoreV1Api.readNamespacedSecret.mockResolvedValue({
+      mockCoreV1Api.readNamespacedSecret.mockResolvedValue({
         data: {
           '.dockerconfigjson': Buffer.from(
             JSON.stringify({ auths: { [portRegistryHost]: { auth: rawAuth } } }),
@@ -931,7 +921,7 @@ describe('RegistryApiService', () => {
         },
       });
       const auth = Buffer.from('robot:token').toString('base64');
-      mockSaCoreV1Api.readNamespacedSecret.mockResolvedValue({
+      mockCoreV1Api.readNamespacedSecret.mockResolvedValue({
         data: {
           '.dockerconfigjson': Buffer.from(
             JSON.stringify({ auths: { 'quay.io': { auth } } }),

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/registryApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/registryApi.spec.ts
@@ -97,6 +97,18 @@ describe('RegistryApiService', () => {
     jest.clearAllMocks();
   });
 
+  describe('SA API regression guard', () => {
+    it('should use prepareCoreV1API exactly once (user kubeconfig only, no SA)', () => {
+      const { prepareCoreV1API } = jest.requireMock(
+        '@/devworkspaceClient/services/helpers/prepareCoreV1API',
+      );
+      prepareCoreV1API.mockClear();
+      new RegistryApiService(mockKubeConfig as any, mockSaKubeConfig as any);
+      expect(prepareCoreV1API).toHaveBeenCalledTimes(1);
+      expect(prepareCoreV1API).toHaveBeenCalledWith(mockKubeConfig);
+    });
+  });
+
   describe('K8s DNS-1123 Validation', () => {
     it('should reject empty namespace', async () => {
       await expect(service.listBackupImages('')).rejects.toMatchObject({

--- a/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
@@ -46,6 +46,11 @@ import {
 const IMAGESTREAM_GROUP = 'image.openshift.io';
 const IMAGESTREAM_VERSION = 'v1';
 
+// DWO always copies the configured auth secret into the workspace namespace under this name.
+// Reading it from the workspace namespace avoids 403 errors that occur when the Dashboard SA
+// tries to read the original secret from the operator namespace.
+const BACKUP_REGISTRY_AUTH_SECRET_NAME = 'devworkspace-backup-registry-auth';
+
 interface IBackupImage {
   workspaceName: string;
   imageUrl: string;
@@ -113,13 +118,11 @@ export class RegistryApiService {
   private customObjectsApi: CustomObjectsApi;
   private saCustomObjectsApi: CustomObjectsApi;
   private coreV1Api: CoreV1API;
-  private saCoreV1Api: CoreV1API;
 
   constructor(kubeConfig: KubeConfig, saKubeConfig: KubeConfig) {
     this.customObjectsApi = kubeConfig.makeApiClient(CustomObjectsApi);
     this.saCustomObjectsApi = saKubeConfig.makeApiClient(CustomObjectsApi);
     this.coreV1Api = prepareCoreV1API(kubeConfig);
-    this.saCoreV1Api = prepareCoreV1API(saKubeConfig);
   }
 
   /**
@@ -208,7 +211,12 @@ export class RegistryApiService {
   }
 
   /**
-   * Reads the registry auth credentials from the DWOC authSecret.
+   * Reads the registry auth credentials from the workspace-namespace copy of the auth secret.
+   * DWO copies the configured auth secret into every workspace namespace as
+   * `devworkspace-backup-registry-auth`, so we read it there with the user kubeconfig
+   * instead of attempting to read the original from the operator namespace (which the
+   * Dashboard SA is not permitted to access — 403 Forbidden).
+   *
    * Returns a pre-formed Authorization header value, or empty string.
    *
    * Lookup order:
@@ -216,11 +224,11 @@ export class RegistryApiService {
    * 2. .dockerconfigjson auths entry → "Basic <rawBase64>"  (standard docker creds)
    * 3. Neither present → ""  (public repos, no auth header sent)
    */
-  private async getRegistryCredentials(secretName: string, registryHost: string): Promise<string> {
+  private async getRegistryCredentials(namespace: string, registryHost: string): Promise<string> {
     try {
-      const secret = await this.saCoreV1Api.readNamespacedSecret({
-        name: secretName,
-        namespace: dwoNamespace,
+      const secret = await this.coreV1Api.readNamespacedSecret({
+        name: BACKUP_REGISTRY_AUTH_SECRET_NAME,
+        namespace,
       });
 
       // 1. Preferred: dedicated OAuth/robot API token
@@ -316,21 +324,21 @@ export class RegistryApiService {
       // Step 1: Read DWOC registry config. If backup is not configured (or DWOC is not
       // accessible), return an empty list immediately — no point querying user-namespace data.
       let registryPath: string;
-      let authSecret: string | undefined;
       try {
-        ({ registryPath, authSecret } = await this.getBackupRegistryPath());
+        ({ registryPath } = await this.getBackupRegistryPath());
       } catch {
         return [];
       }
 
-      // Step 2: Get registry credentials for external registries
+      // Step 2: Get registry credentials for external registries.
+      // We always attempt to read the workspace-namespace copy of the auth secret
+      // (regardless of whether DWOC configured an authSecret), since DWO copies it
+      // unconditionally. If the secret does not exist, getRegistryCredentials returns ''.
       const registryType = detectRegistryType(registryPath);
       let registryClient: IExternalRegistryClient | undefined;
       if (registryType !== 'openshift-internal') {
         const registryHost = registryPath.split('/')[0];
-        const authHeader = authSecret
-          ? await this.getRegistryCredentials(authSecret, registryHost)
-          : '';
+        const authHeader = await this.getRegistryCredentials(namespace, registryHost);
         registryClient = createRegistryClient(registryPath, authHeader);
       }
 

--- a/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
@@ -32,6 +32,7 @@ import {
   DEVWORKSPACE_VERSION,
 } from '@/constants/k8s';
 import { createError } from '@/devworkspaceClient/services/helpers/createError';
+import { logger } from '@/utils/logger';
 import {
   createRegistryClient,
   detectRegistryType,
@@ -49,6 +50,7 @@ const IMAGESTREAM_VERSION = 'v1';
 // DWO always copies the configured auth secret into the workspace namespace under this name.
 // Reading it from the workspace namespace avoids 403 errors that occur when the Dashboard SA
 // tries to read the original secret from the operator namespace.
+// Source: github.com/devfile/devworkspace-operator/pkg/constants/metadata.go (DevWorkspaceBackupAuthSecretName)
 const BACKUP_REGISTRY_AUTH_SECRET_NAME = 'devworkspace-backup-registry-auth';
 
 interface IBackupImage {
@@ -180,7 +182,7 @@ export class RegistryApiService {
   /**
    * Get backup registry path and auth secret name from DevWorkspaceOperatorConfig
    */
-  private async getBackupRegistryPath(): Promise<{ registryPath: string; authSecret?: string }> {
+  private async getBackupRegistryPath(): Promise<{ registryPath: string }> {
     try {
       const response = await this.saCustomObjectsApi.getNamespacedCustomObject({
         group: DEVWORKSPACE_OPERATOR_CONFIG_GROUP,
@@ -194,13 +196,12 @@ export class RegistryApiService {
         throw new Error('Unexpected response format for DevWorkspaceOperatorConfig');
       }
       const registryPath = response.config?.workspace?.backupCronJob?.registry?.path;
-      const authSecret = response.config?.workspace?.backupCronJob?.registry?.authSecret;
 
       if (!registryPath) {
         throw new Error('Backup registry path not configured');
       }
 
-      return { registryPath: registryPath.replace(/\/+$/, ''), authSecret };
+      return { registryPath: registryPath.replace(/\/+$/, '') };
     } catch (e) {
       throw createError(
         e,
@@ -250,7 +251,8 @@ export class RegistryApiService {
       }
 
       return `Basic ${authEntry.auth.trim()}`;
-    } catch {
+    } catch (error) {
+      logger.warn(error, 'Failed to read backup auth secret "%s" in namespace "%s"', BACKUP_REGISTRY_AUTH_SECRET_NAME, namespace);
       return '';
     }
   }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
@@ -32,12 +32,12 @@ import {
   DEVWORKSPACE_VERSION,
 } from '@/constants/k8s';
 import { createError } from '@/devworkspaceClient/services/helpers/createError';
-import { logger } from '@/utils/logger';
 import {
   createRegistryClient,
   detectRegistryType,
   IExternalRegistryClient,
 } from '@/devworkspaceClient/services/helpers/externalRegistry';
+import { logger } from '@/utils/logger';
 import {
   CoreV1API,
   prepareCoreV1API,
@@ -252,7 +252,12 @@ export class RegistryApiService {
 
       return `Basic ${authEntry.auth.trim()}`;
     } catch (error) {
-      logger.warn(error, 'Failed to read backup auth secret "%s" in namespace "%s"', BACKUP_REGISTRY_AUTH_SECRET_NAME, namespace);
+      logger.warn(
+        error,
+        'Failed to read backup auth secret "%s" in namespace "%s"',
+        BACKUP_REGISTRY_AUTH_SECRET_NAME,
+        namespace,
+      );
       return '';
     }
   }

--- a/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/registryApi.ts
@@ -37,11 +37,11 @@ import {
   detectRegistryType,
   IExternalRegistryClient,
 } from '@/devworkspaceClient/services/helpers/externalRegistry';
-import { logger } from '@/utils/logger';
 import {
   CoreV1API,
   prepareCoreV1API,
 } from '@/devworkspaceClient/services/helpers/prepareCoreV1API';
+import { logger } from '@/utils/logger';
 
 // ImageStream constants
 const IMAGESTREAM_GROUP = 'image.openshift.io';


### PR DESCRIPTION
### What does this PR do?

Fixes the `Backups` tab showing no entries for deleted workspaces even when backup images still exist in the registry.

`getRegistryCredentials()` in `registryApi.ts` was reading the auth secret from the operator namespace using the SA kubeconfig. The Dashboard SA has no RBAC to read secrets there — every call returned 403 Forbidden, causing the registry listing to fall back to unauthenticated access and return `[]` for private registries.

DWO always copies the configured auth secret into the workspace namespace as `devworkspace-backup-registry-auth`. This PR switches `getRegistryCredentials()` to read it from there using the user kubeconfig.

Note: this is one of two fixes needed to fully resolve [CRW-11079](https://redhat.atlassian.net/browse/CRW-11079). The other is in [devworkspace-operator#1631](https://github.com/devfile/devworkspace-operator/pull/1631) — without it, DWO sets an `ownerRef` on the workspace-namespace secret causing it to be GC'd on workspace deletion.

### Screenshot/screencast of this PR

<!-- Please add a screenshot showing the deleted workspace entry visible in the Backups tab -->

### What issues does this PR fix or reference?

Fixes https://issues.redhat.com/browse/CRW-11079

Related: https://github.com/devfile/devworkspace-operator/pull/1631

### Is it tested? How?

1. Deploy Eclipse Che with the dashboard image from this PR and DWO that doesn't set `ownerRef` on the workspace namespace auth secret (e.g. DWO `quay.io/devfile/devworkspace-controller:sha-ec6de18`).
2. Configure `DevWorkspaceOperatorConfig` with backup enabled and a private registry (e.g. quay.io).
3. Create a workspace, stop it, wait for the backup job to complete, then delete the workspace.
4. Open the Dashboard and navigate to the `Backups` tab, see: the deleted workspace entry is visible with a `(Deleted)` label.
5. Without this fix: repeat with the stock dashboard image, see: the `Backups` tab is empty.

#### Release Notes

Fixed: backup entries for deleted workspaces are now visible in the Backups tab when using a private OCI registry.

#### Docs PR

N/A