### PR TITLE
chore(claude): add project skills and rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,23 @@ See @../AGENTS.md for project guidelines.
 
 See @../redhat-compliance-and-responsible-ai.md for Red Hat compliance and responsible AI rules.
 
+See @rules/che-dashboard-dev.md for development conventions — commits, CSS, deps, git patterns, accessibility.
+
+## Available Skills
+
+Project-specific skills live in `.claude/skills/`. Invoke with `/skill-name`:
+
+| Skill | When to use |
+|---|---|
+| `commit-message` | Write a human-style commit message following project conventions |
+| `manage-resolutions` | Audit and clean up the `resolutions` field in `package.json` |
+| `fix-cve-dep` | Upgrade a vulnerable npm dependency (CVE/Jira ticket) |
+| `rebase-to-main` | Rebase a branch onto latest main, resolve `.deps/` conflicts, force-push |
+| `fix-pr-feedback` | Fetch PR review comments, triage fixed vs open, apply outstanding fixes |
+| `check-coverage` | Verify test coverage meets thresholds before opening a PR |
+| `pr-test-section` | Write the "Is it tested? How?" section of a PR description |
+| `pr-description` | Generate a PR description and save to `openspec/docs/` (run `check-coverage` first) |
+
 ## Hard Rules
 
 - **No `any` type**: NEVER use `any` or cast to `any` in TypeScript code. Use proper types, type guards, `unknown`, or specific interfaces instead.

