### PR TITLE
feat(a11y): add pause/resume toggle to workspace events stream

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,104 +2,122 @@
 
 exports[`WorkspaceEventsItem component snapshot 1`] = `
 <div
-  className="pf-v6-c-content"
-  data-ouia-component-id="OUIA-Generated-Content-1"
-  data-ouia-component-type="PF6/Content"
-  data-ouia-safe={true}
-  data-pf-content={true}
+  className="eventRow"
 >
   <div
-    className="pf-v6-c-card pf-m-compact"
-    data-ouia-component-id="OUIA-Generated-Card-1"
-    data-ouia-component-type="PF6/Card"
-    data-ouia-safe={true}
-    id=""
+    className="iconBox"
+  >
+    <i
+      className="eventIcon"
+    />
+    <div
+      className="iconLine"
+    />
+  </div>
+  <div
+    className="eventBox"
   >
     <div
-      className="pf-v6-c-card__header header"
+      className="pf-v6-c-content"
+      data-ouia-component-id="OUIA-Generated-Content-1"
+      data-ouia-component-type="PF6/Content"
+      data-ouia-safe={true}
+      data-pf-content={true}
     >
       <div
-        className="pf-v6-c-card__header-main"
+        className="pf-v6-c-card pf-m-compact"
+        data-ouia-component-id="OUIA-Generated-Card-1"
+        data-ouia-component-type="PF6/Card"
+        data-ouia-safe={true}
+        id=""
       >
         <div
-          className="pf-v6-l-flex"
+          className="pf-v6-c-card__header header"
         >
           <div
-            className=""
+            className="pf-v6-c-card__header-main"
           >
-            <small
-              className="pf-v6-c-content--small"
-              data-ouia-component-id="OUIA-Generated-Content-2"
-              data-ouia-component-type="PF6/Content"
-              data-ouia-safe={true}
-              data-pf-content={true}
+            <div
+              className="pf-v6-l-flex"
             >
-              <span
-                data-testid="event-involved-object"
+              <div
+                className=""
               >
-                <div
-                  data-testid="patternfly-tooltip"
+                <small
+                  className="pf-v6-c-content--small"
+                  data-ouia-component-id="OUIA-Generated-Content-2"
+                  data-ouia-component-type="PF6/Content"
+                  data-ouia-safe={true}
+                  data-pf-content={true}
                 >
                   <span
-                    data-testid="tooltip-props"
+                    data-testid="event-involved-object"
                   >
-                    {"aria":"none","aria-live":"polite"}
-                  </span>
-                  <div
-                    data-testid="tooltip-content"
-                  >
-                    Pod
-                  </div>
-                  <div
-                    data-testid="tooltip-placed-to"
-                  >
-                    <span
-                      className="icon"
+                    <div
+                      data-testid="patternfly-tooltip"
                     >
-                      P
-                    </span>
+                      <span
+                        data-testid="tooltip-props"
+                      >
+                        {"aria":"none","aria-live":"polite"}
+                      </span>
+                      <div
+                        data-testid="tooltip-content"
+                      >
+                        Pod
+                      </div>
+                      <div
+                        data-testid="tooltip-placed-to"
+                      >
+                        <span
+                          className="icon"
+                        >
+                          P
+                        </span>
+                      </div>
+                    </div>
+                    pod-name
+                  </span>
+                  <div>
+                    Generated from 
+                    component on 0.0.0.0
                   </div>
-                </div>
-                pod-name
-              </span>
-              <div>
-                Generated from 
-                component on 0.0.0.0
+                </small>
               </div>
-            </small>
-          </div>
-          <div
-            className="pf-m-align-right"
-          >
-            <small
-              className="pf-v6-c-content--small"
-              data-ouia-component-id="OUIA-Generated-Content-3"
-              data-ouia-component-type="PF6/Content"
-              data-ouia-safe={true}
-              data-pf-content={true}
-            >
-              <span
-                data-testid="event-time"
+              <div
+                className="pf-m-align-right"
               >
-                14:00:00
-              </span>
-            </small>
+                <small
+                  className="pf-v6-c-content--small"
+                  data-ouia-component-id="OUIA-Generated-Content-3"
+                  data-ouia-component-type="PF6/Content"
+                  data-ouia-safe={true}
+                  data-pf-content={true}
+                >
+                  <span
+                    data-testid="event-time"
+                  >
+                    14:00:00
+                  </span>
+                </small>
+              </div>
+            </div>
           </div>
         </div>
+        <div
+          className="pf-v6-c-card__body"
+        >
+          <p
+            className="pf-v6-c-content--p"
+            data-ouia-component-id="OUIA-Generated-Content-4"
+            data-ouia-component-type="PF6/Content"
+            data-ouia-safe={true}
+            data-pf-content={true}
+          >
+            Event message
+          </p>
+        </div>
       </div>
-    </div>
-    <div
-      className="pf-v6-c-card__body"
-    >
-      <p
-        className="pf-v6-c-content--p"
-        data-ouia-component-id="OUIA-Generated-Content-4"
-        data-ouia-component-type="PF6/Content"
-        data-ouia-safe={true}
-        data-pf-content={true}
-      >
-        Event message
-      </p>
     </div>
   </div>
 </div>

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.module.css
@@ -20,3 +20,53 @@
 
   display: block;
 }
+
+/* Timeline row layout */
+
+.eventRow {
+  display: flex;
+}
+
+.iconBox {
+  position: relative;
+  flex: 0 0 50px;
+}
+
+.eventIcon {
+  position: absolute;
+  z-index: 10;
+  top: 50%;
+  left: -10px;
+  transform: translateY(-50%);
+
+  display: inline-block;
+
+  width: 18px;
+  height: 18px;
+
+  background-color: var(--che-events-icon-bg);
+  border: var(--pf-t--global--border--width--extra-strong) solid var(--che-events-border);
+  border-radius: var(--pf-t--global--border--radius--400);
+}
+
+@media (width < 75rem) {
+  .iconBox {
+    display: none;
+  }
+}
+
+.iconLine {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  left: 0;
+
+  height: 3px;
+
+  background-color: var(--che-events-border);
+}
+
+.eventBox {
+  flex: 1 1 auto;
+  min-width: 0;
+}

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/Item/index.tsx
@@ -80,26 +80,34 @@ export class WorkspaceEventsItem extends React.PureComponent<Props> {
     const { event } = this.props;
 
     return (
-      <Content>
-        <Card isCompact>
-          <CardHeader className={styles.header}>
-            <Flex>
-              <FlexItem>
-                <Content component={ContentVariants.small}>
-                  {this.getInvolvedObj(event)}
-                  {this.getSource(event)}
-                </Content>
-              </FlexItem>
-              <FlexItem align={{ default: 'alignRight' }}>
-                <Content component={ContentVariants.small}>{this.getTime(event)}</Content>
-              </FlexItem>
-            </Flex>
-          </CardHeader>
-          <CardBody>
-            <Content component="p">{event.message}</Content>
-          </CardBody>
-        </Card>
-      </Content>
+      <div className={styles.eventRow}>
+        <div className={styles.iconBox}>
+          <i className={styles.eventIcon} title={event.reason ?? undefined} />
+          <div className={styles.iconLine} />
+        </div>
+        <div className={styles.eventBox}>
+          <Content>
+            <Card isCompact>
+              <CardHeader className={styles.header}>
+                <Flex>
+                  <FlexItem>
+                    <Content component={ContentVariants.small}>
+                      {this.getInvolvedObj(event)}
+                      {this.getSource(event)}
+                    </Content>
+                  </FlexItem>
+                  <FlexItem align={{ default: 'alignRight' }}>
+                    <Content component={ContentVariants.small}>{this.getTime(event)}</Content>
+                  </FlexItem>
+                </Flex>
+              </CardHeader>
+              <CardBody>
+                <Content component="p">{event.message}</Content>
+              </CardBody>
+            </Card>
+          </Content>
+        </div>
+      </div>
     );
   }
 }

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/__snapshots__/index.spec.tsx.snap
@@ -56,17 +56,56 @@ exports[`The WorkspaceEvents component snapshot - no events 1`] = `
   >
     <div
       aria-label="Workspace events"
