### PR TITLE
fix(backend): fix kubeconfig injection race in slow-starting workspaces

### DIFF
--- a/packages/dashboard-backend/src/services/PostStartInjector.ts
+++ b/packages/dashboard-backend/src/services/PostStartInjector.ts
@@ -17,7 +17,9 @@ import { MessageListener } from '@/services/types/Observer';
 import { logger } from '@/utils/logger';
 
 const INJECTION_TIMEOUT_MS = 300000;
-const POLL_INTERVAL_MS = 10000;
+// 2 s gives ~6 poll attempts within the ~12 s window that the UDI entrypoint.sh
+// waits for ~/.kube/config before giving up and falling back to the pod SA token.
+const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 300000;
 
 function isTerminalPhase(phase: string): boolean {
@@ -143,6 +145,38 @@ export class PostStartInjector {
           kubeConfigApi,
           podmanApi,
         );
+      });
+
+    // Immediate initial check: if the workspace reached RUNNING before the watch
+    // stream opened (narrow LIST→STREAM race window), the watch will never fire for
+    // the transition.  A single GET right after registering the watch catches this.
+    devworkspaceApi
+      .getByName(namespace, workspaceName)
+      .then(async dw => {
+        // Guard: if the watch listener already handled RUNNING (and called
+        // cleanupWithTimeout), the key is gone — avoid double injection.
+        if (!PostStartInjector.activeWatches.has(key)) {
+          return;
+        }
+        const phase = dw.status?.phase;
+        const devworkspaceId = dw.status?.devworkspaceId;
+        if (phase === DevWorkspaceStatus.RUNNING && devworkspaceId) {
+          logger.info(
+            `PostStartInjector: ${key} already Running at watch start — injecting immediately`,
+          );
+          cleanupWithTimeout();
+          await PostStartInjector.injectCredentials(
+            namespace,
+            devworkspaceId,
+            kubeConfigApi,
+            podmanApi,
+            key,
+          );
+        }
+      })
+      .catch((e: unknown) => {
+        // Non-fatal: the watch or polling fallback will still handle the RUNNING event.
+        logger.warn(e, `PostStartInjector: initial getByName failed for ${key}`);
       });
   }
 

--- a/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
+++ b/packages/dashboard-backend/src/services/__tests__/PostStartInjector.spec.ts
@@ -45,7 +45,9 @@ describe('PostStartInjector', () => {
         return Promise.resolve();
       }),
       stopWatching: jest.fn(),
