### PR TITLE
[cherry-pick] fix(backend): restore user OAuth token injection in workspace terminals (CRW-11193)

### DIFF
--- a/packages/common/src/__tests__/index.spec.ts
+++ b/packages/common/src/__tests__/index.spec.ts
@@ -10,11 +10,16 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import common from '../';
+import common, { DevWorkspaceStatus } from '../';
 
 describe('Common', () => {
   it('should export all shared code', () => {
     expect(common).toBeDefined();
     expect(common.helpers).toBeDefined();
+  });
+
+  it('should export DevWorkspaceStatus', () => {
+    expect(DevWorkspaceStatus).toBeDefined();
+    expect(DevWorkspaceStatus.RUNNING).toBe('Running');
   });
 });

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -222,6 +222,16 @@ export type IEditors = Array<V230Devfile>;
 export type IEventList = CoreV1EventList;
 export type IPodList = V1PodList;
 
+export enum DevWorkspaceStatus {
+  FAILED = 'Failed',
+  FAILING = 'Failing',
+  STARTING = 'Starting',
+  TERMINATING = 'Terminating',
+  RUNNING = 'Running',
+  STOPPED = 'Stopped',
+  STOPPING = 'Stopping',
+}
+
 export interface IDevWorkspaceList {
   apiVersion?: string;
   kind?: string;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -17,6 +17,7 @@ export * from './dto/cluster-info';
 export * from './dto/cluster-config';
 export * from './types';
 export * from './constants';
+export { DevWorkspaceStatus } from './dto/api';
 
 export { helpers, api };
 

--- a/packages/dashboard-backend/src/routes/api/__tests__/devworkspaces.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/devworkspaces.spec.ts
@@ -80,9 +80,9 @@ describe('DevWorkspaces Routes', () => {
 
     const { PostStartInjector } = jest.requireMock('@/services/PostStartInjector');
     expect(PostStartInjector.watchAndInject).toHaveBeenCalledWith(
-      expect.any(Object),
       namespace,
       workspaceName,
+      expect.objectContaining({ watchInNamespace: expect.any(Function) }),
       expect.objectContaining({ injectKubeConfig: expect.any(Function) }),
       expect.objectContaining({ podmanLogin: expect.any(Function) }),
     );
@@ -132,9 +132,9 @@ describe('DevWorkspaces Routes', () => {
 
     const { PostStartInjector } = jest.requireMock('@/services/PostStartInjector');
     expect(PostStartInjector.watchAndInject).toHaveBeenCalledWith(
-      expect.any(Object),
       namespace,
       workspaceName,
+      expect.objectContaining({ watchInNamespace: expect.any(Function) }),
       expect.objectContaining({ injectKubeConfig: expect.any(Function) }),
       expect.objectContaining({ podmanLogin: expect.any(Function) }),
     );

--- a/packages/dashboard-backend/src/routes/api/devworkspaces.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaces.ts
@@ -21,7 +21,7 @@ import {
   namespacedWorkspaceSchema,
 } from '@/constants/schemas';
 import { restParams } from '@/models';
-import { getDevWorkspaceClient, getKubeConfig } from '@/routes/api/helpers/getDevWorkspaceClient';
+import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
 import { getToken } from '@/routes/api/helpers/getToken';
 import { getSchema } from '@/services/helpers';
 import { PostStartInjector } from '@/services/PostStartInjector';
@@ -68,11 +68,14 @@ export function registerDevworkspacesRoutes(instance: FastifyInstance) {
         // PATCH /spec/started=true (restart), missing first-time creation.
         const workspaceName = devWorkspace.metadata?.name;
         if (devworkspace.spec?.started === true && workspaceName) {
-          const kc = getKubeConfig(token);
+          // Pass a fresh devworkspaceApi instance (DevWorkspaceClient.devworkspaceApi is a
+          // getter — each access returns a new DevWorkspaceApiService). PostStartInjector
+          // calls stopWatching() on this instance when done; passing the same instance that
+          // the route already used for .create() would cancel the route's own watch.
           PostStartInjector.watchAndInject(
-            kc,
             namespace,
             workspaceName,
+            dwClient.devworkspaceApi,
             dwClient.kubeConfigApi,
             dwClient.podmanApi,
           );
@@ -111,11 +114,11 @@ export function registerDevworkspacesRoutes(instance: FastifyInstance) {
 
         const isStarting = patch.some(p => p.path === '/spec/started' && p.value === true);
         if (isStarting) {
-          const kc = getKubeConfig(token);
+          // See comment above — pass a fresh devworkspaceApi instance.
           PostStartInjector.watchAndInject(
-            kc,
             namespace,
             workspaceName,
+            dwClient.devworkspaceApi,
             dwClient.kubeConfigApi,
             dwClient.podmanApi,
           );

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDevWorkspaceClient.ts
@@ -240,6 +240,8 @@ export const getDevWorkspaceClient = jest.fn(
         listInNamespace: _namespace => Promise.resolve(stubDevWorkspacesList),
         patch: (_namespace, _name, _patches) =>
           Promise.resolve({ devWorkspace: stubDevWorkspace, headers: stubHeaders }),
+        watchInNamespace: (_listener, _params) => Promise.resolve(),
+        stopWatching: () => undefined,
       } as IDevWorkspaceApi,
       dockerConfigApi: {
         read: _namespace => Promise.resolve(stubDockerConfig),

--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -10,35 +10,46 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V1alpha2DevWorkspace } from '@devfile/api';
-import {
-  devworkspaceGroup,
-  devworkspaceLatestVersion,
-  devworkspacePlural,
-} from '@devfile/api/constants/constants';
-import * as k8s from '@kubernetes/client-node';
-import { V1Status } from '@kubernetes/client-node';
+import { api, DevWorkspaceStatus } from '@eclipse-che/common';
 
-import { IKubeConfigApi, IPodmanApi } from '@/devworkspaceClient/types';
+import { IDevWorkspaceApi, IKubeConfigApi, IPodmanApi } from '@/devworkspaceClient/types';
+import { MessageListener } from '@/services/types/Observer';
 import { logger } from '@/utils/logger';
 
-const INJECTION_TIMEOUT_MS = 60_000;
+const INJECTION_TIMEOUT_MS = 60000;
+const POLL_INTERVAL_MS = 10000;
+const POLL_TIMEOUT_MS = 300000;
+
+function isTerminalPhase(phase: string): boolean {
+  return (
+    phase === DevWorkspaceStatus.FAILED ||
+    phase === DevWorkspaceStatus.FAILING ||
+    phase === DevWorkspaceStatus.STOPPED ||
+    phase === DevWorkspaceStatus.STOPPING ||
+    phase === DevWorkspaceStatus.TERMINATING
+  );
+}
 
 /**
  * Watches a specific DevWorkspace after it is started and injects
  * kubeconfig + podman credentials once it reaches the Running phase.
  *
+ * Uses the same watchInNamespace() path as the WebSocket SUBSCRIBE DEV_WORKSPACE
+ * channel so there is no separate watch infrastructure.
+ *
  * Guards:
  * - Only one watch per workspace (keyed by namespace/name).
- * - Auto-unsubscribes on: success, Failed phase, timeout, or watch error.
+ * - Unsubscribes (stopWatching) on: success, terminal phase, timeout, or watch error.
+ * - Falls back to polling (GET every 10 s, up to 300 s) if the watch fails.
  */
 export class PostStartInjector {
-  private static activeWatches = new Map<string, AbortController>();
+  // Stores a cleanup function per active workspace key.
+  private static activeWatches = new Map<string, () => void>();
 
   static watchAndInject(
-    kc: k8s.KubeConfig,
     namespace: string,
     workspaceName: string,
+    devworkspaceApi: IDevWorkspaceApi,
     kubeConfigApi: IKubeConfigApi,
     podmanApi: IPodmanApi,
   ): void {
@@ -49,87 +60,169 @@ export class PostStartInjector {
       return;
     }
 
-    const watch = new k8s.Watch(kc);
-    const path = `/apis/${devworkspaceGroup}/${devworkspaceLatestVersion}/watch/namespaces/${namespace}/${devworkspacePlural}`;
-    const queryParams = {
-      watch: true,
-      fieldSelector: `metadata.name=${workspaceName}`,
+    const cleanup = () => {
+      devworkspaceApi.stopWatching();
+      PostStartInjector.activeWatches.delete(key);
     };
 
-    const cleanup = (abortController?: AbortController) => {
-      PostStartInjector.activeWatches.delete(key);
-      abortController?.abort();
-    };
+    PostStartInjector.activeWatches.set(key, cleanup);
 
     const timeoutHandle = setTimeout(() => {
       logger.warn(`PostStartInjector: timed out waiting for ${key} to reach Running`);
-      const ac = PostStartInjector.activeWatches.get(key);
-      cleanup(ac);
+      cleanup();
     }, INJECTION_TIMEOUT_MS);
 
-    const cleanupWithTimeout = (abortController?: AbortController) => {
+    const cleanupWithTimeout = () => {
       clearTimeout(timeoutHandle);
-      cleanup(abortController);
+      cleanup();
     };
 
-    watch
-      .watch(
-        path,
-        queryParams,
-        async (eventPhase: string, apiObj: V1alpha2DevWorkspace | V1Status) => {
-          if (eventPhase === 'ERROR') {
-            logger.warn(`PostStartInjector: watch ERROR for ${key}`);
-            const ac = PostStartInjector.activeWatches.get(key);
-            cleanupWithTimeout(ac);
-            return;
-          }
+    const listener: MessageListener = async message => {
+      if (message.eventPhase === api.webSocket.EventPhase.ERROR) {
+        logger.warn(`PostStartInjector: watch ERROR for ${key}, starting polling fallback`);
+        cleanupWithTimeout();
+        PostStartInjector.startPollingFallback(
+          namespace,
+          workspaceName,
+          devworkspaceApi,
+          kubeConfigApi,
+          podmanApi,
+        );
+        return;
+      }
 
-          const dw = apiObj as V1alpha2DevWorkspace;
+      if (!api.webSocket.isDevWorkspaceMessage(message)) {
+        return;
+      }
+
+      const { devWorkspace } = message;
+      if (devWorkspace.metadata?.name !== workspaceName) {
+        return;
+      }
+
+      const phase = devWorkspace.status?.phase;
+      const devworkspaceId = devWorkspace.status?.devworkspaceId;
+
+      if (phase && isTerminalPhase(phase)) {
+        logger.info(`PostStartInjector: ${key} entered ${phase} phase, aborting`);
+        cleanupWithTimeout();
+        return;
+      }
+
+      if (phase === DevWorkspaceStatus.RUNNING && devworkspaceId) {
+        cleanupWithTimeout();
+        await PostStartInjector.injectCredentials(
+          namespace,
+          devworkspaceId,
+          kubeConfigApi,
+          podmanApi,
+          key,
+        );
+      }
+    };
+
+    devworkspaceApi
+      .watchInNamespace(listener, { namespace, resourceVersion: '' })
+      .catch((error: unknown) => {
+        logger.warn(
+          error,
+          `PostStartInjector: watchInNamespace rejected for ${key}, starting polling fallback`,
+        );
+        cleanupWithTimeout();
+        PostStartInjector.startPollingFallback(
+          namespace,
+          workspaceName,
+          devworkspaceApi,
+          kubeConfigApi,
+          podmanApi,
+        );
+      });
+  }
+
+  private static startPollingFallback(
+    namespace: string,
+    workspaceName: string,
+    devworkspaceApi: IDevWorkspaceApi,
+    kubeConfigApi: IKubeConfigApi,
+    podmanApi: IPodmanApi,
+  ): void {
+    const key = `${namespace}/${workspaceName}`;
+
+    logger.info(`PostStartInjector: polling fallback started for ${key}`);
+
+    let cancelled = false;
+    const cleanup = () => {
+      cancelled = true;
+      PostStartInjector.activeWatches.delete(key);
+    };
+
+    // Re-register so duplicate watchAndInject calls are still blocked during polling.
+    PostStartInjector.activeWatches.set(key, cleanup);
+
+    let elapsed = 0;
+
+    const intervalHandle = setInterval(() => {
+      if (cancelled) {
+        clearInterval(intervalHandle);
+        return;
+      }
+
+      elapsed += POLL_INTERVAL_MS;
+      if (elapsed >= POLL_TIMEOUT_MS) {
+        logger.warn(`PostStartInjector: polling timed out for ${key}`);
+        clearInterval(intervalHandle);
+        cleanup();
+        return;
+      }
+
+      devworkspaceApi
+        .getByName(namespace, workspaceName)
+        .then(async dw => {
           const phase = dw.status?.phase;
           const devworkspaceId = dw.status?.devworkspaceId;
 
-          if (phase === 'Failed') {
-            logger.info(`PostStartInjector: ${key} entered Failed phase, aborting`);
-            const ac = PostStartInjector.activeWatches.get(key);
-            cleanupWithTimeout(ac);
+          if (!phase || (phase !== DevWorkspaceStatus.RUNNING && !isTerminalPhase(phase))) {
             return;
           }
 
-          if (phase === 'Running' && devworkspaceId) {
-            logger.info(
-              `PostStartInjector: ${key} is Running, injecting kubeconfig and podman login`,
-            );
-            try {
-              await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
-            } catch (e) {
-              logger.error(e, `PostStartInjector: failed to inject kubeconfig for ${key}`);
-            }
-            try {
-              await podmanApi.podmanLogin(namespace, devworkspaceId);
-            } catch (e) {
-              logger.error(e, `PostStartInjector: failed podman login for ${key}`);
-            }
-            const ac = PostStartInjector.activeWatches.get(key);
-            cleanupWithTimeout(ac);
-          }
-        },
-        (error: unknown) => {
-          logger.warn(error, `PostStartInjector: watch connection lost for ${key}`);
-          cleanupWithTimeout();
-        },
-      )
-      .then((abortController: AbortController) => {
-        if (!PostStartInjector.activeWatches.has(key)) {
-          abortController.abort();
-        } else {
-          PostStartInjector.activeWatches.set(key, abortController);
-        }
-      })
-      .catch((error: unknown) => {
-        logger.error(error, `PostStartInjector: failed to start watch for ${key}`);
-        cleanupWithTimeout();
-      });
+          clearInterval(intervalHandle);
+          cleanup();
 
-    PostStartInjector.activeWatches.set(key, new AbortController());
+          if (phase === DevWorkspaceStatus.RUNNING && devworkspaceId) {
+            await PostStartInjector.injectCredentials(
+              namespace,
+              devworkspaceId,
+              kubeConfigApi,
+              podmanApi,
+              key,
+            );
+          } else {
+            logger.info(`PostStartInjector: ${key} is in phase ${phase}, stopping poll`);
+          }
+        })
+        .catch((e: unknown) => {
+          logger.warn(e, `PostStartInjector: poll GET failed for ${key}, will retry`);
+        });
+    }, POLL_INTERVAL_MS);
+  }
+
+  private static async injectCredentials(
+    namespace: string,
+    devworkspaceId: string,
+    kubeConfigApi: IKubeConfigApi,
+    podmanApi: IPodmanApi,
+    key: string,
+  ): Promise<void> {
+    logger.info(`PostStartInjector: ${key} is Running, injecting kubeconfig and podman login`);
+    try {
+      await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
+    } catch (e) {
+      logger.error(e, `PostStartInjector: failed to inject kubeconfig for ${key}`);
+    }
+    try {
+      await podmanApi.podmanLogin(namespace, devworkspaceId);
+    } catch (e) {
+      logger.error(e, `PostStartInjector: failed podman login for ${key}`);
+    }
   }
 }

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -10,40 +10,11 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { V1alpha2DevWorkspace } from '@devfile/api';
-import * as k8s from '@kubernetes/client-node';
+import { api } from '@eclipse-che/common';
 
-import { IKubeConfigApi, IPodmanApi } from '@/devworkspaceClient/types';
+import { IDevWorkspaceApi, IKubeConfigApi, IPodmanApi } from '@/devworkspaceClient/types';
 import { PostStartInjector } from '@/services/PostStartInjector';
-
-type WatchCallback = (phase: string, obj: V1alpha2DevWorkspace) => Promise<void>;
-type DoneCallback = (error: unknown) => void;
-
-let watchCallback: WatchCallback;
-let doneCallback: DoneCallback;
-let watchPromiseResolve: (ac: AbortController) => void;
-let watchPromiseReject: (error: unknown) => void;
-
-const mockAbortController = { abort: jest.fn() } as unknown as AbortController;
-
-const mockWatch = jest.fn().mockImplementation((_path, _params, cb, doneCb) => {
-  watchCallback = cb;
-  doneCallback = doneCb;
-  return new Promise<AbortController>((resolve, reject) => {
-    watchPromiseResolve = resolve;
-    watchPromiseReject = reject;
-  });
-});
-
-jest.mock('@kubernetes/client-node', () => {
-  const original = jest.requireActual('@kubernetes/client-node');
-  return {
-    ...original,
-    Watch: jest.fn().mockImplementation(() => ({
-      watch: mockWatch,
-    })),
-  };
-});
+import { MessageListener } from '@/services/types/Observer';
 
 jest.mock('@/utils/logger', () => ({
   logger: {
@@ -56,20 +27,31 @@ jest.mock('@/utils/logger', () => ({
 describe('PostStartInjector', () => {
   const namespace = 'user-che';
   const workspaceName = 'my-workspace';
-  let kc: k8s.KubeConfig;
+  const key = `${namespace}/${workspaceName}`;
+
+  let capturedListener: MessageListener;
+  let devworkspaceApi: IDevWorkspaceApi;
   let kubeConfigApi: IKubeConfigApi;
   let podmanApi: IPodmanApi;
 
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
-    // Reset static map between tests
     (PostStartInjector as any).activeWatches = new Map();
 
-    kc = new k8s.KubeConfig();
+    devworkspaceApi = {
+      watchInNamespace: jest.fn().mockImplementation((listener: MessageListener) => {
+        capturedListener = listener;
+        return Promise.resolve();
+      }),
+      stopWatching: jest.fn(),
+      getByName: jest.fn(),
+    } as unknown as IDevWorkspaceApi;
+
     kubeConfigApi = {
       injectKubeConfig: jest.fn().mockResolvedValue(undefined),
     } as unknown as IKubeConfigApi;
+
     podmanApi = {
       podmanLogin: jest.fn().mockResolvedValue(undefined),
     } as unknown as IPodmanApi;
@@ -79,170 +61,224 @@ describe('PostStartInjector', () => {
     jest.useRealTimers();
   });
 
-  test('should set up a watch and register in activeWatches', () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
+  // ── helpers ──────────────────────────────────────────────────────────────
 
-    expect(mockWatch).toHaveBeenCalledTimes(1);
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      true,
-    );
-  });
-
-  test('should skip if watch already active for the same workspace', () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    expect(mockWatch).toHaveBeenCalledTimes(1);
-  });
-
-  test('should inject kubeconfig and podman on Running phase', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    const dw: V1alpha2DevWorkspace = {
-      status: { phase: 'Running', devworkspaceId: 'workspace123' },
+  function dwMessage(
+    phase: string,
+    devworkspaceId: string,
+    name = workspaceName,
+  ): api.webSocket.DevWorkspaceMessage {
+    return {
+      eventPhase: api.webSocket.EventPhase.MODIFIED,
+      devWorkspace: {
+        metadata: { name },
+        status: { phase, devworkspaceId },
+      },
     };
-    await watchCallback('MODIFIED', dw);
+  }
 
-    expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'workspace123');
-    expect(podmanApi.podmanLogin).toHaveBeenCalledWith(namespace, 'workspace123');
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      false,
+  function dwMessageNoId(phase: string): api.webSocket.DevWorkspaceMessage {
+    return {
+      eventPhase: api.webSocket.EventPhase.MODIFIED,
+      devWorkspace: {
+        metadata: { name: workspaceName },
+        status: { phase },
+      },
+    } as api.webSocket.DevWorkspaceMessage;
+  }
+
+  function errorMessage(): api.webSocket.StatusMessage {
+    return {
+      eventPhase: api.webSocket.EventPhase.ERROR,
+      status: { kind: 'Status', apiVersion: 'v1', status: 'Failure' },
+      params: { namespace, resourceVersion: '0' },
+    };
+  }
+
+  function invoke() {
+    PostStartInjector.watchAndInject(
+      namespace,
+      workspaceName,
+      devworkspaceApi,
+      kubeConfigApi,
+      podmanApi,
     );
+  }
+
+  // ── watch setup ───────────────────────────────────────────────────────────
+
+  test('registers in activeWatches and calls watchInNamespace', () => {
+    invoke();
+
+    expect(devworkspaceApi.watchInNamespace).toHaveBeenCalledWith(expect.any(Function), {
+      namespace,
+      resourceVersion: '',
+    });
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
   });
 
-  test('should handle injectKubeConfig failure gracefully', async () => {
-    (kubeConfigApi.injectKubeConfig as jest.Mock).mockRejectedValue(new Error('kubeconfig failed'));
+  test('skips if a watch is already active for the same workspace', () => {
+    invoke();
+    invoke();
 
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
+    expect(devworkspaceApi.watchInNamespace).toHaveBeenCalledTimes(1);
+  });
 
-    const dw: V1alpha2DevWorkspace = {
-      status: { phase: 'Running', devworkspaceId: 'workspace123' },
-    };
-    await watchCallback('MODIFIED', dw);
+  // ── Running phase ─────────────────────────────────────────────────────────
+
+  test('injects and unsubscribes on Running phase', async () => {
+    invoke();
+    await capturedListener(dwMessage('Running', 'ws-123'));
+
+    expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-123');
+    expect(podmanApi.podmanLogin).toHaveBeenCalledWith(namespace, 'ws-123');
+    expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+  });
+
+  test('skips injection when Running but devworkspaceId is missing', async () => {
+    invoke();
+    await capturedListener(dwMessageNoId('Running'));
+
+    expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
+  });
+
+  test('handles injectKubeConfig failure gracefully', async () => {
+    (kubeConfigApi.injectKubeConfig as jest.Mock).mockRejectedValue(new Error('kube error'));
+    invoke();
+    await capturedListener(dwMessage('Running', 'ws-123'));
+
+    expect(podmanApi.podmanLogin).toHaveBeenCalled();
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+  });
+
+  test('handles podmanLogin failure gracefully', async () => {
+    (podmanApi.podmanLogin as jest.Mock).mockRejectedValue(new Error('podman error'));
+    invoke();
+    await capturedListener(dwMessage('Running', 'ws-123'));
 
     expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalled();
-    expect(podmanApi.podmanLogin).toHaveBeenCalled();
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
   });
 
-  test('should handle podmanLogin failure gracefully', async () => {
-    (podmanApi.podmanLogin as jest.Mock).mockRejectedValue(new Error('podman failed'));
+  // ── terminal phases ───────────────────────────────────────────────────────
 
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
+  test.each(['Failed', 'Failing', 'Stopped', 'Stopping', 'Terminating'])(
+    'stops watching without injection on %s phase',
+    async phase => {
+      invoke();
+      await capturedListener(dwMessageNoId(phase));
 
-    const dw: V1alpha2DevWorkspace = {
-      status: { phase: 'Running', devworkspaceId: 'workspace123' },
-    };
-    await watchCallback('MODIFIED', dw);
+      expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
+      expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
+      expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+    },
+  );
 
-    expect(podmanApi.podmanLogin).toHaveBeenCalled();
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      false,
-    );
-  });
-
-  test('should skip injection if Running but no devworkspaceId', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    const dw = {
-      status: { phase: 'Running' },
-    } as V1alpha2DevWorkspace;
-    await watchCallback('MODIFIED', dw);
+  test('ignores non-terminal phases (e.g. Starting)', async () => {
+    invoke();
+    await capturedListener(dwMessage('Starting', 'ws-123'));
 
     expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
-    expect(podmanApi.podmanLogin).not.toHaveBeenCalled();
+    expect(devworkspaceApi.stopWatching).not.toHaveBeenCalled();
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
   });
 
-  test('should cleanup on Failed phase', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
+  // ── filtering ─────────────────────────────────────────────────────────────
 
-    const dw = {
-      status: { phase: 'Failed' },
-    } as V1alpha2DevWorkspace;
-    await watchCallback('MODIFIED', dw);
+  test('ignores events for a different workspace name', async () => {
+    invoke();
+    await capturedListener(dwMessage('Running', 'ws-123', 'other-workspace')); // different name
 
     expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      false,
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
+  });
+
+  // ── timeout ───────────────────────────────────────────────────────────────
+
+  test('cleans up on 60 s timeout', () => {
+    invoke();
+    jest.advanceTimersByTime(60000);
+
+    expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+  });
+
+  // ── polling fallback (triggered by ERROR event) ───────────────────────────
+
+  describe('polling fallback', () => {
+    async function triggerErrorAndFlush(): Promise<void> {
+      invoke();
+      await capturedListener(errorMessage());
+      await Promise.resolve().then(() => Promise.resolve());
+    }
+
+    test('starts polling when watch receives ERROR event', async () => {
+      (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+        status: { phase: 'Starting' },
+      });
+
+      await triggerErrorAndFlush();
+
+      // Watch stopped, but polling keeps the key registered
+      expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
+      expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
+    });
+
+    test('injects on Running phase during polling', async () => {
+      (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+        status: { phase: 'Running', devworkspaceId: 'ws-poll-id' },
+      });
+
+      await triggerErrorAndFlush();
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve().then(() => Promise.resolve());
+
+      expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-poll-id');
+      expect(podmanApi.podmanLogin).toHaveBeenCalledWith(namespace, 'ws-poll-id');
+      expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+    });
+
+    test.each(['Failed', 'Failing', 'Stopped', 'Stopping', 'Terminating'])(
+      'stops polling without injection on %s phase',
+      async phase => {
+        (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({ status: { phase } });
+
+        await triggerErrorAndFlush();
+        jest.advanceTimersByTime(10000);
+        await Promise.resolve().then(() => Promise.resolve());
+
+        expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
+        expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+      },
     );
-  });
 
-  test('should cleanup on ERROR event phase', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
+    test('stops polling after 300 s timeout', async () => {
+      (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+        status: { phase: 'Starting' },
+      });
 
-    const dw: V1alpha2DevWorkspace = {};
-    await watchCallback('ERROR', dw);
+      await triggerErrorAndFlush();
+      jest.advanceTimersByTime(300000);
 
-    expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      false,
-    );
-  });
+      expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
+      expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+    });
 
-  test('should ignore non-terminal phases (e.g. Starting)', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
+    test('retries after a GET error during polling', async () => {
+      (devworkspaceApi.getByName as jest.Mock)
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValue({ status: { phase: 'Running', devworkspaceId: 'ws-retry-id' } });
 
-    const dw: V1alpha2DevWorkspace = {
-      status: { phase: 'Starting', devworkspaceId: 'workspace123' },
-    };
-    await watchCallback('MODIFIED', dw);
+      await triggerErrorAndFlush();
 
-    expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      true,
-    );
-  });
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve().then(() => Promise.resolve());
+      expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
 
-  test('should cleanup on watch connection lost (done callback)', () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    doneCallback(new Error('connection lost'));
-
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      false,
-    );
-  });
-
-  test('should store real AbortController from .then()', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    watchPromiseResolve(mockAbortController);
-    await Promise.resolve();
-
-    const stored = (PostStartInjector as any).activeWatches.get(`${namespace}/${workspaceName}`);
-    expect(stored).toBe(mockAbortController);
-  });
-
-  test('should abort if watch already cleaned up before .then() fires', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    // Simulate cleanup before .then() resolves
-    (PostStartInjector as any).activeWatches.delete(`${namespace}/${workspaceName}`);
-
-    watchPromiseResolve(mockAbortController);
-    await Promise.resolve();
-
-    expect(mockAbortController.abort).toHaveBeenCalled();
-  });
-
-  test('should cleanup on watch .catch()', async () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    watchPromiseReject(new Error('watch failed'));
-    // Wait for microtask
-    await Promise.resolve().then(() => Promise.resolve());
-
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      false,
-    );
-  });
-
-  test('should cleanup on timeout', () => {
-    PostStartInjector.watchAndInject(kc, namespace, workspaceName, kubeConfigApi, podmanApi);
-
-    jest.advanceTimersByTime(60_000);
-
-    expect((PostStartInjector as any).activeWatches.has(`${namespace}/${workspaceName}`)).toBe(
-      false,
-    );
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve().then(() => Promise.resolve());
+      expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-retry-id');
+    });
   });
 });

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { DevWorkspaceStatus } from '@eclipse-che/common';
 import { AlertVariant } from '@patternfly/react-core';
 import * as React from 'react';
 
@@ -91,15 +92,7 @@ export enum WorkspaceStatus {
   ERROR = 'ERROR',
 }
 
-export enum DevWorkspaceStatus {
-  FAILED = 'Failed',
-  FAILING = 'Failing',
-  STARTING = 'Starting',
-  TERMINATING = 'Terminating',
-  RUNNING = 'Running',
-  STOPPED = 'Stopped',
-  STOPPING = 'Stopping',
-}
+export { DevWorkspaceStatus };
 
 export function isDevWorkspaceStatus(status: unknown): status is DevWorkspaceStatus {
   return Object.values(DevWorkspaceStatus).includes(status as DevWorkspaceStatus);

--- a/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/devWorkspaceBuilder.ts
@@ -19,7 +19,6 @@ import getRandomString from '@/services/helpers/random';
 import { DevWorkspaceStatus } from '@/services/helpers/types';
 
 export class DevWorkspaceBuilder {
-  private name = 'dev-wksp-' + getRandomString(4);
   private workspace: any = {
     kind: 'DevWorkspace',
     apiVersion: 'workspace.devfile.io/v1alpha2',


### PR DESCRIPTION
### What does this PR do?

Cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1606 to the `7.119.x` branch.

Fixes `oc whoami` returning the workspace pod service account identity instead of the logged-in user's identity in workspace terminals after Dev Spaces 3.28.1.

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11193
