### PR TITLE
fix(deps): upgrade deps to address multiple CVEs

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -4,11 +4,13 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | --- | --- |
 | `any-signal@4.2.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/any-signal/4.2.0) |
 | `cronstrue@3.13.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/cronstrue/3.13.0) |
-| `fast-uri@2.4.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/2.4.0) |
+| `fast-uri@3.1.3` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fast-uri/3.1.3) |
 | `fastify-plugin@5.2.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fastify-plugin/5.2.1) |
 | `jsep@1.3.9` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsep/1.3.9) |
 | `undici@7.28.0` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/undici/7.28.0) |
 | `@hapi/wreck@18.1.2` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@hapi/wreck/18.1.2) |
 | `joi@17.13.4` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/joi/17.13.4) |
+| `launder@1.7.1` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/launder/1.7.1) |
+| `brace-expansion@5.0.7` | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/brace-expansion/5.0.7) |
 
 

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -100,12 +100,15 @@
 | `crypto-browserify@3.12.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/crypto-browserify/3.12.0) |
 | `date-fns@3.6.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/date-fns/3.6.0) |
 | `dateformat@4.6.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/dateformat/4.6.3) |
+| `dayjs@1.11.21` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/dayjs/1.11.21) |
 | `depd@2.0.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/depd/2.0.0) |
 | `des.js@1.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/des.js/1.1.0) |
 | `detect-browser@5.3.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/detect-browser/5.3.0) |
 | `diffie-hellman@5.0.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/diffie-hellman/5.0.3) |
+| `domutils@3.2.2` | BSD-2-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/domutils/3.2.2) |
 | `dunder-proto@1.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/dunder-proto/1.0.1) |
 | `duplexify@4.1.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/duplexify/4.1.3) |
+| `entities@7.0.1` | BSD-2-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/entities/7.0.1) |
 | `es-define-property@1.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/es-define-property/1.0.1) |
 | `es-errors@1.3.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/es-errors/1.3.0) |
 | `es-object-atoms@1.1.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/es-object-atoms/1.1.1) |
@@ -137,6 +140,7 @@
 | `hasown@2.0.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/hasown/2.0.2) |
 | `help-me@4.2.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/help-me/4.2.0) |
 | `history@4.10.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/history/4.10.1) |
+| `htmlparser2@10.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/htmlparser2/10.1.0) |
 | `http-errors@2.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/http-errors/2.0.1) |
 | `https@1.0.0` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/https/1.0.0) |
 | `immer@10.1.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/immer/10.1.1) |
@@ -154,6 +158,7 @@
 | `jsonc-parser@3.2.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonc-parser/3.2.0) |
 | `jsonfile@6.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonfile/6.1.0) |
 | `jsonschema@1.4.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/jsonschema/1.4.1) |
+| `launder@1.7.1` |  | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/launder/1.7.1) |
 | `leven@2.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/leven/2.1.0) |
 | `light-my-request@6.6.0` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/light-my-request/6.6.0) |
 | `lodash@4.18.1` | CC0-1.0 AND MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/lodash/4.18.1) |
@@ -211,7 +216,7 @@
 | `rfdc@1.3.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/rfdc/1.3.0) |
 | `ripemd160@2.0.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/ripemd160/2.0.2) |
 | `safe-stable-stringify@2.4.3` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/safe-stable-stringify/2.4.3) |
-| `sanitize-html@2.17.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/sanitize-html/2.17.0) |
+| `sanitize-html@2.17.5` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/sanitize-html/2.17.5) |
 | `secure-json-parse@2.7.0` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/secure-json-parse/2.7.0) |
 | `secure-json-parse@4.1.0` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/secure-json-parse/4.1.0) |
 | `set-cookie-parser@2.7.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/set-cookie-parser/2.7.2) |

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cross-spawn": "^7.0.6",
     "elliptic": "^6.6.1",
     "find-my-way": "9.0.1",