-      getByName: jest.fn(),
+      // Default: return 'Starting' so the initial check does not trigger injection
+      // in tests that do not explicitly override getByName.
+      getByName: jest.fn().mockResolvedValue({ status: { phase: 'Starting' } }),
     } as unknown as IDevWorkspaceApi;
 
     kubeConfigApi = {
@@ -194,9 +196,45 @@ describe('PostStartInjector', () => {
     expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
   });
 
+  // ── initial immediate check (Race 1 fix) ─────────────────────────────────
+
+  test('injects immediately when workspace is already Running at watch startup', async () => {
+    // Simulates the race: workspace reached RUNNING before watch stream opened.
+    (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+      status: { phase: 'Running', devworkspaceId: 'ws-already-running' },
+    });
+
+    invoke();
+    // Flush the initial getByName() promise chain
+    await Promise.resolve().then(() => Promise.resolve());
+
+    expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-already-running');
+    expect(podmanApi.podmanLogin).toHaveBeenCalledWith(namespace, 'ws-already-running');
+    expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
+  });
+
+  test('does not double-inject when watch listener fires before initial check resolves', async () => {
+    // Both the watch listener and the initial getByName see Running.
+    // The listener fires first (synchronously via capturedListener), removes the key,
+    // then the initial check resolves and must be a no-op.
+    (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
+      status: { phase: 'Running', devworkspaceId: 'ws-race-id' },
+    });
+
+    invoke();
+
+    // Simulate watch listener firing first
+    await capturedListener(dwMessage('Running', 'ws-race-id'));
+    // Now flush the initial check promise — key is already gone
+    await Promise.resolve().then(() => Promise.resolve());
+
+    expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledTimes(1);
+  });
+
   // ── timeout ───────────────────────────────────────────────────────────────
 
   test('stops watch and starts polling fallback on 300 s timeout', () => {
+    // Return 'Starting' so the initial check does not trigger injection.
     (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
       status: { phase: 'Starting' },
     });
@@ -210,16 +248,18 @@ describe('PostStartInjector', () => {
     expect((PostStartInjector as any).activeWatches.has(key)).toBe(true);
   });
 
-  test('injects credentials via polling fallback after 60 s watch timeout', async () => {
-    (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
-      status: { phase: 'Running', devworkspaceId: 'ws-timeout-id' },
-    });
+  test('injects credentials via polling fallback after watch timeout', async () => {
+    // First call = initial check → Starting (no injection).
+    // Subsequent calls (polling) → Running.
+    (devworkspaceApi.getByName as jest.Mock)
+      .mockResolvedValueOnce({ status: { phase: 'Starting' } })
+      .mockResolvedValue({ status: { phase: 'Running', devworkspaceId: 'ws-timeout-id' } });
 
     invoke();
     jest.advanceTimersByTime(300000);
 
-    // Advance polling interval so getByName is called
-    jest.advanceTimersByTime(10000);
+    // Advance one polling interval (2 s) so getByName is called
+    jest.advanceTimersByTime(2000);
     await Promise.resolve().then(() => Promise.resolve());
 
     expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-timeout-id');
@@ -248,12 +288,13 @@ describe('PostStartInjector', () => {
     });
 
     test('injects on Running phase during polling', async () => {
-      (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({
-        status: { phase: 'Running', devworkspaceId: 'ws-poll-id' },
-      });
+      // First call = initial check → Starting. Subsequent calls (poll) → Running.
+      (devworkspaceApi.getByName as jest.Mock)
+        .mockResolvedValueOnce({ status: { phase: 'Starting' } })
+        .mockResolvedValue({ status: { phase: 'Running', devworkspaceId: 'ws-poll-id' } });
 
       await triggerErrorAndFlush();
-      jest.advanceTimersByTime(10000);
+      jest.advanceTimersByTime(2000);
       await Promise.resolve().then(() => Promise.resolve());
 
       expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-poll-id');
@@ -264,10 +305,11 @@ describe('PostStartInjector', () => {
     test.each(['Failed', 'Failing', 'Stopped', 'Stopping', 'Terminating'])(
       'stops polling without injection on %s phase',
       async phase => {
+        // Initial check + poll both return the terminal phase (no injection either way).
         (devworkspaceApi.getByName as jest.Mock).mockResolvedValue({ status: { phase } });
 
         await triggerErrorAndFlush();
-        jest.advanceTimersByTime(10000);
+        jest.advanceTimersByTime(2000);
         await Promise.resolve().then(() => Promise.resolve());
 
         expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
@@ -287,18 +329,38 @@ describe('PostStartInjector', () => {
       expect((PostStartInjector as any).activeWatches.has(key)).toBe(false);
     });
 
-    test('retries after a GET error during polling', async () => {
+    test('poll interval is 2 s (catches RUNNING before entrypoint.sh gives up)', async () => {
+      // The UDI entrypoint.sh waits ~12 s; 2 s poll gives ~6 attempts in that window.
+      // First call = initial check → Starting. Poll at T+2 s → Running.
       (devworkspaceApi.getByName as jest.Mock)
-        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce({ status: { phase: 'Starting' } })
+        .mockResolvedValue({ status: { phase: 'Running', devworkspaceId: 'ws-fast-id' } });
+
+      await triggerErrorAndFlush();
+
+      // One 2 s poll — should inject without needing 10 s
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve().then(() => Promise.resolve());
+
+      expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-fast-id');
+    });
+
+    test('retries after a GET error during polling', async () => {
+      // Call #1 (initial check) → rejection.
+      // Call #2 (poll #1) → rejection.
+      // Call #3 (poll #2) → Running.
+      (devworkspaceApi.getByName as jest.Mock)
+        .mockRejectedValueOnce(new Error('network error')) // initial check
+        .mockRejectedValueOnce(new Error('network error')) // poll #1
         .mockResolvedValue({ status: { phase: 'Running', devworkspaceId: 'ws-retry-id' } });
 
       await triggerErrorAndFlush();
 
-      jest.advanceTimersByTime(10000);
+      jest.advanceTimersByTime(2000);
       await Promise.resolve().then(() => Promise.resolve());
       expect(kubeConfigApi.injectKubeConfig).not.toHaveBeenCalled();
 
-      jest.advanceTimersByTime(10000);
+      jest.advanceTimersByTime(2000);
       await Promise.resolve().then(() => Promise.resolve());
       expect(kubeConfigApi.injectKubeConfig).toHaveBeenCalledWith(namespace, 'ws-retry-id');
     });


### PR DESCRIPTION
### What does this PR do?

Fixes two race conditions in `PostStartInjector` that caused user OAuth tokens to not be
injected into workspace terminals intermittently after PR #1606.

#### Root Cause

**Race 1 — Already-RUNNING workspace (primary):**
`watchAndInject()` starts a Kubernetes watch and waits for a `RUNNING` event. The watch
protocol does a LIST then opens a streaming WATCH from that list's `resourceVersion`. A
fast-starting workspace can reach `Running` inside the narrow window between LIST and the
stream opening — the `RUNNING` event falls before the stream's start boundary and is never
delivered. With no watch event and no polling yet, injection never happens.

**Race 2 — Polling fallback too slow (secondary):**
When the watch falls back to polling, the interval was 10 s. The UDI `entrypoint.sh`
polls for `~/.kube/config` for ~12 s before giving up. A workspace becoming `Running`
right after a poll check left a 10 s gap — long enough for the container to give up and
fall back to the pod service account identity.

Both races are observed in the CI log from 2026-07-07 as `KubedockPodmanTest` failures:
```
Kubeconfig doesn't exist yet. Waiting...  [repeated 10×]
Could not find Kubeconfig at /home/user/.kube/config
Giving up...
Error: logging into "image-registry...": invalid username/password
```

#### Fix

1. **Immediate initial check** — after registering the watch, a single `getByName()` is
   issued immediately. If the workspace is already `Running`, credentials are injected
   without waiting for watch events, eliminating the LIST→STREAM race window.

2. **Reduced poll interval** — `POLL_INTERVAL_MS` reduced from `10 000 ms` → `2 000 ms`,
   giving ~6 poll attempts within the 12 s window the UDI entrypoint.sh waits.

### Screenshot/screencast of this PR

N/A — backend-only change.

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11193

### Is it tested? How?

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Start a workspace from a factory URL (fast-path: workspace reaches `Running` before
   the watch stream opens).
3. Open a terminal and run `oc whoami` — verify it returns the OpenShift user identity,
   not `system:serviceaccount:<ns>:<sa>`.
4. Run `oc whoami -t` — verify a valid OAuth token is returned.

#### Release Notes

Fixed intermittent failure where workspace terminals used the pod service account identity
instead of the logged-in user's OAuth token when workspaces started quickly.

#### Docs PR

N/A
