### PR TITLE
fix: prevent devfile command removal on workspace start

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/StartWorkspace/index.tsx
@@ -251,6 +251,10 @@ class StartingStepStartWorkspace extends ProgressStep<Props, State> {
       this.state.shouldStart &&
       workspaceStatusIs(workspace, DevWorkspaceStatus.STOPPED, DevWorkspaceStatus.FAILED)
     ) {
+      // Flip shouldStart immediately so that any re-render triggered by an intermediate
+      // PATCH during startWorkspace() (e.g. managePvcStrategy, manageContainerSccAttribute)
+      // does not dispatch a second concurrent startWorkspace call.
+      this.setState({ shouldStart: false });
       await this.props.startWorkspace(workspace, getStartParams(this.props.location));
     }
 

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/aiTools.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/aiTools.spec.ts
@@ -40,19 +40,18 @@ const CLAUDE_TOOL: api.AiToolDefinition = {
   envVarName: 'ANTHROPIC_API_KEY',
 };
 
-const GEMINI_TOOL: api.AiToolDefinition = {
-  providerId: 'google/gemini',
-  tag: 'latest',
-  name: 'Gemini CLI',
-  url: 'https://github.com/google-gemini/gemini-cli',
-  binary: 'gemini',
-  pattern: 'bundle',
-  injectorImage: 'quay.io/example/gemini-cli:next',
-  envVarName: 'GEMINI_API_KEY',
-  setupCommand: 'mkdir -p /tmp/gemini-home/.gemini',
+const OPENCODE_TOOL: api.AiToolDefinition = {
+  providerId: 'opencodeai/opencode',
+  tag: 'next',
+  name: 'OpenCode',
+  url: 'https://opencode.ai',
+  binary: 'opencode',
+  pattern: 'init',
+  injectorImage: 'quay.io/example/opencode:next',
+  envVarName: 'GOOGLE_GENERATIVE_AI_API_KEY',
 };
 
-const ALL_TOOLS = [CLAUDE_TOOL, GEMINI_TOOL];
+const ALL_TOOLS = [CLAUDE_TOOL, OPENCODE_TOOL];
 
 function buildWorkspaceWithComponents(
   components: Array<Record<string, unknown>>,
@@ -124,11 +123,11 @@ describe('aiTools', () => {
       const workspace = buildWorkspaceWithComponents([
         { name: 'editor', container: { image: 'che-code:latest' } },
         {
-          name: 'gemini-cli-injector',
-          container: { image: 'quay.io/example/gemini-cli:next' },
+          name: 'opencode-injector',
+          container: { image: 'quay.io/example/opencode:next' },
         },
       ]);
-      expect(getInjectedAiToolIds(workspace, ALL_TOOLS)).toEqual(['google/gemini']);
+      expect(getInjectedAiToolIds(workspace, ALL_TOOLS)).toEqual(['opencodeai/opencode']);
     });
 
     it('should detect multiple injected tools', () => {
@@ -139,13 +138,13 @@ describe('aiTools', () => {
           container: { image: 'quay.io/example/claude-code:next' },
         },
         {
-          name: 'gemini-cli-injector',
-          container: { image: 'quay.io/example/gemini-cli:next' },
+          name: 'opencode-injector',
+          container: { image: 'quay.io/example/opencode:next' },
         },
       ]);
       expect(getInjectedAiToolIds(workspace, ALL_TOOLS)).toEqual([
         'anthropic/claude',
-        'google/gemini',
+        'opencodeai/opencode',
       ]);
     });
 
@@ -247,20 +246,18 @@ describe('aiTools', () => {
       expect(template.events?.postStart).toContain('symlink-claude-code');
     });
 
-    it('should add bundle-pattern tool with correct copy command', () => {
+    it('should add init-pattern opencode with correct copy command', () => {
       const workspace = buildWorkspaceWithComponents([
         { name: 'editor', container: { image: 'che-code:latest' } },
       ]);
 
-      const patched = addAiToolToWorkspace(workspace, 'google/gemini', ALL_TOOLS);
-      const injector = patched.spec.template.components?.find(
-        c => c.name === 'gemini-cli-injector',
-      );
+      const patched = addAiToolToWorkspace(workspace, 'opencodeai/opencode', ALL_TOOLS);
+      const injector = patched.spec.template.components?.find(c => c.name === 'opencode-injector');
       expect(injector?.container?.command).toEqual(['/bin/sh']);
-      expect(injector?.container?.args).toEqual([
-        '-c',
-        'rm -rf /injected-tools/gemini-cli 2>/dev/null; cp -a /opt/gemini-cli/. /injected-tools/gemini-cli/',
-      ]);
+      expect(injector?.container?.args?.[0]).toBe('-c');
+      expect(injector?.container?.args?.[1]).toContain(
+        'cp /usr/local/bin/opencode /injected-tools/bin/opencode',
+      );
     });
 
     it('should mark injector component with admin-manageable attribute', () => {
@@ -404,19 +401,19 @@ describe('aiTools', () => {
       expect(mount?.path).toBe('/injected-tools');
     });
 
-    it('should include setupCommand for bundle-pattern tools', () => {
+    it('should create symlink-opencode command that exports the injected-tools PATH', () => {
       const workspace = buildWorkspaceWithComponents([
         { name: 'editor', container: { image: 'che-code:latest' } },
       ]);
 
-      const patched = addAiToolToWorkspace(workspace, 'google/gemini', ALL_TOOLS);
+      const patched = addAiToolToWorkspace(workspace, 'opencodeai/opencode', ALL_TOOLS);
       const symlinkCmd = patched.spec.template.commands?.find(
-        (c: { id?: string }) => c.id === 'symlink-gemini-cli',
+        (c: { id?: string }) => c.id === 'symlink-opencode',
       ) as { exec?: { commandLine?: string } } | undefined;
 
-      expect(symlinkCmd?.exec?.commandLine).toContain('mkdir -p /tmp/gemini-home/.gemini');
-      expect(symlinkCmd?.exec?.commandLine).toContain('ln -sf');
-      expect(symlinkCmd?.exec?.commandLine).toContain('/injected-tools/gemini-cli/bin/gemini');
+      // init-pattern: binary is copied directly to /injected-tools/bin — PATH export only
+      expect(symlinkCmd?.exec?.commandLine).toContain('injected-tools');
+      expect(symlinkCmd?.exec?.commandLine).toContain('PATH');
     });
 
     it('should throw for unknown tool ID', () => {
@@ -564,21 +561,20 @@ describe('aiTools', () => {
       expect(cleanupCmd?.exec?.commandLine).toMatch(/^nohup sh -c '.*' >\/dev\/null 2>&1 &$/);
     });
 
-    it('should add cleanup that removes bundle directory for bundle-pattern tools', () => {
+    it('should add cleanup that removes the binary for init-pattern tools', () => {
       const workspace = buildWorkspaceWithComponents([
         { name: 'editor', container: { image: 'che-code:latest' } },
       ]);
 
-      const added = addAiToolToWorkspace(workspace, 'google/gemini', ALL_TOOLS);
+      const added = addAiToolToWorkspace(workspace, 'opencodeai/opencode', ALL_TOOLS);
       const addedWorkspace = constructWorkspace(added);
-      const removed = removeAiToolFromWorkspace(addedWorkspace, 'google/gemini', ALL_TOOLS);
+      const removed = removeAiToolFromWorkspace(addedWorkspace, 'opencodeai/opencode', ALL_TOOLS);
 
       const cleanupCmd = removed.spec.template.commands?.find(
-        (c: { id?: string }) => c.id === 'cleanup-gemini-cli',
+        (c: { id?: string }) => c.id === 'cleanup-opencode',
       ) as { exec?: { commandLine?: string } } | undefined;
       expect(cleanupCmd).toBeDefined();
-      expect(cleanupCmd?.exec?.commandLine).toContain('rm -rf /injected-tools/gemini-cli');
-      expect(cleanupCmd?.exec?.commandLine).toContain('rm -f /injected-tools/bin/gemini');
+      expect(cleanupCmd?.exec?.commandLine).toContain('rm -f /injected-tools/bin/opencode');
     });
 
     it('should remove cleanup command when re-adding a previously removed tool', () => {
@@ -626,18 +622,22 @@ describe('aiTools', () => {
 
       const withBoth = addAiToolToWorkspace(
         addAiToolToWorkspace(workspace, 'anthropic/claude', ALL_TOOLS),
-        'google/gemini',
+        'opencodeai/opencode',
         ALL_TOOLS,
       );
       const withBothWs = constructWorkspace(withBoth);
       const removedClaude = removeAiToolFromWorkspace(withBothWs, 'anthropic/claude', ALL_TOOLS);
       const removedClaudeWs = constructWorkspace(removedClaude);
-      const removedBoth = removeAiToolFromWorkspace(removedClaudeWs, 'google/gemini', ALL_TOOLS);
+      const removedBoth = removeAiToolFromWorkspace(
+        removedClaudeWs,
+        'opencodeai/opencode',
+        ALL_TOOLS,
+      );
 
       const annotation = removedBoth.metadata?.annotations?.[PENDING_CLEANUP_ANNOTATION] ?? '';
       const slugs = annotation.split(',');
       expect(slugs).toContain('claude-code');
-      expect(slugs).toContain('gemini-cli');
+      expect(slugs).toContain('opencode');
     });
   });
 
@@ -903,6 +903,70 @@ describe('aiTools', () => {
       expect(result!.spec.template.events?.postStart).toHaveLength(0);
     });
 
+    it('should not remove user devfile commands that happen to start with install- or run-', () => {
+      // Regression for che-23892: commands like 'install-chectl' or 'run-claude-yolo'
+      // must not be treated as orphaned AI tool commands.
+      const workspace = buildWorkspaceWithComponents(
+        [
+          {
+            name: 'tools',
+            container: { image: 'quay.io/devfile/universal-developer-image:latest' },
+          },
+          {
+            name: 'opencode-injector',
+            attributes: { 'che.eclipse.org/admin-manageable': true },
+            // Use the same base as OPENCODE_TOOL so it is recognized (not stale)
+            container: { image: 'quay.io/example/opencode:next' },
+          },
+        ],
+        [
+          { id: 'build-sources', exec: { component: 'tools' } },
+          { id: 'install-chectl', exec: { component: 'tools' } },
+          { id: 'install-claude', exec: { component: 'tools' } },
+          { id: 'run-claude-yolo', exec: { component: 'tools' } },
+          { id: 'install-opencode', apply: { component: 'opencode-injector' } },
+          { id: 'symlink-opencode', exec: { component: 'tools' } },
+        ],
+        {
+          preStart: ['install-opencode'],
+          postStart: ['symlink-opencode'],
+        },
+      );
+
+      // No stale tools: sanitizeStaleAiTools should return null (no changes needed)
+      const result = sanitizeStaleAiTools(workspace.ref, ALL_TOOLS);
+      expect(result).toBeNull();
+    });
+
+    it('should not remove user cleanup- commands that do not match any registered tool slug', () => {
+      // Regression: /^cleanup-(.+)$/ must not remove user commands like 'cleanup-old-cache'.
+      const workspace = buildWorkspaceWithComponents(
+        [
+          {
+            name: 'tools',
+            container: { image: 'quay.io/devfile/universal-developer-image:latest' },
+          },
+          {
+            name: 'opencode-injector',
+            attributes: { 'che.eclipse.org/admin-manageable': true },
+            container: { image: 'quay.io/example/opencode:next' },
+          },
+        ],
+        [
+          { id: 'cleanup-old-cache', exec: { component: 'tools' } },
+          { id: 'install-opencode', apply: { component: 'opencode-injector' } },
+          { id: 'symlink-opencode', exec: { component: 'tools' } },
+        ],
+        {
+          preStart: ['install-opencode'],
+          postStart: ['symlink-opencode'],
+        },
+      );
+
+      const result = sanitizeStaleAiTools(workspace.ref, ALL_TOOLS);
+      expect(result).toBeNull();
+    });
+
     it('should keep cleanup command when pending-cleanup annotation is present', () => {
       // First cold start after tool removal: annotation marks cleanup as pending,
       // so the command must survive this start cycle to execute during postStart.
@@ -1058,9 +1122,21 @@ describe('aiTools', () => {
 
     it('should select the best tool by tag priority when multiple tools share a providerId', () => {
       const toolsWithMultipleVersions: api.AiToolDefinition[] = [
-        { ...CLAUDE_TOOL, tag: '1.0.0', injectorImage: 'quay.io/example/claude-code:1.0.0' },
-        { ...CLAUDE_TOOL, tag: 'next', injectorImage: 'quay.io/example/claude-code:next' },
-        { ...CLAUDE_TOOL, tag: 'latest', injectorImage: 'quay.io/example/claude-code:latest' },
+        {
+          ...CLAUDE_TOOL,
+          tag: '1.0.0',
+          injectorImage: 'quay.io/example/claude-code:1.0.0',
+        },
+        {
+          ...CLAUDE_TOOL,
+          tag: 'next',
+          injectorImage: 'quay.io/example/claude-code:next',
+        },
+        {
+          ...CLAUDE_TOOL,
+          tag: 'latest',
+          injectorImage: 'quay.io/example/claude-code:latest',
+        },
       ];
 
       const workspace = buildWorkspaceWithComponents([
@@ -1089,9 +1165,21 @@ describe('aiTools', () => {
 
     it('should select the highest semver when no named tags are present', () => {
       const toolsWithSemver: api.AiToolDefinition[] = [
-        { ...CLAUDE_TOOL, tag: '1.0.0', injectorImage: 'quay.io/example/claude-code:1.0.0' },
-        { ...CLAUDE_TOOL, tag: '3.21', injectorImage: 'quay.io/example/claude-code:3.21' },
-        { ...CLAUDE_TOOL, tag: '2.55', injectorImage: 'quay.io/example/claude-code:2.55' },
+        {
+          ...CLAUDE_TOOL,
+          tag: '1.0.0',
+          injectorImage: 'quay.io/example/claude-code:1.0.0',
+        },
+        {
+          ...CLAUDE_TOOL,
+          tag: '3.21',
+          injectorImage: 'quay.io/example/claude-code:3.21',
+        },
+        {
+          ...CLAUDE_TOOL,
+          tag: '2.55',
+          injectorImage: 'quay.io/example/claude-code:2.55',
+        },
       ];
 
       const workspace = buildWorkspaceWithComponents([

--- a/packages/dashboard-frontend/src/services/helpers/aiTools.ts
+++ b/packages/dashboard-frontend/src/services/helpers/aiTools.ts
@@ -510,6 +510,11 @@ export function sanitizeStaleAiTools(
       .map(c => c.name!.replace(/-injector$/, '')),
   );
 
+  // Slugs derived from all registered AI tools. Only commands whose slug appears here
+  // are candidates for orphan removal — this prevents user devfile commands like
+  // 'install-chectl' or 'run-claude-yolo' from being mistaken for orphaned AI tool commands.
+  const registeredToolSlugs = new Set(allTools.map(getToolSlug));
+
   // Find orphaned tool commands whose injector component no longer exists.
   const commands = (template.commands ?? []) as Array<{ id?: string }>;
   const toolCmdPattern = /^(install|symlink|run)-(.+)$/;
@@ -520,7 +525,7 @@ export function sanitizeStaleAiTools(
       continue;
     }
     const match = cmd.id.match(toolCmdPattern);
-    if (match && !remainingInjectorSlugs.has(match[2])) {
+    if (match && registeredToolSlugs.has(match[2]) && !remainingInjectorSlugs.has(match[2])) {
       orphanedCommandIds.add(cmd.id);
     }
   }
@@ -541,7 +546,7 @@ export function sanitizeStaleAiTools(
       continue;
     }
     const match = cmd.id.match(cleanupCmdPattern);
-    if (match && !remainingInjectorSlugs.has(match[1])) {
+    if (match && registeredToolSlugs.has(match[1]) && !remainingInjectorSlugs.has(match[1])) {
       const slug = match[1];
       if (pendingSlugs.has(slug)) {
         // Cleanup has not yet executed — keep the command, clear the annotation


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes user-defined devfile commands being silently removed from the workspace spec whenever `sanitizeStaleAiTools()` runs on workspace start.

### Root Cause

`sanitizeStaleAiTools()` removes commands left behind when an AI tool injector component is deleted. To find them it matches command IDs against `/^(install|symlink|run)-(.+)$/` and `/^cleanup-(.+)$/`, then checks whether the extracted slug still has a live injector component. If not, the command is marked orphaned and deleted.

### Fix

Add one extra condition: the slug must appear in `registeredToolSlugs`, the set of slugs derived from all tools registered in the AI registry. Commands that start with `install-`, `run-`, or `cleanup-` but whose slug does not match any registered tool are left untouched.

```diff
-    if (match && !remainingInjectorSlugs.has(match[2])) {
+    if (match && registeredToolSlugs.has(match[2]) && !remainingInjectorSlugs.has(match[2])) {
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<img width="1909" height="1027" alt="Знімок екрана 2026-06-24 о 13 44 56" src="https://github.com/user-attachments/assets/95d22673-80d3-45f2-9a52-fffffcfc79ac" />

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23892

### Is it tested? How?

1. Deploy Dev Spaces with the dashboard image built from this PR.
2. Create a workspace from a factory URL with an AI provider, e.g.:
   `https://github.com/eclipse-che/che-server.git` with `?ai-provider=opencodeai/opencode` appended.
3. Wait for the workspace to reach Running.
4. Open the workspace IDE and check the **Run Task** or **Terminal → Run Task** panel.
5. Verify: user-defined devfile commands (`1. Build sources`, `2. Build image`, `3. Install chectl`) are present in the task list.
   Without this fix, those commands are missing.


#### Release Notes

Fixed user-defined devfile commands being incorrectly removed from the workspace spec when start.

#### Docs PR

N/A