+      aria-live="polite"
       role="log"
     >
       <div
-        className="pf-v6-l-stack pf-m-gutter"
+        className="pf-v6-l-stack"
       >
         <div
           className="pf-v6-l-stack__item"
         >
           <div
-            className="pf-v6-l-flex"
+            className="pf-v6-l-flex pf-m-align-items-center"
           >
+            <div
+              className=""
+            >
+              <button
+                aria-label="Pause event streaming"
+                aria-pressed={false}
+                className="pf-v6-c-button pf-m-plain pauseButton active"
+                data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="pf-v6-c-button__text"
+                >
+                  <span
+                    className="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      className="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 448 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M144 479H48c-26.5 0-48-21.5-48-48V79c0-26.5 21.5-48 48-48h96c26.5 0 48 21.5 48 48v352c0 26.5-21.5 48-48 48zm304-48V79c0-26.5-21.5-48-48-48h-96c-26.5 0-48 21.5-48 48v352c0 26.5 21.5 48 48 48h96c26.5 0 48-21.5 48-48z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </button>
+            </div>
             <div
               className=""
             >
@@ -105,7 +144,7 @@ exports[`The WorkspaceEvents component snapshot - no events 1`] = `
           className="pf-v6-l-stack__item"
         >
           <small
-            className="pf-v6-c-content--small"
+            className="pf-v6-c-content--small footer"
             data-ouia-component-id="OUIA-Generated-Content-3"
             data-ouia-component-type="PF6/Content"
             data-ouia-safe={true}
@@ -129,17 +168,56 @@ exports[`The WorkspaceEvents component snapshot - with events 1`] = `
   >
     <div
       aria-label="Workspace events"