-    "form-data": "4.0.4",
+    "form-data": "4.0.6",
     "glob": "^11.1.0",
     "glob-parent": "^6.0.2",
     "js-yaml": "^4.2.0",
@@ -91,6 +91,7 @@
     "follow-redirects": "^1.16.0",
     "@fastify/static": "^9.1.1",
     "brace-expansion@^1.0.0": "^1.1.13",
-    "fast-uri": "^3.1.1"
+    "brace-expansion@^5.0.5": "5.0.7",
+    "fast-uri": "3.1.3"
   }
 }

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -68,7 +68,7 @@
     "reconnecting-websocket": "^4.4.0",
     "redux": "^5.0.1",
     "reflect-metadata": "^0.1.13",
-    "sanitize-html": "^2.16.0"
+    "sanitize-html": "^2.17.4"
   },
   "devDependencies": {
     "@devfile/api": "2.3.0-1747843475",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,7 +1230,7 @@ __metadata:
     redux-logger: "npm:^3.0.6"
     redux-mock-store: "npm:^1.5.4"
     reflect-metadata: "npm:^0.1.13"
-    sanitize-html: "npm:^2.16.0"
+    sanitize-html: "npm:^2.17.4"
     source-map-loader: "npm:^4.0.1"
     speed-measure-webpack-plugin: "npm:^1.5.0"
     style-loader: "npm:^3.3.3"
@@ -4649,6 +4649,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.15
   resolution: "brace-expansion@npm:1.1.15"
@@ -4656,15 +4665,6 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10/f2a950034e670523cc186da61aabe3beab74b1b8a7c74a756bf6b172dad1917312f255d9ec46906c9f0cab530868095d8c143918576930dd0e1323c3803850f1
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
   languageName: node
   linkType: hard
 
@@ -5844,6 +5844,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dayjs@npm:^1.11.7":
+  version: 1.11.21
+  resolution: "dayjs@npm:1.11.21"
+  checksum: 10/dd16f9f2706b61b90e3c346a3211ac3afd9e26193136ce0e87f70bf74d1c17a447bceb230a88b175467fc9f5e3243d8c1544b9897092a12d9c80ee44d338dcb6
+  languageName: node
+  linkType: hard
+
 "debounce@npm:^1.2.1":
   version: 1.2.1
   resolution: "debounce@npm:1.2.1"
@@ -6187,6 +6194,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"domutils@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "domutils@npm:3.2.2"
+  dependencies:
+    dom-serializer: "npm:^2.0.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+  checksum: 10/2e08842151aa406f50fe5e6d494f4ec73c2373199fa00d1f77b56ec604e566b7f226312ae35ab8160bb7f27a27c7285d574c8044779053e499282ca9198be210
+  languageName: node
+  linkType: hard
+
 "dot-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "dot-case@npm:3.0.4"
@@ -6383,6 +6401,13 @@ __metadata:
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10/ede2a35c9bce1aeccd055a1b445d41c75a14a2bb1cd22e242f20cf04d236cdcd7f9c859eb83f76885327bfae0c25bf03303665ee1ce3d47c5927b98b0e3e3d48
+  languageName: node
+  linkType: hard
+
+"entities@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "entities@npm:7.0.1"
+  checksum: 10/3c0c58d869c45148463e96d21dee2d1b801bd3fe4cf47aa470cd26dfe81d59e9e0a9be92ae083fa02fa441283c883a471486e94538dcfb8544428aa80a55271b
   languageName: node
   linkType: hard
 
@@ -7187,10 +7212,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10/1dff04865b2a38d3e0659deadfbf72efdf83a776bfbf9667e4aa9e5a3ec31bc341cda9622136b32b7652a857c8ba11896794186e8f876f8b2b72731fce8622f6
+"fast-uri@npm:3.1.3":
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10/7969a50a327482035d5c8c93faf51b26d7a93ce62bc750c91b3df158550004b5fbb378c95c900fd71f4dded36b5a78d1c666fb8043bb1214efbaebd8518d873e
   languageName: node
   linkType: hard
 
@@ -7463,16 +7488,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.4":
-  version: 4.0.4
-  resolution: "form-data@npm:4.0.4"
+"form-data@npm:4.0.6":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/a4b62e21932f48702bc468cc26fb276d186e6b07b557e3dd7cc455872bdbb82db7db066844a64ad3cf40eaf3a753c830538183570462d3649fdfd705601cbcfb
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10/de6614c8537c92fa5fa3ee7e827758f98f5a9c033f348b7de81855ef36e5cb867e75d9f405d9483ab8d724a4a20d4e79926a299fa8dbba38f530eb659f0884e4
   languageName: node
   linkType: hard
 
@@ -8063,6 +8088,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/13823863ae48161068b4c51606a3128451c66f14545a5169d667fe9fca168dcd38c27570c7a299e32ef844b8da3d55def7fe88602f8970d4311fb543ee88001a
+  languageName: node
+  linkType: hard
+
 "he@npm:^1.2.0":
   version: 1.2.0
   resolution: "he@npm:1.2.0"
@@ -8179,6 +8213,18 @@ __metadata:
     webpack:
       optional: true
   checksum: 10/d651f3a88a7c932c72c6a30f0fdd610b49a864a69f1ddb34562c750f1602ea471e27fd8fc32c01adadd484b38fa6b74f055d1ccce26e5f8fcf814ee0d398a121
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "htmlparser2@npm:10.1.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.2.2"
+    entities: "npm:^7.0.1"
+  checksum: 10/660fb094a53fb77a3c771db969778b58af0e8a572a1bdc8e5952a4241e4b04e0a6063b16f6422e22c821441081c8de339e3f06ddda362ac2a42c8767d5e5ad53
   languageName: node
   linkType: hard
 
@@ -9904,6 +9950,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"launder@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "launder@npm:1.7.1"
+  dependencies:
+    dayjs: "npm:^1.11.7"
+  checksum: 10/e0fbf7934728c9dd82eea3ccbebc31c021c9ffee225861cf6e2f219bdeb2be0d8585748eb700ec58a41a7dff5529e50ac84500657a7a927305685ec9f1cb3ab3
+  languageName: node
+  linkType: hard
+
 "leven@npm:2.1.0":
   version: 2.1.0
   resolution: "leven@npm:2.1.0"
@@ -10351,7 +10406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.19":
+"mime-types@npm:^2.1.27, mime-types@npm:^2.1.35, mime-types@npm:~2.1.19":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -12746,17 +12801,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sanitize-html@npm:^2.16.0":
-  version: 2.17.0
-  resolution: "sanitize-html@npm:2.17.0"
+"sanitize-html@npm:^2.17.4":
+  version: 2.17.5
+  resolution: "sanitize-html@npm:2.17.5"
   dependencies:
     deepmerge: "npm:^4.2.2"
     escape-string-regexp: "npm:^4.0.0"
-    htmlparser2: "npm:^8.0.0"
+    htmlparser2: "npm:^10.1.0"
     is-plain-object: "npm:^5.0.0"
+    launder: "npm:^1.7.1"
     parse-srcset: "npm:^1.0.2"
     postcss: "npm:^8.3.11"
-  checksum: 10/93a91c629b91f1ad25ede5cd000d4212f3ed495a9b8eeb2cb1b50c936807ab11e736d6c6a75d141daac28430d14e40351981809fbb05f7be7bdffb60318cfebd
+  checksum: 10/93c7ae236faa9bf281533394caebd5cbbc3e52349c1d82c32fb921826b65fcdab435238eee2931d70e9781f46be47c9e530909d258e239fa230f12496bfdc4f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Upgrades `form-data`, `sanitize-html`, `fast-uri`, and `brace-expansion`
to fix four security vulnerabilities.

1. **`form-data` 4.0.4 → 4.0.6** — fixes CRLF injection (CVE-2026-12143,
   [CRW-11376](https://redhat.atlassian.net/browse/CRW-11376)). Field names and filenames passed to `FormData#append` were
   concatenated verbatim into `Content-Disposition` headers without escaping
   CR, LF, or `"`, allowing an attacker to inject arbitrary headers or smuggle
   additional multipart parts. Fixed in 4.0.6 by percent-encoding those
   characters.

2. **`sanitize-html` 2.17.0 → 2.17.5** — fixes stored XSS via HTML sanitizer
   bypass (CVE-2026-44990, [CRW-11484](https://redhat.atlassian.net/browse/CRW-11484)). Content inside a disallowed `<xmp>`
   element could survive sanitization and become live HTML or JavaScript under
   the default `disallowedTagsMode: 'discard'` path. Fixed in 2.17.4.

3. **`fast-uri` 3.1.2 → 3.1.3** — fixes security policy bypass due to improper
   Unicode (IDN) hostname canonicalization (CVE-2026-13676, [CRW-11535](https://redhat.atlassian.net/browse/CRW-11535)).
   Versions 2.3.1–3.1.2 failed to convert IDN hostnames to their ASCII form,
   causing `normalize()` and `equal()` to return results inconsistent with
   WHATWG URL parsers. Applications using `fast-uri` for host-based policy
   enforcement (denylists, redirect validation) could be bypassed. Fixed in
   3.1.3 (3.x line).

4. **`brace-expansion` 5.0.6 → 5.0.7** — fixes denial of service due to
   exponential-time complexity (CVE-2026-13149, [CRW-11663](https://redhat.atlassian.net/browse/CRW-11663)). The `expand()`
   function exhibited exponential-time complexity in the number of consecutive
   non-expanding `{}` brace groups, allowing an attacker who passes a crafted
   string to `expand()` to cause significant CPU consumption and event-loop
   blocking. The `max` option did not mitigate this as it bounds output size
   rather than recursion work. Fixed in 5.0.7. Pinned via
   `resolutions["brace-expansion@^5.0.5"]` since 5.0.7 is not yet indexed in
   ClearlyDefined and added to `EXCLUDED/prod.md`.

The remaining three tickets are not applicable to this project:
- [CRW-11410](https://redhat.atlassian.net/browse/CRW-11410) and [CRW-11464](https://redhat.atlassian.net/browse/CRW-11464) (`react-router` v7 CVEs) — this project uses
  `react-router` v6.30.3; the vulnerabilities only affect v7.

`launder@1.7.1`, a new transitive dependency introduced by `sanitize-html`
2.17.5, is added to `.deps/EXCLUDED/prod.md` as it is not yet indexed in
ClearlyDefined.

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11376
fixes https://redhat.atlassian.net/browse/CRW-11484
fixes https://redhat.atlassian.net/browse/CRW-11535
fixes https://redhat.atlassian.net/browse/CRW-11663
references https://redhat.atlassian.net/browse/CRW-11410
references https://redhat.atlassian.net/browse/CRW-11450
references https://redhat.atlassian.net/browse/CRW-11464

### Is it tested? How?

- No runtime logic changed — pure dependency upgrades.
- `yarn install` resolves cleanly: `form-data@4.0.6`, `sanitize-html@2.17.5`,
  `fast-uri@3.1.3`, and `brace-expansion@5.0.7` installed; previous versions
  removed.
- `yarn license:generate` completes without unresolved dependencies:
  - `form-data@4.0.6` — ClearlyDefined score 89, MIT
  - `sanitize-html@2.17.5` — ClearlyDefined score 55, MIT
  - `fast-uri@3.1.3` — not yet indexed; added to `EXCLUDED/prod.md`
  - `launder@1.7.1` — not yet indexed; added to `EXCLUDED/prod.md`
  - `brace-expansion@5.0.7` — not yet indexed; added to `EXCLUDED/prod.md`
- `yarn license:check` passes.

#### Release Notes

Updated `form-data`, `sanitize-html`, `fast-uri`, and `brace-expansion` to
address CRLF injection, stored XSS, hostname canonicalization bypass, and
denial-of-service security vulnerabilities.

#### Docs PR

N/A
