### PR TITLE
fix: add missing SCC mismatch check to RESTART_WORKSPACE

### DIFF
--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/Provider.tsx
@@ -174,6 +174,11 @@ class WorkspaceActionsProvider extends React.Component<Props, State> {
         break;
       case WorkspaceAction.RESTART_WORKSPACE:
         {
+          if (this.checkSccMismatch(workspace)) {
+            console.warn(
+              `Workspace "${workspace.name}" has SCC mismatch. The workspace was created with a different container SCC than what is currently configured.`,
+            );
+          }
           await this.props.restartWorkspace(workspace);
         }
         break;

--- a/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/Provider.spec.tsx
+++ b/packages/dashboard-frontend/src/contexts/WorkspaceActions/__tests__/Provider.spec.tsx
@@ -434,6 +434,26 @@ describe('WorkspaceActionsProvider', () => {
         );
       });
 
+      test('restart workspace with SCC mismatch logs warning', async () => {
+        console.warn = jest.fn();
+        mockRestartWorkspace.mockResolvedValueOnce(undefined);
+
+        renderComponent(storeWithScc, WorkspaceAction.RESTART_WORKSPACE, wantDelete[0]);
+
+        const handleActionBtn = screen.getByTestId('test-component-handle-action');
+
+        await user.click(handleActionBtn);
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('SCC mismatch'));
+
+        expect(mockRestartWorkspace).toHaveBeenCalledTimes(1);
+        expect(mockRestartWorkspace).toHaveBeenCalledWith(
+          expect.objectContaining({ uid: wantDelete[0] }),
+        );
+      });
+
       test('restart debug and open logs with SCC mismatch logs warning', async () => {
         console.warn = jest.fn();
         mockRestartWorkspace.mockResolvedValueOnce(undefined);


### PR DESCRIPTION
### What does this PR do?

Adds the missing `checkSccMismatch()` call to the `RESTART_WORKSPACE` action handler in `Provider.tsx`, consistent with all other start/restart actions.

### Screenshot/screencast of this PR

No UI change — this adds a `console.warn` when an SCC mismatch is detected during a plain restart, matching the existing behaviour of `START_DEBUG_AND_OPEN_LOGS`, `START_IN_BACKGROUND`, and `RESTART_DEBUG_AND_OPEN_LOGS`.

### What issues does this PR fix or reference?

Fixes https://github.com/eclipse-che/che/issues/23905

Spotted during review of eclipse-che/che-dashboard#1593 by @olexii4.

### Is it tested? How?

**Automated:**
- New test `restart workspace with SCC mismatch logs warning` in `Provider.spec.tsx` — follows the same pattern as the existing SCC mismatch tests for other actions.
- All 17 tests in `Provider.spec.tsx` pass.

**Manual:**
1. Deploy Eclipse Che on a cluster with a non-default SCC configured for workspace containers.
2. Create a workspace, then change the SCC configuration.
3. Open the kebab menu for the workspace and select "Restart Workspace".
4. Open browser devtools — verify a `console.warn` message containing "SCC mismatch" appears.
5. Verify the workspace still restarts normally.

#### Release Notes

Fixed missing SCC mismatch warning when using the "Restart Workspace" action. All start/restart actions now consistently warn when the workspace was created with a different container SCC.

#### Docs PR

N/A — no user-facing documentation change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)