### PR TITLE
fix(deps): upgrade undici to 7.28.0 to fix MITM via SOCKS5 proxy (CRW-11335)

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -9,5 +9,6 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `fast-uri@2.4.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.4.0) |
 | `fastify-plugin@5.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify-plugin/5.2.1) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |
+| `undici@7.28.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/undici/7.28.0) |
 
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "handlebars": "^4.7.9",
     "yaml": "^2.8.3",
     "picomatch": "^2.3.2",
-    "undici": "^7.24.5",
+    "undici": "7.28.0",
     "svgo": "^3.3.3",
     "follow-redirects": "^1.16.0",
     "@fastify/static": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13698,10 +13698,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.24.5":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10/038d3568c72bb976e3cc389284f7f1cc64cd70d578300e4676a449fbcb624a35fe99ac127b5f3729f18b8246d6c090444ab61b1b67736bb88f52a3e913d76bf8
+"undici@npm:7.28.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Upgrades `undici` from 7.25.0 to 7.28.0 to fix a man-in-the-middle vulnerability in its SOCKS5 proxy path.

### Root Cause

`undici`'s `ProxyAgent` silently drops the `requestTls` option when the proxy URI uses the `socks5://` or `socks://` scheme. The target HTTPS connection through the SOCKS5 tunnel falls back to Node's default trust store, ignoring any user-configured `ca`, `cert`, `key`, `rejectUnauthorized`, and `servername` settings.

Applications that pin to a corporate or internal CA via `requestTls.ca` get the default Mozilla CA bundle as the trust anchor instead when their proxy is SOCKS5. Any certificate signed by any publicly-trusted CA for the target hostname is accepted, breaking the intended pin and enabling read and tamper of the HTTPS exchange.

The bug was introduced in undici 7.23.0 when SOCKS5 support was added.

### Fix

Pins the `resolutions` entry to exactly `7.28.0` (the minimum patched release). An exact pin prevents yarn from resolving to a newer un-indexed version, which would fail `yarn license:generate`. Adds `undici@7.28.0` to `.deps/EXCLUDED/prod.md` pending ClearlyDefined indexing.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11335

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
- No runtime logic changed — pure dependency upgrade.
- `yarn install` resolves cleanly: `undici@7.28.0` installed, `undici@7.25.0` removed.
- `yarn license:generate` completes without unresolved dependencies (`All found licenses are approved to use`).

#### Release Notes

Updated undici to 7.28.0 to address a man-in-the-middle vulnerability when using a SOCKS5 proxy with TLS scope restriction.

#### Docs PR

N/A