### PR TITLE
fix(backend): fix kubeconfig injection for slow-starting workspaces (CRW-11193)

### DIFF
--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -68,8 +68,15 @@ export class PostStartInjector {
     PostStartInjector.activeWatches.set(key, cleanup);
 
     const timeoutHandle = setTimeout(() => {
-      logger.warn(`PostStartInjector: timed out waiting for ${key} to reach Running`);
+      logger.warn(`PostStartInjector: watch timed out for ${key}, starting polling fallback`);
       cleanup();
+      PostStartInjector.startPollingFallback(
+        namespace,
+        workspaceName,
+        devworkspaceApi,
+        kubeConfigApi,
+        podmanApi,
+      );
     }, INJECTION_TIMEOUT_MS);
 
     const cleanupWithTimeout = () => {

--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -16,7 +16,7 @@ import { IDevWorkspaceApi, IKubeConfigApi, IPodmanApi } from '@/devworkspaceClie
 import { MessageListener } from '@/services/types/Observer';
 import { logger } from '@/utils/logger';
 
-const INJECTION_TIMEOUT_MS = 60000;
+const INJECTION_TIMEOUT_MS = 120000;
 const POLL_INTERVAL_MS = 10000;
 const POLL_TIMEOUT_MS = 300000;
 
@@ -164,6 +164,9 @@ export class PostStartInjector {
     };
 
     // Re-register so duplicate watchAndInject calls are still blocked during polling.
+    // Note: the same devworkspaceApi instance is reused here. stopWatching() was already
+    // called before startPollingFallback(), but getByName() is a standalone REST call
+    // with no dependency on watch state, so the instance is safe to reuse.
     PostStartInjector.activeWatches.set(key, cleanup);
 
     let elapsed = 0;
@@ -202,6 +205,7 @@ export class PostStartInjector {
               kubeConfigApi,
               podmanApi,
               key,
+              elapsed,
             );
           } else {
             logger.info(`PostStartInjector: ${key} is in phase ${phase}, stopping poll`);
@@ -219,8 +223,13 @@ export class PostStartInjector {
     kubeConfigApi: IKubeConfigApi,
     podmanApi: IPodmanApi,
     key: string,
+    elapsedMs?: number,
   ): Promise<void> {
-    logger.info(`PostStartInjector: ${key} is Running, injecting kubeconfig and podman login`);
+    const elapsed =
+      elapsedMs !== undefined ? ` (workspace ready after ${Math.round(elapsedMs / 1000)}s)` : '';
+    logger.info(
+      `PostStartInjector: ${key} is Running, injecting kubeconfig and podman login${elapsed}`,
+    );
     try {
       await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
     } catch (e) {

--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -16,7 +16,7 @@ import { IDevWorkspaceApi, IKubeConfigApi, IPodmanApi } from '@/devworkspaceClie
 import { MessageListener } from '@/services/types/Observer';
 import { logger } from '@/utils/logger';
 
-const INJECTION_TIMEOUT_MS = 120000;
+const INJECTION_TIMEOUT_MS = 300000;
 const POLL_INTERVAL_MS = 10000;
 const POLL_TIMEOUT_MS = 300000;
 

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -196,12 +196,34 @@ describe('PostStartInjector', () => {
 
   // ── timeout ───────────────────────────────────────────────────────────────
 
-  test('cleans up on 60 s timeout', () => {
+  test('stops watch and starts polling fallback on 60 s timeout', () => {
+    (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+      status: { phase: 'Starting' },
+    });
+
     invoke();
     jest.advanceTimersByTime(60000);
 
+    // Watch stopped
     expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
-    expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+    // Polling fallback re-registers the key so injection can still complete
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
+  });
+
+  test('injects credentials via polling fallback after 60 s watch timeout', async () => {
+    (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+      status: { phase: 'Running', devworkspaceId: 'ws-timeout-id' },
+    });
+
+    invoke();
+    jest.advanceTimersByTime(60000);
+
+    // Advance polling interval so getByName is called
+    jest.advanceTimersByTime(10000);
+    await Promise.resolve().then(() => Promise.resolve());
+
+    expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-timeout-id');
+    expect(podmanApi.podmanLogin).toHaveBeenCalledWith(namespace, 'ws-timeout-id');
   });
 
   // ── polling fallback (triggered by ERROR event) ───────────────────────────

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -196,13 +196,13 @@ describe('PostStartInjector', () => {
 
   // ── timeout ───────────────────────────────────────────────────────────────
 
-  test('stops watch and starts polling fallback on 60 s timeout', () => {
+  test('stops watch and starts polling fallback on 120 s timeout', () => {
     (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
       status: { phase: 'Starting' },
     });
 
     invoke();
-    jest.advanceTimersByTime(60000);
+    jest.advanceTimersByTime(120000);
 
     // Watch stopped
     expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
@@ -216,7 +216,7 @@ describe('PostStartInjector', () => {
     });
 
     invoke();
-    jest.advanceTimersByTime(60000);
+    jest.advanceTimersByTime(120000);
 
     // Advance polling interval so getByName is called
     jest.advanceTimersByTime(10000);

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -196,13 +196,13 @@ describe('PostStartInjector', () => {
 
   // ── timeout ───────────────────────────────────────────────────────────────
 
-  test('stops watch and starts polling fallback on 120 s timeout', () => {
+  test('stops watch and starts polling fallback on 300 s timeout', () => {
     (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
       status: { phase: 'Starting' },
     });
 
     invoke();
-    jest.advanceTimersByTime(120000);
+    jest.advanceTimersByTime(300000);
 
     // Watch stopped
     expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
@@ -216,7 +216,7 @@ describe('PostStartInjector', () => {
     });
 
     invoke();
-    jest.advanceTimersByTime(120000);
+    jest.advanceTimersByTime(300000);
 
     // Advance polling interval so getByName is called
     jest.advanceTimersByTime(10000);


### PR DESCRIPTION
### What does this PR do?

Fixes kubeconfig and podman credentials not being injected into workspace containers when a
workspace takes longer than 300 seconds to start.

### Root Cause

`PostStartInjector.watchAndInject()` started a Kubernetes Watch on the workspace namespace and
set a timeout as a safety guard. When the timeout fired, it stopped the watch and removed the
workspace from the active-watch registry — but never started the polling fallback. Any workspace
that took longer to reach the `Running` phase (common on first-time starts or large images)
silently missed kubeconfig injection entirely.

The ERROR path and the watch-rejected path already started the polling fallback correctly. Only
the timeout path was missing it.

### Fix

1. **Start `startPollingFallback()` from the timeout handler** alongside the existing `cleanup()` call:

```diff
 const timeoutHandle = setTimeout(() => {
-  logger.warn(`PostStartInjector: timed out waiting for ${key} to reach Running`);
+  logger.warn(`PostStartInjector: watch timed out for ${key}, starting polling fallback`);
   cleanup();
+  PostStartInjector.startPollingFallback(
+    namespace,
+    workspaceName,
+    devworkspaceApi,
+    kubeConfigApi,
+    podmanApi,
+  );
 }, INJECTION_TIMEOUT_MS);
```

The polling fallback polls `getByName` every 10 seconds for up to 5 minutes, so injection
completes as soon as the workspace reaches Running regardless of how long startup takes.

2. **Increase `INJECTION_TIMEOUT_MS` from 60 s to 300 s** — matching the server-side
   `startTimeout` default. The watch is a cheap long-lived HTTP connection and should stay
   alive for the full startup window. Polling (a GET every 10 seconds) is the fallback for
   when the watch fails, not a replacement for a healthy watch.

3. **Log elapsed time when injection completes via polling.** The injection log now includes how
   long the workspace was in the Starting phase, e.g.:

   ```
   PostStartInjector: user-che/my-workspace is Running, injecting kubeconfig and podman login (workspace ready after 95s)
   ```

   This helps operators diagnose slow-start clusters without needing to correlate timestamps
   across multiple log lines.

### Screenshot/screencast of this PR

N/A — backend-only behavioral change, no UI modifications.

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11193

### Is it tested? How?

All 24 `PostStartInjector` tests pass (2 new tests added for the timeout path):

- **stops watch and starts polling fallback on 300 s timeout** — verifies that after the watch
  timeout fires, `stopWatching` is called and the polling fallback re-registers the workspace key
  so injection can still complete.
- **injects credentials via polling fallback after 300 s watch timeout** — verifies end-to-end
  that `injectKubeConfig` and `podmanLogin` are called with the correct namespace and workspace ID
  when the workspace reaches Running after the watch has timed out.

Manual verification on cluster:

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Start a workspace using an image that takes longer than expected to pull/start (e.g. a
   large JetBrains workspace or a first-time pull on a slow node).
3. Once the workspace is running, open a terminal and run:
   ```bash
   oc whoami
   cat ~/.kube/config
   ```
4. Verify: `oc whoami` returns the logged-in user (not the service account), and `~/.kube/config`
   contains a valid token for that user.
5. Check the dashboard pod logs — confirm a line like:
   ```
   injecting kubeconfig and podman login (workspace ready after Xs)
   ```

Without this fix: the commands in step 3 would fail or return the workspace pod service account
identity for any workspace that took longer to start than the old 60-second watch timeout.