--- a/.claude/rules/che-dashboard-dev.md
+++ b/.claude/rules/che-dashboard-dev.md
@@ -1,0 +1,164 @@
+# che-dashboard Development Conventions
+
+---
+
+## 1. Commit Trailers
+
+Only these trailers are permitted:
+
+```
+Assisted-by: {AGENT_NAME}
+Signed-off-by: {AUTHOR_NAME} <{AUTHOR_EMAIL}>
+```
+
+`{AGENT_NAME}` — specific agent name, e.g. `Claude Sonnet 4.6`.  
+`{AUTHOR_NAME}` / `{AUTHOR_EMAIL}` — from `git config user.name` / `git config user.email`.
+
+**Do NOT add:** `Made-with`, `Co-authored-by`, or duplicate trailers.  
+**Do NOT add** AI explanation comments inside source code.  
+**On amend:** always pass the full message with `-m "..."` so trailers are not stacked.
+
+### Commit message format
+
+- Subject line ≤ 50 chars, conventional commits: `type(scope): short description`
+- Common types: `fix`, `feat`, `chore`, `refactor`, `test`, `docs`
+
+### Example
+
+```
+fix(ui): prevent error message from overflowing the ErrorReporter widget
+
+Assisted-by: Claude Sonnet 4.6
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+---
+
+## 2. Pre-commit Checks
+
+**Before each commit** (fast — run every time):
+
+```bash
+yarn lint:fix
+yarn format:fix
+yarn workspace @eclipse-che/dashboard-frontend test --testPathPatterns="ComponentName" --no-cache
+```
+
+**Before pushing / opening a PR** (full suite):
+
+```bash
+yarn build
+yarn test
+```
+
+Follow the Surgical Change Workflow in `AGENTS.md` — targeted test runs before commit, full suite before push.
+
+### Updating snapshots
+
+When rendering changes break existing snapshots:
+
+```bash
+yarn workspace @eclipse-che/dashboard-frontend test --testPathPatterns="ComponentName" --updateSnapshot
+```
+
+Always verify the snapshot diff makes sense before committing.
+
+---
+
+## 3. Dependency Changes — License Regeneration
+
+When `package.json` or `yarn.lock` changes:
+
+```bash
+yarn license:generate
+```
+
+If it exits with **"UNRESOLVED dependencies"**, add the missing package to `.deps/EXCLUDED/dev.md` (dev dep) or `.deps/EXCLUDED/prod.md` (runtime dep):
+
+```markdown
+| `package-name@X.Y.Z` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/package-name/X.Y.Z) |
+```
+
+Then re-run `yarn license:generate`. Remove entries for packages no longer in `yarn.lock`.
+
+---
+
+## 4. CSS Property Ordering
+
+This project uses `stylelint-config-clean-order`. Follow these group conventions:
+
+| Group | Properties |
+|-------|-----------|
+| Layout | `position`, `z-index`, `overflow`, `overflow-x`, `overflow-y`, `display`, `flex-*`, `grid-*` |
+| Box/Size | `box-sizing`, `width`, `min-width`, `max-width`, `height`, `margin`, `padding` |
+| Typography | `font-*`, `color`, `text-*`, `word-break`, `white-space`, `line-height` |
+| Visual | `background`, `background-color`, `border*`, `border-radius`, `box-shadow` |
+| Animation | `transition`, `animation` |
+
+- Empty lines **between groups** when rule has ≥ 5 properties
+- **No empty lines within a group**
+
+---
+
+## 5. Error Handling
+
+Use typed error classes with status codes instead of string matching:
+
+```typescript
+export class GitClientError extends Error {
+  constructor(public readonly statusCode: number, message: string) {
+    super(message);
+    this.name = 'GitClientError';
+  }
+}
+
+// In route handler:
+const statusCode = e instanceof GitClientError ? e.statusCode : 500;
+reply.status(statusCode).send(helpers.errors.getMessage(e));
+```
+
+---
+
+## 6. Git Workflow Patterns
+
+### Squash all branch commits into one
+
+```bash
+git reset $(git merge-base origin/main HEAD)
+git add -A
+git commit -m "feat: ..."
+```
+
+### Strip forbidden trailers from new local commits (not yet pushed)
+
+Use only on commits that have never been pushed. Once a branch has a remote tracking branch, use `git rebase -i` to reword commit messages instead.
+
+```bash
+FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch -f --msg-filter \
+  'sed "/^Made-with:/d; /^Co-authored-by:/d"' \
+  -- HEAD~1..HEAD
+
+git update-ref -d refs/original/refs/heads/$(git branch --show-current)
+```
+
+Note: `--msg-filter` only rewrites commit messages — no stash needed.
+
+### Resolve .deps merge conflicts
+
+```bash
+git checkout --theirs .deps/EXCLUDED/dev.md .deps/EXCLUDED/prod.md
+git add .deps/EXCLUDED/dev.md .deps/EXCLUDED/prod.md
+```
+
+Then re-run `yarn license:generate` after the rebase continues.
+
+---
+
+## 7. Accessibility and UI Conventions
+
+- Icon hover color: `var(--pf-t--global--icon--color--subtle)` default, `var(--pf-t--global--text--color--link--default)` on hover
+- Tooltip `<a>` link colors: inverse background — use dark tokens in light theme, light tokens in dark theme (see the tooltip CSS module)
+- Keyboard toggle for `Switch`: wrap in `<div onKeyDown>` and handle `Enter`
+- Keyboard selection in `Select`/`SelectOption` with `hasCheckbox`: add explicit `onKeyDown` on each `SelectOption`
+- `ErrorReporter` overlay: `position: fixed; inset: 0; z-index: 9999`
+- Error `<pre>` blocks: `max-width: 100%; overflow-x: auto`

--- a/.claude/skills/check-coverage/SKILL.md
+++ b/.claude/skills/check-coverage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: check-coverage
+description: Run test coverage for all packages changed on this branch and identify uncovered code. Always invoke before writing a PR description, after adding new code, or when a PR receives coverage-related review feedback. Prevents CI coverage failures and catches untested code before reviewers do.
+---
+
+# Check Test Coverage
+
+## Coverage thresholds (enforced by CI)
+
+| Package | Statements | Branches | Functions | Lines |
+|---|---|---|---|---|
+| `common` | 99% | 99% | **100%** | 99% |
+| `dashboard-frontend` | 92% | 88% | 85% | 92% |
+| `dashboard-backend` | 86% | 80% | 86% | 86% |
+
+## Workflow
+
+### 1. Identify changed packages
+
+```bash
+git diff origin/main..HEAD --name-only | grep "^packages/" | cut -d/ -f2 | sort -u
+```
+
+Only run coverage for packages with changed files.
+
+### 2. Run coverage
+
+```bash
+yarn workspace @eclipse-che/common test --coverage --no-cache
+yarn workspace @eclipse-che/dashboard-frontend test --coverage --no-cache
+yarn workspace @eclipse-che/dashboard-backend test --coverage --no-cache
+```
+
+Look for the `Coverage summary` block at the end:
+
+```
+Statements   : 91.5% ( 1001/1094 )   ← must be ≥ threshold
+Branches     : 87.2% ( 106/122 )
+Functions    : 84.6% ( 22/26 )
+Lines        : 91.5% ( 1001/1094 )
+Jest: "global" coverage threshold for statements (92%) not met: 91.5%
+```
+
+All thresholds met → go to step 5.
+
+### 3. Find uncovered code
+
+```bash
+yarn workspace @eclipse-che/<package> test --coverage --no-cache \
+  --coverageReporters=text 2>&1 | grep "| " | \
+  awk -F'|' '{if ($3+0 < 90 || $4+0 < 85 || $5+0 < 85) print}' | head -20
+```
+
+Also check whether changed source files have corresponding test files:
+
+```bash
+# Changed source files (not tests)
+git diff origin/main..HEAD --name-only | grep "^packages/<pkg>/src" | grep -v "__tests__\|spec\|mock"
+# Expected test location: src/<path>/__tests__/<name>.spec.ts
+```
+
+### 4. Write missing tests
+
+For each uncovered file or function:
+
+1. Read the source file
+2. Create or update `__tests__/<name>.spec.ts`
+3. Cover happy path, error path, edge cases, and both sides of every branch
+
+Iterate quickly with `--testPathPatterns`:
+
+```bash
+yarn workspace @eclipse-che/<package> test \
+  --testPathPatterns "<FileName>" --coverage --no-cache
+```
+
+### 5. Verify thresholds
+
+```bash
+yarn workspace @eclipse-che/<package> test --coverage --no-cache 2>&1 | tail -10
+```
+
+Must show no `"coverage threshold … not met"` lines. Do not proceed to PR description until every changed package passes.
+
+## Common patterns for untested code
+
+### New utility function
+```typescript
+it('returns X for valid input', () => { ... });
+it('throws for invalid input', () => { ... });
+it('handles empty array', () => { ... });
+```
+
+### New React component
+```typescript
+it('renders without crashing', () => { renderComponent(); });
+it('shows error state when prop is true', () => { ... });
+it('calls callback on button click', () => { ... });
+```
+
+### New async action / Redux thunk
+```typescript
+it('dispatches success on 200', async () => { ... });
+it('dispatches error on network failure', async () => { ... });
+```
+
+### New API route (backend)
+```typescript
+it('returns 200 with correct body', async () => { ... });
+it('returns 403 when not authorized', async () => { ... });
+```
+
+## What NOT to test (excluded from coverage)
+
+- `src/**/__tests__/**` — test files themselves
+- `src/**/*.d.ts` — type declarations
+- `src/**/*.config.ts` — config files
+- `src/index.tsx`, `src/App.tsx`, `src/Routes.tsx` — frontend entry points
+- `src/localRun/**`, `src/utils/**`, `src/server.ts` — backend exclusions
+
+## Note on snapshots
+
+Updating snapshots (`--updateSnapshot`) does not improve branch/function coverage. Add behavioral tests alongside snapshot updates when coverage is at risk.

--- a/.claude/skills/commit-message/SKILL.md
+++ b/.claude/skills/commit-message/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: commit-message
+description: Write a git commit message for any che-dashboard change. Invoke this before running git commit — for bug fixes, features, deps, a11y, refactors, or any other change type. Produces a conventional-commit subject line, optional body, and the required Assisted-by trailer in the project's human-sounding style.
+---
+
+# Write a Commit Message
+
+## Subject line
+
+```
+type(scope): short description
+```
+
+- **≤ 50 characters**
+- Lowercase after the colon
+- No trailing period
+- Imperative or declarative — both are fine in this repo
+
+| type | when |
+|---|---|
+| `fix` | bug fix, broken behavior |
+| `feat` | new user-visible feature |
+| `chore` | deps, CI, tooling, housekeeping |
+| `refactor` | restructuring without behavior change |
+| `test` | adding or updating tests |
+| `docs` | documentation only |
+| `fix(deps)` | security/CVE dependency upgrade |
+| `fix(a11y)` | accessibility fix |
+| `feat(ui)` | UI/UX addition |
+
+## Body (only when the subject line isn't self-explanatory)
+
+**Add a body when:**
+- The fix is non-obvious — explain the root cause, not just the symptom
+- The change covers multiple independent items
+- A CVE or issue tracker reference is needed
+
+**How to write it:**
+- One blank line after the subject
+- 1–3 short paragraphs; keep it under 10 lines total
+- Plain declarative sentences — state what changed and why
+- No bullet lists unless listing 2+ separate items
+
+**Skip the body when:**
+- The subject line already says everything (`fix(a11y): add workspace name to kebab menu aria-label`)
+- It's a single-line fix
+
+## Trailers
+
+Always add at the very end, after a blank line:
+
+```
+Assisted-by: {AGENT_NAME}
+Signed-off-by: {AUTHOR_NAME} <{AUTHOR_EMAIL}>
+```
+
+Get the values from:
+```bash
+git config user.name   # AUTHOR_NAME
+git config user.email  # AUTHOR_EMAIL
+```
+
+## Anti-patterns
+
+| ❌ Avoid | ✅ Instead |
+|---|---|
+| "This commit improves..." | Just say what it does |
+| "In this change we..." | State the change directly |
+| "Enhanced the validation logic" | "Fix validation not triggered on empty input" |
+| "Leverages PatternFly's..." | "Use PatternFly's..." |
+| Long bulleted lists for a single concept | 1–2 sentences |
+| Passive voice in subject | Active: "fix" not "fixed" or "is fixed" |
+| Capitalized subject after colon | `fix: improve contrast` not `fix: Improve contrast` |
+
+## Real examples from this repo
+
+```
+fix(ui): disable Save button when Gitconfig name or email fields are empty
+```
+*(no body — subject is complete)*
+
+```
+fix(deps): upgrade axios to 1.15.2 and follow-redirects to 1.16.0
+
+Fixes two security vulnerabilities:
+- follow-redirects < 1.16.0: custom auth headers leaked on cross-domain redirects
+- axios < 1.15.1: prototype pollution enables arbitrary HTTP header injection
+```
+
+```
+fix(a11y): remove prohibited aria-label from backup schedule element
+
+The <small> element does not support aria-label per ARIA specs
+(aria-prohibited-attr). The visible text already provides full context
+for screen readers, making the aria-label redundant.
+
+Fixes: https://issues.redhat.com/browse/CRW-10738
+```
+
+```
+fix: enable keyboard selection in git provider dropdown
+
+Add onSelect handler and shouldFocusFirstItemOnOpen to the Dropdown,
+and value prop to each DropdownItem, so keyboard Enter/Space selects
+a provider after opening the dropdown.
+
+Resolves: https://redhat.atlassian.net/browse/CRW-10662
+```
+
+## Issue references
+
+Add at the end of the body when relevant:
+
+```
+Fixes: https://redhat.atlassian.net/browse/CRW-XXXXX
+Resolves: https://redhat.atlassian.net/browse/CRW-XXXXX
+```

--- a/.claude/skills/fix-cve-dep/SKILL.md
+++ b/.claude/skills/fix-cve-dep/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: fix-cve-dep
+description: Upgrade a vulnerable npm dependency end-to-end — version bump, resolutions pin, yarn install, license regeneration, and commit. Invoke for any CVE, security advisory, or dependency vulnerability ticket (Jira CRW-*, GHSA-*, or a user request to "fix the X vulnerability" or "upgrade Y for security"). Handles ClearlyDefined indexing checks, .deps/ file updates, and produces a properly formatted commit automatically.
+argument-hint: "[package-name] [fix-version] [jira-ticket]"
+---
+
+# Fix CVE Dependency Upgrade
+
+## Required input
+
+- Package name (e.g. `axios`, `ws`, `ip-address`)
+- Minimum fix version from the CVE description
+- Jira ticket ID (e.g. `CRW-11204`)
+
+If `$ARGUMENTS` is missing fields, extract them from context (open Jira ticket, branch name, etc.).
+
+## Workflow
+
+### 1. Check current version
+
+```bash
+grep -A 3 '"<package>@npm' yarn.lock | head -6
+```
+
+If current ≥ fix version, document as already fixed and stop.
+
+### 2. Find the best upgrade target
+
+Pick the **latest indexed version**, not just the minimum fix version:
+
+```bash
+yarn npm info <package> dist-tags 2>/dev/null | grep latest
+```
+
+For each candidate (latest, latest-1, fix-version), check ClearlyDefined score:
+
+```bash
+curl -s --max-time 10 \
+  "https://api.clearlydefined.io/definitions/npm/npmjs/-/<package>/<version>" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('scores',{}).get('effective',0), d.get('licensed',{}).get('declared','?'))"
+```
+
+Choose the **highest-versioned** package with score > 0 and a resolved SPDX license. A newer un-indexed version resolves via semver (`^`) and breaks `yarn license:generate` — pin the exact indexed version.
+
+### 3. Update package.json
+
+Update in ALL locations:
+
+- Root `package.json` → `resolutions` field (exact version, e.g. `"<package>": "1.16.1"`)
+- Any workspace `package.json` with it as a direct dep (update range, e.g. `"<package>": "^1.16.1"`)
+
+```bash
+grep -rn '"<package>"' packages/*/package.json package.json
+```
+
+**Pinning rules:**
+- Use exact version (no `^`) in `resolutions` to prevent resolution to newer un-indexed versions
+- For packages crossing a major semver boundary (e.g. `^9.x` → `10.x`), the `resolutions` override is mandatory
+
+### 4. Reinstall and verify
+
+```bash
+yarn install
+grep -A 2 '"<package>@npm' yarn.lock | head -4   # confirm lock updated
+```
+
+### 5. Regenerate license files
+
+```bash
+yarn license:generate
+```
+
+**If UNRESOLVED exits:**
+
+Check ClearlyDefined individually:
+
+```bash
+curl -s --max-time 10 \
+  "https://api.clearlydefined.io/definitions/npm/npmjs/-/<dep>/<version>" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('scores',{}).get('effective',0), d.get('licensed',{}).get('declared','?'))"
+```
+
+- Score > 0: batch API timed out — retry (usually succeeds on attempt 2–4)
+- Score = 0: not yet indexed — add to `.deps/EXCLUDED/prod.md` (runtime) or `.deps/EXCLUDED/dev.md` (dev only):
+
+```markdown
+| `<package>@<version>` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/<package>/<version>) |
+```
+
+Then re-run `yarn license:generate`.
+
+### 6. Verify
+
+```bash
+yarn license:check   # must exit 0
+```
+
+### 7. Commit
+
+```bash
+git add package.json packages/*/package.json yarn.lock \
+  .deps/dev.md .deps/prod.md .deps/EXCLUDED/dev.md .deps/EXCLUDED/prod.md
+```
+
+Commit message:
+
+```
+fix(deps): upgrade <package> to <version> to fix <vulnerability-type> (<JIRA>)
+
+<Package> versions prior to <fix-version> <vulnerability description>.
+Upgrade from <old-version> to <new-version> (pinned in resolutions) and
+regenerate license dependency files.
+
+CVE reference: <CVE-ID or GHSA>
+Fixed in: <package> <fix-version>
+
+Assisted-by: {AGENT_NAME}
+Signed-off-by: {AUTHOR_NAME} <{AUTHOR_EMAIL}>
+```
+
+### 8. Push
+
+```bash
+git push -u origin <branch>
+```
+
+## Special cases
+
+### Package crosses major semver boundary (e.g. 9.x → 10.x)
+
+The fix version exceeds the range declared by transitive dependents (`"ip-address": "^9.0.5"` won't accept 10.x). Add a hard pin:
+
+```json
+"ip-address": "10.2.0"
+```
+
+### Multiple CVEs in one PR
+
+Fix all packages in a single commit; list each in the commit body:
+
+```
+1. <package-a> — fixes <type> (CRW-XXXXX)
+2. <package-b> — fixes <type> (CRW-XXXXX)
+```
+
+### ClearlyDefined batch API failures
+
+The batch API sometimes returns HTTP 502 or times out. Always retry before adding packages to EXCLUDED. Usually succeeds on attempt 2–4.

--- a/.claude/skills/fix-pr-feedback/SKILL.md
+++ b/.claude/skills/fix-pr-feedback/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: fix-pr-feedback
+description: Fetch all review comments from a GitHub PR, triage which are already fixed and which still need work, apply the outstanding fixes, and push. Invoke whenever the user shares reviewer feedback, pastes a PR comment, or asks to "address feedback", "fix review comments", or "respond to the review". Also use proactively after completing a PR round-trip when there are open review threads.
+argument-hint: "[PR-number or PR-URL]"
+---
+
+# Fix PR Review Feedback
+
+## Required input
+
+A PR number or URL. If `$ARGUMENTS` is empty, ask the user.
+
+## Workflow
+
+### 1. Fetch all review comments
+
+```bash
+PR_NUM=<number>   # parse from $ARGUMENTS or URL
+
+# Inline comments (on specific lines)
+gh api repos/eclipse-che/che-dashboard/pulls/${PR_NUM}/comments \
+  --jq '.[] | {user: .user.login, path: .path, line: .line, body: .body}' \
+  | python3 -c "
+import json, sys
+for line in sys.stdin:
+    obj = json.loads(line)
+    print(f'=== [{obj[\"user\"]}] {obj[\"path\"]}:{obj[\"line\"]} ===')
+    print(obj['body'][:500])
+    print()
+"
+
+# General (non-inline) review comments
+gh pr view ${PR_NUM} --repo eclipse-che/che-dashboard --json reviews \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for r in data.get('reviews', []):
+    if r['body']:
+        print(f'[{r[\"author\"][\"login\"]}] state={r[\"state\"]}')
+        print(r['body'][:500])
+        print()
+"
+```
+
+### 2. Read current file state
+
+For each file mentioned in the comments, read the current version to check whether the feedback is already incorporated.
+
+### 3. Triage
+
+Classify each comment:
+
+- **FIXED** — the code already matches the suggestion (the fix was in the original commit)
+- **OPEN** — needs a code change
+
+Report the triage before making any changes.
+
+### 4. Apply fixes for OPEN items
+
+For each open item:
+
+1. Read the relevant file
+2. Apply the minimal change that satisfies the feedback — do not over-engineer
+3. If the reviewer asked for a comment addition, add only the comment; if they asked for a rename, rename only
+
+### 5. Run tests, format, lint
+
+```bash
+# Frontend
+yarn workspace @eclipse-che/dashboard-frontend test \
+  --testPathPatterns "<changed-component>" --no-cache
+
+# Backend
+yarn workspace @eclipse-che/dashboard-backend test \
+  --testPathPatterns "<changed-service>" --no-cache
+
+yarn format:fix
+yarn lint:fix
+```
+
+All tests must pass before committing.
+
+### 6. Commit and push
+
+One commit per logical group of feedback items:
+
+```
+fix: address code review findings for <context>
+
+- <item 1 fixed>
+- <item 2 fixed>
+
+Assisted-by: {AGENT_NAME}
+Signed-off-by: {AUTHOR_NAME} <{AUTHOR_EMAIL}>
+```
+
+```bash
+git push origin <branch>
+```
+
+## Handling specific feedback patterns
+
+### "Add a cross-reference comment"
+
+Add a one-line code comment pointing to the related location:
+
+```typescript
+// Note: getProjectFromLocation.ts uses the same split('/tree/') pattern —
+// if this changes (e.g. to support Bitbucket /src/ paths), update both.
+```
+
+### "Add a test for edge case X"
+
+Add the test even if the behavior is already correct — it serves as regression documentation.
+
+### "Rename function to Y"
+
+Rename everywhere the function is used, including test mocks.
+
+### "Use yarn instead of npx"
+
+In Yarn Berry projects, `npx` may fail if `node_modules/.bin` lookup fails. Replace `npx <tool>` with `yarn <tool>`.
+
+### "Add #!/bin/sh shebang"
+
+Add `#!/bin/sh` as the first line of any shell script that lacks it.
+
+### Informational comments (not actionable)
+
+Some reviewer comments are observations marked "not a blocker". For these:
+
+- Add a test that documents the known limitation/behavior
+- Do NOT change production code
+- Use a descriptive test name that explains the trade-off:
+
+```typescript
+it('should <observed behavior> (<reason it is acceptable>)', () => {
+  // Known limitation: <explanation of trade-off>
+  expect(result).toBe(<expected-value>);
+});
+```

--- a/.claude/skills/manage-resolutions/SKILL.md
+++ b/.claude/skills/manage-resolutions/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: manage-resolutions
+description: Audit and clean up the resolutions field in package.json — find orphaned pins, verify which are still needed, and safely remove stale ones. Invoke when asked to "check resolutions", "remove stale pins", "clean up package.json resolutions", or after a CVE fix adds a new resolution override that needs validation.
+---
+
+# Manage `resolutions` in package.json
+
+The `resolutions` field forces yarn to use a specific version of a package across the entire dependency tree. Resolutions serve two purposes:
+
+1. **Version floor** — prevent a vulnerable or broken version even if a transitive dep requests it
+2. **Deduplication anchor** — collapse conflicting ranges into one version, reducing bundle size
+
+Static analysis of yarn.lock is not enough to decide whether a resolution is safe to remove — it might look redundant but still be acting as a deduplication anchor across hidden transitive deps. Always test removal.
+
+## Quick audit
+
+This project has a built-in check script:
+
+```bash
+yarn resolutions:check
+```
+
+It reads `package.json` and `yarn.lock` and prints each resolution with its status:
+- **⚠️ KEEP** — overrides older ranges that would resolve to a lower version
+- **✅ POSSIBLY REMOVABLE** — no older ranges found (but still verify before removing)
+- **❓ NOT FOUND IN LOCK** — package no longer in the tree (orphan — remove immediately)
+
+## Detailed audit (alternative)
+
+If you need more detail than the script provides:
+
+```bash
+python3 << 'EOF'
+import re, json
+
+with open('package.json') as f:
+    resolutions = json.load(f).get('resolutions', {})
+with open('yarn.lock') as f:
+    lock = f.read()
+
+for res_key, res_val in sorted(resolutions.items()):
+    bare = ('@' + res_key.split('@')[1]) if res_key.startswith('@') \
+           else (res_key.split('@')[0] if '@' in res_key else res_key)
+
+    pattern = rf'"({re.escape(bare)}@npm:[^"]+(?:, {re.escape(bare)}@npm:[^"]+)*)":\n  version: "?([^"\n]+)'
+    matches = re.findall(pattern, lock)
+
+    if not matches:
+        print(f'[ORPHAN]  {res_key}: {res_val}')
+        continue
+
+    for descriptor, version in matches:
+        ranges = re.findall(rf'{re.escape(bare)}@npm:([^,>"]+)', descriptor)
+        print(f'[ACTIVE]  {res_key}: {res_val}  →  v{version.strip()}  (requesters: {[r.strip() for r in ranges]})')
+EOF
+```
+
+| Status | Meaning | Action |
+|---|---|---|
+| `[ORPHAN]` | Not in yarn.lock | Remove immediately |
+| `[ACTIVE]` exact pin | Prevents resolution to a different version | Keep unless CVE is fixed upstream |
+| `[ACTIVE]` cross-major | Forces upgrade past semver boundary | Keep — transitive dep hasn't updated |
+| `[ACTIVE]` `^` range, multiple conflicting requesters | Deduplication anchor | Keep |
+| `[ACTIVE]` `^` range, sole requester = same range | Possible no-op | Test before removing |
+
+## Safe removal — always test individually
+
+Never remove multiple resolutions at once:
+
+```bash
+# 1. Remove ONE entry from resolutions in package.json
+# 2. Reinstall:
+yarn install
+
+# 3. Check what changed:
+git diff yarn.lock | grep "^[+-]  version:" | head -20
+
+# Safe to remove if the package version did not change and no other packages split.
+# Revert if the package downgraded or other packages multiplied:
+git checkout -- package.json yarn.lock
+```
+
+**Real example from this project:** removing `"glob": "^11.1.0"` caused glob to downgrade from `11.1.0` to `10.5.0` because a transitive dependency requests `^10.x`. The static analysis (only one visible requester at `^11.1.0`) missed this. Always test.
+
+## Add a resolution (CVE fix)
+
+### `^` range — minimum floor within the major
+
+```json
+"follow-redirects": "^1.16.0"
+```
+
+Use when you want a minimum floor but allow upgrades within the major.
+
+### Exact pin — for ClearlyDefined indexing constraints
+
+```json
+"axios": "1.16.1"
+```
+
+Use when the package isn't indexed at higher versions (check: `curl -s "https://api.clearlydefined.io/definitions/npm/npmjs/-/axios/1.18.0" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['scores']['effective'])"`) or you need to prevent automatic resolution to a newer un-tested version.
+
+### Cross-major override — when requester declares a lower major
+
+```json
+"ip-address": "10.2.0"
+```
+
+Use when the CVE fix is in a new major version and the requester hasn't updated its `^9.x` range yet.
+
+### Scoped version override — force a specific range only
+
+```json
+"ajv@^6.0.0": "6.14.0"
+```
+
+Use when you want to force only the `^6.x` range to a safe 6.x version without affecting the `^8.x` range.
+
+## After adding a resolution
+
+```bash
+yarn install
+grep -A 3 '"<package>@npm' yarn.lock | head -5   # confirm correct version
+yarn license:generate
+```
+
+If `yarn license:generate` fails with UNRESOLVED, see the `fix-cve-dep` skill.

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: pr-description
+description: Generate a full PR description following the che-dashboard template and save it to openspec/docs/. Invoke when asked to "write a PR description", "prepare the PR", "create a description for this branch", or "document what this PR does". Always run check-coverage first — do not write the PR description if any changed package fails its coverage threshold.
+argument-hint: "[branch or ticket-id]"
+---
+
+# Generate PR Description
+
+> **Prerequisite:** Run the `check-coverage` skill first. Do not write the PR description if any changed package fails its coverage threshold.
+
+## Related skills
+
+- **`check-coverage`** — run before writing the PR (coverage must pass first)
+- **`pr-test-section`** — use for the "Is it tested? How?" section
+
+## Workflow
+
+### 1. Gather context
+
+```bash
+git log --oneline origin/main..HEAD   # commits on this branch
+git diff origin/main..HEAD --stat     # changed files
+git branch --show-current             # branch name / ticket
+```
+
+For a CVE/dependency fix, also read the Jira ticket description if provided.
+
+### 2. Choose save path and filename
+
+- Frontend-only changes: `packages/dashboard-frontend/openspec/docs/<name>.md`
+- General / backend / security changes: `openspec/docs/<name>.md`
+
+Filename: `pr-<jira-id>-<short-kebab-topic>.md`
+
+### 3. Write the PR description
+
+Follow the project template **exactly** (from `.github/PULL_REQUEST_TEMPLATE.md`):
+
+```markdown
+### What does this PR do?
+
+<one-sentence summary of the primary change>
+
+<Root Cause + Fix subsections for bugs; numbered bold list for multiple changes>
+
+### Screenshot/screencast of this PR
+
+<omit section if not applicable>
+
+### What issues does this PR fix or reference?
+
+fixes https://redhat.atlassian.net/browse/<TICKET>
+
+### Is it tested? How?
+
+<use the pr-test-section skill>
+
+#### Release Notes
+
+<single past-tense user-facing sentence>
+
+#### Docs PR
+
+N/A
+```
+
+### 4. Writing style
+
+**Lead with an action verb.** First sentence starts with `Fixes / Adds / Upgrades / Prevents / Removes` — present tense, no passive voice.
+
+**For bugs — include Root Cause + Fix:**
+
+```markdown
+### Root Cause
+
+<Exact technical mechanism. Name the function, variable, or condition.>
+
+### Fix
+
+<What changed and why it works. Show a diff block for 1–3 line changes.>
+```
+
+**For multiple independent changes — numbered bold list:**
+
+```markdown
+1. **Thing A** — short explanation of what it fixes/adds and why
+2. **Thing B** — short explanation
+```
+
+**Show diffs for small changes:**
+
+````markdown
+```diff
+-function isPollStopPhase(phase: string): boolean {
++function isTerminalPhase(phase: string): boolean {
+   return (
+-    phase === DevWorkspaceStatus.RUNNING ||
+     phase === DevWorkspaceStatus.FAILED ||
+```
+````
+
+**Release Notes:** Single past-tense sentence from the user's perspective — no internal component names, no TypeScript.
+
+**Avoid:** "This PR implements…", "In order to fix…", "Please note that…", em dash overuse, nested bullet lists.
+
+### 5. Security/CVE format
+
+```markdown
+### What does this PR do?
+
+Upgrades `<package>` to <version> to fix a <vulnerability-type> vulnerability.
+
+`<package>` versions prior to <fix-version> <vulnerability description>. The
+dependency is transitively required by <requester>, so the upgrade requires a
+`resolutions` override in the root `package.json`.
+
+### What issues does this PR fix or reference?
+
+fixes https://redhat.atlassian.net/browse/<JIRA>
+
+### Is it tested? How?
+
+- No runtime logic changed — pure dependency upgrade.
+- `yarn install` resolves cleanly: `<package>@<new-version>` installed, `<package>@<old-version>` removed.
+- `yarn license:generate` completes without unresolved dependencies (`<package>@<version>` ClearlyDefined score <N>, <LICENSE>).
+- `yarn license:check` passes.
+
+#### Release Notes
+
+Updated <package> to <version> to address a <type> vulnerability.
+```
+
+### 6. Save and confirm
+
+Write the file to the determined path, then confirm:
+
+```bash
+ls <path>/<filename>.md
+```

--- a/.claude/skills/pr-test-section/SKILL.md
+++ b/.claude/skills/pr-test-section/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: pr-test-section
+description: Write the "Is it tested? How?" section of a che-dashboard PR description. Invoke any time you need to fill in the test section — UI fixes needing deploy-and-verify steps, logic fixes needing unit test counts, or dependency upgrades needing the license-check checklist. Also use when a reviewer asks for better test documentation.
+---
+
+# Write "Is it tested? How?"
+
+Pick the template that matches the change, then fill in the specifics.
+
+## Choose by change type
+
+| Change type | Template |
+|---|---|
+| UI fix or feature | Deploy + navigate + verify steps |
+| Accessibility fix | Deploy + navigate + DOM/keyboard/reader check |
+| Bug fix with observable behavior | Deploy + reproduce original bug + verify fix |
+| Unit test only | Test suite name + count + pass statement |
+| Dependency / CVE upgrade | `yarn install` + `yarn license:generate` + test suite pass |
+| Pure refactor / rename / N/A | `N/A` or test count only |
+| Platform / hardware specific | Hardware env + build + test pass |
+
+---
+
+## Template 1 — Deploy and verify (UI fix, feature, bug fix)
+
+```
+1. Deploy Eclipse Che with the dashboard image from this PR.
+2. Navigate to **<Page>** → **<Tab or section>**.
+3. <Perform the action that was broken or is new>.
+4. Verify: <what the reviewer should see>.
+```
+
+**Tips:**
+- Step 1 is almost always "Deploy Eclipse Che with the dashboard image from this PR" — include it even if obvious.
+- Use **bold** for UI element names, backticks for terminal commands or DOM attributes.
+- Add a contrast line when useful: "Without this fix: <old wrong behavior>."
+- For multi-scenario fixes, add separate numbered paths ("Idle path:" / "Active path:").
+
+**Real examples:**
+
+```
+1. Deploy Eclipse Che with the dashboard image from this PR.
+2. Start a workspace and verify the kebab (⋮) appears in the loader page header with Start and Stop items.
+3. Press Stop — confirm the workspace stops and the Events tab still shows events collected during startup.
+4. Press Start from the kebab on a stopped workspace — confirm the workspace starts again.
+```
+
+```
+1. Deploy Eclipse Che with the image from this PR.
+2. Create a workspace from a sample with "Create New" OFF.
+3. Navigate to the same factory URL — existing workspace is opened, no duplicate.
+4. Repeat with an airgap sample — same behaviour.
+```
+
+---
+
+## Template 2 — Accessibility fix
+
+```
+1. Deploy Eclipse Che with the dashboard image from this PR.
+2. Navigate to **<Page>**.
+3. <Inspect DOM / run axe / use Tab / use screen reader>.
+4. Verify: <no violation / focus order / announcement>.
+```
+
+**Real examples:**
+
+```
+1. Deploy Eclipse Che with the dashboard image from this PR.
+2. Click the hamburger button (top-left) to collapse the left sidebar.
+3. Press Tab repeatedly — verify focus never enters the collapsed sidebar.
+4. Expand the sidebar again — verify all navigation links are reachable with Tab.
+```
+
+```
+Existing snapshot tests updated to include the new live region elements (25 snapshots updated).
+Manually verified with macOS VoiceOver on Chrome (Command+F5) that status changes are announced without user focus movement.
+```
+
+---
+
+## Template 3 — Unit tests + build only (no deploy needed)
+
+```
+All <N> <SuiteName> tests pass. Full `yarn build` completes with zero errors.
+```
+
+Or for multiple suites:
+
+```
+- All <N> <Suite A> tests pass (<M> suites).
+- All <N> <Suite B> tests pass.
+- `yarn build` (webpack with ts-loader) completes with zero errors.
+```
+
+Use when the fix is pure logic, a new test, a snapshot update, or a mock fix — when no visual change requires a live deploy to verify.
+
+---
+
+## Template 4 — Dependency / CVE upgrade
+
+```
+- No runtime logic changed — pure dependency upgrade.
+- `yarn install` resolves cleanly: `<package>@<new-version>` installed, `<package>@<old-version>` removed.
+- `yarn license:generate` completes without unresolved dependencies.
+- `yarn license:check` passes.
+```
+
+---
+
+## Template 5 — Platform / hardware specific
+
+```
+Tested end-to-end on <hardware/platform>:
+
+1. Native image build — `podman build -f build/dockerfiles/rhel.Dockerfile` completed successfully on <arch>.
+2. Architecture verification — `podman inspect` confirms `OS/Arch: linux/<arch>`.
+3. Full unit test suite — `yarn test` ran natively: <N> tests passed.
+```
+
+---
+
+## Template 6 — N/A
+
+Use only for pure refactoring, doc/comment/whitespace changes, or changes fully covered by existing tests with no new scenarios:
+
+```
+N/A
+```
+
+---
+
+## CLI commands in steps
+
+When the fix requires a cluster command to reproduce, include it inline:
+
+```
+2. Shorten the session timeout to trigger the scenario quickly:
+   ```bash
+   kubectl patch checluster/eclipse-che -n eclipse-che --type=merge \
+     -p '{"spec":{"networking":{"auth":{"gateway":{"oAuthProxy":{"cookieExpireSeconds":120}}}}}}'
+   ```
+3. Idle path: open the dashboard, do not move the mouse. Modal appears at 60 s; sign-out at 120 s.
+4. Active path: keep moving the mouse. Modal must not appear.
+```
+
+---
+
+## What NOT to write
+
+- "Tested" with no specifics — reviewers can't reproduce it
+- The template comment (`<!-- Please provide instructions... -->`)
+- What the code does — describe what the reviewer should DO and SEE
+- Passive voice ("it was verified that") — write in imperative ("verify", "confirm", "run")

--- a/.claude/skills/rebase-to-main/SKILL.md
+++ b/.claude/skills/rebase-to-main/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: rebase-to-main
+description: Rebase the current branch onto latest main and force-push. Invoke whenever the user asks to rebase, bring a branch up to date, resolve rebase conflicts, or push after a rebase. Handles .deps/ conflict resolution, license regeneration, and forbidden-trailer cleanup — all the che-dashboard-specific steps that go wrong without this.
+---
+
+# Rebase Branch to Main
+
+## Workflow
+
+### 1. Fetch and compare
+
+```bash
+git fetch origin main
+git log --oneline FETCH_HEAD..HEAD    # commits to replay
+git log --oneline HEAD..FETCH_HEAD | head -10  # what main added
+```
+
+### 2. Rebase
+
+```bash
+git rebase FETCH_HEAD
+```
+
+No conflicts → skip to step 5.
+
+### 3. Resolve conflicts
+
+#### `.deps/EXCLUDED/prod.md` or `.deps/EXCLUDED/dev.md`
+
+Both sides may have added entries. Merge them — keep all of main's entries and re-apply ours:
+
+```bash
+git checkout --ours .deps/EXCLUDED/prod.md .deps/EXCLUDED/dev.md
+git add .deps/EXCLUDED/prod.md .deps/EXCLUDED/dev.md
+```
+
+Then after continuing the rebase, re-run `yarn license:generate` to restore any entries our branch added.
+
+#### `.deps/prod.md` or `.deps/dev.md`
+
+Always regenerated. Take main's version, then regenerate:
+
+```bash
+git checkout --ours .deps/prod.md .deps/dev.md
+git add .deps/prod.md .deps/dev.md
+```
+
+#### `package.json` / `yarn.lock`
+
+Usually auto-merges. If not, reconcile manually (keep our dep additions alongside main's changes), then:
+
+```bash
+yarn install
+```
+
+#### Continue
+
+```bash
+git add <resolved-files>
+git rebase --continue
+```
+
+### 4. Reinstall and regenerate licenses
+
+```bash
+yarn install 2>&1 | grep -E "(added|removed|Done|Error)" | head -5
+yarn license:generate
+```
+
+**If `yarn license:generate` exits with UNRESOLVED:**
+
+| Symptom | Fix |
+|---|---|
+| Package from main now missing from EXCLUDED | ClearlyDefined batch timeout — retry |
+| New package our branch added | Check score; add to EXCLUDED if 0 |
+
+Check score:
+```bash
+curl -s --max-time 10 \
+  "https://api.clearlydefined.io/definitions/npm/npmjs/-/<package>/<version>" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('scores',{}).get('effective',0))"
+```
+
+Add to EXCLUDED if score = 0:
+```markdown
+| `<package>@<version>` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/<package>/<version>) |
+```
+
+### 5. Verify
+
+```bash
+yarn license:check   # must exit 0
+git log --oneline -5
+git show --stat HEAD
+```
+
+### 6. Strip forbidden trailers
+
+Check for `Made-with` or `Co-authored-by` in any replayed commit:
+
+```bash
+git log FETCH_HEAD..HEAD --format='%H %s' | while read hash rest; do
+  git log -1 --format='%B' "$hash" | grep -qiE '^(Made-with|Co-authored-by):' && echo "DIRTY: $hash $rest"
+done
+```
+
+If dirty:
+```bash
+FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch -f --msg-filter \
+  'sed "/^Made-with:/d; /^Co-authored-by:/d"' \
+  -- FETCH_HEAD..HEAD
+git update-ref -d refs/original/refs/heads/$(git branch --show-current)
+```
+
+For a single-commit branch, amending is simpler:
+```bash
+git commit --amend -m "$(git log -1 --format='%s')"
+# add trailers manually if needed
+```
+
+### 7. Force push
+
+```bash
+git push --force origin <branch>
+```
+
+## Common `.deps/` conflict patterns
+
+**Pattern 1 — Both sides added entries, neither is a superset**
+
+Merge manually: keep all of main's entries, then append ours below them.
+
+**Pattern 2 — Our branch removed a dep entry that main still has**
+
+Take main's version and let `yarn license:generate` clean it up:
+```bash
+git checkout --ours .deps/prod.md
+git add .deps/prod.md
+```
+
+**Pattern 3 — ClearlyDefined link vs `ecd.che` reference for the same package**
+
+Keep the ClearlyDefined link (more complete, preferred by the tool).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,4 +114,23 @@ yarn lint:fix
 
 ## Red Hat Compliance and Responsible AI Rules
 
-See `./redhat-compliance-and-responsible-ai.md` and the Cursor rules file under `./.cursor/rules/`.
+See `./redhat-compliance-and-responsible-ai.md`.
+
+## Project Rules (Claude Code)
+
+Project-specific rules live in `.claude/rules/`:
+
+- **`che-dashboard-dev.md`** — commits, CSS property ordering, dependency license regeneration, git workflow patterns, accessibility conventions
+
+## Project Skills (Claude Code)
+
+Project-specific skills live in `.claude/skills/`. Use `/skill-name` to invoke:
+
+- **`commit-message`** — write a human-style commit message: subject line, optional body, trailers
+- **`manage-resolutions`** — audit `resolutions` in `package.json`: find orphans and stale pins, safely remove them one at a time with `yarn install` diff verification
+- **`fix-cve-dep`** — upgrade a vulnerable npm dependency, check ClearlyDefined, regenerate `.deps/` files, commit and push
+- **`rebase-to-main`** — rebase branch onto latest main, resolve `.deps/` conflicts, regenerate licenses, force-push
+- **`fix-pr-feedback`** — fetch GitHub PR review comments, triage fixed vs open, apply fixes, push
+- **`check-coverage`** — run coverage for changed packages, identify uncovered code, write missing tests; run before `pr-description`
+- **`pr-test-section`** — write the "Is it tested? How?" section: choose the right template (deploy+verify, unit tests, dep upgrade, N/A) based on change type
+- **`pr-description`** — generate a PR description and save to `openspec/docs/` (always run `check-coverage` first)


### PR DESCRIPTION
### What does this PR do?

Adds eight Claude Code skills for recurring che-dashboard workflows.

1. **`fix-cve-dep`** — upgrade a vulnerable npm dep: check ClearlyDefined for license indexing, pin in `resolutions` when needed, reinstall, regenerate `.deps` files, commit with CVE reference.

2. **`rebase-to-main`** — rebase a branch onto latest `main`, resolve the recurring `.deps/` conflict patterns (take-theirs then regenerate), run license check, force-push.

3. **`fix-pr-feedback`** — fetch inline and general PR review comments via `gh api`, triage fixed vs open, apply outstanding fixes, push.

4. **`check-coverage`** — run coverage for changed packages only, identify uncovered code, write missing tests. Enforces thresholds (common 99%/100%, frontend 92/88/85, backend 86/80/86) before a PR is opened.

5. **`pr-description`** — generate a PR description from branch context, save to `openspec/docs/`. Requires `check-coverage` to pass first.

6. **`pr-test-section`** — write the "Is it tested? How?" section using the right template (deploy + verify, unit tests, dep upgrade, N/A) based on change type. Derived from analysis of 25+ closed PRs.

7. **`commit-message`** — write a human-style commit message: subject line, optional body, trailers. Includes anti-pattern table drawn from the actual commit history.

8. **`manage-resolutions`** — audit `resolutions` in `package.json`, identify orphans and stale pins, safely remove them one at a time with `yarn install` diff verification.

### Screenshot/screencast of this PR

N/A — tooling/config changes only.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse-che/che/issues/23852

### Is it tested? How?

Skills are SKILL.md prose files — no executable code changed. 

#### Release Notes

N/A

#### Docs PR

N/A
