### PR TITLE
[cherry-pick] fix(backend): fix kubeconfig injection for slow-starting workspaces (CRW-11193)

### DIFF
--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -68,8 +68,15 @@ export class PostStartInjector {
     PostStartInjector.activeWatches.set(key, cleanup);
 
     const timeoutHandle = setTimeout(() => {
-      logger.warn(`PostStartInjector: timed out waiting for ${key} to reach Running`);
+      logger.warn(`PostStartInjector: watch timed out for ${key}, starting polling fallback`);
       cleanup();
+      PostStartInjector.startPollingFallback(
+        namespace,
+        workspaceName,
+        devworkspaceApi,
+        kubeConfigApi,
+        podmanApi,
+      );
     }, INJECTION_TIMEOUT_MS);
 
     const cleanupWithTimeout = () => {

--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -16,7 +16,7 @@ import { IDevWorkspaceApi, IKubeConfigApi, IPodmanApi } from '@/devworkspaceClie
 import { MessageListener } from '@/services/types/Observer';
 import { logger } from '@/utils/logger';
 
-const INJECTION_TIMEOUT_MS = 60000;
+const INJECTION_TIMEOUT_MS = 120000;
 const POLL_INTERVAL_MS = 10000;
 const POLL_TIMEOUT_MS = 300000;
 
@@ -164,6 +164,9 @@ export class PostStartInjector {
     };
 
     // Re-register so duplicate watchAndInject calls are still blocked during polling.
+    // Note: the same devworkspaceApi instance is reused here. stopWatching() was already
+    // called before startPollingFallback(), but getByName() is a standalone REST call
+    // with no dependency on watch state, so the instance is safe to reuse.
     PostStartInjector.activeWatches.set(key, cleanup);
 
     let elapsed = 0;
@@ -202,6 +205,7 @@ export class PostStartInjector {
               kubeConfigApi,
               podmanApi,
               key,
+              elapsed,
             );
           } else {
             logger.info(`PostStartInjector: ${key} is in phase ${phase}, stopping poll`);
@@ -219,8 +223,13 @@ export class PostStartInjector {
     kubeConfigApi: IKubeConfigApi,
     podmanApi: IPodmanApi,
     key: string,
+    elapsedMs?: number,
   ): Promise<void> {
-    logger.info(`PostStartInjector: ${key} is Running, injecting kubeconfig and podman login`);
+    const elapsed =
+      elapsedMs !== undefined ? ` (workspace ready after ${Math.round(elapsedMs / 1000)}s)` : '';
+    logger.info(
+      `PostStartInjector: ${key} is Running, injecting kubeconfig and podman login${elapsed}`,
+    );
     try {
       await kubeConfigApi.injectKubeConfig(namespace, devworkspaceId);
     } catch (e) {

--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -16,7 +16,7 @@ import { IDevWorkspaceApi, IKubeConfigApi, IPodmanApi } from '@/devworkspaceClie
 import { MessageListener } from '@/services/types/Observer';
 import { logger } from '@/utils/logger';
 
-const INJECTION_TIMEOUT_MS = 120000;
+const INJECTION_TIMEOUT_MS = 300000;
 const POLL_INTERVAL_MS = 10000;
 const POLL_TIMEOUT_MS = 300000;
 

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -196,12 +196,34 @@ describe('PostStartInjector', () => {
 
   // ── timeout ───────────────────────────────────────────────────────────────
 
-  test('cleans up on 60 s timeout', () => {
+  test('stops watch and starts polling fallback on 60 s timeout', () => {
+    (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+      status: { phase: 'Starting' },
+    });
+
     invoke();
     jest.advanceTimersByTime(60000);
 
+    // Watch stopped
     expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
-    expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+    // Polling fallback re-registers the key so injection can still complete
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
+  });
+
+  test('injects credentials via polling fallback after 60 s watch timeout', async () => {
+    (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+      status: { phase: 'Running', devworkspaceId: 'ws-timeout-id' },
+    });
+
+    invoke();
+    jest.advanceTimersByTime(60000);
+
+    // Advance polling interval so getByName is called
+    jest.advanceTimersByTime(10000);
+    await Promise.resolve().then(() => Promise.resolve());
+
+    expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-timeout-id');
+    expect(podmanApi.podmanLogin).toHaveBeenCalledWith(namespace, 'ws-timeout-id');
   });
 
   // ── polling fallback (triggered by ERROR event) ───────────────────────────

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -196,13 +196,13 @@ describe('PostStartInjector', () => {
 
   // ── timeout ───────────────────────────────────────────────────────────────
 
-  test('stops watch and starts polling fallback on 60 s timeout', () => {
+  test('stops watch and starts polling fallback on 120 s timeout', () => {
     (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
       status: { phase: 'Starting' },
     });
 
     invoke();
-    jest.advanceTimersByTime(60000);
+    jest.advanceTimersByTime(120000);
 
     // Watch stopped
     expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
@@ -216,7 +216,7 @@ describe('PostStartInjector', () => {
     });
 
     invoke();
-    jest.advanceTimersByTime(60000);
+    jest.advanceTimersByTime(120000);
 
     // Advance polling interval so getByName is called
     jest.advanceTimersByTime(10000);

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -196,13 +196,13 @@ describe('PostStartInjector', () => {
 
   // ── timeout ───────────────────────────────────────────────────────────────
 
-  test('stops watch and starts polling fallback on 120 s timeout', () => {
+  test('stops watch and starts polling fallback on 300 s timeout', () => {
     (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
       status: { phase: 'Starting' },
     });
 
     invoke();
-    jest.advanceTimersByTime(120000);
+    jest.advanceTimersByTime(300000);
 
     // Watch stopped
     expect(devworkspaceApi.stopWatching).toHaveBeenCalled();
@@ -216,7 +216,7 @@ describe('PostStartInjector', () => {
     });
 
     invoke();
-    jest.advanceTimersByTime(120000);
+    jest.advanceTimersByTime(300000);
 
     // Advance polling interval so getByName is called
     jest.advanceTimersByTime(10000);


### PR DESCRIPTION
### What does this PR do?

Fixes kubeconfig and podman credentials not being injected into workspace containers when a
workspace takes longer than expected to start.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1620 to the 7.119.x branch

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11193
