### PR TITLE
fix: open existing workspace when factory URL contains a /tree/<branc…

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
@@ -311,6 +311,85 @@ describe('Creating steps, checking existing workspaces', () => {
         );
       });
 
+      it('should open the existing workspace created from the same repo and branch embedded in /tree/ URL', async () => {
+        searchParams.delete(DEV_WORKSPACE_ATTR);
+        searchParams.set(EXISTING_WORKSPACE_NAME, 'project-1');
+        searchParams.set(
+          FACTORY_URL_ATTR,
+          'https://github.com/eclipse-che/che-dashboard/tree/my-feature-branch',
+        );
+
+        const resources: DevWorkspaceResources = [
+          {
+            metadata: {
+              name: workspaceName,
+            },
+          } as devfileApi.DevWorkspace,
+          {} as devfileApi.DevWorkspaceTemplate,
+        ];
+        store = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: 'project-1',
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params:
+                          'url=https://github.com/eclipse-che/che-dashboard/tree/my-feature-branch',
+                      },
+                    }),
+                  },
+                })
+                .withSpec({
+                  template: {
+                    projects: [
+                      {
+                        git: {
+                          remotes: {
+                            origin: 'https://github.com/eclipse-che/che-dashboard.git',
+                          },
+                          checkoutFrom: { revision: 'my-feature-branch' },
+                        },
+                        name: 'project-1',
+                      },
+                    ],
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withDevfileRegistries({
+            devWorkspaceResources: {
+              [resourcesUrl]: {
+                resources,
+              },
+            },
+          })
+          .withFactoryResolver({
+            resolver: {
+              location: 'https://github.com/eclipse-che/che-dashboard/tree/my-feature-branch',
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: {
+                  name: workspaceName,
+                },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(store, searchParams);
+
+        await waitFor(() =>
+          expect(mockTabManagerReplace).toHaveBeenCalledWith(
+            expect.stringContaining(`/ide/user-che/project-1`),
+          ),
+        );
+      });
+
       it('should not open the existing workspace created from the same repo with revision in workspace', async () => {
         searchParams.delete(DEV_WORKSPACE_ATTR);
         searchParams.set(EXISTING_WORKSPACE_NAME, 'project-1');

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/buildFactoryParams.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/buildFactoryParams.spec.ts
@@ -169,6 +169,17 @@ describe('buildFactoryParams', () => {
         });
         expect(buildFactoryParams(searchParams).revision).toBeUndefined();
       });
+
+      it('should return the full path after /tree/ for file-level URLs (branch+path are indistinguishable)', () => {
+        // Known limitation: split('/tree/') cannot tell apart a branch name containing
+        // slashes (feature/my-branch) from a branch + subdirectory path (main/src/file.ts).
+        // GitHub resolves this ambiguity server-side. Returning the full remainder is
+        // consistent with getProjectFromLocation.ts and acceptable for workspace deduplication.
+        const searchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: 'https://github.com/eclipse-che/che-dashboard/tree/main/src/file.ts',
+        });
+        expect(buildFactoryParams(searchParams).revision).toBe('main/src/file.ts');
+      });
     });
 
     it('should return factory identity without EXISTING_WORKSPACE_NAME attributes', () => {

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/buildFactoryParams.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/buildFactoryParams.spec.ts
@@ -155,6 +155,20 @@ describe('buildFactoryParams', () => {
         });
         expect(buildFactoryParams(searchParams).revision).toBe('param-branch');
       });