+      aria-live="polite"
       role="log"
     >
       <div
-        className="pf-v6-l-stack pf-m-gutter"
+        className="pf-v6-l-stack"
       >
         <div
           className="pf-v6-l-stack__item"
         >
           <div
-            className="pf-v6-l-flex"
+            className="pf-v6-l-flex pf-m-align-items-center"
           >
+            <div
+              className=""
+            >
+              <button
+                aria-label="Pause event streaming"
+                aria-pressed={false}
+                className="pf-v6-c-button pf-m-plain pauseButton active"
+                data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="pf-v6-c-button__text"
+                >
+                  <span
+                    className="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      className="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 448 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M144 479H48c-26.5 0-48-21.5-48-48V79c0-26.5 21.5-48 48-48h96c26.5 0 48 21.5 48 48v352c0 26.5-21.5 48-48 48zm304-48V79c0-26.5-21.5-48-48-48h-96c-26.5 0-48 21.5-48 48v352c0 26.5 21.5 48 48 48h96c26.5 0 48-21.5 48-48z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </button>
+            </div>
             <div
               className=""
             >
@@ -178,67 +256,79 @@ exports[`The WorkspaceEvents component snapshot - with events 1`] = `
           className="pf-v6-l-stack__item"
         >
           <div
-            className="fadeIn"
+            className="eventsTimeline"
           >
             <div
-              data-testid="event-item"
+              className="pf-v6-l-stack pf-m-gutter"
             >
-              <span
-                data-testid="event-message"
+              <div
+                className="pf-v6-l-stack__item"
               >
-                message 2
-              </span>
-              <span
-                data-testid="event-time"
+                <div
+                  className="fadeIn"
+                >
+                  <div
+                    data-testid="event-item"
+                  >
+                    <span
+                      data-testid="event-message"
+                    >
+                      message 2
+                    </span>
+                    <span
+                      data-testid="event-time"
+                    >
+                      2021-03-31T14:01:00.000Z
+                    </span>
+                    <span
+                      data-testid="event-source"
+                    >
+                       on 
+                    </span>
+                    <span
+                      data-testid="event-involved-object"
+                    >
+                      Pod
+                       
+                      devWorkspace-pod
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="pf-v6-l-stack__item"
               >
-                2021-03-31T14:01:00.000Z
-              </span>
-              <span
-                data-testid="event-source"
-              >
-                 on 
-              </span>
-              <span
-                data-testid="event-involved-object"
-              >
-                Pod
-                 
-                devWorkspace-pod
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          className="pf-v6-l-stack__item"
-        >
-          <div
-            className="fadeIn"
-          >
-            <div
-              data-testid="event-item"
-            >
-              <span
-                data-testid="event-message"
-              >
-                message 1
-              </span>
-              <span
-                data-testid="event-time"
-              >
-                2021-03-31T14:00:00.000Z
-              </span>
-              <span
-                data-testid="event-source"
-              >
-                 on 
-              </span>
-              <span
-                data-testid="event-involved-object"
-              >
-                Pod
-                 
-                devWorkspace-pod
-              </span>
+                <div
+                  className="fadeIn"
+                >
+                  <div
+                    data-testid="event-item"
+                  >
+                    <span
+                      data-testid="event-message"
+                    >
+                      message 1
+                    </span>
+                    <span
+                      data-testid="event-time"
+                    >
+                      2021-03-31T14:00:00.000Z
+                    </span>
+                    <span
+                      data-testid="event-source"
+                    >
+                       on 
+                    </span>
+                    <span
+                      data-testid="event-involved-object"
+                    >
+                      Pod
+                       
+                      devWorkspace-pod
+                    </span>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -246,7 +336,7 @@ exports[`The WorkspaceEvents component snapshot - with events 1`] = `
           className="pf-v6-l-stack__item"
         >
           <small
