### PR TITLE
Add 'aria-label' attribute to the buttons

### DIFF
--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/AiTool/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/AiTool/index.tsx
@@ -136,6 +136,7 @@ class AiToolFormGroup extends React.PureComponent<Props, State> {
               data-testid="overview-ai-tool-edit-toggle"
               variant="plain"
               onClick={() => this.setState({ isSelectorOpen: true })}
+              aria-label="Change AI Tool"
               title="Change AI Tool"
             >
               <PencilAltIcon />

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/GitRepo/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/GitRepo/index.tsx
@@ -142,7 +142,7 @@ class GitRepoFormGroup extends React.PureComponent<Props, State> {
             <Button
               variant="link"
               icon={<CopyIcon />}
-              name="Copy to Clipboard"
+              aria-label="Copy to Clipboard"
               data-testid="copy-to-clipboard"
             />
           </CopyToClipboard>

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/GitRepo/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/GitRepo/index.tsx
@@ -142,6 +142,7 @@ class GitRepoFormGroup extends React.PureComponent<Props, State> {
             <Button
               variant="link"
               icon={<CopyIcon />}
+              name="Copy to Clipboard"
               aria-label="Copy to Clipboard"
               data-testid="copy-to-clipboard"
             />

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/__tests__/__snapshots__/index.spec.tsx.snap
@@ -63,7 +63,7 @@ exports[`StorageTypeFormGroup editable storage type screenshot 1`] = `
     >
       per-workspace
       <button
-        aria-label={null}
+        aria-label="Change Storage Type"
         className="pf-v6-c-button pf-m-plain"
         data-ouia-component-id="OUIA-Generated-Button-plain-3"
         data-ouia-component-type="PF6/Button"

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.tsx
@@ -299,6 +299,7 @@ class StorageTypeFormGroup extends React.PureComponent<Props, State> {
               data-testid="overview-storage-edit-toggle"
               variant="plain"
               onClick={() => this.handleEditToggle(true)}
+              aria-label="Change Storage Type"
               title="Change Storage Type"
             >
               <PencilAltIcon />

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__tests__/__snapshots__/index.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`WorkspaceNameFormGroup snapshots editable 1`] = `
     >
       my-project
       <button
-        aria-label={null}
+        aria-label="Edit Workspace Name"
         className="pf-v6-c-button pf-m-plain"
         data-ouia-component-id="OUIA-Generated-Button-plain-1"
         data-ouia-component-type="PF6/Button"

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.tsx
@@ -285,6 +285,7 @@ class WorkspaceNameFormGroup extends React.PureComponent<Props, State> {
               data-testid="edit-workspace-name-button"
               variant="plain"
               onClick={() => this.handleEditToggle(true)}
+              aria-label="Edit Workspace Name"
               title="Edit Workspace Name"
             >
               <PencilAltIcon />


### PR DESCRIPTION
### What does this PR do?
Fixes accessibility violations (WCAG 2.2 criterion 4.1.2 - Name, Role, Value, Level A) on the Workspace Details Overview page. Icon-only action buttons were announced by screen readers as just "Button" with no context about their function.

_Changes_:
- GitRepo copy button: added aria-label="Copy to Clipboard"
- Edit Workspace Name button: added aria-label="Edit Workspace Name"
- Change Storage Type button: added aria-label="Change Storage Type"
- Change AI Tool button: added aria-label="Change AI Tool"

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10235

### Is it tested? How?
Install Eclipse Che Next with quay.io/eclipse/che-dashboard:pr-1622 as a dashboard, go to Workspace Details page and run patternfly-a11y tests, or "WAVE Evaluation" tool extension


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

--
Assisted-By Claude Code