+
+      it('should extract branch names containing slashes from /tree/ path', () => {
+        const searchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: 'https://github.com/eclipse-che/che-dashboard/tree/feature/CRW-10950',
+        });
+        expect(buildFactoryParams(searchParams).revision).toBe('feature/CRW-10950');
+      });
+
+      it('should return undefined for /tree/ with no branch name', () => {
+        const searchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: 'https://github.com/eclipse-che/che-dashboard/tree/',
+        });
+        expect(buildFactoryParams(searchParams).revision).toBeUndefined();
+      });
     });
 
     it('should return factory identity without EXISTING_WORKSPACE_NAME attributes', () => {

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/buildFactoryParams.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/__tests__/buildFactoryParams.spec.ts
@@ -16,7 +16,9 @@ import {
   EDITOR_ATTR,
   EXISTING_WORKSPACE_NAME,
   FACTORY_ID_IGNORE_ATTRS,
+  FACTORY_URL_ATTR,
   POLICIES_CREATE_ATTR,
+  REVISION_ATTR,
   STORAGE_TYPE_ATTR,
 } from '@/services/helpers/factoryFlow/buildFactoryParams';
 
@@ -123,6 +125,38 @@ describe('buildFactoryParams', () => {
         'che-editor=che-incubator/che-code/latest&storageType=per-user',
       );
     });
+    describe('revision', () => {
+      it('should return undefined when neither ?revision= nor /tree/ is present', () => {
+        const searchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: 'https://github.com/eclipse-che/che-dashboard',
+        });
+        expect(buildFactoryParams(searchParams).revision).toBeUndefined();
+      });
+
+      it('should return the ?revision= query param when present', () => {
+        const searchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: 'https://github.com/eclipse-che/che-dashboard',
+          [REVISION_ATTR]: 'my-feature-branch',
+        });
+        expect(buildFactoryParams(searchParams).revision).toBe('my-feature-branch');
+      });
+
+      it('should extract the branch from a GitHub /tree/<branch> factory URL', () => {
+        const searchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: 'https://github.com/eclipse-che/che-dashboard/tree/my-feature-branch',
+        });
+        expect(buildFactoryParams(searchParams).revision).toBe('my-feature-branch');
+      });
+
+      it('should prefer ?revision= over the /tree/ branch in the factory URL', () => {
+        const searchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: 'https://github.com/eclipse-che/che-dashboard/tree/url-branch',
+          [REVISION_ATTR]: 'param-branch',
+        });
+        expect(buildFactoryParams(searchParams).revision).toBe('param-branch');
+      });
+    });
+
     it('should return factory identity without EXISTING_WORKSPACE_NAME attributes', () => {
       const searchParams = new URLSearchParams({
         [EDITOR_ATTR]: 'che-incubator/che-code/next',

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -180,6 +180,8 @@ function getRevision(searchParams: URLSearchParams): string | undefined {
   // Extract branch from a GitHub-style /tree/<branch> factory URL path so that
   // getSameRepoWorkspaces() can match workspaces whose devfile projects were created
   // with checkoutFrom.revision set to that branch name.
+  // Note: getProjectFromLocation.ts uses the same split('/tree/') pattern — if this
+  // ever changes (e.g. to support Bitbucket's /src/ paths), update both locations.
   const factoryUrl = getFactoryUrl(searchParams);
   if (factoryUrl) {
     try {

--- a/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
+++ b/packages/dashboard-frontend/src/services/helpers/factoryFlow/buildFactoryParams.ts
@@ -173,7 +173,26 @@ function getRemotes(searchParams: URLSearchParams): string | undefined {
 }
 
 function getRevision(searchParams: URLSearchParams): string | undefined {
-  return searchParams.get(REVISION_ATTR) || undefined;
+  const revisionParam = searchParams.get(REVISION_ATTR) || undefined;
+  if (revisionParam) {
+    return revisionParam;
+  }
+  // Extract branch from a GitHub-style /tree/<branch> factory URL path so that
+  // getSameRepoWorkspaces() can match workspaces whose devfile projects were created
+  // with checkoutFrom.revision set to that branch name.
+  const factoryUrl = getFactoryUrl(searchParams);
+  if (factoryUrl) {
+    try {
+      const url = new URL(factoryUrl);
+      const parts = url.pathname.split('/tree/');
+      if (parts.length > 1 && parts[1]) {
+        return parts[1];
+      }
+    } catch {
+      // not a valid URL, ignore
+    }
+  }
+  return undefined;
 }
 
 function buildFactoryId(searchParams: URLSearchParams): string {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

Fixes duplicate workspace creation when a factory URL contains a GitHub `/tree/<branch>` path and "Create New" is disabled.

### Root Cause

`getSameRepoWorkspaces()` in `CheckExistingWorkspaces` determines whether an existing workspace was created from the same repository by testing two conditions:

```typescript
workspace.source === factoryParams.sourceUrl && revision === factoryParams.revision
```

When a workspace is created from `https://github.com/org/repo/tree/my-branch`:

- `workspace.source` is stored as the full URL including `/tree/my-branch`.
- The devfile project is created with `checkoutFrom.revision = 'my-branch'` (extracted by `getProjectFromLocation.ts` which splits on `/tree/`).

When the user returns with the same URL and "Create New" unchecked:

- `factoryParams.sourceUrl` correctly equals `workspace.source` — the full URL including `/tree/my-branch`.
- `factoryParams.revision` is `undefined` because `getRevision()` only reads the explicit `?revision=` query parameter, never the `/tree/<branch>` path segment.

The revision mismatch (`'my-branch' !== undefined`) makes every existing workspace fail the filter, so `getSameRepoWorkspaces()` returns an empty list and a duplicate is created.

URLs without an explicit branch are unaffected because both `workspace.checkoutFrom.revision` and `factoryParams.revision` are `undefined` in that case.

### Fix

Extended `getRevision()` in `buildFactoryParams.ts` to also extract the branch name from the factory URL's `/tree/<branch>` path segment when no explicit `?revision=` query parameter is present:

```diff
 function getRevision(searchParams: URLSearchParams): string | undefined {
-  return searchParams.get(REVISION_ATTR) || undefined;
+  const revisionParam = searchParams.get(REVISION_ATTR) || undefined;
+  if (revisionParam) {
+    return revisionParam;
+  }
+  const factoryUrl = getFactoryUrl(searchParams);
+  if (factoryUrl) {
+    try {
+      const url = new URL(factoryUrl);
+      const parts = url.pathname.split('/tree/');
+      if (parts.length > 1 && parts[1]) {
+        return parts[1];
+      }
+    } catch { /* not a valid URL */ }
+  }
+  return undefined;
 }
```

The explicit `?revision=` query parameter still takes precedence.

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-10950


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. Deploy Dev Spaces with the dashboard image built from this PR.
2. Go to the User Dashboard and confirm **Create New** is enabled (default).
3. In **Create Workspace**, paste a GitHub URL that includes a branch path, e.g.:
   `https://github.com/<org>/<repo>/tree/<branch>`
   Create the workspace and wait for it to reach Running.
4. Return to **Create Workspace**.
5. Disable **Create New**.
6. Paste the same GitHub URL (same branch) and open the workspace.

Expected: the existing workspace is opened — no duplicate is created.

Before this fix: a new workspace would be created because the branch embedded in the
`/tree/<branch>` path was not matched against the existing workspace's revision, so
`getSameRepoWorkspaces()` always returned an empty list.

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
