### PR TITLE
fix(a11y): render workspace progress steps as spans instead of buttons

### DIFF
--- a/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
+++ b/packages/dashboard-frontend/src/__tests__/workspaceCreationTimeCheck.check.tsx
@@ -196,16 +196,16 @@ describe('Workspace creation time', () => {
     );
 
     // step 1: Initializing
-    const stepInitializing = screen.getByRole('button', { name: 'Initializing' });
+    const stepInitializing = screen.getByText('Initializing').closest('.pf-v6-c-wizard__nav-link');
     expect(stepInitializing).toBeInTheDocument();
     await waitFor(() => expect(stepInitializing).toHaveAttribute('aria-current', 'step'), {
       timeout: 5000,
     });
 
     // step 2: Checking for the limit of running workspaces
-    const stepCheckingForLimit = screen.getByRole('button', {
-      name: 'Checking for the limit of running workspaces',
-    });
+    const stepCheckingForLimit = screen
+      .getByText('Checking for the limit of running workspaces')
+      .closest('.pf-v6-c-wizard__nav-link');
     expect(stepCheckingForLimit).toBeInTheDocument();
     await waitFor(() => expect(stepCheckingForLimit).toHaveAttribute('aria-current', 'step'), {
       timeout: 5000,
@@ -215,18 +215,16 @@ describe('Workspace creation time', () => {
     // skipping because it is never activated, but it's substeps are
 
     // step 4: Waiting for workspace to start
-    const stepStartingWorkspace = screen.getByRole('button', {
-      name: 'Waiting for workspace to start',
-    });
+    const stepStartingWorkspace = screen
+      .getByText('Waiting for workspace to start')
+      .closest('.pf-v6-c-wizard__nav-link');
     expect(stepStartingWorkspace).toBeInTheDocument();
     await waitFor(() => expect(stepStartingWorkspace).toHaveAttribute('aria-current', 'step'), {
       timeout: 5000,
     });
 
     // step 5: Open IDE
-    const stepOpenIde = screen.getByRole('button', {
-      name: 'Open IDE',
-    });
+    const stepOpenIde = screen.getByText('Open IDE').closest('.pf-v6-c-wizard__nav-link');
     expect(stepOpenIde).toBeInTheDocument();
     await waitFor(() => expect(stepOpenIde).toHaveAttribute('aria-current', 'step'), {
       timeout: 5000,

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
@@ -15,62 +15,42 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-1"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
           >
             initialize
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
+        <span
           aria-current="step"
-          aria-disabled={null}
           className="pf-v6-c-wizard__nav-link pf-m-current"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-2"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
           >
             limit-check
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-3"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
           >
             create
           </span>
-        </button>
+        </span>
         <ol
           className="pf-v6-c-wizard__nav-list"
           role="list"
@@ -78,62 +58,41 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
           <li
             className="pf-v6-c-wizard__nav-item"
           >
-            <button
-              aria-current={false}
-              aria-disabled={true}
+            <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-WizardNavItem-4"
-              data-ouia-component-type="PF6/WizardNavItem"
-              data-ouia-safe={true}
-              disabled={true}
-              onClick={[Function]}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
               >
                 fetch
               </span>
-            </button>
+            </span>
           </li>
           <li
             className="pf-v6-c-wizard__nav-item"
           >
-            <button
-              aria-current={false}
-              aria-disabled={true}
+            <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-WizardNavItem-5"
-              data-ouia-component-type="PF6/WizardNavItem"
-              data-ouia-safe={true}
-              disabled={true}
-              onClick={[Function]}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
               >
                 conflict-check
               </span>
-            </button>
+            </span>
           </li>
           <li
             className="pf-v6-c-wizard__nav-item"
           >
-            <button
-              aria-current={false}
-              aria-disabled={true}
+            <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-WizardNavItem-6"
-              data-ouia-component-type="PF6/WizardNavItem"
-              data-ouia-safe={true}
-              disabled={true}
-              onClick={[Function]}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
               >
                 apply
               </span>
-            </button>
+            </span>
           </li>
         </ol>
       </li>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/index.spec.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 
 import { Step, StepId } from '@/components/WorkspaceProgress';
-import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
+import getComponentRenderer from '@/services/__mocks__/getComponentRenderer';
 
 import WorkspaceProgressWizard, { WorkspaceProgressWizardStep } from '..';
 
@@ -79,24 +79,27 @@ describe('WorkspaceProgressWizard', () => {
 
     const { reRenderComponent } = renderComponent(activeStepId, steps, ref);
 
-    const buttonInitialize = screen.getByRole('button', { name: Step.INITIALIZE });
-    const buttonLimitCheck = screen.getByRole('button', { name: Step.LIMIT_CHECK });
+    const navLinks = document.querySelectorAll('.pf-v6-c-wizard__nav-link');
+    const spanInitialize = navLinks[0];
+    const spanLimitCheck = navLinks[1];
 
-    expect(buttonInitialize.className.split(' ')).toEqual(expect.arrayContaining(['pf-m-current']));
-    expect(buttonLimitCheck.className.split(' ')).not.toEqual(
+    expect(spanInitialize.tagName.toLowerCase()).toBe('span');
+    expect(spanInitialize.className.split(' ')).toEqual(expect.arrayContaining(['pf-m-current']));
+    expect(spanLimitCheck.className.split(' ')).not.toEqual(
       expect.arrayContaining(['pf-m-current']),
     );
 
     const nextActiveStepId = Step.LIMIT_CHECK;
     reRenderComponent(nextActiveStepId, steps, ref);
 
-    const nextButtonInitialize = screen.getByRole('button', { name: Step.INITIALIZE });
-    const nextButtonLimitCheck = screen.getByRole('button', { name: Step.LIMIT_CHECK });
+    const nextNavLinks = document.querySelectorAll('.pf-v6-c-wizard__nav-link');
+    const nextSpanInitialize = nextNavLinks[0];
+    const nextSpanLimitCheck = nextNavLinks[1];
 
-    expect(nextButtonInitialize.className.split(' ')).not.toEqual(
+    expect(nextSpanInitialize.className.split(' ')).not.toEqual(
       expect.arrayContaining(['pf-m-current']),
     );
-    expect(nextButtonLimitCheck.className.split(' ')).toEqual(
+    expect(nextSpanLimitCheck.className.split(' ')).toEqual(
       expect.arrayContaining(['pf-m-current']),
     );
   });

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { WizardNav, WizardNavItem } from '@patternfly/react-core';
+import { WizardNav } from '@patternfly/react-core';
 import wizardStyles from '@patternfly/react-styles/css/components/Wizard/wizard';
 import React from 'react';
 
@@ -34,11 +34,6 @@ export type Props = {
 };
 
 class WorkspaceProgressWizard extends React.Component<Props> {
-  private handleGoToStepById() {
-    console.warn('Not implemented: handleGoToStepById');
-    return false;
-  }
-
   public goToNext(): void {
     const flattenedSteps = this.flattenSteps(this.props.steps);
     // find the index of the next after the current active step
@@ -91,53 +86,62 @@ class WorkspaceProgressWizard extends React.Component<Props> {
     return flattenedSteps.findIndex(step => step.id === stepId) + 1;
   }
 
+  private navLinkClassName(isCurrent: boolean, isDisabled: boolean): string {
+    return [
+      wizardStyles.wizardNavLink,
+      isCurrent ? wizardStyles.modifiers.current : '',
+      isDisabled ? wizardStyles.modifiers.disabled : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
+
   private buildWizardNav(
     activeStepId: StepId,
     steps: WorkspaceProgressWizardStep[],
   ): React.ReactElement {
     const stepsWithDefaults = this.setDefaultValues(steps);
-    const flattenedSteps = this.flattenSteps(stepsWithDefaults);
 
     return (
       <WizardNav aria-label="Workspace Progress Steps">
         {stepsWithDefaults.map(step => {
           const { canJumpTo, name, steps = [], id } = step;
-          const flattenedStepNumber = this.getFlattenedStepsNumber(flattenedSteps, id);
 
           const hasChildren = steps.length !== 0;
           const allChildrenFinished = steps.every(subStep => subStep.isFinishedStep);
           const showChildren = hasChildren && allChildrenFinished === false;
 
           const hasActiveChild = steps.some(subStep => subStep.id === activeStepId);
+          const isCurrent = activeStepId === id || hasActiveChild;
 
           return (
-            <WizardNavItem
-              key={id}
-              content={name}
-              stepIndex={flattenedStepNumber}
-              isCurrent={activeStepId === id || hasActiveChild}
-              isDisabled={!canJumpTo}
-              onClick={() => this.handleGoToStepById()}
-            >
+            <li key={id} className={wizardStyles.wizardNavItem}>
+              <span
+                className={this.navLinkClassName(isCurrent, !canJumpTo)}
+                aria-current={isCurrent ? 'step' : undefined}
+              >
+                <span className={wizardStyles.wizardNavLinkMain}>{name}</span>
+              </span>
               {showChildren && (
                 <WizardNav isInnerList>
                   {steps.map(subStep => {
                     const { canJumpTo, name, id } = subStep;
-                    const flattenedStepNumber = this.getFlattenedStepsNumber(flattenedSteps, id);
+                    const isSubCurrent = activeStepId === id;
+
                     return (
-                      <WizardNavItem
-                        key={id}
-                        content={name}
-                        stepIndex={flattenedStepNumber}
-                        isCurrent={activeStepId === id}
-                        isDisabled={!canJumpTo}
-                        onClick={() => this.handleGoToStepById()}
-                      />
+                      <li key={id} className={wizardStyles.wizardNavItem}>
+                        <span
+                          className={this.navLinkClassName(isSubCurrent, !canJumpTo)}
+                          aria-current={isSubCurrent ? 'step' : undefined}
+                        >
+                          <span className={wizardStyles.wizardNavLinkMain}>{name}</span>
+                        </span>
+                      </li>
                     );
                   })}
                 </WizardNav>
               )}
-            </WizardNavItem>
+            </li>
           );
         })}
       </WizardNav>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
@@ -15,15 +15,9 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
+        <span
           aria-current="step"
-          aria-disabled={null}
           className="pf-v6-c-wizard__nav-link pf-m-current"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-1"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -71,20 +65,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-2"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -132,20 +119,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-3"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -193,7 +173,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
         <ol
           className="pf-v6-c-wizard__nav-list"
           role="list"
@@ -201,15 +181,8 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
           <li
             className="pf-v6-c-wizard__nav-item"
           >
-            <button
-              aria-current={false}
-              aria-disabled={true}
+            <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-WizardNavItem-4"
-              data-ouia-component-type="PF6/WizardNavItem"
-              data-ouia-safe={true}
-              disabled={true}
-              onClick={[Function]}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -257,20 +230,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                   />
                 </div>
               </span>
-            </button>
+            </span>
           </li>
           <li
             className="pf-v6-c-wizard__nav-item"
           >
-            <button
-              aria-current={false}
-              aria-disabled={true}
+            <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-WizardNavItem-5"
-              data-ouia-component-type="PF6/WizardNavItem"
-              data-ouia-safe={true}
-              disabled={true}
-              onClick={[Function]}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -318,20 +284,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                   />
                 </div>
               </span>
-            </button>
+            </span>
           </li>
           <li
             className="pf-v6-c-wizard__nav-item"
           >
-            <button
-              aria-current={false}
-              aria-disabled={true}
+            <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-WizardNavItem-6"
-              data-ouia-component-type="PF6/WizardNavItem"
-              data-ouia-safe={true}
-              disabled={true}
-              onClick={[Function]}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -379,20 +338,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                   />
                 </div>
               </span>
-            </button>
+            </span>
           </li>
           <li
             className="pf-v6-c-wizard__nav-item"
           >
-            <button
-              aria-current={false}
-              aria-disabled={true}
+            <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
-              data-ouia-component-id="OUIA-Generated-WizardNavItem-7"
-              data-ouia-component-type="PF6/WizardNavItem"
-              data-ouia-safe={true}
-              disabled={true}
-              onClick={[Function]}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -440,22 +392,15 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
                   />
                 </div>
               </span>
-            </button>
+            </span>
           </li>
         </ol>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-8"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -503,20 +448,13 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-9"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -564,7 +502,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
     </ol>
   </nav>
@@ -586,15 +524,9 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
+        <span
           aria-current="step"
-          aria-disabled={null}
           className="pf-v6-c-wizard__nav-link pf-m-current"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-132"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -642,20 +574,13 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-133"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -703,20 +628,13 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-134"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -764,20 +682,13 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
       <li
         className="pf-v6-c-wizard__nav-item"
       >
-        <button
-          aria-current={false}
-          aria-disabled={null}
+        <span
           className="pf-v6-c-wizard__nav-link"
-          data-ouia-component-id="OUIA-Generated-WizardNavItem-135"
-          data-ouia-component-type="PF6/WizardNavItem"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -825,7 +736,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
               />
             </div>
           </span>
-        </button>
+        </span>
       </li>
     </ol>
   </nav>


### PR DESCRIPTION
### What does this PR do?

Fixes workspace creation progress steps rendering as `<button>` elements instead of non-interactive labels.

PatternFly's `WizardNavItem` defaults to `component="button"`, which is appropriate for navigable wizard steps but wrong for progress indicators that can't be clicked. The steps on the "Create Workspace" loader page (Initializing, Fetching devfile, etc.) are display-only — they already had `pointer-events: none` applied via CSS, but the underlying elements were still `<button>` with the associated role and class.

The fix replaces `WizardNavItem` with plain `<li>/<span>` elements that apply PatternFly's wizard nav CSS classes directly (`pf-v6-c-wizard__nav-item`, `pf-v6-c-wizard__nav-link`, `pf-m-current`, `pf-m-disabled`). The visual output is identical, but the elements are now semantically correct non-interactive labels.

### Screenshot/screencast of this PR
<img width="1906" height="976" alt="Знімок екрана 2026-07-02 о 00 22 14" src="https://github.com/user-attachments/assets/972fc3fc-cfa8-4a51-95d5-5d2dd0fd3b16" />

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-10924

### Is it tested? How?

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Open the "Create Workspace" page and click "Empty Workspace".
3. While the workspace initializes, right-click any step label (e.g. "Initializing") → Inspect. Verify the element is a `<span>`, not a `<button>`, and has no `button` role.
4. Verify the active step still shows the `pf-m-current` highlight and inactive steps are visually unchanged.