### PR TITLE
fix(a11y): add tabIndex to workspace progress steps

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/PureSubCondition.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/PureSubCondition.tsx
@@ -32,7 +32,7 @@ export class PureSubCondition extends React.PureComponent<Props> {
     return (
       <ol className="pf-c-wizard__nav-list">
         <li className="pf-c-wizard__nav-item">
-          <div className="pf-c-wizard__nav-link">
+          <div className="pf-c-wizard__nav-link" tabIndex={0}>
             <ProgressStepTitle distance={distance} parentStepName={parentStepName}>
               {title}
             </ProgressStepTitle>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/__snapshots__/PureSubCondition.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/StartingSteps/WorkspaceConditions/__tests__/__snapshots__/PureSubCondition.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`Starting sub-steps, checking rendering snapshot with a title 1`] = `
   >
     <div
       className="pf-c-wizard__nav-link"
+      tabIndex={0}
     >
       <div>
         <div

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
@@ -17,6 +17,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -31,6 +32,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
         <span
           aria-current="step"
           className="pf-v6-c-wizard__nav-link pf-m-current"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -44,6 +46,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -60,6 +63,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
           >
             <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              tabIndex={0}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -73,6 +77,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
           >
             <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              tabIndex={0}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -86,6 +91,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
           >
             <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              tabIndex={0}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/__tests__/__snapshots__/index.spec.tsx.snap
@@ -62,7 +62,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
-              className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
               <span
@@ -76,7 +76,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
-              className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
               <span
@@ -90,7 +90,7 @@ exports[`WorkspaceProgressWizard component snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
-              className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
               <span

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
@@ -119,6 +119,7 @@ class WorkspaceProgressWizard extends React.Component<Props> {
               <span
                 className={this.navLinkClassName(isCurrent, !canJumpTo)}
                 aria-current={isCurrent ? 'step' : undefined}
+                tabIndex={0}
               >
                 <span className={wizardStyles.wizardNavLinkMain}>{name}</span>
               </span>
@@ -133,6 +134,7 @@ class WorkspaceProgressWizard extends React.Component<Props> {
                         <span
                           className={this.navLinkClassName(isSubCurrent, !canJumpTo)}
                           aria-current={isSubCurrent ? 'step' : undefined}
+                          tabIndex={0}
                         >
                           <span className={wizardStyles.wizardNavLinkMain}>{name}</span>
                         </span>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
@@ -59,11 +59,11 @@ class WorkspaceProgressWizard extends React.Component<Props> {
       Object.assign({ canJumpTo: true }, step);
 
     return steps.map(step => {
-      const subSteps = step.steps;
-      if (subSteps !== undefined) {
-        subSteps.map(subStep => withDefaults(subStep));
+      const defaultStep = withDefaults(step);
+      if (defaultStep.steps !== undefined) {
+        defaultStep.steps = defaultStep.steps.map(subStep => withDefaults(subStep));
       }
-      return withDefaults(step);
+      return defaultStep;
     });
   }
 
@@ -119,7 +119,8 @@ class WorkspaceProgressWizard extends React.Component<Props> {
               <span
                 className={this.navLinkClassName(isCurrent, !canJumpTo)}
                 aria-current={isCurrent ? 'step' : undefined}
-                tabIndex={0}
+                aria-disabled={!canJumpTo ? true : undefined}
+                tabIndex={canJumpTo ? 0 : -1}
               >
                 <span className={wizardStyles.wizardNavLinkMain}>{name}</span>
               </span>
@@ -134,7 +135,8 @@ class WorkspaceProgressWizard extends React.Component<Props> {
                         <span
                           className={this.navLinkClassName(isSubCurrent, !canJumpTo)}
                           aria-current={isSubCurrent ? 'step' : undefined}
-                          tabIndex={0}
+                          aria-disabled={!canJumpTo ? true : undefined}
+                          tabIndex={canJumpTo ? 0 : -1}
                         >
                           <span className={wizardStyles.wizardNavLinkMain}>{name}</span>
                         </span>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
@@ -185,7 +185,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
-              className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
               <span
@@ -240,7 +240,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
-              className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
               <span
@@ -295,7 +295,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
-              className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
               <span
@@ -350,7 +350,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
-              className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
               <span

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
@@ -18,6 +18,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
         <span
           aria-current="step"
           className="pf-v6-c-wizard__nav-link pf-m-current"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -72,6 +73,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -126,6 +128,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -183,6 +186,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
           >
             <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              tabIndex={0}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -237,6 +241,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
           >
             <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              tabIndex={0}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -291,6 +296,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
           >
             <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              tabIndex={0}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -345,6 +351,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
           >
             <span
               className="pf-v6-c-wizard__nav-link pf-m-disabled"
+              tabIndex={0}
             >
               <span
                 className="pf-v6-c-wizard__nav-link-main"
@@ -401,6 +408,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -455,6 +463,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -527,6 +536,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
         <span
           aria-current="step"
           className="pf-v6-c-wizard__nav-link pf-m-current"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -581,6 +591,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -635,6 +646,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"
@@ -689,6 +701,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
       >
         <span
           className="pf-v6-c-wizard__nav-link"
+          tabIndex={0}
         >
           <span
             className="pf-v6-c-wizard__nav-link-main"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Makes steps and sub-steps during workspace creation flow reachable by 'Tab' button.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10923


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1.Deploy Eclipse Che with the dashboard image from this PR.
2.Open the "Create Workspace" page and click "Empty Workspace".
3.While the workspace initializes, use 'Tab' button to go through elements on page.
4.Verify that focus can be set to steps and sub-steps.
