### PR TITLE
fix(ai): double injected-tools volume size to 512Mi

### DIFF
--- a/packages/dashboard-frontend/src/services/helpers/__tests__/aiTools.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/aiTools.spec.ts
@@ -670,7 +670,7 @@ describe('aiTools', () => {
         {
           name: 'injected-tools',
           attributes: { [ADMIN_MANAGEABLE_ATTRIBUTE]: true },
-          volume: { size: '256Mi' },
+          volume: { size: '512Mi' },
         },
       ]);
 
@@ -711,7 +711,7 @@ describe('aiTools', () => {
         {
           name: 'injected-tools',
           attributes: { [ADMIN_MANAGEABLE_ATTRIBUTE]: true },
-          volume: { size: '256Mi' },
+          volume: { size: '512Mi' },
         },
       ]);
 
@@ -1027,7 +1027,7 @@ describe('aiTools', () => {
         {
           name: 'injected-tools',
           attributes: { [ADMIN_MANAGEABLE_ATTRIBUTE]: true },
-          volume: { size: '256Mi' },
+          volume: { size: '512Mi' },
         },
       ]);
 
@@ -1073,7 +1073,7 @@ describe('aiTools', () => {
         {
           name: 'injected-tools',
           attributes: { [ADMIN_MANAGEABLE_ATTRIBUTE]: true },
-          volume: { size: '256Mi' },
+          volume: { size: '512Mi' },
         },
       ]);
 
@@ -1104,7 +1104,7 @@ describe('aiTools', () => {
         {
           name: 'injected-tools',
           attributes: { [ADMIN_MANAGEABLE_ATTRIBUTE]: true },
-          volume: { size: '256Mi' },
+          volume: { size: '512Mi' },
         },
       ]);
 

--- a/packages/dashboard-frontend/src/services/helpers/aiTools.ts
+++ b/packages/dashboard-frontend/src/services/helpers/aiTools.ts
@@ -238,7 +238,7 @@ export function addAiToolToWorkspace(
     template.components.push({
       name: 'injected-tools',
       attributes: { [ADMIN_MANAGEABLE_ATTRIBUTE]: true },
-      volume: { size: '256Mi' },
+      volume: { size: '512Mi' },
     } as unknown as DevWorkspaceComponent);
   }
 
@@ -254,7 +254,7 @@ export function addAiToolToWorkspace(
           '-c',
           `rm -f /injected-tools/bin/${tool.binary} /injected-tools/bin/${tool.binary}-bin 2>/dev/null; mkdir -p /injected-tools/bin && cp /usr/local/bin/${tool.binary} /injected-tools/bin/${tool.binary} && { test -f /usr/local/bin/${tool.binary}-bin && cp /usr/local/bin/${tool.binary}-bin /injected-tools/bin/${tool.binary}-bin || true; }`,
         ],
-        memoryLimit: '512Mi',
+        memoryLimit: '1024Mi',
         mountSources: false,
         volumeMounts: [{ name: 'injected-tools', path: '/injected-tools' }],
       },
@@ -270,7 +270,7 @@ export function addAiToolToWorkspace(
           '-c',
           `rm -rf /injected-tools/${slug} 2>/dev/null; cp -a /opt/${slug}/. /injected-tools/${slug}/`,
         ],
-        memoryLimit: '512Mi',
+        memoryLimit: '1024Mi',
         mountSources: false,
         volumeMounts: [{ name: 'injected-tools', path: '/injected-tools' }],
       },


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR doubles the memory limit for AI tool injector init containers (512Mi → 1024Mi) and the shared `injected-tools` volume (256Mi → 512Mi) to prevent OOM-kills that cause intermittent workspace start failures.

Both values are doubled in `addAiToolToWorkspace` (`src/services/helpers/aiTools.ts`):

```diff
-      volume: { size: '256Mi' },
+      volume: { size: '512Mi' },
```

```diff
-        memoryLimit: '512Mi',   // init pattern
+        memoryLimit: '1024Mi',
```

```diff
-        memoryLimit: '512Mi',   // bundle pattern
+        memoryLimit: '1024Mi',
```
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A — internal resource limits change, no UI impact.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse-che/che/issues/23872

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
  1. Deploy Eclipse Che with an image built from this PR.
  2. Open the Eclipse Che Dashboard.
  3. On the Get Started page, select an AI provider in the AI Selector widget.
  4. Start an empty workspace.
  5. Observe that the workspace starts successfully and the AI tool binary is available in the container.
  
#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