-            className="pf-v6-c-content--small"
+            className="pf-v6-c-content--small footer"
             data-ouia-component-id="OUIA-Generated-Content-6"
             data-ouia-component-type="PF6/Content"
             data-ouia-safe={true}

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/__tests__/index.spec.tsx
@@ -12,6 +12,7 @@
 
 import { CoreV1Event } from '@kubernetes/client-node';
 import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
@@ -140,6 +141,88 @@ describe('The WorkspaceEvents component', () => {
     const eventItems = screen.getAllByTestId('event-item');
     expect(within(eventItems[0]).getByText('message 2')).toBeTruthy();
     expect(within(eventItems[1]).getByText('message 1')).toBeTruthy();
+  });
+
+  describe('pause / resume streaming', () => {
+    it('should render the pause button when streaming', () => {
+      const devWorkspace = devWorkspaceBuilder.withStatus({ phase: 'STARTING' }).build();
+      const store = new MockStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [devWorkspace],
+          startedWorkspaces: { [WorkspaceAdapter.getUID(devWorkspace)]: '1' },
+        })
+        .withEvents({ events: [event1] })
+        .build();
+      renderComponent(store, devWorkspace);
+
+      expect(screen.getByRole('button', { name: 'Pause event streaming' })).toBeInTheDocument();
+      expect(screen.getByText('Streaming events...')).toBeInTheDocument();
+    });
+
+    it('should freeze the event list when paused', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      const devWorkspace = devWorkspaceBuilder.withStatus({ phase: 'STARTING' }).build();
+      const store = new MockStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [devWorkspace],
+          startedWorkspaces: { [WorkspaceAdapter.getUID(devWorkspace)]: '1' },
+        })
+        .withEvents({ events: [event1] })
+        .build();
+      const { reRenderComponent } = renderComponent(store, devWorkspace);
+
+      expect(screen.getByText('1 event')).toBeTruthy();
+
+      await user.click(screen.getByRole('button', { name: 'Pause event streaming' }));
+
+      expect(screen.getByRole('button', { name: 'Resume event streaming' })).toBeInTheDocument();
+      expect(screen.getByText(/Event stream is paused\./)).toBeInTheDocument();
+
+      // new event arrives in Redux while paused
+      const nextStore = new MockStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [devWorkspace],
+          startedWorkspaces: { [WorkspaceAdapter.getUID(devWorkspace)]: '1' },
+        })
+        .withEvents({ events: [event1, event2] })
+        .build();
+      reRenderComponent(nextStore, devWorkspace);
+
+      // still shows 1 event (frozen) and indicates 1 new waiting
+      expect(screen.getByText('1 event')).toBeTruthy();
+      expect(screen.getByText(/1 new event waiting/)).toBeInTheDocument();
+    });
+
+    it('should resume streaming and show accumulated events', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      const devWorkspace = devWorkspaceBuilder.withStatus({ phase: 'STARTING' }).build();
+      const store = new MockStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [devWorkspace],
+          startedWorkspaces: { [WorkspaceAdapter.getUID(devWorkspace)]: '1' },
+        })
+        .withEvents({ events: [event1] })
+        .build();
+      const { reRenderComponent } = renderComponent(store, devWorkspace);
+
+      await user.click(screen.getByRole('button', { name: 'Pause event streaming' }));
+
+      const nextStore = new MockStoreBuilder()
+        .withDevWorkspaces({
+          workspaces: [devWorkspace],
+          startedWorkspaces: { [WorkspaceAdapter.getUID(devWorkspace)]: '1' },
+        })
+        .withEvents({ events: [event1, event2] })
+        .build();
+      reRenderComponent(nextStore, devWorkspace);
+
+      await user.click(screen.getByRole('button', { name: 'Resume event streaming' }));
+
+      expect(screen.getByText('Streaming events...')).toBeInTheDocument();
+      expect(screen.getByText('2 events')).toBeTruthy();
+    });
   });
 
   it('should not sort', () => {

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/index.module.css
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/index.module.css
@@ -23,3 +23,44 @@
     opacity: 1;
   }
 }
