### PR TITLE
fix(ai): add missing resourceName to AiToolIcon test mock

### DIFF
--- a/packages/dashboard-frontend/src/components/AiToolIcon/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/AiToolIcon/__tests__/index.spec.tsx
@@ -48,6 +48,7 @@ const mockWorkspace: Workspace = {
   id: 'test-id',
   uid: 'test-uid',
   name: 'test-workspace',
+  resourceName: 'test-workspace',
   namespace: 'test-ns',
   infrastructureNamespace: 'test-ns',
   created: Date.now(),


### PR DESCRIPTION
### What does this PR do?

Adds the missing `resourceName` field to the `Workspace` mock in the `AiToolIcon` test, fixing the `main` branch Docker image build.

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?


### Is it tested? How?

All 5 `AiToolIcon` tests pass. Full `yarn build` (webpack with ts-loader) completes with zero errors.

#### Release Notes


#### Docs PR