+
+/* Vertical timeline that runs through the event list */
+
+.eventsTimeline {
+  position: relative;
+
+  margin-left: 17px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+
+  border-left: var(--pf-t--global--border--width--extra-strong) solid var(--che-events-border);
+}
+
+@media (width < 75rem) {
+  .eventsTimeline {
+    margin-left: 0;
+    border-left: none;
+  }
+}
+
+.footer {
+  padding-top: 15px;
+}
+
+.pauseButton {
+  align-items: center;
+
+  width: 37px;
+  height: 37px;
+  margin-right: 15px;
+  padding: 0;
+
+  background-color: var(--pf-t--global--background--color--primary--default);
+  border: var(--pf-t--global--border--width--extra-strong) solid
+    var(--pf-t--global--border--color--default);
+  border-radius: 50%;
+}
+
+.pauseButton.active {
+  border-color: var(--pf-t--global--border--color--status--success--default);
+}

--- a/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceEvents/index.tsx
@@ -12,6 +12,7 @@
 
 import { CoreV1Event } from '@kubernetes/client-node';
 import {
+  Button,
   Content,
   ContentVariants,
   EmptyState,
@@ -23,7 +24,7 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { FileIcon } from '@patternfly/react-icons';
+import { FileIcon, PauseIcon, PlayIcon } from '@patternfly/react-icons';
 import React from 'react';
 import Pluralize from 'react-pluralize';
 import { connect, ConnectedProps } from 'react-redux';
@@ -49,9 +50,19 @@ export type Props = {
   isActive?: boolean;
 } & MappedProps;
 
-class WorkspaceEvents extends React.PureComponent<Props> {
+type State = {
+  isPaused: boolean;
+  frozenEvents: CoreV1Event[];
+};
+
+class WorkspaceEvents extends React.PureComponent<Props, State> {
   // Tracks UIDs of events already announced so we never repeat them.
   private readonly announcedUIDs = new Set<string>();
+
+  readonly state: State = {
+    isPaused: false,
+    frozenEvents: [],
+  };
 
   public componentDidMount(): void {
     // Pre-seed announced UIDs with all events that already exist at mount time
@@ -118,6 +129,15 @@ class WorkspaceEvents extends React.PureComponent<Props> {
     return allWorkspaces.find(workspace => workspace.uid === workspaceUID);
   }
 
+  private handleTogglePause(liveEvents: CoreV1Event[]): void {
+    const { isPaused } = this.state;
+    if (!isPaused) {
+      this.setState({ isPaused: true, frozenEvents: liveEvents });
+    } else {
+      this.setState({ isPaused: false, frozenEvents: [] });
+    }
+  }
+
   private getEventItems(events: CoreV1Event[]): React.ReactNodeArray {
     return events
       .filter(event => event.message)
@@ -135,6 +155,7 @@ class WorkspaceEvents extends React.PureComponent<Props> {
 
   render() {
     const { workspaceUID, allWorkspaces, startedWorkspaces, hideWhenStopped = true } = this.props;
+    const { isPaused, frozenEvents } = this.state;
 
     const workspace = this.findWorkspace(workspaceUID, allWorkspaces);
 
@@ -151,15 +172,40 @@ class WorkspaceEvents extends React.PureComponent<Props> {
     }
 
     const startResourceVersion = startedWorkspaces[workspaceUID] || '0';
+    const liveEvents = this.props.eventsFromResourceVersionFn(startResourceVersion);
+    const visibleEvents = isPaused ? frozenEvents : liveEvents;
 
-    const events = this.props.eventsFromResourceVersionFn(startResourceVersion);
-    const eventItems = this.getEventItems(events);
+    const pendingCount = isPaused
+      ? Math.max(
+          0,
+          liveEvents.filter(e => e.message).length - frozenEvents.filter(e => e.message).length,
+        )
+      : 0;
+
+    const eventItems = this.getEventItems(visibleEvents);
 
     const tailStackItem = (
       <StackItem>
-        <Flex>
+        <Flex alignItems={{ default: 'alignItemsCenter' }}>
           <FlexItem>
-            <Content component={ContentVariants.small}>Streaming events...</Content>
+            <Button
+              variant="plain"
+              className={`${styles.pauseButton}${isPaused ? '' : ` ${styles.active}`}`}
+              aria-label={isPaused ? 'Resume event streaming' : 'Pause event streaming'}
+              aria-pressed={isPaused}
+              onClick={() => this.handleTogglePause(liveEvents)}
+            >
+              <span className="pf-v6-c-button__icon">
+                {isPaused ? <PlayIcon /> : <PauseIcon />}
+              </span>
+            </Button>
+          </FlexItem>
+          <FlexItem>
+            <Content component={ContentVariants.small}>
+              {isPaused
+                ? `Event stream is paused.${pendingCount > 0 ? ` ${pendingCount} new event${pendingCount === 1 ? '' : 's'} waiting.` : ''}`
+                : 'Streaming events...'}
+            </Content>
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
             <Content component={ContentVariants.small}>
@@ -171,16 +217,24 @@ class WorkspaceEvents extends React.PureComponent<Props> {
     );
     const headStackItem = (
       <StackItem>
-        <Content component={ContentVariants.small}>Older events are not stored.</Content>
+        <Content component={ContentVariants.small} className={styles.footer}>
+          Older events are not stored.
+        </Content>
       </StackItem>
     );
 
     return (
       <PageSection variant={PageSectionVariants.default}>
-        <div role="log" aria-label="Workspace events">
-          <Stack hasGutter>
+        <div role="log" aria-label="Workspace events" aria-live={isPaused ? 'off' : 'polite'}>
+          <Stack>
             {tailStackItem}
-            {eventItems}
+            {eventItems.length > 0 && (
+              <StackItem>
+                <div className={styles.eventsTimeline}>
+                  <Stack hasGutter>{eventItems}</Stack>
+                </div>
+              </StackItem>
+            )}
             {headStackItem}
           </Stack>
         </div>

--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -89,6 +89,26 @@ html.pf-v6-theme-dark .pf-v6-c-page__main-section {
   background-color: #414141;
 }
 
+/* Workspace Events: prevent the outer log stack from inheriting any gutter gap.
+   Selector specificity (0,3,0) beats .pf-v6-l-stack.pf-m-gutter (0,2,0),
+   so this works even when a cached JS bundle still renders hasGutter. */
+[role='log'][aria-label='Workspace events'] > .pf-v6-l-stack {
+  gap: 0;
+}
+
+/* Workspace Events timeline theme tokens.
+   --che-events-icon-bg   : icon background matches the page section surface.
+   --che-events-border    : timeline/icon/connector line color. */
+:root {
+  --che-events-icon-bg: #f9f9f9;
+  --che-events-border: var(--pf-t--global--color--nonstatus--gray--default);
+}
+
+html.pf-v6-theme-dark {
+  --che-events-icon-bg: #414141; /* same as dark page section */
+  --che-events-border: var(--pf-t--color--gray--40); /* #a3a3a3 */
+}
+
 /* Dark theme danger button contrast override for WCAG 2.2 Level AA compliance - Overrides PF v6 variables */
 html.pf-v6-theme-dark .pf-v6-c-button.pf-m-danger {
   --pf-v6-c-button--m-danger--BackgroundColor: #e57373;


### PR DESCRIPTION
### What does this PR do?

Adds a Pause / Resume toggle to the Events tab on the Workspace Creation page to satisfy [WCAG 2.2 criterion 2.2.2 Pause, Stop, Hide (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html).

Previously there was no explicit control to stop the live event stream. Users could only implicitly interrupt auto-scrolling by manually scrolling the page — the events kept prepending into the list with no way to freeze them.

The fix adds a `PauseIcon` / `PlayIcon` toggle button next to the "Streaming events..." label:

- **Pause**: captures a snapshot of the current event list, stops new events from being rendered into the DOM, and shows a "N new events waiting" badge so the user knows updates are queued.
- **Resume**: releases the snapshot and renders all accumulated events at once.

The `role="log"` container also switches `aria-live` between `"polite"` (streaming) and `"off"` (paused) so screen readers stop announcing updates when the user has explicitly paused.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1791" height="876" alt="Знімок екрана 2026-07-02 о 17 29 38" src="https://github.com/user-attachments/assets/d3874b56-fc7f-41bf-a869-4b50f09ab362" />
<img width="1791" height="876" alt="Знімок екрана 2026-07-02 о 17 28 23" src="https://github.com/user-attachments/assets/73b0acf2-71e4-4925-a440-a9de7f1c9886" />


### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-10283

### Is it tested? How?

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Start a workspace and navigate to the Workspace Creation page → Events tab.
3. Verify a Pause button (⏸) appears next to "Streaming events..." and is keyboard-focusable.
4. Click Pause — verify the event list freezes, the button changes to Play (▶), and the label reads "Paused — N new events waiting" as events continue arriving in the background.
5. Click Resume — verify the buffered events appear immediately and streaming resumes.
