### PR TITLE
feat: add Device Auth Tokens tab to User Preferences

### DIFF
--- a/docs/superpowers/plans/2026-08-06-device-auth-decouple.md
+++ b/docs/superpowers/plans/2026-08-06-device-auth-decouple.md
@@ -1,0 +1,701 @@
+# Device Auth Decoupled from Git Services OAuth — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `getGitHubClientId()` 3-tier fallback and Che Server `isGitHubOAuthConfigured()` check with a single admin-configurable `device-auth-config` ConfigMap that makes device auth fully independent of Git Services OAuth.
+
+**Architecture:** A new route-layer helper `getDeviceAuthClientId()` reads `github_client_id` from a `device-auth-config` ConfigMap in the Che namespace (via SA KubeConfig) and caches the result with a 90 s TTL. `clusterConfig.ts` uses it to set `githubDeviceAuthEnabled`. The device auth route passes the resolved `clientId` to the service — removing all config-reading logic from `deviceAuthTokenApi.ts`.
+
+**Tech Stack:** TypeScript, Fastify, `@kubernetes/client-node`, Jest.
+
+## Global Constraints
+
+- No `any` type; strict TypeScript throughout.
+- Absolute imports with `@/` alias only.
+- EPL-2.0 copyright header on every new file.
+- Assisted-by trailer on the commit.
+- Run `yarn format:fix && yarn lint:fix` before committing.
+- Run targeted tests with `yarn workspace @eclipse-che/dashboard-backend test --testPathPatterns="<pattern>" --no-cache`.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|---------------|
+| **Create** | `src/routes/api/helpers/getDeviceAuthClientId.ts` | SA-based ConfigMap read + 90 s cache |
+| **Create** | `src/routes/api/helpers/__mocks__/getDeviceAuthClientId.ts` | Jest auto-mock for route tests |
+| **Create** | `src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts` | Unit tests for the helper |
+| **Create** | `src/routes/api/__tests__/deviceAuthToken.spec.ts` | Route-level tests for initiate / poll |
+| **Modify** | `src/routes/api/clusterConfig.ts` | Use `getDeviceAuthClientId()` → drop old cache + HTTP call |
+| **Modify** | `src/routes/api/__tests__/clusterConfig.spec.ts` | Mock `getDeviceAuthClientId` |
+| **Modify** | `src/routes/api/deviceAuthToken.ts` | Resolve `clientId` in route, gate on null |
+| **Modify** | `src/devworkspaceClient/types/index.ts` | Add `clientId` param to `initiateDeviceAuth`/`pollDeviceAuth` |
+| **Modify** | `src/devworkspaceClient/services/deviceAuthTokenApi.ts` | Accept `clientId` param, delete `getGitHubClientId()` |
+| **Modify** | `src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts` | Pass `clientId` in all test calls |
+
+---
+
+### Task 1: Create `getDeviceAuthClientId` helper + mock + tests
+
+**Files:**
+- Create: `packages/dashboard-backend/src/routes/api/helpers/getDeviceAuthClientId.ts`
+- Create: `packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDeviceAuthClientId.ts`
+- Create: `packages/dashboard-backend/src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts`
+
+**Interfaces:**
+- Produces: `getDeviceAuthClientId(): Promise<string | null>`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard-backend/src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as mockClient from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+jest.mock('@/routes/api/helpers/getServiceAccountToken');
+jest.mock('@/devworkspaceClient/services/helpers/retryableExec');
+
+const mockReadNamespacedConfigMap = jest.fn();
+const stubCoreV1Api = {
+  readNamespacedConfigMap: mockReadNamespacedConfigMap,
+} as unknown as CoreV1Api;
+
+describe('getDeviceAuthClientId', () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...origEnv };
+    delete process.env.DEVICE_AUTH_GITHUB_CLIENT_ID;
+    process.env.CHECLUSTER_CR_NAMESPACE = 'eclipse-che';
+    const { KubeConfig } = mockClient;
+    KubeConfig.prototype.makeApiClient = jest.fn().mockReturnValue(stubCoreV1Api);
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+    jest.clearAllMocks();
+  });
+
+  it('returns client_id from ConfigMap when present', async () => {
+    mockReadNamespacedConfigMap.mockResolvedValueOnce({
+      data: { github_client_id: '01ab8ac9400c4e429b23' },
+    });
+    const { getDeviceAuthClientId } = await import(
+      '@/routes/api/helpers/getDeviceAuthClientId'
+    );
+    const result = await getDeviceAuthClientId();
+    expect(result).toBe('01ab8ac9400c4e429b23');
+  });
+
+  it('returns null when ConfigMap key is absent', async () => {
+    mockReadNamespacedConfigMap.mockResolvedValueOnce({ data: {} });
+    const { getDeviceAuthClientId } = await import(
+      '@/routes/api/helpers/getDeviceAuthClientId'
+    );
+    const result = await getDeviceAuthClientId();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when ConfigMap does not exist (404)', async () => {
+    mockReadNamespacedConfigMap.mockRejectedValueOnce(
+      Object.assign(new Error('Not Found'), { code: 404 }),
+    );
+    const { getDeviceAuthClientId } = await import(
+      '@/routes/api/helpers/getDeviceAuthClientId'
+    );
+    const result = await getDeviceAuthClientId();
+    expect(result).toBeNull();
+  });
+
+  it('returns value from DEVICE_AUTH_GITHUB_CLIENT_ID env var (local dev override)', async () => {
+    process.env.DEVICE_AUTH_GITHUB_CLIENT_ID = 'local-override-id';
+    const { getDeviceAuthClientId } = await import(
+      '@/routes/api/helpers/getDeviceAuthClientId'
+    );
+    const result = await getDeviceAuthClientId();
+    expect(result).toBe('local-override-id');
+    expect(mockReadNamespacedConfigMap).not.toHaveBeenCalled();
+  });
+
+  it('returns null when CHECLUSTER_CR_NAMESPACE is not set', async () => {
+    delete process.env.CHECLUSTER_CR_NAMESPACE;
+    const { getDeviceAuthClientId } = await import(
+      '@/routes/api/helpers/getDeviceAuthClientId'
+    );
+    const result = await getDeviceAuthClientId();
+    expect(result).toBeNull();
+    expect(mockReadNamespacedConfigMap).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+yarn workspace @eclipse-che/dashboard-backend test --testPathPatterns="getDeviceAuthClientId" --no-cache
+```
+
+Expected: Module not found error.
+
+- [ ] **Step 3: Implement the helper**
+
+```typescript
+// packages/dashboard-backend/src/routes/api/helpers/getDeviceAuthClientId.ts
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as k8s from '@kubernetes/client-node';
+
+import { prepareCoreV1API } from '@/devworkspaceClient/services/helpers/prepareCoreV1API';
+import { getServiceAccountToken } from '@/routes/api/helpers/getServiceAccountToken';
+import { KubeConfigProvider } from '@/services/kubeclient/kubeConfigProvider';
+
+const DEVICE_AUTH_CONFIG_MAP = 'device-auth-config';
+const GITHUB_CLIENT_ID_KEY = 'github_client_id';
+const CACHE_TTL_MS = 90_000;
+
+let cache: { value: string | null; expiresAt: number } | null = null;
+
+export async function getDeviceAuthClientId(): Promise<string | null> {
+  if (cache && Date.now() < cache.expiresAt) {
+    return cache.value;
+  }
+
+  const value = await resolveClientId();
+  cache = { value, expiresAt: Date.now() + CACHE_TTL_MS };
+  return value;
+}
+
+async function resolveClientId(): Promise<string | null> {
+  // Local dev / CI override
+  if (process.env.DEVICE_AUTH_GITHUB_CLIENT_ID) {
+    return process.env.DEVICE_AUTH_GITHUB_CLIENT_ID;
+  }
+
+  const namespace = process.env.CHECLUSTER_CR_NAMESPACE;
+  if (!namespace) {
+    return null;
+  }
+
+  try {
+    const token = getServiceAccountToken();
+    const kc = new KubeConfigProvider().getKubeConfig(token);
+    const coreV1API = prepareCoreV1API(kc);
+    const configMap = await coreV1API.readNamespacedConfigMap({
+      name: DEVICE_AUTH_CONFIG_MAP,
+      namespace,
+    });
+    const clientId = configMap.data?.[GITHUB_CLIENT_ID_KEY]?.trim() ?? '';
+    return clientId || null;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Create the mock**
+
+```typescript
+// packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDeviceAuthClientId.ts
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export const stubDeviceAuthClientId: string | null = null;
+
+export async function getDeviceAuthClientId(): Promise<string | null> {
+  return stubDeviceAuthClientId;
+}
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```bash
+yarn workspace @eclipse-che/dashboard-backend test --testPathPatterns="getDeviceAuthClientId" --no-cache
+```
+
+Expected: All 5 tests pass.
+
+- [ ] **Step 6: Format and lint**
+
+```bash
+yarn format:fix && yarn lint:fix
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/dashboard-backend/src/routes/api/helpers/getDeviceAuthClientId.ts \
+  packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDeviceAuthClientId.ts \
+  packages/dashboard-backend/src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts
+git commit -m "feat(device-auth): add getDeviceAuthClientId helper reading device-auth-config ConfigMap"
+```
+
+---
+
+### Task 2: Update `IDeviceAuthTokenApi` interface and `deviceAuthTokenApi.ts` service
+
+**Files:**
+- Modify: `packages/dashboard-backend/src/devworkspaceClient/types/index.ts:642-648`
+- Modify: `packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts`
+- Modify: `packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (service layer is isolated)
+- Produces: `initiateDeviceAuth(namespace: string, clientId: string): Promise<DeviceCodeResponse>`, `pollDeviceAuth(namespace: string, deviceCode: string, clientId: string): Promise<DeviceAuthPollResult>`
+
+- [ ] **Step 1: Update the interface in `types/index.ts`**
+
+Find lines 642–648 and replace:
+```typescript
+  initiateDeviceAuth(namespace: string): Promise<DeviceCodeResponse>;
+  // ...
+  pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult>;
+```
+with:
+```typescript
+  initiateDeviceAuth(namespace: string, clientId: string): Promise<DeviceCodeResponse>;
+  // ...
+  pollDeviceAuth(namespace: string, deviceCode: string, clientId: string): Promise<DeviceAuthPollResult>;
+```
+
+Full replacement block (lines 639–649 in `types/index.ts`):
+```typescript
+  /**
+   * Initiates a GitHub Device Authorization flow and returns the device code and user code.
+   */
+  initiateDeviceAuth(namespace: string, clientId: string): Promise<DeviceCodeResponse>;
+
+  /**
+   * Polls GitHub for the access token using the device code.
+   * On success, stores the token as a Kubernetes secret.
+   */
+  pollDeviceAuth(namespace: string, deviceCode: string, clientId: string): Promise<DeviceAuthPollResult>;
+  validateToken(namespace: string, tokenName: string): Promise<'valid' | 'invalid' | 'unknown'>;
+```
+
+- [ ] **Step 2: Update `deviceAuthTokenApi.ts` service**
+
+Remove these items from the service file:
+- `import { existsSync, readFileSync } from 'fs';`
+- `const GITHUB_OAUTH_ID_FILE` constant
+- The entire `getGitHubClientId()` async function (lines ~66–111)
+
+Change `initiateDeviceAuth`:
+```typescript
+async initiateDeviceAuth(namespace: string, clientId: string): Promise<DeviceCodeResponse> {
+  const data = await githubPostDeviceCode({
+    client_id: clientId,
+    scope: GITHUB_SCOPES,
+  });
+  if (!data.device_code || !data.user_code || !data.verification_uri) {
+    if (data.error === 'device_flow_disabled' || data.error === 'device_flow_not_enabled') {
+      throw new Error(
+        'Device Flow is not enabled for this GitHub OAuth App. ' +
+          'An administrator must enable it at GitHub Settings → Developer settings → OAuth Apps.',
+      );
+    }
+    throw new Error(
+      `Failed to initiate device auth: ${data.error_description ?? JSON.stringify(data)}`,
+    );
+  }
+  const expiresAt = Date.now() + (data.expires_in ?? 900) * 1_000;
+  activeDeviceCodes.set(namespace, { code: data.device_code, expiresAt });
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    interval: data.interval ?? 5,
+  };
+}
+```
+
+Change `pollDeviceAuth`:
+```typescript
+async pollDeviceAuth(namespace: string, deviceCode: string, clientId: string): Promise<DeviceAuthPollResult> {
+  const stored = activeDeviceCodes.get(namespace);
+  if (!stored || stored.code !== deviceCode || Date.now() > stored.expiresAt) {
+    if (stored && Date.now() > stored.expiresAt) {
+      activeDeviceCodes.delete(namespace);
+    }
+    return {
+      status: 'error',
+      message: 'Device code is not valid for this session. Please initiate a new connection.',
+    };
+  }
+  const data = await githubPostToken({
+    client_id: clientId,
+    device_code: deviceCode,
+    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+  });
+
+  if (data.error === 'authorization_pending') {
+    return { status: 'pending' };
+  }
+  if (data.error === 'slow_down') {
+    return { status: 'slow_down' };
+  }
+  if (data.error === 'expired_token') {
+    return { status: 'expired' };
+  }
+  if (data.error) {
+    return { status: 'error', message: data.error_description ?? data.error };
+  }
+  if (!data.access_token) {
+    return { status: 'error', message: 'No access_token in response' };
+  }
+
+  activeDeviceCodes.delete(namespace);
+  const token = await this.createDeviceAuthSecret(namespace, data.access_token);
+  return { status: 'authorized', token };
+}
+```
+
+- [ ] **Step 3: Update the service unit tests**
+
+In `deviceAuthTokenApi.spec.ts`:
+- Remove the `origClientId` / `process.env.CHE_GITHUB_OAUTH_CLIENT_ID` setup in `initiateDeviceAuth` and `pollDeviceAuth` describe blocks.
+- Pass `'test-client-id'` as the `clientId` argument to every `service.initiateDeviceAuth(namespace, 'test-client-id')` and `service.pollDeviceAuth(namespace, 'dev-code-123', 'test-client-id')` call.
+- Remove the test "should throw when CHE_GITHUB_OAUTH_CLIENT_ID is not set" (no longer applicable).
+
+- [ ] **Step 4: Run the service tests**
+
+```bash
+yarn workspace @eclipse-che/dashboard-backend test --testPathPatterns="deviceAuthTokenApi" --no-cache
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Format and lint**
+
+```bash
+yarn format:fix && yarn lint:fix
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/dashboard-backend/src/devworkspaceClient/types/index.ts \
+  packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts \
+  packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
+git commit -m "refactor(device-auth): accept clientId param; remove 3-tier getGitHubClientId fallback"
+```
+
+---
+
+### Task 3: Update `clusterConfig.ts` and its spec
+
+**Files:**
+- Modify: `packages/dashboard-backend/src/routes/api/clusterConfig.ts`
+- Modify: `packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts`
+
+**Interfaces:**
+- Consumes: `getDeviceAuthClientId()` from Task 1
+
+- [ ] **Step 1: Update `clusterConfig.ts`**
+
+Replace the entire file with:
+```typescript
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { ClusterConfig } from '@eclipse-che/common';
+import { FastifyInstance } from 'fastify';
+
+import { baseApiPath } from '@/constants/config';
+import { getDeviceAuthClientId } from '@/routes/api/helpers/getDeviceAuthClientId';
+import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
+import { getServiceAccountToken } from '@/routes/api/helpers/getServiceAccountToken';
+import { getSchema } from '@/services/helpers';
+
+const tags = ['Cluster Config'];
+
+export function registerClusterConfigRoute(instance: FastifyInstance) {
+  instance.register(async server => {
+    server.get(`${baseApiPath}/cluster-config`, getSchema({ tags }), async () =>
+      buildClusterConfig(),
+    );
+  });
+}
+
+async function buildClusterConfig(): Promise<ClusterConfig> {
+  const token = getServiceAccountToken();
+  const { serverConfigApi } = getDevWorkspaceClient(token);
+
+  const cheCustomResource = await serverConfigApi.fetchCheCustomResource();
+  const dashboardWarning = serverConfigApi.getDashboardWarning(cheCustomResource);
+  const runningWorkspacesLimit = serverConfigApi.getRunningWorkspacesLimit(cheCustomResource);
+  const allWorkspacesLimit = serverConfigApi.getAllWorkspacesLimit(cheCustomResource);
+  const dashboardFavicon = serverConfigApi.getDashboardLogo(cheCustomResource);
+  const currentArchitecture = await serverConfigApi.getCurrentArchitecture();
+  const clientId = await getDeviceAuthClientId();
+
+  return {
+    dashboardWarning,
+    dashboardFavicon,
+    allWorkspacesLimit,
+    runningWorkspacesLimit,
+    currentArchitecture,
+    githubDeviceAuthEnabled: clientId !== null,
+  };
+}
+```
+
+- [ ] **Step 2: Update `clusterConfig.spec.ts`**
+
+Add `jest.mock('../helpers/getDeviceAuthClientId.ts');` at the top with the other mocks. The auto-mock returns `null` (from the `__mocks__` file written in Task 1), so `githubDeviceAuthEnabled` stays `false` — no assertion changes needed.
+
+Full updated spec (only the mock line changes):
+```typescript
+jest.mock('../helpers/getServiceAccountToken.ts');
+jest.mock('../helpers/getDevWorkspaceClient.ts');
+jest.mock('../helpers/getDeviceAuthClientId.ts');
+```
+
+- [ ] **Step 3: Run the clusterConfig spec**
+
+```bash
+yarn workspace @eclipse-che/dashboard-backend test --testPathPatterns="clusterConfig" --no-cache
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 4: Format and lint**
+
+```bash
+yarn format:fix && yarn lint:fix
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/dashboard-backend/src/routes/api/clusterConfig.ts \
+  packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts
+git commit -m "refactor(device-auth): use device-auth-config ConfigMap for githubDeviceAuthEnabled"
+```
+
+---
+
+### Task 4: Update `deviceAuthToken.ts` route + add route-level spec
+
+**Files:**
+- Modify: `packages/dashboard-backend/src/routes/api/deviceAuthToken.ts`
+- Create: `packages/dashboard-backend/src/routes/api/__tests__/deviceAuthToken.spec.ts`
+
+**Interfaces:**
+- Consumes: `getDeviceAuthClientId()` from Task 1; `initiateDeviceAuth(namespace, clientId)` / `pollDeviceAuth(namespace, deviceCode, clientId)` from Task 2
+
+- [ ] **Step 1: Update `deviceAuthToken.ts`**
+
+Add `import { getDeviceAuthClientId } from '@/routes/api/helpers/getDeviceAuthClientId';` at the top.
+
+Replace the `initiate` route handler body:
+```typescript
+async function (request: FastifyRequest, reply: FastifyReply) {
+  const clientId = await getDeviceAuthClientId();
+  if (!clientId) {
+    return reply.code(503).send({
+      message:
+        'GitHub device auth is not configured. Create a device-auth-config ConfigMap in the Che namespace.',
+    });
+  }
+  const { namespace } = request.params as restParams.INamespacedParams;
+  const token = getToken(request);
+  const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
+  return deviceAuthTokenApi.initiateDeviceAuth(namespace, clientId);
+},
+```
+
+Replace the `poll` route handler body:
+```typescript
+async function (request: FastifyRequest, reply: FastifyReply) {
+  const clientId = await getDeviceAuthClientId();
+  if (!clientId) {
+    return reply.code(503).send({
+      message:
+        'GitHub device auth is not configured. Create a device-auth-config ConfigMap in the Che namespace.',
+    });
+  }
+  const { namespace } = request.params as restParams.INamespacedParams;
+  const { deviceCode } = request.body as { deviceCode: string };
+  const token = getToken(request);
+  const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
+  return deviceAuthTokenApi.pollDeviceAuth(namespace, deviceCode, clientId);
+},
+```
+
+Add `FastifyReply` to the `fastify` import.
+
+- [ ] **Step 2: Write the route spec**
+
+```typescript
+// packages/dashboard-backend/src/routes/api/__tests__/deviceAuthToken.spec.ts
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance } from 'fastify';
+
+import { baseApiPath } from '@/constants/config';
+import {
+  stubDeviceAuthClientId,
+} from '@/routes/api/helpers/__mocks__/getDeviceAuthClientId';
+import { setup, teardown } from '@/utils/appBuilder';
+
+jest.mock('../helpers/getServiceAccountToken.ts');
+jest.mock('../helpers/getDevWorkspaceClient.ts');
+jest.mock('../helpers/getDeviceAuthClientId.ts');
+
+// Allow the mock to be overridden per test
+let mockClientId: string | null = stubDeviceAuthClientId;
+jest.mock('@/routes/api/helpers/getDeviceAuthClientId', () => ({
+  getDeviceAuthClientId: () => Promise.resolve(mockClientId),
+}));
+
+const namespace = 'user-che';
+
+describe('Device Auth Token Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await setup();
+  });
+
+  afterAll(() => {
+    teardown(app);
+  });
+
+  beforeEach(() => {
+    mockClientId = null;
+  });
+
+  describe('POST /initiate', () => {
+    it('returns 503 when device auth is not configured', async () => {
+      mockClientId = null;
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/initiate`,
+      });
+      expect(res.statusCode).toBe(503);
+    });
+
+    it('calls initiateDeviceAuth with clientId when configured', async () => {
+      mockClientId = 'test-client-id';
+      // getDevWorkspaceClient mock returns stub that throws; 500 is expected but 503 must not occur
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/initiate`,
+      });
+      expect(res.statusCode).not.toBe(503);
+    });
+  });
+
+  describe('POST /poll', () => {
+    it('returns 503 when device auth is not configured', async () => {
+      mockClientId = null;
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/poll`,
+        payload: { deviceCode: 'ABCD-1234' },
+      });
+      expect(res.statusCode).toBe(503);
+    });
+
+    it('does not return 503 when configured', async () => {
+      mockClientId = 'test-client-id';
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/poll`,
+        payload: { deviceCode: 'ABCD-1234' },
+      });
+      expect(res.statusCode).not.toBe(503);
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the route spec**
+
+```bash
+yarn workspace @eclipse-che/dashboard-backend test --testPathPatterns="deviceAuthToken.spec" --no-cache
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Run the full backend test suite to confirm no regressions**
+
+```bash
+yarn workspace @eclipse-che/dashboard-backend test --no-cache 2>&1 | tail -20
+```
+
+Expected: All suites pass.
+
+- [ ] **Step 5: Format and lint**
+
+```bash
+yarn format:fix && yarn lint:fix
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/dashboard-backend/src/routes/api/deviceAuthToken.ts \
+  packages/dashboard-backend/src/routes/api/__tests__/deviceAuthToken.spec.ts
+git commit -m "feat(device-auth): gate initiate/poll on device-auth-config; pass clientId from route"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] Spec coverage: ConfigMap read ✓, TTL cache ✓, `githubDeviceAuthEnabled` via ConfigMap ✓, service `clientId` param ✓, 503 gate on routes ✓, 3-tier fallback removed ✓, no Che Server call for device auth ✓, no env-var injection dependency ✓
+- [x] Placeholder scan: all code blocks are complete and self-contained
+- [x] Type consistency: `initiateDeviceAuth(namespace: string, clientId: string)` and `pollDeviceAuth(namespace: string, deviceCode: string, clientId: string)` used consistently across Task 2, 3, and 4

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -78,6 +78,8 @@ export type DeviceAuthToken = {
   provider?: string;
   /** ISO 8601 timestamp string as returned by Kubernetes and serialized by Fastify */
   creationTimestamp?: string;
+  /** Whether the token is still accepted by GitHub. Set by a separate validate call. */
+  valid?: boolean;
 };
 
 export type DeviceCodeResponse = {

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -73,6 +73,29 @@ export type NewSshKey = Omit<SshKey, 'creationTimestamp'> & {
   key: string;
 };
 
+export type DeviceAuthToken = {
+  name: string;
+  provider?: string;
+  /** ISO 8601 timestamp string as returned by Kubernetes and serialized by Fastify */
+  creationTimestamp?: string;
+  /** Whether the stored token is still accepted by GitHub. Undefined means the check was not performed or timed out. */
+  valid?: boolean;
+};
+
+export type DeviceCodeResponse = {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  interval: number;
+};
+
+export type DeviceAuthPollResult =
+  | { status: 'pending' }
+  | { status: 'slow_down' }
+  | { status: 'authorized'; token: DeviceAuthToken }
+  | { status: 'expired' }
+  | { status: 'error'; message: string };
+
 export interface IPatch {
   op: string;
   path: string;

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -78,8 +78,8 @@ export type DeviceAuthToken = {
   provider?: string;
   /** ISO 8601 timestamp string as returned by Kubernetes and serialized by Fastify */
   creationTimestamp?: string;
-  /** Whether the token is still accepted by GitHub. Set by a separate validate call. */
-  valid?: boolean;
+  /** Token validity from a separate validate call. 'unknown' means check could not complete. */
+  valid?: 'valid' | 'invalid' | 'unknown';
 };
 
 export type DeviceCodeResponse = {

--- a/packages/common/src/dto/api/index.ts
+++ b/packages/common/src/dto/api/index.ts
@@ -78,8 +78,6 @@ export type DeviceAuthToken = {
   provider?: string;
   /** ISO 8601 timestamp string as returned by Kubernetes and serialized by Fastify */
   creationTimestamp?: string;
-  /** Whether the stored token is still accepted by GitHub. Undefined means the check was not performed or timed out. */
-  valid?: boolean;
 };
 
 export type DeviceCodeResponse = {

--- a/packages/common/src/dto/cluster-config.ts
+++ b/packages/common/src/dto/cluster-config.ts
@@ -28,4 +28,5 @@ export interface ClusterConfig {
   allWorkspacesLimit: number;
   runningWorkspacesLimit: number;
   currentArchitecture?: Architecture;
+  githubDeviceAuthEnabled: boolean;
 }

--- a/packages/dashboard-backend/src/app.ts
+++ b/packages/dashboard-backend/src/app.ts
@@ -29,6 +29,7 @@ import { registerBackupRoutes } from '@/routes/api/backup';
 import { registerClusterConfigRoute } from '@/routes/api/clusterConfig';
 import { registerClusterInfoRoute } from '@/routes/api/clusterInfo';
 import { registerDataResolverRoute } from '@/routes/api/dataResolver';
+import { registerDeviceAuthTokenRoutes } from '@/routes/api/deviceAuthToken';
 import { registerDevWorkspaceClusterRoutes } from '@/routes/api/devworkspaceCluster';
 import { registerDevworkspaceResourcesRoute } from '@/routes/api/devworkspaceResources';
 import { registerDevworkspacesRoutes } from '@/routes/api/devworkspaces';
@@ -149,5 +150,7 @@ export default async function buildApp(server: FastifyInstance): Promise<unknown
     registerAiConfigRoutes(server),
 
     registerAiRegistryRoute(isLocalRun(), server),
+
+    registerDeviceAuthTokenRoutes(server),
   ]);
 }

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -298,6 +298,29 @@ export const aiProviderKeyParamsSchema: JSONSchema7 = {
   required: ['namespace', 'toolId'],
 };
 
+export const deviceAuthTokenParamsSchema: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    namespace: {
+      type: 'string',
+    },
+    tokenName: {
+      type: 'string',
+      pattern: '^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$',
+      maxLength: 253,
+    },
+  },
+  required: ['namespace', 'tokenName'],
+};
+
+export const deviceAuthPollBodySchema: JSONSchema7 = {
+  type: 'object',
+  required: ['deviceCode'],
+  properties: {
+    deviceCode: { type: 'string', minLength: 1, maxLength: 100 },
+  },
+};
+
 // namespaced schemas
 
 export const namespacedSchema: JSONSchema7 = {

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -317,8 +317,30 @@ export const deviceAuthPollBodySchema: JSONSchema7 = {
   type: 'object',
   required: ['deviceCode'],
   properties: {
-    deviceCode: { type: 'string', minLength: 1, maxLength: 100 },
+    deviceCode: { type: 'string', minLength: 1, maxLength: 100, pattern: '^[a-zA-Z0-9_-]+$' },
   },
+};
+
+export const deviceAuthTokenResponseSchema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      provider: { type: 'string' },
+      creationTimestamp: { type: 'string' },
+      valid: { type: 'string', enum: ['valid', 'invalid', 'unknown'] },
+    },
+    required: ['name'],
+  },
+};
+
+export const deviceAuthValidateResponseSchema = {
+  type: 'object',
+  properties: {
+    valid: { type: 'string', enum: ['valid', 'invalid', 'unknown'] },
+  },
+  required: ['valid'],
 };
 
 // namespaced schemas

--- a/packages/dashboard-backend/src/constants/schemas.ts
+++ b/packages/dashboard-backend/src/constants/schemas.ts
@@ -329,7 +329,6 @@ export const deviceAuthTokenResponseSchema = {
       name: { type: 'string' },
       provider: { type: 'string' },
       creationTimestamp: { type: 'string' },
-      valid: { type: 'string', enum: ['valid', 'invalid', 'unknown'] },
     },
     required: ['name'],
   },

--- a/packages/dashboard-backend/src/devworkspaceClient/__mocks__/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/__mocks__/index.ts
@@ -14,6 +14,7 @@ import {
   IAiProviderKeyApi,
   IAiRegistryApi,
   IAirGapSampleApi,
+  IDeviceAuthTokenApi,
   IDevWorkspaceApi,
   IDevWorkspaceClusterApi,
   IDevWorkspaceSingletonClient,
@@ -90,6 +91,10 @@ export class DevWorkspaceClient implements IDevWorkspaceClient {
   }
 
   get aiRegistryApi(): IAiRegistryApi {
+    throw new Error('Method not implemented.');
+  }
+
+  get deviceAuthTokenApi(): IDeviceAuthTokenApi {
     throw new Error('Method not implemented.');
   }
 

--- a/packages/dashboard-backend/src/devworkspaceClient/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/index.ts
@@ -15,6 +15,7 @@ import * as k8s from '@kubernetes/client-node';
 import { AiProviderKeyApiService } from '@/devworkspaceClient/services/aiProviderKeyApi';
 import { AiRegistryApiService } from '@/devworkspaceClient/services/aiRegistryApi';
 import { AirGapSampleApiService } from '@/devworkspaceClient/services/airGapSampleApi';
+import { DeviceAuthTokenApiService } from '@/devworkspaceClient/services/deviceAuthTokenApi';
 import { DevWorkspaceApiService } from '@/devworkspaceClient/services/devWorkspaceApi';
 import { DevWorkspaceClusterApiService } from '@/devworkspaceClient/services/devWorkspaceClusterApiService';
 import { DevWorkspaceTemplateApiService } from '@/devworkspaceClient/services/devWorkspaceTemplateApi';
@@ -36,6 +37,7 @@ import {
   IAiProviderKeyApi,
   IAiRegistryApi,
   IAirGapSampleApi,
+  IDeviceAuthTokenApi,
   IDevWorkspaceApi,
   IDevWorkspaceClient,
   IDevWorkspaceClusterApi,
@@ -139,6 +141,10 @@ export class DevWorkspaceClient implements IDevWorkspaceClient {
 
   get aiRegistryApi(): IAiRegistryApi {
     return new AiRegistryApiService(this.kubeConfig);
+  }
+
+  get deviceAuthTokenApi(): IDeviceAuthTokenApi {
+    return new DeviceAuthTokenApiService(this.kubeConfig);
   }
 
   get sccPermissionApi(): ISccPermissionApi {

--- a/packages/dashboard-backend/src/devworkspaceClient/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/index.ts
@@ -15,7 +15,7 @@ import * as k8s from '@kubernetes/client-node';
 import { AiProviderKeyApiService } from '@/devworkspaceClient/services/aiProviderKeyApi';
 import { AiRegistryApiService } from '@/devworkspaceClient/services/aiRegistryApi';
 import { AirGapSampleApiService } from '@/devworkspaceClient/services/airGapSampleApi';
-import { DeviceAuthTokenApiService } from '@/devworkspaceClient/services/deviceAuthTokenApi';
+import { GitHubDeviceAuthTokenApiService } from '@/devworkspaceClient/services/deviceAuthTokenApi';
 import { DevWorkspaceApiService } from '@/devworkspaceClient/services/devWorkspaceApi';
 import { DevWorkspaceClusterApiService } from '@/devworkspaceClient/services/devWorkspaceClusterApiService';
 import { DevWorkspaceTemplateApiService } from '@/devworkspaceClient/services/devWorkspaceTemplateApi';
@@ -143,8 +143,10 @@ export class DevWorkspaceClient implements IDevWorkspaceClient {
     return new AiRegistryApiService(this.kubeConfig);
   }
 
+  private _deviceAuthTokenApi: IDeviceAuthTokenApi | undefined;
+
   get deviceAuthTokenApi(): IDeviceAuthTokenApi {
-    return new DeviceAuthTokenApiService(this.kubeConfig);
+    return (this._deviceAuthTokenApi ??= new GitHubDeviceAuthTokenApiService(this.kubeConfig));
   }
 
   get sccPermissionApi(): ISccPermissionApi {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { api } from '@eclipse-che/common';
+import * as mockClient from '@kubernetes/client-node';
+import { CoreV1Api, V1Secret, V1SecretList } from '@kubernetes/client-node';
+
+import { DeviceAuthTokenApiService } from '@/devworkspaceClient/services/deviceAuthTokenApi';
+
+jest.mock('@/devworkspaceClient/services/helpers/retryableExec');
+
+const namespace = 'user-che';
+const tokenName = 'device-authentication-secret-abc12';
+const resourceVersion = 'rv-123';
+
+const DEVICE_AUTH_LABEL = 'che.eclipse.org/device-authentication';
+const DEVICE_AUTH_PROVIDER_LABEL = 'che.eclipse.org/device-authentication-provider';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('DeviceAuthToken API Service', () => {
+  let service: DeviceAuthTokenApiService;
+
+  const stubCoreV1Api = {
+    listNamespacedSecret: () => {
+      return Promise.resolve({ items: [] } as V1SecretList);
+    },
+    readNamespacedSecret: () => {
+      return Promise.resolve({
+        metadata: {
+          name: tokenName,
+          resourceVersion,
+          labels: { [DEVICE_AUTH_LABEL]: 'true' },
+          creationTimestamp: new Date('2024-01-01'),
+        },
+      } as V1Secret);
+    },
+    deleteNamespacedSecret: () => {
+      return Promise.resolve(undefined);
+    },
+  } as unknown as CoreV1Api;
+
+  const spyListNamespacedSecret = jest.spyOn(stubCoreV1Api, 'listNamespacedSecret');
+  const spyReadNamespacedSecret = jest.spyOn(stubCoreV1Api, 'readNamespacedSecret');
+  const spyDeleteNamespacedSecret = jest.spyOn(stubCoreV1Api, 'deleteNamespacedSecret');
+
+  beforeEach(() => {
+    const { KubeConfig } = mockClient;
+    const kubeConfig = new KubeConfig();
+    kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => stubCoreV1Api);
+    service = new DeviceAuthTokenApiService(kubeConfig);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listTokens', () => {
+    it('should return tokens from labeled secrets', async () => {
+      const creationTimestamp = new Date('2024-01-01');
+      spyListNamespacedSecret.mockResolvedValueOnce({
+        items: [
+          {
+            metadata: {
+              name: tokenName,
+              creationTimestamp,
+              labels: { [DEVICE_AUTH_LABEL]: 'true' },
+            },
+          } as V1Secret,
+        ],
+      } as V1SecretList);
+
+      const result = await service.listTokens(namespace);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(tokenName);
+      expect(result[0].provider).toBeUndefined();
+      expect(result[0].creationTimestamp).toBe(creationTimestamp.toISOString());
+      expect(spyListNamespacedSecret).toHaveBeenCalledWith({
+        namespace,
+        labelSelector: `${DEVICE_AUTH_LABEL}=true`,
+      });
+    });
+
+    it('should include provider from label when present', async () => {
+      spyListNamespacedSecret.mockResolvedValueOnce({
+        items: [
+          {
+            metadata: {
+              name: tokenName,
+              labels: {
+                [DEVICE_AUTH_LABEL]: 'true',
+                [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+              },
+            },
+          } as V1Secret,
+        ],
+      } as V1SecretList);
+
+      const result = await service.listTokens(namespace);
+
+      expect(result[0].provider).toBe('github');
+    });
+
+    it('should return an empty array when no labeled secrets exist', async () => {
+      spyListNamespacedSecret.mockResolvedValueOnce({ items: [] } as V1SecretList);
+
+      const result = await service.listTokens(namespace);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should filter out secrets without a name', async () => {
+      spyListNamespacedSecret.mockResolvedValueOnce({
+        items: [{ metadata: {} } as V1Secret],
+      } as V1SecretList);
+
+      const result = await service.listTokens(namespace);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should throw a formatted error when the API call fails', async () => {
+      spyListNamespacedSecret.mockRejectedValueOnce(new Error('API error'));
+
+      await expect(service.listTokens(namespace)).rejects.toThrow(
+        `Unable to list Device Authentication tokens in the namespace "${namespace}"`,
+      );
+    });
+  });
+
+  describe('deleteToken', () => {
+    it('should read and delete with resourceVersion precondition', async () => {
+      await service.deleteToken(namespace, tokenName);
+
+      expect(spyReadNamespacedSecret).toHaveBeenCalledWith({ name: tokenName, namespace });
+      expect(spyDeleteNamespacedSecret).toHaveBeenCalledWith({
+        name: tokenName,
+        namespace,
+        body: { preconditions: { resourceVersion } },
+      });
+    });
+
+    it('should throw a distinct error when the secret does not carry the device-auth label', async () => {
+      spyReadNamespacedSecret.mockResolvedValueOnce({
+        metadata: { name: tokenName, labels: {} },
+      } as V1Secret);
+
+      await expect(service.deleteToken(namespace, tokenName)).rejects.toThrow(
+        `Secret "${tokenName}" does not carry the`,
+      );
+      expect(spyDeleteNamespacedSecret).not.toHaveBeenCalled();
+    });
+
+    it('should throw a formatted error when the read API call fails', async () => {
+      spyReadNamespacedSecret.mockRejectedValueOnce(new Error('API error'));
+
+      await expect(service.deleteToken(namespace, tokenName)).rejects.toThrow(
+        `Unable to delete Device Authentication token "${tokenName}" in the namespace "${namespace}"`,
+      );
+    });
+
+    it('should throw a formatted error when the delete API call fails', async () => {
+      spyDeleteNamespacedSecret.mockRejectedValueOnce(new Error('API error'));
+
+      await expect(service.deleteToken(namespace, tokenName)).rejects.toThrow(
+        `Unable to delete Device Authentication token "${tokenName}" in the namespace "${namespace}"`,
+      );
+    });
+
+    it('should still delete the K8s secret when GitHub token revocation throws', async () => {
+      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
+
+      // Secret has a token in data field (base64 encoded)
+      spyReadNamespacedSecret.mockResolvedValueOnce({
+        metadata: {
+          name: tokenName,
+          resourceVersion,
+          labels: { [DEVICE_AUTH_LABEL]: 'true' },
+        },
+        data: { token: Buffer.from('ghp_test_token').toString('base64') },
+      } as V1Secret);
+
+      // fetch (revocation call) throws a network error
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      // Should NOT throw — deleteNamespacedSecret must still be called
+      await expect(service.deleteToken(namespace, tokenName)).resolves.toBeUndefined();
+      expect(spyDeleteNamespacedSecret).toHaveBeenCalled();
+
+      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+    });
+  });
+
+  describe('initiateDeviceAuth', () => {
+    beforeEach(() => {
+      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
+    });
+    afterEach(() => {
+      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+      jest.clearAllMocks();
+    });
+
+    it('should return device code response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            device_code: 'dev-code-123',
+            user_code: 'ABCD-1234',
+            verification_uri: 'https://github.com/login/device',
+            interval: 5,
+          }),
+      });
+
+      const result = await service.initiateDeviceAuth();
+
+      expect(result).toEqual({
+        deviceCode: 'dev-code-123',
+        userCode: 'ABCD-1234',
+        verificationUri: 'https://github.com/login/device',
+        interval: 5,
+      });
+    });
+
+    it('should throw when CHE_GITHUB_OAUTH_CLIENT_ID is not set', async () => {
+      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+      await expect(service.initiateDeviceAuth()).rejects.toThrow('CHE_GITHUB_OAUTH_CLIENT_ID');
+    });
+
+    it('should throw when GitHub returns an error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ error: 'invalid_client', error_description: 'Bad client' }),
+      });
+      await expect(service.initiateDeviceAuth()).rejects.toThrow('Bad client');
+    });
+  });
+
+  describe('pollDeviceAuth', () => {
+    beforeEach(() => {
+      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
+      stubCoreV1Api.createNamespacedSecret = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'device-authentication-secret-abc12',
+          creationTimestamp: new Date('2024-01-01'),
+        },
+      });
+    });
+    afterEach(() => {
+      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+      jest.clearAllMocks();
+    });
+
+    it('should return pending when GitHub returns authorization_pending', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ error: 'authorization_pending' }),
+      });
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      expect(result).toEqual({ status: 'pending' });
+    });
+
+    it('should return slow_down when GitHub returns slow_down', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ error: 'slow_down' }),
+      });
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      expect(result).toEqual({ status: 'slow_down' });
+    });
+
+    it('should return expired when GitHub returns expired_token', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ error: 'expired_token' }),
+      });
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      expect(result).toEqual({ status: 'expired' });
+    });
+
+    it('should create K8s secret and return authorized on success', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ access_token: 'ghp_token123', token_type: 'bearer', scope: 'repo' }),
+      });
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      expect(result.status).toBe('authorized');
+      expect((result as { status: 'authorized'; token: api.DeviceAuthToken }).token.provider).toBe(
+        'github',
+      );
+    });
+
+    it('should return error when GitHub returns unknown error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ error: 'access_denied', error_description: 'User denied access' }),
+      });
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      expect(result).toEqual({ status: 'error', message: 'User denied access' });
+    });
+
+    it('should return error when response has no access_token', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      expect(result).toEqual({ status: 'error', message: 'No access_token in response' });
+    });
+  });
+});

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
@@ -181,29 +181,45 @@ describe('DeviceAuthToken API Service', () => {
     });
 
     describe('revocation behavior', () => {
-      const origClientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
-      afterEach(() => {
-        process.env.CHE_GITHUB_OAUTH_CLIENT_ID = origClientId;
-      });
+      const rawToken = 'ghp_test_token';
+      const encodedToken = Buffer.from(rawToken).toString('base64');
 
-      it('should still delete the K8s secret when GitHub token revocation throws', async () => {
-        process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
-
-        // Secret has a token in data field (base64 encoded)
-        spyReadNamespacedSecret.mockResolvedValueOnce({
+      beforeEach(() => {
+        spyReadNamespacedSecret.mockResolvedValue({
           metadata: {
             name: tokenName,
             resourceVersion,
             labels: { [DEVICE_AUTH_LABEL]: 'true' },
           },
-          data: { token: Buffer.from('ghp_test_token').toString('base64') },
+          data: { token: encodedToken },
         } as V1Secret);
+      });
 
-        // fetch (revocation call) throws a network error
+      it('should still delete the K8s secret when GitHub token revocation throws', async () => {
         mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
         // Should NOT throw — deleteNamespacedSecret must still be called
         await expect(service.deleteToken(namespace, tokenName)).resolves.toBeUndefined();
+        expect(spyDeleteNamespacedSecret).toHaveBeenCalled();
+      });
+
+      it('should call GitHub revoke API with correct URL, headers, and body on success', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        await service.deleteToken(namespace, tokenName);
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://api.github.com/credentials/revoke',
+          expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({
+              Authorization: `Bearer ${rawToken}`,
+              'Content-Type': 'application/json',
+              'X-GitHub-Api-Version': '2022-11-28',
+            }),
+            body: JSON.stringify({ credentials: [rawToken] }),
+          }),
+        );
         expect(spyDeleteNamespacedSecret).toHaveBeenCalled();
       });
     }); // revocation behavior
@@ -317,7 +333,19 @@ describe('DeviceAuthToken API Service', () => {
       expect((result as { status: 'authorized'; token: api.DeviceAuthToken }).token.provider).toBe(
         'github',
       );
-      expect(stubCoreV1Api.createNamespacedSecret).toHaveBeenCalled();
+      expect(stubCoreV1Api.createNamespacedSecret).toHaveBeenCalledWith({
+        namespace,
+        body: expect.objectContaining({
+          metadata: expect.objectContaining({
+            name: 'device-authentication-github',
+            labels: {
+              [DEVICE_AUTH_LABEL]: 'true',
+              [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+            },
+          }),
+          data: { token: Buffer.from('ghp_token123').toString('base64') },
+        }),
+      });
       expect(stubCoreV1Api.replaceNamespacedSecret).not.toHaveBeenCalled();
     });
 

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
@@ -179,50 +179,6 @@ describe('DeviceAuthToken API Service', () => {
         `Unable to delete Device Authentication token "${tokenName}" in the namespace "${namespace}"`,
       );
     });
-
-    describe('revocation behavior', () => {
-      const rawToken = 'ghp_test_token';
-      const encodedToken = Buffer.from(rawToken).toString('base64');
-
-      beforeEach(() => {
-        spyReadNamespacedSecret.mockResolvedValue({
-          metadata: {
-            name: tokenName,
-            resourceVersion,
-            labels: { [DEVICE_AUTH_LABEL]: 'true' },
-          },
-          data: { token: encodedToken },
-        } as V1Secret);
-      });
-
-      it('should still delete the K8s secret when GitHub token revocation throws', async () => {
-        mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-        // Should NOT throw — deleteNamespacedSecret must still be called
-        await expect(service.deleteToken(namespace, tokenName)).resolves.toBeUndefined();
-        expect(spyDeleteNamespacedSecret).toHaveBeenCalled();
-      });
-
-      it('should call GitHub revoke API with correct URL, headers, and body on success', async () => {
-        mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
-
-        await service.deleteToken(namespace, tokenName);
-
-        expect(mockFetch).toHaveBeenCalledWith(
-          'https://api.github.com/credentials/revoke',
-          expect.objectContaining({
-            method: 'POST',
-            headers: expect.objectContaining({
-              Authorization: `Bearer ${rawToken}`,
-              'Content-Type': 'application/json',
-              'X-GitHub-Api-Version': '2022-11-28',
-            }),
-            body: JSON.stringify({ credentials: [rawToken] }),
-          }),
-        );
-        expect(spyDeleteNamespacedSecret).toHaveBeenCalled();
-      });
-    }); // revocation behavior
   });
 
   describe('initiateDeviceAuth', () => {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
@@ -16,7 +16,7 @@ import { api } from '@eclipse-che/common';
 import * as mockClient from '@kubernetes/client-node';
 import { CoreV1Api, V1Secret, V1SecretList } from '@kubernetes/client-node';
 
-import { DeviceAuthTokenApiService } from '@/devworkspaceClient/services/deviceAuthTokenApi';
+import { GitHubDeviceAuthTokenApiService } from '@/devworkspaceClient/services/deviceAuthTokenApi';
 
 jest.mock('@/devworkspaceClient/services/helpers/retryableExec');
 
@@ -31,7 +31,7 @@ const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
 
 describe('DeviceAuthToken API Service', () => {
-  let service: DeviceAuthTokenApiService;
+  let service: GitHubDeviceAuthTokenApiService;
 
   const stubCoreV1Api = {
     listNamespacedSecret: () => {
@@ -60,7 +60,7 @@ describe('DeviceAuthToken API Service', () => {
     const { KubeConfig } = mockClient;
     const kubeConfig = new KubeConfig();
     kubeConfig.makeApiClient = jest.fn().mockImplementation(_api => stubCoreV1Api);
-    service = new DeviceAuthTokenApiService(kubeConfig);
+    service = new GitHubDeviceAuthTokenApiService(kubeConfig);
   });
 
   afterEach(() => {
@@ -180,36 +180,42 @@ describe('DeviceAuthToken API Service', () => {
       );
     });
 
-    it('should still delete the K8s secret when GitHub token revocation throws', async () => {
-      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
+    describe('revocation behavior', () => {
+      const origClientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+      afterEach(() => {
+        process.env.CHE_GITHUB_OAUTH_CLIENT_ID = origClientId;
+      });
 
-      // Secret has a token in data field (base64 encoded)
-      spyReadNamespacedSecret.mockResolvedValueOnce({
-        metadata: {
-          name: tokenName,
-          resourceVersion,
-          labels: { [DEVICE_AUTH_LABEL]: 'true' },
-        },
-        data: { token: Buffer.from('ghp_test_token').toString('base64') },
-      } as V1Secret);
+      it('should still delete the K8s secret when GitHub token revocation throws', async () => {
+        process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
 
-      // fetch (revocation call) throws a network error
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+        // Secret has a token in data field (base64 encoded)
+        spyReadNamespacedSecret.mockResolvedValueOnce({
+          metadata: {
+            name: tokenName,
+            resourceVersion,
+            labels: { [DEVICE_AUTH_LABEL]: 'true' },
+          },
+          data: { token: Buffer.from('ghp_test_token').toString('base64') },
+        } as V1Secret);
 
-      // Should NOT throw — deleteNamespacedSecret must still be called
-      await expect(service.deleteToken(namespace, tokenName)).resolves.toBeUndefined();
-      expect(spyDeleteNamespacedSecret).toHaveBeenCalled();
+        // fetch (revocation call) throws a network error
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
-      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
-    });
+        // Should NOT throw — deleteNamespacedSecret must still be called
+        await expect(service.deleteToken(namespace, tokenName)).resolves.toBeUndefined();
+        expect(spyDeleteNamespacedSecret).toHaveBeenCalled();
+      });
+    }); // revocation behavior
   });
 
   describe('initiateDeviceAuth', () => {
+    const origClientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
     beforeEach(() => {
       process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
     });
     afterEach(() => {
-      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = origClientId;
       jest.clearAllMocks();
     });
 
@@ -225,7 +231,7 @@ describe('DeviceAuthToken API Service', () => {
           }),
       });
 
-      const result = await service.initiateDeviceAuth();
+      const result = await service.initiateDeviceAuth(namespace);
 
       expect(result).toEqual({
         deviceCode: 'dev-code-123',
@@ -237,7 +243,9 @@ describe('DeviceAuthToken API Service', () => {
 
     it('should throw when CHE_GITHUB_OAUTH_CLIENT_ID is not set', async () => {
       delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
-      await expect(service.initiateDeviceAuth()).rejects.toThrow('CHE_GITHUB_OAUTH_CLIENT_ID');
+      await expect(service.initiateDeviceAuth(namespace)).rejects.toThrow(
+        'CHE_GITHUB_OAUTH_CLIENT_ID',
+      );
     });
 
     it('should throw when GitHub returns an error', async () => {
@@ -245,22 +253,42 @@ describe('DeviceAuthToken API Service', () => {
         ok: true,
         json: () => Promise.resolve({ error: 'invalid_client', error_description: 'Bad client' }),
       });
-      await expect(service.initiateDeviceAuth()).rejects.toThrow('Bad client');
+      await expect(service.initiateDeviceAuth(namespace)).rejects.toThrow('Bad client');
     });
   });
 
   describe('pollDeviceAuth', () => {
-    beforeEach(() => {
+    const origClientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+    beforeEach(async () => {
       process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
       stubCoreV1Api.createNamespacedSecret = jest.fn().mockResolvedValue({
         metadata: {
-          name: 'device-authentication-secret-abc12',
+          name: 'device-authentication-github',
           creationTimestamp: new Date('2024-01-01'),
         },
       });
+      stubCoreV1Api.replaceNamespacedSecret = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'device-authentication-github',
+          creationTimestamp: new Date('2024-01-01'),
+        },
+      });
+      // Seed active code cache so pollDeviceAuth accepts 'dev-code-123'
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            device_code: 'dev-code-123',
+            user_code: 'ABCD-1234',
+            verification_uri: 'https://github.com/login/device',
+            interval: 5,
+            expires_in: 900,
+          }),
+      });
+      await service.initiateDeviceAuth(namespace);
     });
     afterEach(() => {
-      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = origClientId;
       jest.clearAllMocks();
     });
 
@@ -302,6 +330,44 @@ describe('DeviceAuthToken API Service', () => {
       expect((result as { status: 'authorized'; token: api.DeviceAuthToken }).token.provider).toBe(
         'github',
       );
+      expect(stubCoreV1Api.createNamespacedSecret).toHaveBeenCalled();
+      expect(stubCoreV1Api.replaceNamespacedSecret).not.toHaveBeenCalled();
+    });
+
+    it('should replace existing K8s secret when reconnecting', async () => {
+      // Seed a second code for this reconnect scenario
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            device_code: 'dev-code-456',
+            user_code: 'EFGH-5678',
+            verification_uri: 'https://github.com/login/device',
+            interval: 5,
+            expires_in: 900,
+          }),
+      });
+      await service.initiateDeviceAuth(namespace);
+      const existingName = 'device-authentication-github';
+      spyListNamespacedSecret.mockResolvedValueOnce({
+        items: [{ metadata: { name: existingName } }],
+      } as V1SecretList);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ access_token: 'ghp_new_token', token_type: 'bearer', scope: 'repo' }),
+      });
+
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-456');
+
+      expect(result.status).toBe('authorized');
+      expect((result as { status: 'authorized'; token: api.DeviceAuthToken }).token.name).toBe(
+        existingName,
+      );
+      expect(stubCoreV1Api.replaceNamespacedSecret).toHaveBeenCalledWith(
+        expect.objectContaining({ name: existingName, namespace }),
+      );
+      expect(stubCoreV1Api.createNamespacedSecret).not.toHaveBeenCalled();
     });
 
     it('should return error when GitHub returns unknown error', async () => {
@@ -321,6 +387,68 @@ describe('DeviceAuthToken API Service', () => {
       });
       const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
       expect(result).toEqual({ status: 'error', message: 'No access_token in response' });
+    });
+  });
+
+  describe('validateToken', () => {
+    const origClientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+    afterEach(() => {
+      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = origClientId;
+      jest.clearAllMocks();
+    });
+
+    it('should return unknown when secret is not found', async () => {
+      spyReadNamespacedSecret.mockRejectedValueOnce(new Error('Not found'));
+      const result = await service.validateToken(namespace, tokenName);
+      expect(result).toBe('unknown');
+    });
+
+    it('should return unknown when secret does not carry the device-auth label', async () => {
+      spyReadNamespacedSecret.mockResolvedValueOnce({
+        metadata: { name: tokenName, labels: {} },
+        data: { token: Buffer.from('ghp_test').toString('base64') },
+      } as V1Secret);
+      const result = await service.validateToken(namespace, tokenName);
+      expect(result).toBe('unknown');
+    });
+
+    it('should return unknown when token data is empty', async () => {
+      spyReadNamespacedSecret.mockResolvedValueOnce({
+        metadata: { name: tokenName, labels: { [DEVICE_AUTH_LABEL]: 'true' } },
+        data: {},
+      } as V1Secret);
+      const result = await service.validateToken(namespace, tokenName);
+      expect(result).toBe('unknown');
+    });
+
+    it('should return valid when GitHub responds with 200', async () => {
+      spyReadNamespacedSecret.mockResolvedValueOnce({
+        metadata: { name: tokenName, labels: { [DEVICE_AUTH_LABEL]: 'true' } },
+        data: { token: Buffer.from('ghp_test_token').toString('base64') },
+      } as V1Secret);
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      const result = await service.validateToken(namespace, tokenName);
+      expect(result).toBe('valid');
+    });
+
+    it('should return invalid when GitHub responds with non-200', async () => {
+      spyReadNamespacedSecret.mockResolvedValueOnce({
+        metadata: { name: tokenName, labels: { [DEVICE_AUTH_LABEL]: 'true' } },
+        data: { token: Buffer.from('ghp_revoked_token').toString('base64') },
+      } as V1Secret);
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+      const result = await service.validateToken(namespace, tokenName);
+      expect(result).toBe('invalid');
+    });
+
+    it('should return unknown when GitHub API throws (network error)', async () => {
+      spyReadNamespacedSecret.mockResolvedValueOnce({
+        metadata: { name: tokenName, labels: { [DEVICE_AUTH_LABEL]: 'true' } },
+        data: { token: Buffer.from('ghp_test_token').toString('base64') },
+      } as V1Secret);
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+      const result = await service.validateToken(namespace, tokenName);
+      expect(result).toBe('unknown');
     });
   });
 });

--- a/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/__tests__/deviceAuthTokenApi.spec.ts
@@ -210,12 +210,7 @@ describe('DeviceAuthToken API Service', () => {
   });
 
   describe('initiateDeviceAuth', () => {
-    const origClientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
-    beforeEach(() => {
-      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
-    });
     afterEach(() => {
-      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = origClientId;
       jest.clearAllMocks();
     });
 
@@ -231,7 +226,7 @@ describe('DeviceAuthToken API Service', () => {
           }),
       });
 
-      const result = await service.initiateDeviceAuth(namespace);
+      const result = await service.initiateDeviceAuth(namespace, 'test-client-id');
 
       expect(result).toEqual({
         deviceCode: 'dev-code-123',
@@ -241,26 +236,19 @@ describe('DeviceAuthToken API Service', () => {
       });
     });
 
-    it('should throw when CHE_GITHUB_OAUTH_CLIENT_ID is not set', async () => {
-      delete process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
-      await expect(service.initiateDeviceAuth(namespace)).rejects.toThrow(
-        'CHE_GITHUB_OAUTH_CLIENT_ID',
-      );
-    });
-
     it('should throw when GitHub returns an error', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ error: 'invalid_client', error_description: 'Bad client' }),
       });
-      await expect(service.initiateDeviceAuth(namespace)).rejects.toThrow('Bad client');
+      await expect(service.initiateDeviceAuth(namespace, 'test-client-id')).rejects.toThrow(
+        'Bad client',
+      );
     });
   });
 
   describe('pollDeviceAuth', () => {
-    const origClientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
     beforeEach(async () => {
-      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
       stubCoreV1Api.createNamespacedSecret = jest.fn().mockResolvedValue({
         metadata: {
           name: 'device-authentication-github',
@@ -285,10 +273,9 @@ describe('DeviceAuthToken API Service', () => {
             expires_in: 900,
           }),
       });
-      await service.initiateDeviceAuth(namespace);
+      await service.initiateDeviceAuth(namespace, 'test-client-id');
     });
     afterEach(() => {
-      process.env.CHE_GITHUB_OAUTH_CLIENT_ID = origClientId;
       jest.clearAllMocks();
     });
 
@@ -297,7 +284,7 @@ describe('DeviceAuthToken API Service', () => {
         ok: true,
         json: () => Promise.resolve({ error: 'authorization_pending' }),
       });
-      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123', 'test-client-id');
       expect(result).toEqual({ status: 'pending' });
     });
 
@@ -306,7 +293,7 @@ describe('DeviceAuthToken API Service', () => {
         ok: true,
         json: () => Promise.resolve({ error: 'slow_down' }),
       });
-      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123', 'test-client-id');
       expect(result).toEqual({ status: 'slow_down' });
     });
 
@@ -315,7 +302,7 @@ describe('DeviceAuthToken API Service', () => {
         ok: true,
         json: () => Promise.resolve({ error: 'expired_token' }),
       });
-      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123', 'test-client-id');
       expect(result).toEqual({ status: 'expired' });
     });
 
@@ -325,7 +312,7 @@ describe('DeviceAuthToken API Service', () => {
         json: () =>
           Promise.resolve({ access_token: 'ghp_token123', token_type: 'bearer', scope: 'repo' }),
       });
-      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123', 'test-client-id');
       expect(result.status).toBe('authorized');
       expect((result as { status: 'authorized'; token: api.DeviceAuthToken }).token.provider).toBe(
         'github',
@@ -347,7 +334,7 @@ describe('DeviceAuthToken API Service', () => {
             expires_in: 900,
           }),
       });
-      await service.initiateDeviceAuth(namespace);
+      await service.initiateDeviceAuth(namespace, 'test-client-id');
       const existingName = 'device-authentication-github';
       spyListNamespacedSecret.mockResolvedValueOnce({
         items: [{ metadata: { name: existingName } }],
@@ -358,7 +345,7 @@ describe('DeviceAuthToken API Service', () => {
           Promise.resolve({ access_token: 'ghp_new_token', token_type: 'bearer', scope: 'repo' }),
       });
 
-      const result = await service.pollDeviceAuth(namespace, 'dev-code-456');
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-456', 'test-client-id');
 
       expect(result.status).toBe('authorized');
       expect((result as { status: 'authorized'; token: api.DeviceAuthToken }).token.name).toBe(
@@ -376,7 +363,7 @@ describe('DeviceAuthToken API Service', () => {
         json: () =>
           Promise.resolve({ error: 'access_denied', error_description: 'User denied access' }),
       });
-      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123', 'test-client-id');
       expect(result).toEqual({ status: 'error', message: 'User denied access' });
     });
 
@@ -385,7 +372,7 @@ describe('DeviceAuthToken API Service', () => {
         ok: true,
         json: () => Promise.resolve({}),
       });
-      const result = await service.pollDeviceAuth(namespace, 'dev-code-123');
+      const result = await service.pollDeviceAuth(namespace, 'dev-code-123', 'test-client-id');
       expect(result).toEqual({ status: 'error', message: 'No access_token in response' });
     });
   });

--- a/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import * as k8s from '@kubernetes/client-node';
+import { randomBytes } from 'crypto';
+
+import { createError } from '@/devworkspaceClient/services/helpers/createError';
+import {
+  CoreV1API,
+  prepareCoreV1API,
+} from '@/devworkspaceClient/services/helpers/prepareCoreV1API';
+import {
+  DeviceAuthPollResult,
+  DeviceCodeResponse,
+  IDeviceAuthTokenApi,
+} from '@/devworkspaceClient/types';
+
+const API_ERROR_LABEL = 'CORE_V1_API_ERROR';
+
+const DEVICE_AUTH_LABEL = 'che.eclipse.org/device-authentication';
+const DEVICE_AUTH_LABEL_SELECTOR = `${DEVICE_AUTH_LABEL}=true`;
+const DEVICE_AUTH_PROVIDER_LABEL = 'che.eclipse.org/device-authentication-provider';
+
+const GITHUB_SCOPES = 'repo user:email workflow';
+const GITHUB_API_TIMEOUT_MS = 30_000;
+
+interface GitHubDeviceCodeResponse {
+  device_code?: string;
+  user_code?: string;
+  verification_uri?: string;
+  interval?: number;
+  expires_in?: number;
+  error?: string;
+  error_description?: string;
+}
+
+interface GitHubTokenResponse {
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+function getGitHubClientId(): string {
+  const clientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
+  if (!clientId) {
+    throw new Error('CHE_GITHUB_OAUTH_CLIENT_ID environment variable is not set');
+  }
+  return clientId;
+}
+
+async function githubPostDeviceCode(
+  params: Record<string, string>,
+): Promise<GitHubDeviceCodeResponse> {
+  const query = new URLSearchParams(params).toString();
+  const url = `https://github.com/login/device/code?${query}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+  });
+  if (
+    !response.ok &&
+    response.headers.get('content-type')?.includes('application/json') === false
+  ) {
+    throw new Error(`GitHub API returned HTTP ${response.status}`);
+  }
+  const data: unknown = await response.json();
+  return data as GitHubDeviceCodeResponse;
+}
+
+async function githubPostToken(params: Record<string, string>): Promise<GitHubTokenResponse> {
+  const query = new URLSearchParams(params).toString();
+  const url = `https://github.com/login/oauth/access_token?${query}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+  });
+  if (
+    !response.ok &&
+    response.headers.get('content-type')?.includes('application/json') === false
+  ) {
+    throw new Error(`GitHub API returned HTTP ${response.status}`);
+  }
+  const data: unknown = await response.json();
+  return data as GitHubTokenResponse;
+}
+
+export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
+  private readonly coreV1API: CoreV1API;
+
+  constructor(kc: k8s.KubeConfig) {
+    this.coreV1API = prepareCoreV1API(kc);
+  }
+
+  async listTokens(namespace: string): Promise<api.DeviceAuthToken[]> {
+    try {
+      const resp = await this.coreV1API.listNamespacedSecret({
+        namespace,
+        labelSelector: DEVICE_AUTH_LABEL_SELECTOR,
+      });
+      const tokens = resp.items.filter(secret => !!secret.metadata?.name);
+      return Promise.all(
+        tokens.map(async secret => {
+          const rawToken = Buffer.from(secret.data?.['token'] ?? '', 'base64').toString('utf-8');
+          let valid: boolean | undefined;
+          if (rawToken) {
+            valid = await this.checkTokenValidity(rawToken);
+          }
+          return {
+            name: secret.metadata?.name ?? '',
+            provider: secret.metadata?.labels?.[DEVICE_AUTH_PROVIDER_LABEL],
+            creationTimestamp: secret.metadata?.creationTimestamp?.toISOString(),
+            valid,
+          };
+        }),
+      );
+    } catch (error) {
+      const additionalMessage = `Unable to list Device Authentication tokens in the namespace "${namespace}"`;
+      throw createError(error, API_ERROR_LABEL, additionalMessage);
+    }
+  }
+
+  private async checkTokenValidity(token: string): Promise<boolean | undefined> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5_000);
+    try {
+      const response = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github+json',
+        },
+        signal: controller.signal,
+      });
+      return response.ok;
+    } catch {
+      return undefined;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async deleteToken(namespace: string, tokenName: string): Promise<void> {
+    const additionalMessage = `Unable to delete Device Authentication token "${tokenName}" in the namespace "${namespace}"`;
+
+    let secret: k8s.V1Secret;
+    try {
+      secret = await this.coreV1API.readNamespacedSecret({ name: tokenName, namespace });
+    } catch (error) {
+      throw createError(error, API_ERROR_LABEL, additionalMessage);
+    }
+
+    if (secret.metadata?.labels?.[DEVICE_AUTH_LABEL] !== 'true') {
+      throw new Error(
+        `Secret "${tokenName}" does not carry the ${DEVICE_AUTH_LABEL_SELECTOR} label`,
+      );
+    }
+
+    // Best-effort GitHub token revocation via POST /credentials/revoke.
+    // This endpoint requires NO app credentials — works for any gho_/ghp_ token.
+    // The token owner receives a GitHub notification email upon revocation.
+    // See: https://docs.github.com/en/rest/credentials/revoke
+    const rawToken = Buffer.from(secret.data?.['token'] ?? '', 'base64').toString('utf-8');
+    if (rawToken) {
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), GITHUB_API_TIMEOUT_MS);
+        try {
+          const revokeResponse = await fetch('https://api.github.com/credentials/revoke', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-GitHub-Api-Version': '2022-11-28',
+            },
+            body: JSON.stringify({ credentials: [rawToken] }),
+            signal: controller.signal,
+          });
+          if (!revokeResponse.ok && revokeResponse.status !== 202) {
+            console.warn(
+              `[device-auth] GitHub token revocation failed (HTTP ${revokeResponse.status}).`,
+            );
+          }
+        } finally {
+          clearTimeout(timer);
+        }
+      } catch (e) {
+        console.warn(`[device-auth] GitHub token revocation error: ${e}`);
+      }
+    }
+
+    try {
+      await this.coreV1API.deleteNamespacedSecret({
+        name: tokenName,
+        namespace,
+        body: { preconditions: { resourceVersion: secret.metadata?.resourceVersion } },
+      });
+    } catch (error) {
+      throw createError(error, API_ERROR_LABEL, additionalMessage);
+    }
+  }
+
+  async initiateDeviceAuth(): Promise<DeviceCodeResponse> {
+    const clientId = getGitHubClientId();
+    const data = await githubPostDeviceCode({
+      client_id: clientId,
+      scope: GITHUB_SCOPES,
+    });
+    if (!data.device_code || !data.user_code || !data.verification_uri) {
+      if (data.error === 'device_flow_disabled' || data.error === 'device_flow_not_enabled') {
+        throw new Error(
+          'Device Flow is not enabled for this GitHub OAuth App. ' +
+            'An administrator must enable it at GitHub Settings → Developer settings → OAuth Apps.',
+        );
+      }
+      throw new Error(
+        `Failed to initiate device auth: ${data.error_description ?? JSON.stringify(data)}`,
+      );
+    }
+    return {
+      deviceCode: data.device_code,
+      userCode: data.user_code,
+      verificationUri: data.verification_uri,
+      interval: data.interval ?? 5,
+    };
+  }
+
+  async pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult> {
+    const clientId = getGitHubClientId();
+    const data = await githubPostToken({
+      client_id: clientId,
+      device_code: deviceCode,
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+    });
+
+    if (data.error === 'authorization_pending') {
+      return { status: 'pending' };
+    }
+    if (data.error === 'slow_down') {
+      return { status: 'slow_down' };
+    }
+    if (data.error === 'expired_token') {
+      return { status: 'expired' };
+    }
+    if (data.error) {
+      return { status: 'error', message: data.error_description ?? data.error };
+    }
+    if (!data.access_token) {
+      return { status: 'error', message: 'No access_token in response' };
+    }
+
+    const token = await this.createDeviceAuthSecret(namespace, data.access_token);
+    return { status: 'authorized', token };
+  }
+
+  private async createDeviceAuthSecret(
+    namespace: string,
+    accessToken: string,
+  ): Promise<api.DeviceAuthToken> {
+    const name = `device-authentication-secret-${randomBytes(6).toString('hex')}`;
+    const secret: k8s.V1Secret = {
+      metadata: {
+        name,
+        namespace,
+        labels: {
+          [DEVICE_AUTH_LABEL]: 'true',
+          [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+        },
+      },
+      data: {
+        token: Buffer.from(accessToken).toString('base64'),
+      },
+    };
+    const created = await this.coreV1API.createNamespacedSecret({ namespace, body: secret });
+    return {
+      name,
+      provider: 'github',
+      creationTimestamp: created.metadata?.creationTimestamp?.toISOString(),
+    };
+  }
+}

--- a/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
@@ -12,7 +12,6 @@
 
 import { api } from '@eclipse-che/common';
 import * as k8s from '@kubernetes/client-node';
-import { randomBytes } from 'crypto';
 
 import { createError } from '@/devworkspaceClient/services/helpers/createError';
 import {
@@ -31,8 +30,15 @@ const DEVICE_AUTH_LABEL = 'che.eclipse.org/device-authentication';
 const DEVICE_AUTH_LABEL_SELECTOR = `${DEVICE_AUTH_LABEL}=true`;
 const DEVICE_AUTH_PROVIDER_LABEL = 'che.eclipse.org/device-authentication-provider';
 
+const DEVICE_AUTH_SECRET_NAME = 'device-authentication-github';
+
 const GITHUB_SCOPES = 'read:user repo user:email workflow';
 const GITHUB_API_TIMEOUT_MS = 30_000;
+
+// Binds an in-flight device code to the namespace that initiated the flow.
+// Prevents a different authenticated user from polling with another user's device code.
+// TTL matches GitHub's device code expiry (~15 min); cleared on successful auth.
+const activeDeviceCodes = new Map<string, { code: string; expiresAt: number }>();
 
 interface GitHubDeviceCodeResponse {
   device_code?: string;
@@ -110,7 +116,8 @@ async function githubPostToken(params: Record<string, string>): Promise<GitHubTo
   }
 }
 
-export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
+// GitHub-specific implementation. Only GitHub OAuth App device flow is supported.
+export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
   private readonly coreV1API: CoreV1API;
 
   constructor(kc: k8s.KubeConfig) {
@@ -153,7 +160,8 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     }
 
     // Best-effort GitHub token revocation via POST /credentials/revoke.
-    // This endpoint requires NO app credentials — works for any gho_/ghp_ token.
+    // Authorization: Bearer <token> is required — the endpoint authenticates via
+    // the token being revoked rather than an OAuth app client secret.
     // The token owner receives a GitHub notification email upon revocation.
     // See: https://docs.github.com/en/rest/credentials/revoke
     const rawToken = Buffer.from(secret.data?.['token'] ?? '', 'base64').toString('utf-8');
@@ -167,6 +175,7 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
             headers: {
               'Content-Type': 'application/json',
               'X-GitHub-Api-Version': '2022-11-28',
+              Authorization: `Bearer ${rawToken}`,
             },
             body: JSON.stringify({ credentials: [rawToken] }),
             signal: controller.signal,
@@ -180,7 +189,9 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
           clearTimeout(timer);
         }
       } catch (e) {
-        console.warn(`[device-auth] GitHub token revocation error: ${e}`);
+        console.warn(
+          `[device-auth] GitHub token revocation error: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
     }
 
@@ -195,7 +206,7 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     }
   }
 
-  async initiateDeviceAuth(): Promise<DeviceCodeResponse> {
+  async initiateDeviceAuth(namespace: string): Promise<DeviceCodeResponse> {
     const clientId = getGitHubClientId();
     const data = await githubPostDeviceCode({
       client_id: clientId,
@@ -212,6 +223,8 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
         `Failed to initiate device auth: ${data.error_description ?? JSON.stringify(data)}`,
       );
     }
+    const expiresAt = Date.now() + (data.expires_in ?? 900) * 1_000;
+    activeDeviceCodes.set(namespace, { code: data.device_code, expiresAt });
     return {
       deviceCode: data.device_code,
       userCode: data.user_code,
@@ -221,6 +234,13 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
   }
 
   async pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult> {
+    const stored = activeDeviceCodes.get(namespace);
+    if (!stored || stored.code !== deviceCode || Date.now() > stored.expiresAt) {
+      return {
+        status: 'error',
+        message: 'Device code is not valid for this session. Please initiate a new connection.',
+      };
+    }
     const clientId = getGitHubClientId();
     const data = await githubPostToken({
       client_id: clientId,
@@ -244,23 +264,27 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
       return { status: 'error', message: 'No access_token in response' };
     }
 
+    activeDeviceCodes.delete(namespace);
     const token = await this.createDeviceAuthSecret(namespace, data.access_token);
     return { status: 'authorized', token };
   }
 
-  async validateToken(namespace: string, tokenName: string): Promise<boolean | undefined> {
+  async validateToken(
+    namespace: string,
+    tokenName: string,
+  ): Promise<'valid' | 'invalid' | 'unknown'> {
     let secret: k8s.V1Secret;
     try {
       secret = await this.coreV1API.readNamespacedSecret({ name: tokenName, namespace });
     } catch {
-      return undefined;
+      return 'unknown'; // secret not found or K8s API error
     }
     if (secret.metadata?.labels?.[DEVICE_AUTH_LABEL] !== 'true') {
-      return undefined;
+      return 'unknown'; // not a device-auth secret
     }
     const rawToken = Buffer.from(secret.data?.['token'] ?? '', 'base64').toString('utf-8');
     if (!rawToken) {
-      return undefined;
+      return 'unknown'; // empty token field
     }
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 5_000);
@@ -269,9 +293,9 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
         headers: { Authorization: `token ${rawToken}`, Accept: 'application/vnd.github+json' },
         signal: controller.signal,
       });
-      return response.ok;
+      return response.ok ? 'valid' : 'invalid';
     } catch {
-      return undefined;
+      return 'unknown'; // network error or timeout
     } finally {
       clearTimeout(timer);
     }
@@ -290,29 +314,36 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     });
     if (existing.items.length > 0 && existing.items[0].metadata?.name) {
       const existingName = existing.items[0].metadata.name;
-      const updated = await this.coreV1API.replaceNamespacedSecret({
-        name: existingName,
-        namespace,
-        body: {
-          metadata: {
-            name: existingName,
-            namespace,
-            labels: {
-              [DEVICE_AUTH_LABEL]: 'true',
-              [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+      try {
+        const updated = await this.coreV1API.replaceNamespacedSecret({
+          name: existingName,
+          namespace,
+          body: {
+            metadata: {
+              name: existingName,
+              namespace,
+              labels: {
+                [DEVICE_AUTH_LABEL]: 'true',
+                [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+              },
             },
+            data: { token: tokenData },
           },
-          data: { token: tokenData },
-        },
-      });
-      return {
-        name: existingName,
-        provider: 'github',
-        creationTimestamp: updated.metadata?.creationTimestamp?.toISOString(),
-      };
+        });
+        return {
+          name: existingName,
+          provider: 'github',
+          creationTimestamp: updated.metadata?.creationTimestamp?.toISOString(),
+        };
+      } catch {
+        // Secret was deleted between list and replace (TOCTOU) — fall through to create
+      }
     }
 
-    const name = `device-authentication-secret-${randomBytes(6).toString('hex')}`;
+    // Use a deterministic name so concurrent poll completions (e.g. two browser
+    // tabs) fail with a 409 Conflict on the second create rather than silently
+    // producing two separate secrets.
+    const name = DEVICE_AUTH_SECRET_NAME;
     const created = await this.coreV1API.createNamespacedSecret({
       namespace,
       body: {

--- a/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
@@ -12,6 +12,7 @@
 
 import { api } from '@eclipse-che/common';
 import * as k8s from '@kubernetes/client-node';
+import { existsSync, readFileSync } from 'fs';
 
 import { createError } from '@/devworkspaceClient/services/helpers/createError';
 import {
@@ -58,12 +59,55 @@ interface GitHubTokenResponse {
   error_description?: string;
 }
 
-function getGitHubClientId(): string {
-  const clientId = process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
-  if (!clientId) {
-    throw new Error('CHE_GITHUB_OAUTH_CLIENT_ID environment variable is not set');
+// Mounted file path — same path Che Server uses when the operator
+// mounts github-oauth-config into the pod as a volume.
+const GITHUB_OAUTH_ID_FILE = '/che-conf/oauth/github/id';
+
+async function getGitHubClientId(): Promise<string> {
+  // Priority 1: env var (operator auto-injection in standard deployments)
+  if (process.env.CHE_GITHUB_OAUTH_CLIENT_ID) {
+    return process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
   }
-  return clientId;
+  // Priority 2: mounted file (only needed with a custom deployment spec where
+  // the operator does not auto-inject the env var)
+  if (existsSync(GITHUB_OAUTH_ID_FILE)) {
+    const id = readFileSync(GITHUB_OAUTH_ID_FILE, 'utf8').trim();
+    if (id) {
+      return id;
+    }
+  }
+  // Priority 3: clientId from GET /api/oauth on the Che Server (available
+  // once che-server#1035 is deployed — no env var or volume mount needed).
+  const cheInternalUrl = process.env.CHE_INTERNAL_URL;
+  if (cheInternalUrl) {
+    try {
+      const { getServiceAccountToken } = await import(
+        '@/routes/api/helpers/getServiceAccountToken'
+      );
+      const saToken = getServiceAccountToken();
+      const response = await fetch(`${cheInternalUrl}/oauth`, {
+        headers: { Authorization: `Bearer ${saToken}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (response.ok) {
+        const providers = (await response.json()) as Array<{
+          name: string;
+          clientId?: string;
+        }>;
+        const github = providers.find(p => p.name === 'github');
+        if (github?.clientId) {
+          return github.clientId;
+        }
+      }
+    } catch {
+      // fall through
+    }
+  }
+  throw new Error(
+    'GitHub OAuth client_id is not available. ' +
+      'Ensure CHE_GITHUB_OAUTH_CLIENT_ID is set, or deploy che-server#1035 ' +
+      'which exposes clientId via GET /api/oauth.',
+  );
 }
 
 async function githubPostDeviceCode(
@@ -207,7 +251,7 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
   }
 
   async initiateDeviceAuth(namespace: string): Promise<DeviceCodeResponse> {
-    const clientId = getGitHubClientId();
+    const clientId = await getGitHubClientId();
     const data = await githubPostDeviceCode({
       client_id: clientId,
       scope: GITHUB_SCOPES,
@@ -241,7 +285,7 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
         message: 'Device code is not valid for this session. Please initiate a new connection.',
       };
     }
-    const clientId = getGitHubClientId();
+    const clientId = await getGitHubClientId();
     const data = await githubPostToken({
       client_id: clientId,
       device_code: deviceCode,

--- a/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
@@ -12,7 +12,6 @@
 
 import { api } from '@eclipse-che/common';
 import * as k8s from '@kubernetes/client-node';
-import { existsSync, readFileSync } from 'fs';
 
 import { createError } from '@/devworkspaceClient/services/helpers/createError';
 import {
@@ -57,57 +56,6 @@ interface GitHubTokenResponse {
   scope?: string;
   error?: string;
   error_description?: string;
-}
-
-// Mounted file path — same path Che Server uses when the operator
-// mounts github-oauth-config into the pod as a volume.
-const GITHUB_OAUTH_ID_FILE = '/che-conf/oauth/github/id';
-
-async function getGitHubClientId(): Promise<string> {
-  // Priority 1: env var (operator auto-injection in standard deployments)
-  if (process.env.CHE_GITHUB_OAUTH_CLIENT_ID) {
-    return process.env.CHE_GITHUB_OAUTH_CLIENT_ID;
-  }
-  // Priority 2: mounted file (only needed with a custom deployment spec where
-  // the operator does not auto-inject the env var)
-  if (existsSync(GITHUB_OAUTH_ID_FILE)) {
-    const id = readFileSync(GITHUB_OAUTH_ID_FILE, 'utf8').trim();
-    if (id) {
-      return id;
-    }
-  }
-  // Priority 3: clientId from GET /api/oauth on the Che Server (available
-  // once che-server#1035 is deployed — no env var or volume mount needed).
-  const cheInternalUrl = process.env.CHE_INTERNAL_URL;
-  if (cheInternalUrl) {
-    try {
-      const { getServiceAccountToken } = await import(
-        '@/routes/api/helpers/getServiceAccountToken'
-      );
-      const saToken = getServiceAccountToken();
-      const response = await fetch(`${cheInternalUrl}/oauth`, {
-        headers: { Authorization: `Bearer ${saToken}` },
-        signal: AbortSignal.timeout(5_000),
-      });
-      if (response.ok) {
-        const providers = (await response.json()) as Array<{
-          name: string;
-          clientId?: string;
-        }>;
-        const github = providers.find(p => p.name === 'github');
-        if (github?.clientId) {
-          return github.clientId;
-        }
-      }
-    } catch {
-      // fall through
-    }
-  }
-  throw new Error(
-    'GitHub OAuth client_id is not available. ' +
-      'Ensure CHE_GITHUB_OAUTH_CLIENT_ID is set, or deploy che-server#1035 ' +
-      'which exposes clientId via GET /api/oauth.',
-  );
 }
 
 async function githubPostDeviceCode(
@@ -198,8 +146,9 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     }
 
     if (secret.metadata?.labels?.[DEVICE_AUTH_LABEL] !== 'true') {
-      throw new Error(
-        `Secret "${tokenName}" does not carry the ${DEVICE_AUTH_LABEL_SELECTOR} label`,
+      throw Object.assign(
+        new Error(`Secret "${tokenName}" does not carry the ${DEVICE_AUTH_LABEL_SELECTOR} label`),
+        { statusCode: 403 },
       );
     }
 
@@ -250,8 +199,7 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     }
   }
 
-  async initiateDeviceAuth(namespace: string): Promise<DeviceCodeResponse> {
-    const clientId = await getGitHubClientId();
+  async initiateDeviceAuth(namespace: string, clientId: string): Promise<DeviceCodeResponse> {
     const data = await githubPostDeviceCode({
       client_id: clientId,
       scope: GITHUB_SCOPES,
@@ -277,15 +225,21 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     };
   }
 
-  async pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult> {
+  async pollDeviceAuth(
+    namespace: string,
+    deviceCode: string,
+    clientId: string,
+  ): Promise<DeviceAuthPollResult> {
     const stored = activeDeviceCodes.get(namespace);
     if (!stored || stored.code !== deviceCode || Date.now() > stored.expiresAt) {
+      if (stored && Date.now() > stored.expiresAt) {
+        activeDeviceCodes.delete(namespace);
+      }
       return {
         status: 'error',
         message: 'Device code is not valid for this session. Please initiate a new connection.',
       };
     }
-    const clientId = await getGitHubClientId();
     const data = await githubPostToken({
       client_id: clientId,
       device_code: deviceCode,
@@ -358,6 +312,7 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     });
     if (existing.items.length > 0 && existing.items[0].metadata?.name) {
       const existingName = existing.items[0].metadata.name;
+      const existingMeta = existing.items[0].metadata;
       try {
         const updated = await this.coreV1API.replaceNamespacedSecret({
           name: existingName,
@@ -366,7 +321,9 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
             metadata: {
               name: existingName,
               namespace,
+              resourceVersion: existingMeta.resourceVersion,
               labels: {
+                ...(existingMeta.labels ?? {}),
                 [DEVICE_AUTH_LABEL]: 'true',
                 [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
               },

--- a/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
@@ -76,8 +76,12 @@ async function githubPostDeviceCode(
     // GitHub returns structured JSON even on 4xx (e.g. device_flow_disabled).
     // Parse the body regardless of HTTP status so the caller can surface
     // specific error codes rather than a generic "HTTP 400".
-    const data: unknown = await response.json();
-    return data as GitHubDeviceCodeResponse;
+    try {
+      const data: unknown = await response.json();
+      return data as GitHubDeviceCodeResponse;
+    } catch {
+      throw new Error(`GitHub API returned HTTP ${response.status} with non-JSON body`);
+    }
   } finally {
     clearTimeout(timer);
   }
@@ -95,8 +99,12 @@ async function githubPostToken(params: Record<string, string>): Promise<GitHubTo
       signal: controller.signal,
     });
     // GitHub returns structured JSON even for error states (authorization_pending, etc.)
-    const data: unknown = await response.json();
-    return data as GitHubTokenResponse;
+    try {
+      const data: unknown = await response.json();
+      return data as GitHubTokenResponse;
+    } catch {
+      throw new Error(`GitHub API returned HTTP ${response.status} with non-JSON body`);
+    }
   } finally {
     clearTimeout(timer);
   }
@@ -238,6 +246,35 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
 
     const token = await this.createDeviceAuthSecret(namespace, data.access_token);
     return { status: 'authorized', token };
+  }
+
+  async validateToken(namespace: string, tokenName: string): Promise<boolean | undefined> {
+    let secret: k8s.V1Secret;
+    try {
+      secret = await this.coreV1API.readNamespacedSecret({ name: tokenName, namespace });
+    } catch {
+      return undefined;
+    }
+    if (secret.metadata?.labels?.[DEVICE_AUTH_LABEL] !== 'true') {
+      return undefined;
+    }
+    const rawToken = Buffer.from(secret.data?.['token'] ?? '', 'base64').toString('utf-8');
+    if (!rawToken) {
+      return undefined;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5_000);
+    try {
+      const response = await fetch('https://api.github.com/user', {
+        headers: { Authorization: `token ${rawToken}`, Accept: 'application/vnd.github+json' },
+        signal: controller.signal,
+      });
+      return response.ok;
+    } catch {
+      return undefined;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async createDeviceAuthSecret(

--- a/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
@@ -31,7 +31,7 @@ const DEVICE_AUTH_LABEL = 'che.eclipse.org/device-authentication';
 const DEVICE_AUTH_LABEL_SELECTOR = `${DEVICE_AUTH_LABEL}=true`;
 const DEVICE_AUTH_PROVIDER_LABEL = 'che.eclipse.org/device-authentication-provider';
 
-const GITHUB_SCOPES = 'repo user:email workflow';
+const GITHUB_SCOPES = 'read:user repo user:email workflow';
 const GITHUB_API_TIMEOUT_MS = 30_000;
 
 interface GitHubDeviceCodeResponse {
@@ -63,37 +63,43 @@ function getGitHubClientId(): string {
 async function githubPostDeviceCode(
   params: Record<string, string>,
 ): Promise<GitHubDeviceCodeResponse> {
-  const query = new URLSearchParams(params).toString();
-  const url = `https://github.com/login/device/code?${query}`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { Accept: 'application/json' },
-  });
-  if (
-    !response.ok &&
-    response.headers.get('content-type')?.includes('application/json') === false
-  ) {
-    throw new Error(`GitHub API returned HTTP ${response.status}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITHUB_API_TIMEOUT_MS);
+  try {
+    const query = new URLSearchParams(params).toString();
+    const url = `https://github.com/login/device/code?${query}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    // GitHub returns structured JSON even on 4xx (e.g. device_flow_disabled).
+    // Parse the body regardless of HTTP status so the caller can surface
+    // specific error codes rather than a generic "HTTP 400".
+    const data: unknown = await response.json();
+    return data as GitHubDeviceCodeResponse;
+  } finally {
+    clearTimeout(timer);
   }
-  const data: unknown = await response.json();
-  return data as GitHubDeviceCodeResponse;
 }
 
 async function githubPostToken(params: Record<string, string>): Promise<GitHubTokenResponse> {
-  const query = new URLSearchParams(params).toString();
-  const url = `https://github.com/login/oauth/access_token?${query}`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { Accept: 'application/json' },
-  });
-  if (
-    !response.ok &&
-    response.headers.get('content-type')?.includes('application/json') === false
-  ) {
-    throw new Error(`GitHub API returned HTTP ${response.status}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITHUB_API_TIMEOUT_MS);
+  try {
+    const query = new URLSearchParams(params).toString();
+    const url = `https://github.com/login/oauth/access_token?${query}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    // GitHub returns structured JSON even for error states (authorization_pending, etc.)
+    const data: unknown = await response.json();
+    return data as GitHubTokenResponse;
+  } finally {
+    clearTimeout(timer);
   }
-  const data: unknown = await response.json();
-  return data as GitHubTokenResponse;
 }
 
 export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
@@ -109,44 +115,16 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
         namespace,
         labelSelector: DEVICE_AUTH_LABEL_SELECTOR,
       });
-      const tokens = resp.items.filter(secret => !!secret.metadata?.name);
-      return Promise.all(
-        tokens.map(async secret => {
-          const rawToken = Buffer.from(secret.data?.['token'] ?? '', 'base64').toString('utf-8');
-          let valid: boolean | undefined;
-          if (rawToken) {
-            valid = await this.checkTokenValidity(rawToken);
-          }
-          return {
-            name: secret.metadata?.name ?? '',
-            provider: secret.metadata?.labels?.[DEVICE_AUTH_PROVIDER_LABEL],
-            creationTimestamp: secret.metadata?.creationTimestamp?.toISOString(),
-            valid,
-          };
-        }),
-      );
+      return resp.items
+        .filter(secret => !!secret.metadata?.name)
+        .map(secret => ({
+          name: secret.metadata?.name ?? '',
+          provider: secret.metadata?.labels?.[DEVICE_AUTH_PROVIDER_LABEL],
+          creationTimestamp: secret.metadata?.creationTimestamp?.toISOString(),
+        }));
     } catch (error) {
       const additionalMessage = `Unable to list Device Authentication tokens in the namespace "${namespace}"`;
       throw createError(error, API_ERROR_LABEL, additionalMessage);
-    }
-  }
-
-  private async checkTokenValidity(token: string): Promise<boolean | undefined> {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5_000);
-    try {
-      const response = await fetch('https://api.github.com/user', {
-        headers: {
-          Authorization: `token ${token}`,
-          Accept: 'application/vnd.github+json',
-        },
-        signal: controller.signal,
-      });
-      return response.ok;
-    } catch {
-      return undefined;
-    } finally {
-      clearTimeout(timer);
     }
   }
 
@@ -266,21 +244,52 @@ export class DeviceAuthTokenApiService implements IDeviceAuthTokenApi {
     namespace: string,
     accessToken: string,
   ): Promise<api.DeviceAuthToken> {
-    const name = `device-authentication-secret-${randomBytes(6).toString('hex')}`;
-    const secret: k8s.V1Secret = {
-      metadata: {
-        name,
+    const tokenData = Buffer.from(accessToken).toString('base64');
+
+    // Match che-code's single-active-token approach: replace existing secret if present
+    const existing = await this.coreV1API.listNamespacedSecret({
+      namespace,
+      labelSelector: DEVICE_AUTH_LABEL_SELECTOR,
+    });
+    if (existing.items.length > 0 && existing.items[0].metadata?.name) {
+      const existingName = existing.items[0].metadata.name;
+      const updated = await this.coreV1API.replaceNamespacedSecret({
+        name: existingName,
         namespace,
-        labels: {
-          [DEVICE_AUTH_LABEL]: 'true',
-          [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+        body: {
+          metadata: {
+            name: existingName,
+            namespace,
+            labels: {
+              [DEVICE_AUTH_LABEL]: 'true',
+              [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+            },
+          },
+          data: { token: tokenData },
         },
+      });
+      return {
+        name: existingName,
+        provider: 'github',
+        creationTimestamp: updated.metadata?.creationTimestamp?.toISOString(),
+      };
+    }
+
+    const name = `device-authentication-secret-${randomBytes(6).toString('hex')}`;
+    const created = await this.coreV1API.createNamespacedSecret({
+      namespace,
+      body: {
+        metadata: {
+          name,
+          namespace,
+          labels: {
+            [DEVICE_AUTH_LABEL]: 'true',
+            [DEVICE_AUTH_PROVIDER_LABEL]: 'github',
+          },
+        },
+        data: { token: tokenData },
       },
-      data: {
-        token: Buffer.from(accessToken).toString('base64'),
-      },
-    };
-    const created = await this.coreV1API.createNamespacedSecret({ namespace, body: secret });
+    });
     return {
       name,
       provider: 'github',

--- a/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/services/deviceAuthTokenApi.ts
@@ -152,41 +152,13 @@ export class GitHubDeviceAuthTokenApiService implements IDeviceAuthTokenApi {
       );
     }
 
-    // Best-effort GitHub token revocation via POST /credentials/revoke.
-    // Authorization: Bearer <token> is required — the endpoint authenticates via
-    // the token being revoked rather than an OAuth app client secret.
-    // The token owner receives a GitHub notification email upon revocation.
-    // See: https://docs.github.com/en/rest/credentials/revoke
-    const rawToken = Buffer.from(secret.data?.['token'] ?? '', 'base64').toString('utf-8');
-    if (rawToken) {
-      try {
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), GITHUB_API_TIMEOUT_MS);
-        try {
-          const revokeResponse = await fetch('https://api.github.com/credentials/revoke', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-GitHub-Api-Version': '2022-11-28',
-              Authorization: `Bearer ${rawToken}`,
-            },
-            body: JSON.stringify({ credentials: [rawToken] }),
-            signal: controller.signal,
-          });
-          if (!revokeResponse.ok && revokeResponse.status !== 202) {
-            console.warn(
-              `[device-auth] GitHub token revocation failed (HTTP ${revokeResponse.status}).`,
-            );
-          }
-        } finally {
-          clearTimeout(timer);
-        }
-      } catch (e) {
-        console.warn(
-          `[device-auth] GitHub token revocation error: ${e instanceof Error ? e.message : String(e)}`,
-        );
-      }
-    }
+    // Note: GitHub's DELETE /applications/{client_id}/token endpoint (the only
+    // supported self-revocation API) requires the OAuth app client secret, which
+    // this backend service does not hold. The POST /credentials/revoke endpoint
+    // is for reporting credentials found exposed by third parties and returns 403
+    // when called by the token owner. We therefore only remove the local K8s
+    // secret; the GitHub token remains valid until the user revokes it from
+    // GitHub Settings → Applications → Authorized OAuth Apps.
 
     try {
       await this.coreV1API.deleteNamespacedSecret({

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -642,14 +642,14 @@ export interface IDeviceAuthTokenApi {
   /**
    * Initiates a GitHub Device Authorization flow and returns the device code and user code.
    */
-  initiateDeviceAuth(): Promise<DeviceCodeResponse>;
+  initiateDeviceAuth(namespace: string): Promise<DeviceCodeResponse>;
 
   /**
    * Polls GitHub for the access token using the device code.
    * On success, stores the token as a Kubernetes secret.
    */
   pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult>;
-  validateToken(namespace: string, tokenName: string): Promise<boolean | undefined>;
+  validateToken(namespace: string, tokenName: string): Promise<'valid' | 'invalid' | 'unknown'>;
 }
 
 export interface ISccPermissionApi {

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -523,6 +523,7 @@ export interface IDevWorkspaceClient {
   editorsApi: IEditorsApi;
   aiProviderKeyApi: IAiProviderKeyApi;
   aiRegistryApi: IAiRegistryApi;
+  deviceAuthTokenApi: IDeviceAuthTokenApi;
   sccPermissionApi: ISccPermissionApi;
 }
 
@@ -621,6 +622,33 @@ export interface IAiProviderKeyApi {
    * Deletes the API key Secret for the given provider from the given namespace.
    */
   delete(namespace: string, providerId: string): Promise<void>;
+}
+
+export type DeviceCodeResponse = api.DeviceCodeResponse;
+export type DeviceAuthPollResult = api.DeviceAuthPollResult;
+
+export interface IDeviceAuthTokenApi {
+  /**
+   * Lists Device Authentication token secrets in the namespace
+   * (identified by the che.eclipse.org/device-authentication=true label).
+   */
+  listTokens(namespace: string): Promise<api.DeviceAuthToken[]>;
+
+  /**
+   * Deletes the Device Authentication token secret by name.
+   */
+  deleteToken(namespace: string, tokenName: string): Promise<void>;
+
+  /**
+   * Initiates a GitHub Device Authorization flow and returns the device code and user code.
+   */
+  initiateDeviceAuth(): Promise<DeviceCodeResponse>;
+
+  /**
+   * Polls GitHub for the access token using the device code.
+   * On success, stores the token as a Kubernetes secret.
+   */
+  pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult>;
 }
 
 export interface ISccPermissionApi {

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -642,13 +642,17 @@ export interface IDeviceAuthTokenApi {
   /**
    * Initiates a GitHub Device Authorization flow and returns the device code and user code.
    */
-  initiateDeviceAuth(namespace: string): Promise<DeviceCodeResponse>;
+  initiateDeviceAuth(namespace: string, clientId: string): Promise<DeviceCodeResponse>;
 
   /**
    * Polls GitHub for the access token using the device code.
    * On success, stores the token as a Kubernetes secret.
    */
-  pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult>;
+  pollDeviceAuth(
+    namespace: string,
+    deviceCode: string,
+    clientId: string,
+  ): Promise<DeviceAuthPollResult>;
   validateToken(namespace: string, tokenName: string): Promise<'valid' | 'invalid' | 'unknown'>;
 }
 

--- a/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
+++ b/packages/dashboard-backend/src/devworkspaceClient/types/index.ts
@@ -649,6 +649,7 @@ export interface IDeviceAuthTokenApi {
    * On success, stores the token as a Kubernetes secret.
    */
   pollDeviceAuth(namespace: string, deviceCode: string): Promise<DeviceAuthPollResult>;
+  validateToken(namespace: string, tokenName: string): Promise<boolean | undefined>;
 }
 
 export interface ISccPermissionApi {

--- a/packages/dashboard-backend/src/models/restParams.ts
+++ b/packages/dashboard-backend/src/models/restParams.ts
@@ -80,3 +80,7 @@ export interface AiProviderKeyBody {
   envVarName: string;
   apiKey: string;
 }
+
+export interface DeviceAuthTokenNamespacedParams extends INamespacedParams {
+  tokenName: string;
+}

--- a/packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts
@@ -47,6 +47,7 @@ describe('Cluster Config Route', () => {
       runningWorkspacesLimit: stubRunningWorkspacesLimit,
       allWorkspacesLimit: stubAllWorkspacesLimit,
       currentArchitecture: stubCurrentArchitecture,
+      githubDeviceAuthEnabled: false,
     });
   });
 });

--- a/packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/clusterConfig.spec.ts
@@ -24,6 +24,7 @@ import { setup, teardown } from '@/utils/appBuilder';
 
 jest.mock('../helpers/getServiceAccountToken.ts');
 jest.mock('../helpers/getDevWorkspaceClient.ts');
+jest.mock('../helpers/getDeviceAuthClientId.ts');
 
 describe('Cluster Config Route', () => {
   let app: FastifyInstance;

--- a/packages/dashboard-backend/src/routes/api/__tests__/deviceAuthToken.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/deviceAuthToken.spec.ts
@@ -24,6 +24,7 @@ jest.mock('@/routes/api/helpers/getDeviceAuthClientId', () => ({
 }));
 
 const namespace = 'user-che';
+const authHeader = { authorization: 'Bearer test-token' };
 
 describe('Device Auth Token Routes', () => {
   let app: FastifyInstance;
@@ -46,6 +47,7 @@ describe('Device Auth Token Routes', () => {
       const res = await app.inject({
         method: 'POST',
         url: `${baseApiPath}/namespace/${namespace}/device-auth-token/initiate`,
+        headers: authHeader,
       });
       expect(res.statusCode).toBe(503);
     });
@@ -57,6 +59,7 @@ describe('Device Auth Token Routes', () => {
       const res = await app.inject({
         method: 'POST',
         url: `${baseApiPath}/namespace/${namespace}/device-auth-token/initiate`,
+        headers: authHeader,
       });
       expect(res.statusCode).not.toBe(503);
     });
@@ -68,6 +71,7 @@ describe('Device Auth Token Routes', () => {
       const res = await app.inject({
         method: 'POST',
         url: `${baseApiPath}/namespace/${namespace}/device-auth-token/poll`,
+        headers: authHeader,
         payload: { deviceCode: 'ABCD-1234' },
       });
       expect(res.statusCode).toBe(503);
@@ -80,6 +84,7 @@ describe('Device Auth Token Routes', () => {
       const res = await app.inject({
         method: 'POST',
         url: `${baseApiPath}/namespace/${namespace}/device-auth-token/poll`,
+        headers: authHeader,
         payload: { deviceCode: 'ABCD-1234' },
       });
       expect(res.statusCode).not.toBe(503);

--- a/packages/dashboard-backend/src/routes/api/__tests__/deviceAuthToken.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/deviceAuthToken.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance } from 'fastify';
+
+import { baseApiPath } from '@/constants/config';
+import { setup, teardown } from '@/utils/appBuilder';
+
+jest.mock('../helpers/getServiceAccountToken.ts');
+jest.mock('../helpers/getDevWorkspaceClient.ts');
+
+let mockClientId: string | null = null;
+jest.mock('@/routes/api/helpers/getDeviceAuthClientId', () => ({
+  getDeviceAuthClientId: () => Promise.resolve(mockClientId),
+}));
+
+const namespace = 'user-che';
+
+describe('Device Auth Token Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await setup();
+  });
+
+  afterAll(() => {
+    teardown(app);
+  });
+
+  beforeEach(() => {
+    mockClientId = null;
+  });
+
+  describe('POST /initiate — device auth not configured', () => {
+    it('returns 503 when device-auth-config ConfigMap is absent', async () => {
+      mockClientId = null;
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/initiate`,
+      });
+      expect(res.statusCode).toBe(503);
+    });
+  });
+
+  describe('POST /initiate — device auth configured', () => {
+    it('does not return 503 when clientId is present', async () => {
+      mockClientId = 'test-client-id';
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/initiate`,
+      });
+      expect(res.statusCode).not.toBe(503);
+    });
+  });
+
+  describe('POST /poll — device auth not configured', () => {
+    it('returns 503 when device-auth-config ConfigMap is absent', async () => {
+      mockClientId = null;
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/poll`,
+        payload: { deviceCode: 'ABCD-1234' },
+      });
+      expect(res.statusCode).toBe(503);
+    });
+  });
+
+  describe('POST /poll — device auth configured', () => {
+    it('does not return 503 when clientId is present', async () => {
+      mockClientId = 'test-client-id';
+      const res = await app.inject({
+        method: 'POST',
+        url: `${baseApiPath}/namespace/${namespace}/device-auth-token/poll`,
+        payload: { deviceCode: 'ABCD-1234' },
+      });
+      expect(res.statusCode).not.toBe(503);
+    });
+  });
+});

--- a/packages/dashboard-backend/src/routes/api/clusterConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterConfig.ts
@@ -45,5 +45,6 @@ async function buildClusterConfig(): Promise<ClusterConfig> {
     allWorkspacesLimit,
     runningWorkspacesLimit,
     currentArchitecture,
+    githubDeviceAuthEnabled: !!process.env.CHE_GITHUB_OAUTH_CLIENT_ID,
   };
 }

--- a/packages/dashboard-backend/src/routes/api/clusterConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterConfig.ts
@@ -14,6 +14,7 @@ import { ClusterConfig } from '@eclipse-che/common';
 import { FastifyInstance } from 'fastify';
 
 import { baseApiPath } from '@/constants/config';
+import { getDeviceAuthClientId } from '@/routes/api/helpers/getDeviceAuthClientId';
 import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
 import { getServiceAccountToken } from '@/routes/api/helpers/getServiceAccountToken';
 import { getSchema } from '@/services/helpers';
@@ -28,36 +29,6 @@ export function registerClusterConfigRoute(instance: FastifyInstance) {
   });
 }
 
-/**
- * Determines whether GitHub OAuth is configured by calling the Che Server's
- * /api/oauth endpoint with the dashboard SA token — the same source the
- * Git Services tab uses. No RBAC changes or env vars required.
- * Falls back to CHE_GITHUB_OAUTH_CLIENT_ID env var for local dev / override.
- */
-async function isGitHubOAuthConfigured(): Promise<boolean> {
-  if (process.env.CHE_GITHUB_OAUTH_CLIENT_ID) {
-    return true;
-  }
-  const cheInternalUrl = process.env.CHE_INTERNAL_URL;
-  if (!cheInternalUrl) {
-    return false;
-  }
-  try {
-    const saToken = getServiceAccountToken();
-    const response = await fetch(`${cheInternalUrl}/oauth`, {
-      headers: { Authorization: `Bearer ${saToken}` },
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!response.ok) {
-      return false;
-    }
-    const providers = (await response.json()) as Array<{ name: string }>;
-    return Array.isArray(providers) && providers.some(p => p.name === 'github');
-  } catch {
-    return false;
-  }
-}
-
 async function buildClusterConfig(): Promise<ClusterConfig> {
   const token = getServiceAccountToken();
   const { serverConfigApi } = getDevWorkspaceClient(token);
@@ -68,6 +39,7 @@ async function buildClusterConfig(): Promise<ClusterConfig> {
   const allWorkspacesLimit = serverConfigApi.getAllWorkspacesLimit(cheCustomResource);
   const dashboardFavicon = serverConfigApi.getDashboardLogo(cheCustomResource);
   const currentArchitecture = await serverConfigApi.getCurrentArchitecture();
+  const clientId = await getDeviceAuthClientId();
 
   return {
     dashboardWarning,
@@ -75,6 +47,6 @@ async function buildClusterConfig(): Promise<ClusterConfig> {
     allWorkspacesLimit,
     runningWorkspacesLimit,
     currentArchitecture,
-    githubDeviceAuthEnabled: await isGitHubOAuthConfigured(),
+    githubDeviceAuthEnabled: clientId !== null,
   };
 }

--- a/packages/dashboard-backend/src/routes/api/clusterConfig.ts
+++ b/packages/dashboard-backend/src/routes/api/clusterConfig.ts
@@ -28,6 +28,36 @@ export function registerClusterConfigRoute(instance: FastifyInstance) {
   });
 }
 
+/**
+ * Determines whether GitHub OAuth is configured by calling the Che Server's
+ * /api/oauth endpoint with the dashboard SA token — the same source the
+ * Git Services tab uses. No RBAC changes or env vars required.
+ * Falls back to CHE_GITHUB_OAUTH_CLIENT_ID env var for local dev / override.
+ */
+async function isGitHubOAuthConfigured(): Promise<boolean> {
+  if (process.env.CHE_GITHUB_OAUTH_CLIENT_ID) {
+    return true;
+  }
+  const cheInternalUrl = process.env.CHE_INTERNAL_URL;
+  if (!cheInternalUrl) {
+    return false;
+  }
+  try {
+    const saToken = getServiceAccountToken();
+    const response = await fetch(`${cheInternalUrl}/oauth`, {
+      headers: { Authorization: `Bearer ${saToken}` },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const providers = (await response.json()) as Array<{ name: string }>;
+    return Array.isArray(providers) && providers.some(p => p.name === 'github');
+  } catch {
+    return false;
+  }
+}
+
 async function buildClusterConfig(): Promise<ClusterConfig> {
   const token = getServiceAccountToken();
   const { serverConfigApi } = getDevWorkspaceClient(token);
@@ -45,6 +75,6 @@ async function buildClusterConfig(): Promise<ClusterConfig> {
     allWorkspacesLimit,
     runningWorkspacesLimit,
     currentArchitecture,
-    githubDeviceAuthEnabled: !!process.env.CHE_GITHUB_OAUTH_CLIENT_ID,
+    githubDeviceAuthEnabled: await isGitHubOAuthConfigured(),
   };
 }

--- a/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
+++ b/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
@@ -105,5 +105,23 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
         return deviceAuthTokenApi.pollDeviceAuth(namespace, deviceCode);
       },
     );
+    /**
+     * GET /dashboard/api/namespace/:namespace/device-auth-token/:tokenName/validate
+     * Checks whether the stored GitHub token is still valid.
+     * Returns { valid: boolean | null } — null means check could not be performed.
+     * Uses user bearer token.
+     */
+    server.get(
+      `${baseApiPath}/namespace/:namespace/device-auth-token/:tokenName/validate`,
+      Object.assign({}, rateLimitConfig, getSchema({ tags, params: deviceAuthTokenParamsSchema })),
+      async function (request: FastifyRequest) {
+        const { namespace, tokenName } =
+          request.params as restParams.DeviceAuthTokenNamespacedParams;
+        const token = getToken(request);
+        const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
+        const valid = await deviceAuthTokenApi.validateToken(namespace, tokenName);
+        return { valid: valid ?? null };
+      },
+    );
   });
 }

--- a/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
+++ b/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import { baseApiPath } from '@/constants/config';
+import {
+  deviceAuthPollBodySchema,
+  deviceAuthTokenParamsSchema,
+  namespacedSchema,
+} from '@/constants/schemas';
+import { restParams } from '@/models';
+import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
+import { getToken } from '@/routes/api/helpers/getToken';
+import { getSchema } from '@/services/helpers';
+
+const tags = ['Device Auth Token'];
+const rateLimitConfig = {
+  config: {
+    rateLimit: {
+      max: 100,
+      timeWindow: '1 minute',
+    },
+  },
+};
+
+export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
+  instance.register(async server => {
+    /**
+     * GET /dashboard/api/namespace/:namespace/device-auth-token
+     * Returns metadata of Device Authentication token secrets in the namespace
+     * (identified by the che.eclipse.org/device-authentication=true label).
+     * Uses user bearer token.
+     */
+    server.get(
+      `${baseApiPath}/namespace/:namespace/device-auth-token`,
+      Object.assign({}, rateLimitConfig, getSchema({ tags, params: namespacedSchema })),
+      async function (request: FastifyRequest) {
+        const { namespace } = request.params as restParams.INamespacedParams;
+        const token = getToken(request);
+        const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
+        return deviceAuthTokenApi.listTokens(namespace);
+      },
+    );
+
+    /**
+     * DELETE /dashboard/api/namespace/:namespace/device-auth-token/:tokenName
+     * Deletes the Device Authentication token secret by name.
+     * Uses user bearer token.
+     */
+    server.delete(
+      `${baseApiPath}/namespace/:namespace/device-auth-token/:tokenName`,
+      Object.assign({}, rateLimitConfig, getSchema({ tags, params: deviceAuthTokenParamsSchema })),
+      async function (request: FastifyRequest, reply: FastifyReply) {
+        const { namespace, tokenName } =
+          request.params as restParams.DeviceAuthTokenNamespacedParams;
+        const token = getToken(request);
+        const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
+        await deviceAuthTokenApi.deleteToken(namespace, tokenName);
+        reply.code(204).send();
+      },
+    );
+
+    /**
+     * POST /dashboard/api/namespace/:namespace/device-auth-token/initiate
+     * Calls GitHub to obtain a device code. Requires CHE_GITHUB_OAUTH_CLIENT_ID env var.
+     * Uses user bearer token for auth.
+     */
+    server.post(
+      `${baseApiPath}/namespace/:namespace/device-auth-token/initiate`,
+      {
+        ...getSchema({ tags, params: namespacedSchema }),
+        config: {
+          rateLimit: {
+            max: 100,
+            timeWindow: '1 minute',
+          },
+        },
+      },
+      async function (request: FastifyRequest) {
+        const token = getToken(request);
+        const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
+        return deviceAuthTokenApi.initiateDeviceAuth();
+      },
+    );
+
+    /**
+     * POST /dashboard/api/namespace/:namespace/device-auth-token/poll
+     * Polls GitHub for a device code exchange. On success, creates the K8s secret.
+     * Uses user bearer token for auth.
+     */
+    server.post(
+      `${baseApiPath}/namespace/:namespace/device-auth-token/poll`,
+      {
+        ...rateLimitConfig,
+        ...getSchema({ tags, params: namespacedSchema, body: deviceAuthPollBodySchema }),
+        preHandler: server.rateLimit({
+          max: 100,
+          timeWindow: '1 minute',
+        }),
+      },
+      async function (request: FastifyRequest) {
+        const { namespace } = request.params as restParams.INamespacedParams;
+        const { deviceCode } = request.body as { deviceCode: string };
+        const token = getToken(request);
+        const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
+        return deviceAuthTokenApi.pollDeviceAuth(namespace, deviceCode);
+      },
+    );
+  });
+}

--- a/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
+++ b/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
@@ -92,13 +92,13 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
     server.post(
       `${baseApiPath}/namespace/:namespace/device-auth-token/initiate`,
       Object.assign({}, rateLimitConfig, getSchema({ tags, params: namespacedSchema })),
-      async function (request: FastifyRequest, reply: FastifyReply) {
-        const clientId = await getDeviceAuthClientId();
-        if (!clientId) {
-          return reply.code(503).send({ message: DEVICE_AUTH_NOT_CONFIGURED_MSG });
-        }
+      async function (request: FastifyRequest) {
         const { namespace } = request.params as restParams.INamespacedParams;
         const token = getToken(request);
+        const clientId = await getDeviceAuthClientId();
+        if (!clientId) {
+          throw Object.assign(new Error(DEVICE_AUTH_NOT_CONFIGURED_MSG), { statusCode: 503 });
+        }
         const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
         return deviceAuthTokenApi.initiateDeviceAuth(namespace, clientId);
       },
@@ -116,14 +116,14 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
         rateLimitConfig,
         getSchema({ tags, params: namespacedSchema, body: deviceAuthPollBodySchema }),
       ),
-      async function (request: FastifyRequest, reply: FastifyReply) {
-        const clientId = await getDeviceAuthClientId();
-        if (!clientId) {
-          return reply.code(503).send({ message: DEVICE_AUTH_NOT_CONFIGURED_MSG });
-        }
+      async function (request: FastifyRequest) {
         const { namespace } = request.params as restParams.INamespacedParams;
         const { deviceCode } = request.body as { deviceCode: string };
         const token = getToken(request);
+        const clientId = await getDeviceAuthClientId();
+        if (!clientId) {
+          throw Object.assign(new Error(DEVICE_AUTH_NOT_CONFIGURED_MSG), { statusCode: 503 });
+        }
         const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
         return deviceAuthTokenApi.pollDeviceAuth(namespace, deviceCode, clientId);
       },

--- a/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
+++ b/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
@@ -16,6 +16,8 @@ import { baseApiPath } from '@/constants/config';
 import {
   deviceAuthPollBodySchema,
   deviceAuthTokenParamsSchema,
+  deviceAuthTokenResponseSchema,
+  deviceAuthValidateResponseSchema,
   namespacedSchema,
 } from '@/constants/schemas';
 import { restParams } from '@/models';
@@ -43,7 +45,15 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
      */
     server.get(
       `${baseApiPath}/namespace/:namespace/device-auth-token`,
-      Object.assign({}, rateLimitConfig, getSchema({ tags, params: namespacedSchema })),
+      Object.assign(
+        {},
+        rateLimitConfig,
+        getSchema({
+          tags,
+          params: namespacedSchema,
+          response: { 200: deviceAuthTokenResponseSchema },
+        }),
+      ),
       async function (request: FastifyRequest) {
         const { namespace } = request.params as restParams.INamespacedParams;
         const token = getToken(request);
@@ -79,9 +89,10 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
       `${baseApiPath}/namespace/:namespace/device-auth-token/initiate`,
       Object.assign({}, rateLimitConfig, getSchema({ tags, params: namespacedSchema })),
       async function (request: FastifyRequest) {
+        const { namespace } = request.params as restParams.INamespacedParams;
         const token = getToken(request);
         const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
-        return deviceAuthTokenApi.initiateDeviceAuth();
+        return deviceAuthTokenApi.initiateDeviceAuth(namespace);
       },
     );
 
@@ -113,14 +124,22 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
      */
     server.get(
       `${baseApiPath}/namespace/:namespace/device-auth-token/:tokenName/validate`,
-      Object.assign({}, rateLimitConfig, getSchema({ tags, params: deviceAuthTokenParamsSchema })),
+      Object.assign(
+        {},
+        rateLimitConfig,
+        getSchema({
+          tags,
+          params: deviceAuthTokenParamsSchema,
+          response: { 200: deviceAuthValidateResponseSchema },
+        }),
+      ),
       async function (request: FastifyRequest) {
         const { namespace, tokenName } =
           request.params as restParams.DeviceAuthTokenNamespacedParams;
         const token = getToken(request);
         const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
         const valid = await deviceAuthTokenApi.validateToken(namespace, tokenName);
-        return { valid: valid ?? null };
+        return { valid };
       },
     );
   });

--- a/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
+++ b/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
@@ -21,6 +21,7 @@ import {
   namespacedSchema,
 } from '@/constants/schemas';
 import { restParams } from '@/models';
+import { getDeviceAuthClientId } from '@/routes/api/helpers/getDeviceAuthClientId';
 import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
 import { getToken } from '@/routes/api/helpers/getToken';
 import { getSchema } from '@/services/helpers';
@@ -34,6 +35,9 @@ const rateLimitConfig = {
     },
   },
 };
+
+const DEVICE_AUTH_NOT_CONFIGURED_MSG =
+  'GitHub device auth is not configured. Create a device-auth-config ConfigMap in the Che namespace with a github_client_id key.';
 
 export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
   instance.register(async server => {
@@ -82,17 +86,21 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
 
     /**
      * POST /dashboard/api/namespace/:namespace/device-auth-token/initiate
-     * Calls GitHub to obtain a device code. Requires CHE_GITHUB_OAUTH_CLIENT_ID env var.
+     * Calls GitHub to obtain a device code. Reads client_id from device-auth-config ConfigMap.
      * Uses user bearer token for auth.
      */
     server.post(
       `${baseApiPath}/namespace/:namespace/device-auth-token/initiate`,
       Object.assign({}, rateLimitConfig, getSchema({ tags, params: namespacedSchema })),
-      async function (request: FastifyRequest) {
+      async function (request: FastifyRequest, reply: FastifyReply) {
+        const clientId = await getDeviceAuthClientId();
+        if (!clientId) {
+          return reply.code(503).send({ message: DEVICE_AUTH_NOT_CONFIGURED_MSG });
+        }
         const { namespace } = request.params as restParams.INamespacedParams;
         const token = getToken(request);
         const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
-        return deviceAuthTokenApi.initiateDeviceAuth(namespace);
+        return deviceAuthTokenApi.initiateDeviceAuth(namespace, clientId);
       },
     );
 
@@ -108,14 +116,19 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
         rateLimitConfig,
         getSchema({ tags, params: namespacedSchema, body: deviceAuthPollBodySchema }),
       ),
-      async function (request: FastifyRequest) {
+      async function (request: FastifyRequest, reply: FastifyReply) {
+        const clientId = await getDeviceAuthClientId();
+        if (!clientId) {
+          return reply.code(503).send({ message: DEVICE_AUTH_NOT_CONFIGURED_MSG });
+        }
         const { namespace } = request.params as restParams.INamespacedParams;
         const { deviceCode } = request.body as { deviceCode: string };
         const token = getToken(request);
         const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
-        return deviceAuthTokenApi.pollDeviceAuth(namespace, deviceCode);
+        return deviceAuthTokenApi.pollDeviceAuth(namespace, deviceCode, clientId);
       },
     );
+
     /**
      * GET /dashboard/api/namespace/:namespace/device-auth-token/:tokenName/validate
      * Checks whether the stored GitHub token is still valid.

--- a/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
+++ b/packages/dashboard-backend/src/routes/api/deviceAuthToken.ts
@@ -77,15 +77,7 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
      */
     server.post(
       `${baseApiPath}/namespace/:namespace/device-auth-token/initiate`,
-      {
-        ...getSchema({ tags, params: namespacedSchema }),
-        config: {
-          rateLimit: {
-            max: 100,
-            timeWindow: '1 minute',
-          },
-        },
-      },
+      Object.assign({}, rateLimitConfig, getSchema({ tags, params: namespacedSchema })),
       async function (request: FastifyRequest) {
         const token = getToken(request);
         const { deviceAuthTokenApi } = getDevWorkspaceClient(token);
@@ -100,14 +92,11 @@ export function registerDeviceAuthTokenRoutes(instance: FastifyInstance) {
      */
     server.post(
       `${baseApiPath}/namespace/:namespace/device-auth-token/poll`,
-      {
-        ...rateLimitConfig,
-        ...getSchema({ tags, params: namespacedSchema, body: deviceAuthPollBodySchema }),
-        preHandler: server.rateLimit({
-          max: 100,
-          timeWindow: '1 minute',
-        }),
-      },
+      Object.assign(
+        {},
+        rateLimitConfig,
+        getSchema({ tags, params: namespacedSchema, body: deviceAuthPollBodySchema }),
+      ),
       async function (request: FastifyRequest) {
         const { namespace } = request.params as restParams.INamespacedParams;
         const { deviceCode } = request.body as { deviceCode: string };

--- a/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDeviceAuthClientId.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__mocks__/getDeviceAuthClientId.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export async function getDeviceAuthClientId(): Promise<string | null> {
+  return null;
+}

--- a/packages/dashboard-backend/src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+const mockReadNamespacedConfigMap = jest.fn();
+
+jest.mock('@/routes/api/helpers/getServiceAccountToken', () => ({
+  getServiceAccountToken: jest.fn().mockReturnValue('sa-token'),
+}));
+
+jest.mock('@/services/kubeclient/kubeConfigProvider', () => ({
+  KubeConfigProvider: jest.fn().mockImplementation(() => ({
+    getKubeConfig: jest.fn().mockReturnValue({}),
+  })),
+}));
+
+jest.mock('@/devworkspaceClient/services/helpers/prepareCoreV1API', () => ({
+  prepareCoreV1API: jest.fn().mockReturnValue({
+    readNamespacedConfigMap: (...args: unknown[]) => mockReadNamespacedConfigMap(...args),
+  }),
+}));
+
+describe('getDeviceAuthClientId', () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...origEnv };
+    delete process.env.DEVICE_AUTH_GITHUB_CLIENT_ID;
+    process.env.CHECLUSTER_CR_NAMESPACE = 'eclipse-che';
+    mockReadNamespacedConfigMap.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('returns client_id from ConfigMap when present', async () => {
+    mockReadNamespacedConfigMap.mockResolvedValueOnce({
+      data: { github_client_id: '01ab8ac9400c4e429b23' },
+    });
+    let result: string | null;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
+      result = getDeviceAuthClientId();
+    });
+    await expect(result!).resolves.toBe('01ab8ac9400c4e429b23');
+  });
+
+  it('returns null when ConfigMap key is absent', async () => {
+    mockReadNamespacedConfigMap.mockResolvedValueOnce({ data: {} });
+    let result: Promise<string | null>;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
+      result = getDeviceAuthClientId();
+    });
+    await expect(result!).resolves.toBeNull();
+  });
+
+  it('returns null when ConfigMap does not exist', async () => {
+    mockReadNamespacedConfigMap.mockRejectedValueOnce(
+      Object.assign(new Error('Not Found'), { code: 404 }),
+    );
+    let result: Promise<string | null>;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
+      result = getDeviceAuthClientId();
+    });
+    await expect(result!).resolves.toBeNull();
+  });
+
+  it('returns value from DEVICE_AUTH_GITHUB_CLIENT_ID env var without hitting K8s', async () => {
+    process.env.DEVICE_AUTH_GITHUB_CLIENT_ID = 'local-override-id';
+    let result: Promise<string | null>;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
+      result = getDeviceAuthClientId();
+    });
+    await expect(result!).resolves.toBe('local-override-id');
+    expect(mockReadNamespacedConfigMap).not.toHaveBeenCalled();
+  });
+
+  it('returns null when CHECLUSTER_CR_NAMESPACE is not set', async () => {
+    delete process.env.CHECLUSTER_CR_NAMESPACE;
+    let result: Promise<string | null>;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
+      result = getDeviceAuthClientId();
+    });
+    await expect(result!).resolves.toBeNull();
+    expect(mockReadNamespacedConfigMap).not.toHaveBeenCalled();
+  });
+
+  it('caches the result for subsequent calls', async () => {
+    mockReadNamespacedConfigMap.mockResolvedValue({
+      data: { github_client_id: 'cached-id' },
+    });
+    let getDeviceAuthClientId: () => Promise<string | null>;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      ({ getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId'));
+    });
+    await getDeviceAuthClientId!();
+    await getDeviceAuthClientId!();
+    expect(mockReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dashboard-backend/src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/__tests__/getDeviceAuthClientId.spec.ts
@@ -10,6 +10,11 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import {
+  _resetCacheForTesting,
+  getDeviceAuthClientId,
+} from '@/routes/api/helpers/getDeviceAuthClientId';
+
 const mockReadNamespacedConfigMap = jest.fn();
 
 jest.mock('@/routes/api/helpers/getServiceAccountToken', () => ({
@@ -32,7 +37,7 @@ describe('getDeviceAuthClientId', () => {
   const origEnv = { ...process.env };
 
   beforeEach(() => {
-    jest.resetModules();
+    _resetCacheForTesting();
     process.env = { ...origEnv };
     delete process.env.DEVICE_AUTH_GITHUB_CLIENT_ID;
     process.env.CHECLUSTER_CR_NAMESPACE = 'eclipse-che';
@@ -47,60 +52,30 @@ describe('getDeviceAuthClientId', () => {
     mockReadNamespacedConfigMap.mockResolvedValueOnce({
       data: { github_client_id: '01ab8ac9400c4e429b23' },
     });
-    let result: string | null;
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
-      result = getDeviceAuthClientId();
-    });
-    await expect(result!).resolves.toBe('01ab8ac9400c4e429b23');
+    await expect(getDeviceAuthClientId()).resolves.toBe('01ab8ac9400c4e429b23');
   });
 
   it('returns null when ConfigMap key is absent', async () => {
     mockReadNamespacedConfigMap.mockResolvedValueOnce({ data: {} });
-    let result: Promise<string | null>;
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
-      result = getDeviceAuthClientId();
-    });
-    await expect(result!).resolves.toBeNull();
+    await expect(getDeviceAuthClientId()).resolves.toBeNull();
   });
 
   it('returns null when ConfigMap does not exist', async () => {
     mockReadNamespacedConfigMap.mockRejectedValueOnce(
       Object.assign(new Error('Not Found'), { code: 404 }),
     );
-    let result: Promise<string | null>;
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
-      result = getDeviceAuthClientId();
-    });
-    await expect(result!).resolves.toBeNull();
+    await expect(getDeviceAuthClientId()).resolves.toBeNull();
   });
 
   it('returns value from DEVICE_AUTH_GITHUB_CLIENT_ID env var without hitting K8s', async () => {
     process.env.DEVICE_AUTH_GITHUB_CLIENT_ID = 'local-override-id';
-    let result: Promise<string | null>;
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
-      result = getDeviceAuthClientId();
-    });
-    await expect(result!).resolves.toBe('local-override-id');
+    await expect(getDeviceAuthClientId()).resolves.toBe('local-override-id');
     expect(mockReadNamespacedConfigMap).not.toHaveBeenCalled();
   });
 
   it('returns null when CHECLUSTER_CR_NAMESPACE is not set', async () => {
     delete process.env.CHECLUSTER_CR_NAMESPACE;
-    let result: Promise<string | null>;
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId');
-      result = getDeviceAuthClientId();
-    });
-    await expect(result!).resolves.toBeNull();
+    await expect(getDeviceAuthClientId()).resolves.toBeNull();
     expect(mockReadNamespacedConfigMap).not.toHaveBeenCalled();
   });
 
@@ -108,13 +83,8 @@ describe('getDeviceAuthClientId', () => {
     mockReadNamespacedConfigMap.mockResolvedValue({
       data: { github_client_id: 'cached-id' },
     });
-    let getDeviceAuthClientId: () => Promise<string | null>;
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      ({ getDeviceAuthClientId } = require('@/routes/api/helpers/getDeviceAuthClientId'));
-    });
-    await getDeviceAuthClientId!();
-    await getDeviceAuthClientId!();
+    await getDeviceAuthClientId();
+    await getDeviceAuthClientId();
     expect(mockReadNamespacedConfigMap).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dashboard-backend/src/routes/api/helpers/getDeviceAuthClientId.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getDeviceAuthClientId.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { prepareCoreV1API } from '@/devworkspaceClient/services/helpers/prepareCoreV1API';
+import { getServiceAccountToken } from '@/routes/api/helpers/getServiceAccountToken';
+import { KubeConfigProvider } from '@/services/kubeclient/kubeConfigProvider';
+
+const DEVICE_AUTH_CONFIG_MAP = 'device-auth-config';
+const GITHUB_CLIENT_ID_KEY = 'github_client_id';
+const CACHE_TTL_MS = 90_000;
+
+let cache: { value: string | null; expiresAt: number } | null = null;
+
+export async function getDeviceAuthClientId(): Promise<string | null> {
+  if (cache && Date.now() < cache.expiresAt) {
+    return cache.value;
+  }
+
+  const value = await resolveClientId();
+  cache = { value, expiresAt: Date.now() + CACHE_TTL_MS };
+  return value;
+}
+
+async function resolveClientId(): Promise<string | null> {
+  // Local dev / CI override — avoids needing a ConfigMap in development
+  if (process.env.DEVICE_AUTH_GITHUB_CLIENT_ID) {
+    return process.env.DEVICE_AUTH_GITHUB_CLIENT_ID;
+  }
+
+  const namespace = process.env.CHECLUSTER_CR_NAMESPACE;
+  if (!namespace) {
+    return null;
+  }
+
+  try {
+    const token = getServiceAccountToken();
+    const kc = new KubeConfigProvider().getKubeConfig(token);
+    const coreV1API = prepareCoreV1API(kc);
+    const configMap = await coreV1API.readNamespacedConfigMap({
+      name: DEVICE_AUTH_CONFIG_MAP,
+      namespace,
+    });
+    const clientId = configMap.data?.[GITHUB_CLIENT_ID_KEY]?.trim() ?? '';
+    return clientId || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/dashboard-backend/src/routes/api/helpers/getDeviceAuthClientId.ts
+++ b/packages/dashboard-backend/src/routes/api/helpers/getDeviceAuthClientId.ts
@@ -20,6 +20,11 @@ const CACHE_TTL_MS = 90_000;
 
 let cache: { value: string | null; expiresAt: number } | null = null;
 
+/** Resets the TTL cache. For testing only. */
+export function _resetCacheForTesting(): void {
+  cache = null;
+}
+
 export async function getDeviceAuthClientId(): Promise<string | null> {
   if (cache && Date.now() < cache.expiresAt) {
     return cache.value;

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__mocks__/index.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+
+export const ConnectModal = ({
+  isOpen,
+  onCloseModal,
+  onSuccess,
+}: {
+  isOpen: boolean;
+  namespace: string;
+  onCloseModal: () => void;
+  onSuccess: (token: unknown) => void;
+}): React.ReactElement => (
+  <div data-testid="connect-modal" data-is-open={isOpen}>
+    <button data-testid="mock-close-button" onClick={onCloseModal}>
+      Cancel
+    </button>
+    <button
+      data-testid="mock-success-button"
+      onClick={() => onSuccess({ name: 'new-token', provider: 'github' })}
+    >
+      Success
+    </button>
+  </div>
+);
+
+export default ConnectModal;

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__tests__/index.spec.tsx
@@ -95,4 +95,22 @@ describe('ConnectModal', () => {
     screen.getByTestId('cancel-button').click();
     expect(mockOnCloseModal).toHaveBeenCalled();
   });
+
+  it('should increase poll interval by 5s on slow_down', async () => {
+    (pollDeviceAuth as jest.Mock).mockResolvedValue({ status: 'slow_down' });
+    renderComponent(true);
+    await waitFor(() => screen.getByTestId('user-code'));
+    // advance by original 5s interval
+    jest.advanceTimersByTime(5000);
+    await waitFor(() => expect(pollDeviceAuth).toHaveBeenCalled());
+    const callCount = (pollDeviceAuth as jest.Mock).mock.calls.length;
+    // advance by 5s (original) — should NOT trigger yet (interval is now 10s)
+    jest.advanceTimersByTime(5000);
+    await Promise.resolve(); // flush microtasks
+    // advance remaining 5s to complete the 10s interval
+    jest.advanceTimersByTime(5000);
+    await waitFor(() =>
+      expect((pollDeviceAuth as jest.Mock).mock.calls.length).toBeGreaterThan(callCount),
+    );
+  });
 });

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__tests__/index.spec.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { ConnectModal } from '@/pages/UserPreferences/DeviceAuthTokens/ConnectModal';
+import getComponentRenderer, { screen, waitFor } from '@/services/__mocks__/getComponentRenderer';
+import { DeviceCodeResponse, pollDeviceAuth } from '@/services/backend-client/deviceAuthTokenApi';
+import { AppThunk } from '@/store';
+import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
+import { deviceAuthTokenActionCreators } from '@/store/DeviceAuthToken';
+
+jest.mock('@/services/backend-client/deviceAuthTokenApi');
+jest.mock('@/store/DeviceAuthToken', () => ({
+  ...jest.requireActual('@/store/DeviceAuthToken'),
+  deviceAuthTokenActionCreators: {
+    initiateDeviceAuth: (): AppThunk<Promise<DeviceCodeResponse>> => async () => ({
+      deviceCode: 'dev-code-123',
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://github.com/login/device',
+      interval: 5,
+    }),
+  } as typeof deviceAuthTokenActionCreators,
+}));
+
+const mockOnCloseModal = jest.fn();
+const mockOnSuccess = jest.fn();
+
+const newToken: api.DeviceAuthToken = {
+  name: 'device-authentication-secret-abc12',
+  provider: 'github',
+};
+
+const { renderComponent } = getComponentRenderer(getComponent);
+
+function getComponent(isOpen: boolean) {
+  const store = new MockStoreBuilder().build();
+  return (
+    <Provider store={store}>
+      <ConnectModal
+        isOpen={isOpen}
+        namespace="test-namespace"
+        onCloseModal={mockOnCloseModal}
+        onSuccess={mockOnSuccess}
+      />
+    </Provider>
+  );
+}
+
+describe('ConnectModal', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('should render the user code when open', async () => {
+    renderComponent(true);
+    await waitFor(() => screen.getByTestId('user-code'));
+    expect(screen.getByTestId('user-code')).toHaveTextContent('ABCD-1234');
+  });
+
+  it('should call onSuccess when poll returns authorized', async () => {
+    (pollDeviceAuth as jest.Mock).mockResolvedValue({ status: 'authorized', token: newToken });
+    renderComponent(true);
+    await waitFor(() => screen.getByTestId('user-code'));
+    jest.runAllTimers();
+    await waitFor(() => expect(mockOnSuccess).toHaveBeenCalledWith(newToken));
+  });
+
+  it('should show error when poll returns expired', async () => {
+    (pollDeviceAuth as jest.Mock).mockResolvedValue({ status: 'expired' });
+    renderComponent(true);
+    await waitFor(() => screen.getByTestId('user-code'));
+    jest.runAllTimers();
+    await waitFor(() => screen.getByTestId('connect-error'));
+    expect(screen.getByTestId('connect-error')).toHaveTextContent('expired');
+  });
+
+  it('should call onCloseModal when Cancel is clicked', async () => {
+    (pollDeviceAuth as jest.Mock).mockResolvedValue({ status: 'pending' });
+    renderComponent(true);
+    await waitFor(() => screen.getByTestId('cancel-button'));
+    screen.getByTestId('cancel-button').click();
+    expect(mockOnCloseModal).toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/__tests__/index.spec.tsx
@@ -15,8 +15,16 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import { ConnectModal } from '@/pages/UserPreferences/DeviceAuthTokens/ConnectModal';
-import getComponentRenderer, { screen, waitFor } from '@/services/__mocks__/getComponentRenderer';
-import { DeviceCodeResponse, pollDeviceAuth } from '@/services/backend-client/deviceAuthTokenApi';
+import getComponentRenderer, {
+  render,
+  screen,
+  waitFor,
+} from '@/services/__mocks__/getComponentRenderer';
+import {
+  DeviceAuthPollResult,
+  DeviceCodeResponse,
+  pollDeviceAuth,
+} from '@/services/backend-client/deviceAuthTokenApi';
 import { AppThunk } from '@/store';
 import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
 import { deviceAuthTokenActionCreators } from '@/store/DeviceAuthToken';
@@ -94,6 +102,29 @@ describe('ConnectModal', () => {
     await waitFor(() => screen.getByTestId('cancel-button'));
     screen.getByTestId('cancel-button').click();
     expect(mockOnCloseModal).toHaveBeenCalled();
+  });
+
+  it('should not call onSuccess when component unmounts before poll resolves', async () => {
+    let resolvePoll!: (result: DeviceAuthPollResult) => void;
+    const pendingPoll = new Promise<DeviceAuthPollResult>(resolve => {
+      resolvePoll = resolve;
+    });
+    (pollDeviceAuth as jest.Mock).mockReturnValue(pendingPoll);
+
+    const { unmount } = render(getComponent(true));
+    await waitFor(() => screen.getByTestId('user-code'));
+
+    // advance to trigger the first scheduled poll
+    jest.advanceTimersByTime(5000);
+
+    // unmount while the poll promise is still pending
+    unmount();
+
+    // resolve the in-flight poll after unmount
+    resolvePoll({ status: 'authorized', token: newToken });
+    await Promise.resolve();
+
+    expect(mockOnSuccess).not.toHaveBeenCalled();
   });
 
   it('should increase poll interval by 5s on slow_down', async () => {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
@@ -215,21 +215,20 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
                 </Content>
                 <Content component="li">Return here — the page will update automatically</Content>
               </Content>
-              <div style={{ display: 'flex', justifyContent: 'center', marginTop: '1rem' }}>
-                <Spinner size="sm" aria-label="Waiting for authorization" />
-              </div>
             </Content>
           )}
         </ModalBody>
         <ModalFooter>
           {deviceCode && !error && (
             <Button
-              variant={ButtonVariant.link}
-              component="a"
-              href={deviceCode.verificationUri}
-              target="_blank"
+              variant={ButtonVariant.primary}
+              onClick={() => {
+                navigator.clipboard?.writeText(deviceCode.userCode ?? '');
+                window.open(deviceCode.verificationUri, '_blank');
+              }}
+              data-testid="copy-continue-button"
             >
-              Open GitHub
+              Copy &amp; Continue to Browser
             </Button>
           )}
           <Button

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import {
+  Button,
+  ButtonVariant,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Spinner,
+  Tooltip,
+} from '@patternfly/react-core';
+import { CopyIcon } from '@patternfly/react-icons';
+import React from 'react';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import { connect, ConnectedProps } from 'react-redux';
+
+import {
+  DeviceAuthPollResult,
+  DeviceCodeResponse,
+  pollDeviceAuth,
+} from '@/services/backend-client/deviceAuthTokenApi';
+import { deviceAuthTokenActionCreators } from '@/store/DeviceAuthToken';
+
+const connector = connect(null, {
+  initiateDeviceAuth: deviceAuthTokenActionCreators.initiateDeviceAuth,
+});
+
+type MappedProps = ConnectedProps<typeof connector>;
+
+type OwnProps = {
+  isOpen: boolean;
+  namespace: string;
+  onCloseModal: () => void;
+  onSuccess: (token: api.DeviceAuthToken) => void;
+};
+
+export type Props = OwnProps & MappedProps;
+
+export type State = {
+  deviceCode: DeviceCodeResponse | undefined;
+  error: string | undefined;
+  isLoading: boolean;
+  copyTimerId: number | undefined;
+};
+
+class ConnectModalClass extends React.PureComponent<Props, State> {
+  private pollTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      deviceCode: undefined,
+      error: undefined,
+      isLoading: false,
+      copyTimerId: undefined,
+    };
+  }
+
+  componentDidMount(): void {
+    if (this.props.isOpen) {
+      this.initiateAuth();
+    }
+  }
+
+  async componentDidUpdate(prevProps: Props): Promise<void> {
+    if (this.props.isOpen && !prevProps.isOpen) {
+      await this.initiateAuth();
+    }
+    if (!this.props.isOpen && prevProps.isOpen) {
+      this.stopPolling();
+    }
+  }
+
+  componentWillUnmount(): void {
+    this.stopPolling();
+  }
+
+  private async initiateAuth(): Promise<void> {
+    this.setState({ deviceCode: undefined, error: undefined, isLoading: true });
+    try {
+      const result = await this.props.initiateDeviceAuth();
+      this.setState({ deviceCode: result, isLoading: false });
+      this.schedulePoll(result);
+    } catch (e) {
+      this.setState({ error: String(e), isLoading: false });
+    }
+  }
+
+  private handleCopyToClipboard(): void {
+    let { copyTimerId } = this.state;
+    if (copyTimerId !== undefined) {
+      window.clearTimeout(copyTimerId);
+    }
+    copyTimerId = window.setTimeout(() => {
+      this.setState({ copyTimerId: undefined });
+    }, 3000);
+    this.setState({ copyTimerId });
+  }
+
+  private schedulePoll(response: DeviceCodeResponse): void {
+    this.pollTimer = setTimeout(() => this.runPoll(response), response.interval * 1000);
+  }
+
+  private async runPoll(response: DeviceCodeResponse): Promise<void> {
+    const { namespace } = this.props;
+    let result: DeviceAuthPollResult;
+    try {
+      result = await pollDeviceAuth(namespace, response.deviceCode);
+    } catch {
+      this.schedulePoll(response);
+      return;
+    }
+    if (result.status === 'pending') {
+      this.schedulePoll(response);
+    } else if (result.status === 'slow_down') {
+      // RFC 8628 §3.5: increase interval by 5s on slow_down
+      this.schedulePoll({ ...response, interval: response.interval + 5 });
+    } else if (result.status === 'authorized') {
+      this.props.onSuccess(result.token);
+    } else if (result.status === 'expired') {
+      this.setState({ error: 'The code has expired. Please try again.' });
+    } else {
+      this.setState({ error: result.message });
+    }
+  }
+
+  private stopPolling(): void {
+    if (this.pollTimer !== undefined) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = undefined;
+    }
+  }
+
+  private handleClose(): void {
+    this.stopPolling();
+    this.props.onCloseModal();
+  }
+
+  public render(): React.ReactElement {
+    const { isOpen } = this.props;
+    const { deviceCode, error, isLoading } = this.state;
+    const modalTitle = 'Connect to GitHub';
+
+    return (
+      <Modal
+        aria-label={modalTitle}
+        variant={ModalVariant.small}
+        isOpen={isOpen}
+        onClose={() => this.handleClose()}
+      >
+        <ModalHeader title={modalTitle} />
+        <ModalBody>
+          {isLoading && <Spinner size="md" />}
+          {error && (
+            <Content
+              data-testid="connect-error"
+              style={{ color: 'var(--pf-t--global--color--status--danger--default)' }}
+            >
+              {error}
+            </Content>
+          )}
+          {deviceCode && !error && (
+            <Content>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                <Content component="p" style={{ margin: 0, whiteSpace: 'nowrap' }}>
+                  Your one-time code:
+                </Content>
+                <code
+                  data-testid="user-code"
+                  style={{
+                    fontFamily: 'monospace',
+                    fontSize: '1.25rem',
+                    fontWeight: 'bold',
+                    letterSpacing: '0.15em',
+                  }}
+                >
+                  {deviceCode.userCode}
+                </code>
+                <Tooltip content={this.state.copyTimerId ? 'Copied!' : 'Copy to clipboard'}>
+                  <CopyToClipboard
+                    text={deviceCode.userCode}
+                    onCopy={() => this.handleCopyToClipboard()}
+                  >
+                    <Button
+                      variant={ButtonVariant.plain}
+                      icon={<CopyIcon />}
+                      aria-label="Copy to clipboard"
+                      data-testid="copy-to-clipboard"
+                    />
+                  </CopyToClipboard>
+                </Tooltip>
+              </div>
+              <Content component="ol" style={{ marginTop: '1rem' }}>
+                <Content component="li">Copy the code above</Content>
+                <Content component="li">
+                  Open{' '}
+                  <a href={deviceCode.verificationUri} target="_blank" rel="noreferrer">
+                    {deviceCode.verificationUri}
+                  </a>{' '}
+                  and paste the code
+                </Content>
+                <Content component="li">Return here — the page will update automatically</Content>
+              </Content>
+              <div style={{ display: 'flex', justifyContent: 'center', marginTop: '1rem' }}>
+                <Spinner size="sm" aria-label="Waiting for authorization" />
+              </div>
+            </Content>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          {deviceCode && !error && (
+            <Button
+              variant={ButtonVariant.link}
+              component="a"
+              href={deviceCode.verificationUri}
+              target="_blank"
+            >
+              Open GitHub
+            </Button>
+          )}
+          <Button
+            variant={ButtonVariant.link}
+            onClick={() => this.handleClose()}
+            data-testid="cancel-button"
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}
+
+export const ConnectModal = connector(ConnectModalClass);
+export default ConnectModal;

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
@@ -152,8 +152,8 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
     if (result.status === 'pending') {
       this.schedulePoll(response);
     } else if (result.status === 'slow_down') {
-      // RFC 8628 §3.5: increase interval by 5s on slow_down
-      this.schedulePoll({ ...response, interval: response.interval + 5 });
+      // RFC 8628 §3.5: increase interval by 5s on slow_down; cap at 60s
+      this.schedulePoll({ ...response, interval: Math.min(response.interval + 5, 60) });
     } else if (result.status === 'authorized') {
       this.setState({ pollErrorCount: 0 });
       this.props.onSuccess(result.token);

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/ConnectModal/index.tsx
@@ -35,6 +35,8 @@ import {
 } from '@/services/backend-client/deviceAuthTokenApi';
 import { deviceAuthTokenActionCreators } from '@/store/DeviceAuthToken';
 
+const MAX_POLL_ERRORS = 15;
+
 const connector = connect(null, {
   initiateDeviceAuth: deviceAuthTokenActionCreators.initiateDeviceAuth,
 });
@@ -55,10 +57,12 @@ export type State = {
   error: string | undefined;
   isLoading: boolean;
   copyTimerId: number | undefined;
+  pollErrorCount: number;
 };
 
 class ConnectModalClass extends React.PureComponent<Props, State> {
   private pollTimer: ReturnType<typeof setTimeout> | undefined;
+  private _isMounted = false;
 
   constructor(props: Props) {
     super(props);
@@ -67,18 +71,20 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
       error: undefined,
       isLoading: false,
       copyTimerId: undefined,
+      pollErrorCount: 0,
     };
   }
 
   componentDidMount(): void {
+    this._isMounted = true;
     if (this.props.isOpen) {
       this.initiateAuth();
     }
   }
 
-  async componentDidUpdate(prevProps: Props): Promise<void> {
+  componentDidUpdate(prevProps: Props): void {
     if (this.props.isOpen && !prevProps.isOpen) {
-      await this.initiateAuth();
+      void this.initiateAuth();
     }
     if (!this.props.isOpen && prevProps.isOpen) {
       this.stopPolling();
@@ -86,11 +92,15 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
   }
 
   componentWillUnmount(): void {
+    this._isMounted = false;
     this.stopPolling();
   }
 
   private async initiateAuth(): Promise<void> {
-    this.setState({ deviceCode: undefined, error: undefined, isLoading: true });
+    if (this.state.isLoading) {
+      return;
+    }
+    this.setState({ deviceCode: undefined, error: undefined, isLoading: true, pollErrorCount: 0 });
     try {
       const result = await this.props.initiateDeviceAuth();
       this.setState({ deviceCode: result, isLoading: false });
@@ -119,9 +129,24 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
     const { namespace } = this.props;
     let result: DeviceAuthPollResult;
     try {
+      // pollDeviceAuth is called directly (not through a Redux thunk) to avoid
+      // storing high-frequency polling results in Redux state. Network/session
+      // errors are caught below and retried via the next scheduled poll.
       result = await pollDeviceAuth(namespace, response.deviceCode);
     } catch {
+      if (!this._isMounted) {
+        return;
+      }
+      const nextCount = this.state.pollErrorCount + 1;
+      this.setState({ pollErrorCount: nextCount });
+      if (nextCount >= MAX_POLL_ERRORS) {
+        this.setState({ error: 'Unable to reach the server. Please close and try again.' });
+        return;
+      }
       this.schedulePoll(response);
+      return;
+    }
+    if (!this._isMounted) {
       return;
     }
     if (result.status === 'pending') {
@@ -130,6 +155,7 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
       // RFC 8628 §3.5: increase interval by 5s on slow_down
       this.schedulePoll({ ...response, interval: response.interval + 5 });
     } else if (result.status === 'authorized') {
+      this.setState({ pollErrorCount: 0 });
       this.props.onSuccess(result.token);
     } else if (result.status === 'expired') {
       this.setState({ error: 'The code has expired. Please try again.' });
@@ -171,6 +197,16 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
               style={{ color: 'var(--pf-t--global--color--status--danger--default)' }}
             >
               {error}
+            </Content>
+          )}
+          {this.state.pollErrorCount >= 3 && !error && (
+            <Content
+              style={{
+                color: 'var(--pf-t--global--color--status--warning--default)',
+                marginBottom: '0.5rem',
+              }}
+            >
+              Having trouble reaching the server. Still trying&hellip;
             </Content>
           )}
           {deviceCode && !error && (
@@ -220,16 +256,14 @@ class ConnectModalClass extends React.PureComponent<Props, State> {
         </ModalBody>
         <ModalFooter>
           {deviceCode && !error && (
-            <Button
-              variant={ButtonVariant.primary}
-              onClick={() => {
-                navigator.clipboard?.writeText(deviceCode.userCode ?? '');
-                window.open(deviceCode.verificationUri, '_blank');
-              }}
-              data-testid="copy-continue-button"
+            <CopyToClipboard
+              text={deviceCode.userCode}
+              onCopy={() => window.open(deviceCode.verificationUri, '_blank')}
             >
-              Copy &amp; Continue to Browser
-            </Button>
+              <Button variant={ButtonVariant.primary} data-testid="copy-continue-button">
+                Copy &amp; Continue to Browser
+              </Button>
+            </CopyToClipboard>
           )}
           <Button
             variant={ButtonVariant.link}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/__mocks__/index.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+
+import { Props } from '..';
+
+export class DeviceAuthTokensDeleteModal extends React.PureComponent<Props> {
+  render() {
+    const { isOpen, tokens, onDelete, onCloseModal } = this.props;
+
+    if (!isOpen) {
+      return null;
+    }
+
+    return (
+      <div data-testid="modal-delete-device-auth-token">
+        <h1>Delete Device Authentication Token</h1>
+        <button data-testid="close-modal" onClick={() => onCloseModal()}>
+          Close
+        </button>
+        <button data-testid="delete-token" onClick={() => onDelete(tokens)}>
+          Delete
+        </button>
+      </div>
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/__tests__/index.spec.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import React from 'react';
+
+import { DeviceAuthTokensDeleteModal } from '@/pages/UserPreferences/DeviceAuthTokens/DeleteModal';
+import getComponentRenderer, { fireEvent, screen } from '@/services/__mocks__/getComponentRenderer';
+
+const token: api.DeviceAuthToken = {
+  name: 'device-authentication-secret-abc12',
+  creationTimestamp: '2024-01-01T00:00:00.000Z',
+};
+const token2: api.DeviceAuthToken = {
+  name: 'device-authentication-secret-xyz34',
+  creationTimestamp: '2024-02-01T00:00:00.000Z',
+};
+
+const mockOnDelete = jest.fn();
+const mockOnClose = jest.fn();
+
+const { renderComponent } = getComponentRenderer(
+  ({ isOpen, tokens }: { isOpen: boolean; tokens: api.DeviceAuthToken[] }) => (
+    <DeviceAuthTokensDeleteModal
+      isOpen={isOpen}
+      tokens={tokens}
+      onCloseModal={mockOnClose}
+      onDelete={mockOnDelete}
+    />
+  ),
+);
+
+describe('DeviceAuthTokensDeleteModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not render when closed', () => {
+    renderComponent({ isOpen: false, tokens: [token] });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('should render when open with a single token', () => {
+    renderComponent({ isOpen: true, tokens: [token] });
+    expect(screen.queryByRole('dialog')).not.toBeNull();
+    expect(screen.getByText(/Delete Device Authentication Token/)).not.toBeNull();
+  });
+
+  it('should render a bulk title when multiple tokens', () => {
+    renderComponent({ isOpen: true, tokens: [token, token2] });
+    expect(screen.getByText(/Delete 2 Device Authentication Tokens/)).not.toBeNull();
+  });
+
+  it('should call onCloseModal when Cancel is clicked', () => {
+    renderComponent({ isOpen: true, tokens: [token] });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should have Delete button disabled until checkbox is checked', () => {
+    renderComponent({ isOpen: true, tokens: [token] });
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(deleteButton).not.toBeDisabled();
+  });
+
+  it('should call onDelete with tokens array when Delete button is clicked', () => {
+    renderComponent({ isOpen: true, tokens: [token] });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(mockOnDelete).toHaveBeenCalledWith([token]);
+  });
+});

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/index.tsx
@@ -78,7 +78,8 @@ export class DeviceAuthTokensDeleteModal extends React.PureComponent<Props, Stat
       ) : (
         <Content component="p">
           Are you sure you want to delete <strong>{count}</strong> Device Authentication Tokens?
-          This removes the tokens from Che. To fully revoke GitHub access, also visit{' '}
+          This removes the tokens from Che and attempts to revoke the GitHub authorizations. If
+          revocation fails, you can also manually revoke at{' '}
           <a href="https://github.com/settings/applications" target="_blank" rel="noreferrer">
             github.com/settings/applications
           </a>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/index.tsx
@@ -68,8 +68,8 @@ export class DeviceAuthTokensDeleteModal extends React.PureComponent<Props, Stat
       count === 1 ? (
         <Content component="p">
           Are you sure you want to delete the token <strong>{tokens[0]?.name}</strong>? This removes
-          the token from Che. The GitHub authorization will remain active — to fully revoke access,
-          also visit{' '}
+          the token from Che and attempts to revoke the GitHub authorization. If revocation fails,
+          you can also manually revoke at{' '}
           <a href="https://github.com/settings/applications" target="_blank" rel="noreferrer">
             github.com/settings/applications
           </a>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/DeleteModal/index.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import {
+  Button,
+  ButtonVariant,
+  Checkbox,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
+import React from 'react';
+
+export type Props = {
+  isOpen: boolean;
+  tokens: api.DeviceAuthToken[];
+  onCloseModal: () => void;
+  onDelete: (tokens: api.DeviceAuthToken[]) => void;
+};
+
+export type State = {
+  isChecked: boolean;
+};
+
+export class DeviceAuthTokensDeleteModal extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { isChecked: false };
+  }
+
+  private handleDelete(): void {
+    const { tokens } = this.props;
+    if (tokens.length > 0) {
+      this.setState({ isChecked: false });
+      this.props.onDelete(tokens);
+    }
+  }
+
+  private handleCloseModal(): void {
+    this.setState({ isChecked: false });
+    this.props.onCloseModal();
+  }
+
+  public render(): React.ReactElement {
+    const { isOpen, tokens } = this.props;
+    const { isChecked } = this.state;
+
+    const count = tokens.length;
+    const modalTitle =
+      count === 1
+        ? 'Delete Device Authentication Token'
+        : `Delete ${count} Device Authentication Tokens`;
+
+    const bodyText =
+      count === 1 ? (
+        <Content component="p">
+          Are you sure you want to delete the token <strong>{tokens[0]?.name}</strong>? This removes
+          the token from Che. The GitHub authorization will remain active — to fully revoke access,
+          also visit{' '}
+          <a href="https://github.com/settings/applications" target="_blank" rel="noreferrer">
+            github.com/settings/applications
+          </a>
+          .
+        </Content>
+      ) : (
+        <Content component="p">
+          Are you sure you want to delete <strong>{count}</strong> Device Authentication Tokens?
+          This removes the tokens from Che. To fully revoke GitHub access, also visit{' '}
+          <a href="https://github.com/settings/applications" target="_blank" rel="noreferrer">
+            github.com/settings/applications
+          </a>
+          .
+        </Content>
+      );
+
+    return (
+      <Modal
+        aria-label={modalTitle}
+        variant={ModalVariant.small}
+        isOpen={isOpen}
+        onClose={() => this.handleCloseModal()}
+        elementToFocus="[data-pf-initial-focus]"
+      >
+        <ModalHeader title={modalTitle} titleIconVariant="warning" />
+        <ModalBody>
+          <Content data-pf-initial-focus tabIndex={-1} style={{ outline: 'none' }}>
+            {bodyText}
+            <Checkbox
+              id="delete-device-auth-token-warning-checkbox"
+              isChecked={isChecked}
+              label="I understand, this operation cannot be reverted."
+              onChange={(_event, checked) => this.setState({ isChecked: checked })}
+            />
+          </Content>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant={ButtonVariant.danger}
+            isDisabled={!isChecked}
+            onClick={() => this.handleDelete()}
+          >
+            Delete
+          </Button>
+          <Button variant={ButtonVariant.link} onClick={() => this.handleCloseModal()}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/EmptyState/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/EmptyState/__tests__/index.spec.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+
+import { DeviceAuthTokensEmptyState } from '@/pages/UserPreferences/DeviceAuthTokens/EmptyState';
+import getComponentRenderer, { fireEvent, screen } from '@/services/__mocks__/getComponentRenderer';
+
+const { renderComponent } = getComponentRenderer(getComponent);
+
+describe('DeviceAuthTokensEmptyState', () => {
+  it('should render the empty state heading', () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: 'No Device Authentication Tokens' })).not.toBeNull();
+  });
+
+  it('should render the informational message', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText(/Connect your GitHub account using device authorization/),
+    ).not.toBeNull();
+  });
+
+  it('should not render "Connect to GitHub" button when isConnectEnabled is false', () => {
+    renderComponent(jest.fn(), false);
+
+    expect(screen.queryByTestId('connect-github-button')).not.toBeInTheDocument();
+  });
+
+  it('should call onConnect when "Connect to GitHub" is clicked', () => {
+    const onConnect = jest.fn();
+    renderComponent(onConnect);
+    fireEvent.click(screen.getByTestId('connect-github-button'));
+    expect(onConnect).toHaveBeenCalled();
+  });
+});
+
+function getComponent(
+  onConnect: () => void = jest.fn(),
+  isConnectEnabled = true,
+): React.ReactElement {
+  return <DeviceAuthTokensEmptyState onConnect={onConnect} isConnectEnabled={isConnectEnabled} />;
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/EmptyState/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/EmptyState/index.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+import { KeyIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+export type Props = {
+  onConnect: () => void;
+  isConnectEnabled: boolean;
+};
+
+export class DeviceAuthTokensEmptyState extends React.PureComponent<Props> {
+  public render(): React.ReactElement {
+    return (
+      <EmptyState
+        isFullHeight={true}
+        variant={EmptyStateVariant.sm}
+        icon={KeyIcon}
+        titleText="No Device Authentication Tokens"
+      >
+        <EmptyStateBody>
+          Connect your GitHub account using device authorization to allow workspaces to clone
+          private repositories and interact with the GitHub API.
+        </EmptyStateBody>
+        {this.props.isConnectEnabled && (
+          <EmptyStateFooter>
+            <Button
+              variant="primary"
+              data-testid="connect-github-button"
+              onClick={this.props.onConnect}
+            >
+              Connect to GitHub
+            </Button>
+          </EmptyStateFooter>
+        )}
+      </EmptyState>
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__mocks__/index.tsx
@@ -16,7 +16,7 @@ import { Props } from '..';
 
 export class DeviceAuthTokensList extends React.PureComponent<Props> {
   render() {
-    const { tokens, onDeleteTokens } = this.props;
+    const { tokens, onDeleteTokens, onConnect, isConnectEnabled } = this.props;
 
     const entries = tokens.map(token => (
       <div key={token.name} data-testid="device-auth-token-entry">
@@ -27,6 +27,15 @@ export class DeviceAuthTokensList extends React.PureComponent<Props> {
       </div>
     ));
 
-    return <div>{entries}</div>;
+    return (
+      <div>
+        {entries}
+        {isConnectEnabled && (
+          <button data-testid="reconnect-token-action" onClick={() => onConnect()}>
+            Reconnect
+          </button>
+        )}
+      </div>
+    );
   }
 }

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__mocks__/index.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+
+import { Props } from '..';
+
+export class DeviceAuthTokensList extends React.PureComponent<Props> {
+  render() {
+    const { tokens, onDeleteTokens } = this.props;
+
+    const entries = tokens.map(token => (
+      <div key={token.name} data-testid="device-auth-token-entry">
+        {token.name}
+        <button data-testid="delete-row-button" onClick={() => onDeleteTokens([token])}>
+          Delete
+        </button>
+      </div>
+    ));
+
+    return <div>{entries}</div>;
+  }
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__tests__/index.spec.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import React from 'react';
+
+import { DeviceAuthTokensList } from '@/pages/UserPreferences/DeviceAuthTokens/List';
+import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
+
+const token1: api.DeviceAuthToken = {
+  name: 'device-authentication-secret-abc12',
+  creationTimestamp: '2024-01-01T00:00:00.000Z',
+};
+const token2: api.DeviceAuthToken = {
+  name: 'device-authentication-secret-xyz34',
+  creationTimestamp: '2024-02-01T00:00:00.000Z',
+};
+
+const mockOnDeleteTokens = jest.fn();
+
+const { renderComponent } = getComponentRenderer(
+  ({ tokens, isDisabled }: { tokens: api.DeviceAuthToken[]; isDisabled?: boolean }) => (
+    <DeviceAuthTokensList
+      tokens={tokens}
+      isDisabled={isDisabled ?? false}
+      onDeleteTokens={mockOnDeleteTokens}
+    />
+  ),
+);
+
+describe('DeviceAuthTokensList', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render token cards', () => {
+    renderComponent({ tokens: [token1] });
+    expect(screen.getByTestId('device-auth-token-row')).not.toBeNull();
+    expect(screen.getByTestId('token-provider')).toHaveTextContent('GitHub');
+    expect(screen.getByTestId('token-name')).toHaveTextContent(token1.name);
+  });
+
+  it('should render multiple token cards', () => {
+    renderComponent({ tokens: [token1, token2] });
+    expect(screen.getAllByTestId('device-auth-token-row')).toHaveLength(2);
+  });
+
+  it('should render token actions toggle', () => {
+    renderComponent({ tokens: [token1] });
+    expect(screen.getByTestId('token-actions-toggle')).not.toBeNull();
+  });
+
+  it('should show valid indicator when token.valid is true', () => {
+    renderComponent({ tokens: [{ ...token1, valid: true }] });
+    expect(screen.getByTitle('Token is valid')).not.toBeNull();
+  });
+
+  it('should show invalid indicator when token.valid is false', () => {
+    renderComponent({ tokens: [{ ...token1, valid: false }] });
+    expect(screen.getByTitle('Token has been revoked or expired')).not.toBeNull();
+  });
+});

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/__tests__/index.spec.tsx
@@ -27,12 +27,16 @@ const token2: api.DeviceAuthToken = {
 
 const mockOnDeleteTokens = jest.fn();
 
+const mockOnConnect = jest.fn();
+
 const { renderComponent } = getComponentRenderer(
   ({ tokens, isDisabled }: { tokens: api.DeviceAuthToken[]; isDisabled?: boolean }) => (
     <DeviceAuthTokensList
       tokens={tokens}
       isDisabled={isDisabled ?? false}
+      isConnectEnabled={true}
       onDeleteTokens={mockOnDeleteTokens}
+      onConnect={mockOnConnect}
     />
   ),
 );
@@ -40,6 +44,11 @@ const { renderComponent } = getComponentRenderer(
 describe('DeviceAuthTokensList', () => {
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('should render Reconnect action toggle', () => {
+    renderComponent({ tokens: [token1] });
+    expect(screen.getByTestId('token-actions-toggle')).not.toBeNull();
   });
 
   it('should render token cards', () => {
@@ -57,15 +66,5 @@ describe('DeviceAuthTokensList', () => {
   it('should render token actions toggle', () => {
     renderComponent({ tokens: [token1] });
     expect(screen.getByTestId('token-actions-toggle')).not.toBeNull();
-  });
-
-  it('should show valid indicator when token.valid is true', () => {
-    renderComponent({ tokens: [{ ...token1, valid: true }] });
-    expect(screen.getByTitle('Token is valid')).not.toBeNull();
-  });
-
-  it('should show invalid indicator when token.valid is false', () => {
-    renderComponent({ tokens: [{ ...token1, valid: false }] });
-    expect(screen.getByTitle('Token has been revoked or expired')).not.toBeNull();
   });
 });

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import {
+  Card,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Content,
+  ContentVariants,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  PageSection,
+} from '@patternfly/react-core';
+import { CheckCircleIcon, EllipsisVIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+import { getFormattedDate } from '@/services/helpers/dates';
+
+export type Props = {
+  tokens: api.DeviceAuthToken[];
+  isDisabled: boolean;
+  onDeleteTokens: (tokens: api.DeviceAuthToken[]) => void;
+};
+
+type State = {
+  openDropdown: string | undefined;
+};
+
+export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { openDropdown: undefined };
+  }
+
+  render(): React.ReactElement {
+    const { tokens, isDisabled, onDeleteTokens } = this.props;
+    const { openDropdown } = this.state;
+
+    const cards = tokens.map(token => {
+      const added = getFormattedDate(
+        token.creationTimestamp ? new Date(token.creationTimestamp) : undefined,
+      );
+
+      return (
+        <Card key={token.name} data-testid="device-auth-token-row">
+          <CardHeader
+            actions={{
+              actions: (
+                <Dropdown
+                  toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                    <MenuToggle
+                      ref={toggleRef}
+                      variant="plain"
+                      isDisabled={isDisabled}
+                      onClick={() =>
+                        this.setState(prev => ({
+                          openDropdown: prev.openDropdown === token.name ? undefined : token.name,
+                        }))
+                      }
+                      isExpanded={openDropdown === token.name}
+                      aria-label="Actions"
+                      data-testid="token-actions-toggle"
+                    >
+                      <EllipsisVIcon />
+                    </MenuToggle>
+                  )}
+                  isOpen={openDropdown === token.name}
+                  onOpenChange={isOpen =>
+                    this.setState({ openDropdown: isOpen ? token.name : undefined })
+                  }
+                  popperProps={{ position: 'right' }}
+                >
+                  <DropdownList>
+                    <DropdownItem
+                      key="delete"
+                      isDanger
+                      isDisabled={isDisabled}
+                      onClick={() => {
+                        this.setState({ openDropdown: undefined });
+                        onDeleteTokens([token]);
+                      }}
+                      data-testid="delete-token-action"
+                    >
+                      Delete
+                    </DropdownItem>
+                  </DropdownList>
+                </Dropdown>
+              ),
+            }}
+          >
+            <CardTitle data-testid="token-provider">
+              {token.provider ?? 'GitHub'}
+              {token.valid === true && (
+                <CheckCircleIcon
+                  color="var(--pf-t--global--color--status--success--default)"
+                  title="Token is valid"
+                  style={{ marginLeft: '0.5rem' }}
+                />
+              )}
+              {token.valid === false && (
+                <ExclamationCircleIcon
+                  color="var(--pf-t--global--color--status--danger--default)"
+                  title="Token has been revoked or expired"
+                  style={{ marginLeft: '0.5rem' }}
+                />
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardFooter>
+            <Content>
+              <Content component={ContentVariants.small} data-testid="token-name">
+                {token.name}
+              </Content>
+              <Content component={ContentVariants.small} data-testid="token-added">
+                Added: {added}
+              </Content>
+            </Content>
+          </CardFooter>
+        </Card>
+      );
+    });
+
+    return <PageSection>{cards}</PageSection>;
+  }
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
@@ -25,7 +25,12 @@ import {
   MenuToggleElement,
   PageSection,
 } from '@patternfly/react-core';
-import { CheckCircleIcon, EllipsisVIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  EllipsisVIcon,
+  ExclamationCircleIcon,
+  QuestionCircleIcon,
+} from '@patternfly/react-icons';
 import React from 'react';
 
 import { CheTooltip } from '@/components/CheTooltip';
@@ -120,7 +125,7 @@ export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
           >
             <CardTitle data-testid="token-provider">
               {token.provider ?? 'GitHub'}
-              {token.valid === true && (
+              {token.valid === 'valid' && (
                 <CheTooltip content={<span>Token is valid</span>}>
                   <CheckCircleIcon
                     color="var(--pf-t--global--color--status--success--default)"
@@ -128,10 +133,18 @@ export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
                   />
                 </CheTooltip>
               )}
-              {token.valid === false && (
+              {token.valid === 'invalid' && (
                 <CheTooltip content={<span>Token has been revoked or expired</span>}>
                   <ExclamationCircleIcon
                     color="var(--pf-t--global--color--status--danger--default)"
+                    style={{ marginLeft: '0.5rem', verticalAlign: 'middle' }}
+                  />
+                </CheTooltip>
+              )}
+              {token.valid === 'unknown' && (
+                <CheTooltip content={<span>Token validity could not be determined</span>}>
+                  <QuestionCircleIcon
+                    color="var(--pf-t--global--color--nonstatus--gray--default)"
                     style={{ marginLeft: '0.5rem', verticalAlign: 'middle' }}
                   />
                 </CheTooltip>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
@@ -124,7 +124,9 @@ export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
             }}
           >
             <CardTitle data-testid="token-provider">
-              {token.provider ?? 'GitHub'}
+              {token.provider != null
+                ? token.provider.charAt(0).toUpperCase() + token.provider.slice(1)
+                : 'GitHub'}
               {token.valid === 'valid' && (
                 <CheTooltip content={<span>Token is valid</span>}>
                   <CheckCircleIcon

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
@@ -25,9 +25,10 @@ import {
   MenuToggleElement,
   PageSection,
 } from '@patternfly/react-core';
-import { EllipsisVIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, EllipsisVIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
+import { CheTooltip } from '@/components/CheTooltip';
 import { getFormattedDate } from '@/services/helpers/dates';
 
 export type Props = {
@@ -117,7 +118,25 @@ export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
               ),
             }}
           >
-            <CardTitle data-testid="token-provider">{token.provider ?? 'GitHub'}</CardTitle>
+            <CardTitle data-testid="token-provider">
+              {token.provider ?? 'GitHub'}
+              {token.valid === true && (
+                <CheTooltip content={<span>Token is valid</span>}>
+                  <CheckCircleIcon
+                    color="var(--pf-t--global--color--status--success--default)"
+                    style={{ marginLeft: '0.5rem', verticalAlign: 'middle' }}
+                  />
+                </CheTooltip>
+              )}
+              {token.valid === false && (
+                <CheTooltip content={<span>Token has been revoked or expired</span>}>
+                  <ExclamationCircleIcon
+                    color="var(--pf-t--global--color--status--danger--default)"
+                    style={{ marginLeft: '0.5rem', verticalAlign: 'middle' }}
+                  />
+                </CheTooltip>
+              )}
+            </CardTitle>
           </CardHeader>
           <CardFooter>
             <Content>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/List/index.tsx
@@ -25,7 +25,7 @@ import {
   MenuToggleElement,
   PageSection,
 } from '@patternfly/react-core';
-import { CheckCircleIcon, EllipsisVIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 import { getFormattedDate } from '@/services/helpers/dates';
@@ -33,7 +33,9 @@ import { getFormattedDate } from '@/services/helpers/dates';
 export type Props = {
   tokens: api.DeviceAuthToken[];
   isDisabled: boolean;
+  isConnectEnabled: boolean;
   onDeleteTokens: (tokens: api.DeviceAuthToken[]) => void;
+  onConnect: () => void;
 };
 
 type State = {
@@ -47,7 +49,7 @@ export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
   }
 
   render(): React.ReactElement {
-    const { tokens, isDisabled, onDeleteTokens } = this.props;
+    const { tokens, isDisabled, isConnectEnabled, onDeleteTokens } = this.props;
     const { openDropdown } = this.state;
 
     const cards = tokens.map(token => {
@@ -85,6 +87,19 @@ export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
                   popperProps={{ position: 'right' }}
                 >
                   <DropdownList>
+                    {isConnectEnabled && (
+                      <DropdownItem
+                        key="reconnect"
+                        isDisabled={isDisabled}
+                        onClick={() => {
+                          this.setState({ openDropdown: undefined });
+                          this.props.onConnect();
+                        }}
+                        data-testid="reconnect-token-action"
+                      >
+                        Reconnect
+                      </DropdownItem>
+                    )}
                     <DropdownItem
                       key="delete"
                       isDanger
@@ -102,23 +117,7 @@ export class DeviceAuthTokensList extends React.PureComponent<Props, State> {
               ),
             }}
           >
-            <CardTitle data-testid="token-provider">
-              {token.provider ?? 'GitHub'}
-              {token.valid === true && (
-                <CheckCircleIcon
-                  color="var(--pf-t--global--color--status--success--default)"
-                  title="Token is valid"
-                  style={{ marginLeft: '0.5rem' }}
-                />
-              )}
-              {token.valid === false && (
-                <ExclamationCircleIcon
-                  color="var(--pf-t--global--color--status--danger--default)"
-                  title="Token has been revoked or expired"
-                  style={{ marginLeft: '0.5rem' }}
-                />
-              )}
-            </CardTitle>
+            <CardTitle data-testid="token-provider">{token.provider ?? 'GitHub'}</CardTitle>
           </CardHeader>
           <CardFooter>
             <Content>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/__tests__/index.spec.tsx
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { StateMock } from '@react-mock/state';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Store } from 'redux';
+
+import { container } from '@/inversify.config';
+import DeviceAuthTokens, { State } from '@/pages/UserPreferences/DeviceAuthTokens';
+import getComponentRenderer, {
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from '@/services/__mocks__/getComponentRenderer';
+import { AppAlerts } from '@/services/alerts/appAlerts';
+import { AlertItem } from '@/services/helpers/types';
+import { AppThunk } from '@/store';
+import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
+import { deviceAuthTokenActionCreators } from '@/store/DeviceAuthToken';
+
+jest.mock('@/pages/UserPreferences/DeviceAuthTokens/ConnectModal');
+jest.mock('@/pages/UserPreferences/DeviceAuthTokens/DeleteModal');
+jest.mock('@/pages/UserPreferences/DeviceAuthTokens/List');
+
+console.error = jest.fn();
+
+const mockShowAlert = jest.fn();
+
+const mockRequestDeviceAuthTokens = jest.fn();
+const mockDeleteDeviceAuthToken = jest.fn();
+jest.mock('@/store/DeviceAuthToken', () => ({
+  ...jest.requireActual('@/store/DeviceAuthToken'),
+  deviceAuthTokenActionCreators: {
+    requestDeviceAuthTokens:
+      (...args): AppThunk =>
+      async () =>
+        mockRequestDeviceAuthTokens(...args),
+    deleteDeviceAuthToken:
+      (...args): AppThunk =>
+      async () =>
+        mockDeleteDeviceAuthToken(...args),
+  } as typeof deviceAuthTokenActionCreators,
+}));
+
+const token1: { name: string; creationTimestamp: string } = {
+  name: 'device-authentication-secret-abc12',
+  creationTimestamp: '2024-01-01T00:00:00.000Z',
+};
+
+const { renderComponent } = getComponentRenderer(getComponent);
+
+describe('DeviceAuthTokens', () => {
+  let storeBuilder: MockStoreBuilder;
+  let localState: Partial<State>;
+
+  beforeEach(() => {
+    storeBuilder = new MockStoreBuilder().withClusterConfig({ githubDeviceAuthEnabled: true });
+
+    class MockAppAlerts extends AppAlerts {
+      showAlert(alert: AlertItem): void {
+        mockShowAlert(alert);
+      }
+    }
+
+    container.snapshot();
+    container.rebind(AppAlerts).to(MockAppAlerts).inSingletonScope();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    container.restore();
+    localState = {};
+  });
+
+  it('should render empty state when there are no tokens', () => {
+    const store = storeBuilder.build();
+    renderComponent(store);
+
+    expect(
+      screen.queryByRole('heading', { name: 'No Device Authentication Tokens' }),
+    ).not.toBeNull();
+  });
+
+  it('should not render empty state with tokens', () => {
+    const store = storeBuilder.withDeviceAuthTokens({ tokens: [token1] }).build();
+    renderComponent(store);
+
+    expect(screen.queryByRole('heading', { name: 'No Device Authentication Tokens' })).toBeNull();
+  });
+
+  it('should request tokens on mount', async () => {
+    const store = storeBuilder.build();
+    renderComponent(store);
+
+    await waitFor(() => expect(mockRequestDeviceAuthTokens).toHaveBeenCalled());
+  });
+
+  describe('connect flow', () => {
+    it('should open ConnectModal when "Connect to GitHub" is clicked on empty state', () => {
+      const store = storeBuilder.build();
+      renderComponent(store);
+
+      expect(screen.getByTestId('connect-modal')).toHaveAttribute('data-is-open', 'false');
+
+      const connectBtn = screen.getByTestId('connect-github-button');
+      fireEvent.click(connectBtn);
+
+      expect(screen.getByTestId('connect-modal')).toHaveAttribute('data-is-open', 'true');
+    });
+
+    it('should close ConnectModal when cancel is clicked', () => {
+      const store = storeBuilder.build();
+      localState = { isConnectOpen: true };
+      renderComponent(store, localState);
+
+      expect(screen.getByTestId('connect-modal')).toHaveAttribute('data-is-open', 'true');
+
+      const closeButton = screen.getByTestId('mock-close-button');
+      fireEvent.click(closeButton);
+
+      expect(screen.getByTestId('connect-modal')).toHaveAttribute('data-is-open', 'false');
+    });
+
+    it('should close ConnectModal and show success alert on connect success', async () => {
+      const store = storeBuilder.build();
+      localState = { isConnectOpen: true };
+      renderComponent(store, localState);
+
+      expect(screen.getByTestId('connect-modal')).toHaveAttribute('data-is-open', 'true');
+
+      const successButton = screen.getByTestId('mock-success-button');
+      fireEvent.click(successButton);
+
+      await waitFor(() =>
+        expect(mockShowAlert).toHaveBeenCalledWith({
+          key: 'device-auth-token-connected',
+          title: 'GitHub account connected successfully.',
+          variant: 'success',
+        } as AlertItem),
+      );
+
+      expect(screen.getByTestId('connect-modal')).toHaveAttribute('data-is-open', 'false');
+    });
+
+    it('should refresh tokens after connect success', async () => {
+      const store = storeBuilder.build();
+      localState = { isConnectOpen: true };
+      renderComponent(store, localState);
+
+      mockRequestDeviceAuthTokens.mockClear();
+      const successButton = screen.getByTestId('mock-success-button');
+      fireEvent.click(successButton);
+
+      await waitFor(() => expect(mockRequestDeviceAuthTokens).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe('delete flow', () => {
+    it('should open delete modal when delete is triggered from list', () => {
+      const store = storeBuilder.withDeviceAuthTokens({ tokens: [token1] }).build();
+      renderComponent(store);
+
+      const entries = screen.getAllByTestId('device-auth-token-entry');
+      const deleteButton = within(entries[0]).getByRole('button', { name: 'Delete' });
+      fireEvent.click(deleteButton);
+
+      expect(screen.queryByTestId('modal-delete-device-auth-token')).not.toBeNull();
+    });
+
+    it('should close the delete modal', () => {
+      const store = storeBuilder.withDeviceAuthTokens({ tokens: [token1] }).build();
+      localState = { isDeleteOpen: true, deletingTokens: [token1] };
+      renderComponent(store, localState);
+
+      expect(screen.queryByTestId('modal-delete-device-auth-token')).not.toBeNull();
+
+      const closeButton = screen.getByTestId('close-modal');
+      fireEvent.click(closeButton);
+
+      expect(screen.queryByTestId('modal-delete-device-auth-token')).toBeNull();
+    });
+
+    it('should delete token and show success notification', async () => {
+      const store = storeBuilder.withDeviceAuthTokens({ tokens: [token1] }).build();
+      localState = { isDeleteOpen: true, deletingTokens: [token1] };
+      renderComponent(store, localState);
+
+      const deleteButton = screen.getByTestId('delete-token');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => expect(mockDeleteDeviceAuthToken).toHaveBeenCalledWith(token1.name));
+
+      await waitFor(() =>
+        expect(mockShowAlert).toHaveBeenCalledWith({
+          key: 'device-auth-token-deleted',
+          title: 'Device Authentication token deleted successfully.',
+          variant: 'success',
+        } as AlertItem),
+      );
+    });
+
+    it('should show error notification when delete fails', async () => {
+      const store = storeBuilder.withDeviceAuthTokens({ tokens: [token1] }).build();
+      localState = { isDeleteOpen: true, deletingTokens: [token1] };
+      renderComponent(store, localState);
+
+      mockDeleteDeviceAuthToken.mockRejectedValueOnce(new Error('delete-error'));
+
+      const deleteButton = screen.getByTestId('delete-token');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() =>
+        expect(mockShowAlert).toHaveBeenCalledWith(expect.objectContaining({ variant: 'danger' })),
+      );
+    });
+  });
+
+  describe('component updated', () => {
+    it('should report error when an error occurs', async () => {
+      const store = storeBuilder.build();
+      const { reRenderComponent } = renderComponent(store);
+
+      const errorMessage = 'device-auth-token-error';
+      const nextStore = new MockStoreBuilder()
+        .withDeviceAuthTokens({ tokens: [], error: errorMessage }, false)
+        .build();
+      reRenderComponent(nextStore);
+
+      await waitFor(() => expect(mockShowAlert).toHaveBeenCalled());
+      expect(mockShowAlert).toHaveBeenCalledWith({
+        key: 'device-auth-token-error',
+        title: errorMessage,
+        variant: 'danger',
+      } as AlertItem);
+    });
+  });
+});
+
+function getComponent(store: Store, localState?: Partial<State>): React.ReactElement {
+  const component = <DeviceAuthTokens />;
+  if (localState) {
+    return (
+      <Provider store={store}>
+        <StateMock state={localState}>{component}</StateMock>
+      </Provider>
+    );
+  }
+  return (
+    <Provider store={store}>
+      <DeviceAuthTokens />
+    </Provider>
+  );
+}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/__tests__/index.spec.tsx
@@ -33,8 +33,6 @@ jest.mock('@/pages/UserPreferences/DeviceAuthTokens/ConnectModal');
 jest.mock('@/pages/UserPreferences/DeviceAuthTokens/DeleteModal');
 jest.mock('@/pages/UserPreferences/DeviceAuthTokens/List');
 
-console.error = jest.fn();
-
 const mockShowAlert = jest.fn();
 
 const mockRequestDeviceAuthTokens = jest.fn();
@@ -63,8 +61,10 @@ const { renderComponent } = getComponentRenderer(getComponent);
 describe('DeviceAuthTokens', () => {
   let storeBuilder: MockStoreBuilder;
   let localState: Partial<State>;
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     storeBuilder = new MockStoreBuilder().withClusterConfig({ githubDeviceAuthEnabled: true });
 
     class MockAppAlerts extends AppAlerts {
@@ -78,6 +78,7 @@ describe('DeviceAuthTokens', () => {
   });
 
   afterEach(() => {
+    consoleErrorSpy.mockRestore();
     jest.clearAllMocks();
     container.restore();
     localState = {};

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
@@ -169,7 +169,9 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
             <DeviceAuthTokensList
               tokens={tokens}
               isDisabled={isLoading}
+              isConnectEnabled={this.props.githubDeviceAuthEnabled}
               onDeleteTokens={selectedTokens => this.handleShowDeleteModal(selectedTokens)}
+              onConnect={() => this.handleOpenConnectModal()}
             />
           )}
         </PageSection>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api, helpers } from '@eclipse-che/common';
+import { AlertVariant, PageSection } from '@patternfly/react-core';
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import ProgressIndicator from '@/components/Progress';
+import { lazyInject } from '@/inversify.config';
+import ConnectModal from '@/pages/UserPreferences/DeviceAuthTokens/ConnectModal';
+import { DeviceAuthTokensDeleteModal } from '@/pages/UserPreferences/DeviceAuthTokens/DeleteModal';
+import { DeviceAuthTokensEmptyState } from '@/pages/UserPreferences/DeviceAuthTokens/EmptyState';
+import { DeviceAuthTokensList } from '@/pages/UserPreferences/DeviceAuthTokens/List';
+import { AppAlerts } from '@/services/alerts/appAlerts';
+import { RootState } from '@/store';
+import { selectGithubDeviceAuthEnabled } from '@/store/ClusterConfig/selectors';
+import {
+  deviceAuthTokenActionCreators,
+  selectDeviceAuthTokenError,
+  selectDeviceAuthTokenIsLoading,
+  selectDeviceAuthTokens,
+} from '@/store/DeviceAuthToken';
+import { selectDefaultNamespace } from '@/store/InfrastructureNamespaces/selectors';
+
+export type Props = MappedProps;
+
+export type State = {
+  isDeleteOpen: boolean;
+  deletingTokens: api.DeviceAuthToken[];
+  isConnectOpen: boolean;
+};
+
+class DeviceAuthTokens extends React.PureComponent<Props, State> {
+  @lazyInject(AppAlerts)
+  private readonly appAlerts: AppAlerts;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      isDeleteOpen: false,
+      deletingTokens: [],
+      isConnectOpen: false,
+    };
+  }
+
+  public async componentDidMount(): Promise<void> {
+    if (this.props.isLoading) {
+      return;
+    }
+    try {
+      await this.props.requestDeviceAuthTokens();
+    } catch (e) {
+      this.appAlerts.showAlert({
+        key: 'request-device-auth-tokens-failed',
+        variant: AlertVariant.danger,
+        title: helpers.errors.getMessage(e),
+      });
+    }
+  }
+
+  public componentDidUpdate(prevProps: Props): void {
+    const { error } = this.props;
+    if (error && error !== prevProps.error) {
+      this.appAlerts.showAlert({
+        key: 'device-auth-token-error',
+        title: helpers.errors.getMessage(error),
+        variant: AlertVariant.danger,
+      });
+    }
+  }
+
+  private handleShowDeleteModal(tokens: api.DeviceAuthToken[]): void {
+    if (tokens.length === 0) {
+      return;
+    }
+    this.setState({ isDeleteOpen: true, deletingTokens: tokens });
+  }
+
+  private handleCloseDeleteModal(): void {
+    this.setState({ isDeleteOpen: false, deletingTokens: [] });
+  }
+
+  private async handleDelete(tokens: api.DeviceAuthToken[]): Promise<void> {
+    this.setState({ isDeleteOpen: false, deletingTokens: [] });
+    const results = await Promise.allSettled(
+      tokens.map(token => this.props.deleteDeviceAuthToken(token.name)),
+    );
+    const failed = results.filter(r => r.status === 'rejected');
+    if (failed.length === 0) {
+      this.appAlerts.showAlert({
+        key: 'device-auth-token-deleted',
+        title:
+          tokens.length === 1
+            ? 'Device Authentication token deleted successfully.'
+            : `${tokens.length} Device Authentication tokens deleted successfully.`,
+        variant: AlertVariant.success,
+      });
+    } else {
+      this.appAlerts.showAlert({
+        key: 'device-auth-token-delete-failed',
+        title: `Failed to delete ${failed.length} of ${tokens.length} token(s).`,
+        variant: AlertVariant.danger,
+      });
+    }
+  }
+
+  private handleOpenConnectModal(): void {
+    this.setState({ isConnectOpen: true });
+  }
+
+  private handleCloseConnectModal(): void {
+    this.setState({ isConnectOpen: false });
+  }
+
+  private async handleConnectSuccess(): Promise<void> {
+    this.setState({ isConnectOpen: false });
+    this.appAlerts.showAlert({
+      key: 'device-auth-token-connected',
+      title: 'GitHub account connected successfully.',
+      variant: AlertVariant.success,
+    });
+    try {
+      await this.props.requestDeviceAuthTokens();
+    } catch {
+      // ignore refresh errors
+    }
+  }
+
+  public render(): React.ReactElement {
+    const { tokens, isLoading, namespace } = this.props;
+    const { isDeleteOpen, deletingTokens, isConnectOpen } = this.state;
+
+    const showEmptyState = tokens.length === 0 && !isLoading;
+    const showList = tokens.length > 0;
+
+    return (
+      <React.Fragment>
+        <ProgressIndicator isLoading={isLoading} />
+        <DeviceAuthTokensDeleteModal
+          isOpen={isDeleteOpen}
+          tokens={deletingTokens}
+          onCloseModal={() => this.handleCloseDeleteModal()}
+          onDelete={tokens => this.handleDelete(tokens)}
+        />
+        <ConnectModal
+          isOpen={isConnectOpen}
+          namespace={namespace}
+          onCloseModal={() => this.handleCloseConnectModal()}
+          onSuccess={() => this.handleConnectSuccess()}
+        />
+        <PageSection>
+          {showEmptyState && (
+            <DeviceAuthTokensEmptyState
+              onConnect={() => this.handleOpenConnectModal()}
+              isConnectEnabled={this.props.githubDeviceAuthEnabled}
+            />
+          )}
+          {showList && (
+            <DeviceAuthTokensList
+              tokens={tokens}
+              isDisabled={isLoading}
+              onDeleteTokens={selectedTokens => this.handleShowDeleteModal(selectedTokens)}
+            />
+          )}
+        </PageSection>
+      </React.Fragment>
+    );
+  }
+}
+
+const mapStateToProps = (state: RootState) => ({
+  tokens: selectDeviceAuthTokens(state),
+  isLoading: selectDeviceAuthTokenIsLoading(state),
+  error: selectDeviceAuthTokenError(state),
+  namespace: selectDefaultNamespace(state).name,
+  githubDeviceAuthEnabled: selectGithubDeviceAuthEnabled(state),
+});
+
+const connector = connect(
+  mapStateToProps,
+  {
+    requestDeviceAuthTokens: deviceAuthTokenActionCreators.requestDeviceAuthTokens,
+    deleteDeviceAuthToken: deviceAuthTokenActionCreators.deleteDeviceAuthToken,
+  },
+  null,
+  { forwardRef: true },
+);
+
+type MappedProps = ConnectedProps<typeof connector>;
+export default connector(DeviceAuthTokens);

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
@@ -39,7 +39,7 @@ export type State = {
   isDeleteOpen: boolean;
   deletingTokens: api.DeviceAuthToken[];
   isConnectOpen: boolean;
-  validatedTokens: Record<string, boolean | undefined>;
+  validatedTokens: Record<string, 'valid' | 'invalid' | 'unknown'>;
 };
 
 class DeviceAuthTokens extends React.PureComponent<Props, State> {
@@ -73,7 +73,9 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
     }
     try {
       await this.props.requestDeviceAuthTokens();
-      this.validateTokensInBackground();
+      // Validation is triggered from componentDidUpdate once the updated tokens
+      // prop arrives — reading this.props.tokens here would be stale due to
+      // React 18 automatic batching deferring the re-render past this point.
     } catch (e) {
       this.appAlerts.showAlert({
         key: 'request-device-auth-tokens-failed',
@@ -84,13 +86,16 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
   }
 
   public componentDidUpdate(prevProps: Props): void {
-    const { error } = this.props;
+    const { error, tokens } = this.props;
     if (error && error !== prevProps.error) {
       this.appAlerts.showAlert({
         key: 'device-auth-token-error',
         title: helpers.errors.getMessage(error),
         variant: AlertVariant.danger,
       });
+    }
+    if (prevProps.tokens.length === 0 && tokens.length > 0) {
+      this.validateTokensInBackground();
     }
   }
 
@@ -156,17 +161,35 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
     this.setState({ isConnectOpen: false });
   }
 
-  private async handleConnectSuccess(): Promise<void> {
+  private async handleConnectSuccess(token: api.DeviceAuthToken): Promise<void> {
     this.setState({ isConnectOpen: false });
     this.appAlerts.showAlert({
       key: 'device-auth-token-connected',
       title: 'GitHub account connected successfully.',
       variant: AlertVariant.success,
     });
+    // Kick off background validation for the new token immediately,
+    // so the status icon appears without waiting for the list re-fetch.
+    const { namespace } = this.props;
+    validateDeviceAuthToken(namespace, token.name)
+      .then(valid => {
+        if (this._isMounted) {
+          this.setState(prev => ({
+            validatedTokens: { ...prev.validatedTokens, [token.name]: valid },
+          }));
+        }
+      })
+      .catch(() => {
+        /* ignore */
+      });
     try {
       await this.props.requestDeviceAuthTokens();
-    } catch {
-      // ignore refresh errors
+    } catch (e) {
+      this.appAlerts.showAlert({
+        key: 'device-auth-token-refresh-failed',
+        title: 'Token added but the list could not be refreshed. Try navigating away and back.',
+        variant: AlertVariant.warning,
+      });
     }
   }
 
@@ -190,7 +213,7 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
           isOpen={isConnectOpen}
           namespace={namespace}
           onCloseModal={() => this.handleCloseConnectModal()}
-          onSuccess={() => this.handleConnectSuccess()}
+          onSuccess={token => this.handleConnectSuccess(token)}
         />
         <PageSection>
           {showEmptyState && (
@@ -201,7 +224,12 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
           )}
           {showList && (
             <DeviceAuthTokensList
-              tokens={tokens.map(t => ({ ...t, valid: validatedTokens[t.name] }))}
+              tokens={tokens.map(t => ({
+                ...t,
+                ...(validatedTokens[t.name] !== undefined
+                  ? { valid: validatedTokens[t.name] }
+                  : {}),
+              }))}
               isDisabled={isLoading}
               isConnectEnabled={this.props.githubDeviceAuthEnabled}
               onDeleteTokens={selectedTokens => this.handleShowDeleteModal(selectedTokens)}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
@@ -94,14 +94,13 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
         variant: AlertVariant.danger,
       });
     }
-    if (prevProps.tokens.length === 0 && tokens.length > 0) {
+    if (tokens.length > 0 && prevProps.tokens !== tokens) {
       this.validateTokensInBackground();
     }
   }
 
   private validateTokensInBackground(): void {
     const { tokens, namespace } = this.props;
-    this.setState({ validatedTokens: {} });
     tokens.forEach(token => {
       validateDeviceAuthToken(namespace, token.name)
         .then(valid => {

--- a/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/DeviceAuthTokens/index.tsx
@@ -22,6 +22,7 @@ import { DeviceAuthTokensDeleteModal } from '@/pages/UserPreferences/DeviceAuthT
 import { DeviceAuthTokensEmptyState } from '@/pages/UserPreferences/DeviceAuthTokens/EmptyState';
 import { DeviceAuthTokensList } from '@/pages/UserPreferences/DeviceAuthTokens/List';
 import { AppAlerts } from '@/services/alerts/appAlerts';
+import { validateDeviceAuthToken } from '@/services/backend-client/deviceAuthTokenApi';
 import { RootState } from '@/store';
 import { selectGithubDeviceAuthEnabled } from '@/store/ClusterConfig/selectors';
 import {
@@ -38,11 +39,14 @@ export type State = {
   isDeleteOpen: boolean;
   deletingTokens: api.DeviceAuthToken[];
   isConnectOpen: boolean;
+  validatedTokens: Record<string, boolean | undefined>;
 };
 
 class DeviceAuthTokens extends React.PureComponent<Props, State> {
   @lazyInject(AppAlerts)
   private readonly appAlerts: AppAlerts;
+
+  private _isMounted = false;
 
   constructor(props: Props) {
     super(props);
@@ -50,15 +54,26 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
       isDeleteOpen: false,
       deletingTokens: [],
       isConnectOpen: false,
+      validatedTokens: {},
     };
   }
 
-  public async componentDidMount(): Promise<void> {
+  public componentDidMount(): void {
+    this._isMounted = true;
+    void this._fetchTokens();
+  }
+
+  public componentWillUnmount(): void {
+    this._isMounted = false;
+  }
+
+  private async _fetchTokens(): Promise<void> {
     if (this.props.isLoading) {
       return;
     }
     try {
       await this.props.requestDeviceAuthTokens();
+      this.validateTokensInBackground();
     } catch (e) {
       this.appAlerts.showAlert({
         key: 'request-device-auth-tokens-failed',
@@ -77,6 +92,25 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
         variant: AlertVariant.danger,
       });
     }
+  }
+
+  private validateTokensInBackground(): void {
+    const { tokens, namespace } = this.props;
+    this.setState({ validatedTokens: {} });
+    tokens.forEach(token => {
+      validateDeviceAuthToken(namespace, token.name)
+        .then(valid => {
+          if (!this._isMounted) {
+            return;
+          }
+          this.setState(prev => ({
+            validatedTokens: { ...prev.validatedTokens, [token.name]: valid },
+          }));
+        })
+        .catch(() => {
+          /* ignore */
+        });
+    });
   }
 
   private handleShowDeleteModal(tokens: api.DeviceAuthToken[]): void {
@@ -138,7 +172,7 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
 
   public render(): React.ReactElement {
     const { tokens, isLoading, namespace } = this.props;
-    const { isDeleteOpen, deletingTokens, isConnectOpen } = this.state;
+    const { isDeleteOpen, deletingTokens, isConnectOpen, validatedTokens = {} } = this.state;
 
     const showEmptyState = tokens.length === 0 && !isLoading;
     const showList = tokens.length > 0;
@@ -167,7 +201,7 @@ class DeviceAuthTokens extends React.PureComponent<Props, State> {
           )}
           {showList && (
             <DeviceAuthTokensList
-              tokens={tokens}
+              tokens={tokens.map(t => ({ ...t, valid: validatedTokens[t.name] }))}
               isDisabled={isLoading}
               isConnectEnabled={this.props.githubDeviceAuthEnabled}
               onDeleteTokens={selectedTokens => this.handleShowDeleteModal(selectedTokens)}

--- a/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/__snapshots__/index.spec.tsx.snap
@@ -137,7 +137,7 @@ exports[`UserPreferences snapshot 1`] = `
                 tabindex="-1"
                 type="button"
               >
-                Device Auth Token
+                Device Auth Tokens
               </button>
             </li>
           </ul>

--- a/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/__snapshots__/index.spec.tsx.snap
@@ -123,6 +123,23 @@ exports[`UserPreferences snapshot 1`] = `
                 SSH Keys
               </button>
             </li>
+            <li
+              class="pf-v6-c-tabs__item"
+              role="presentation"
+            >
+              <button
+                aria-selected="false"
+                class="pf-v6-c-tabs__link"
+                data-ouia-component-type="PF6/TabButton"
+                data-ouia-safe="true"
+                id="pf-tab-DeviceAuthTokens-user-preferences-tabs"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Device Auth Token
+              </button>
+            </li>
           </ul>
         </div>
         <section

--- a/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
@@ -197,7 +197,7 @@ describe('UserPreferences', () => {
       const location = buildUserPreferencesLocation(UserPreferencesTab.DEVICE_AUTH_TOKENS);
       renderComponent(location);
 
-      const tab = screen.getByRole('tab', { name: 'Device Auth Token' });
+      const tab = screen.getByRole('tab', { name: 'Device Auth Tokens' });
       fireEvent.keyDown(tab, { key: 'ArrowRight' });
 
       expect(mockNavigate).toHaveBeenCalledWith(

--- a/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/__tests__/index.spec.tsx
@@ -23,6 +23,7 @@ import { UserPreferencesTab } from '@/services/helpers/types';
 import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
 
 jest.mock('../ContainerRegistriesTab');
+jest.mock('../DeviceAuthTokens');
 jest.mock('../GitConfig');
 jest.mock('../GitServices');
 jest.mock('../PersonalAccessTokens');
@@ -193,10 +194,10 @@ describe('UserPreferences', () => {
     });
 
     it('should wrap around to the first tab on ArrowRight from the last tab', () => {
-      const location = buildUserPreferencesLocation(UserPreferencesTab.SSH_KEYS);
+      const location = buildUserPreferencesLocation(UserPreferencesTab.DEVICE_AUTH_TOKENS);
       renderComponent(location);
 
-      const tab = screen.getByRole('tab', { name: 'SSH Keys' });
+      const tab = screen.getByRole('tab', { name: 'Device Auth Token' });
       fireEvent.keyDown(tab, { key: 'ArrowRight' });
 
       expect(mockNavigate).toHaveBeenCalledWith(
@@ -212,7 +213,7 @@ describe('UserPreferences', () => {
       fireEvent.keyDown(tab, { key: 'ArrowLeft' });
 
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.stringContaining(`tab=${UserPreferencesTab.SSH_KEYS}`),
+        expect.stringContaining(`tab=${UserPreferencesTab.DEVICE_AUTH_TOKENS}`),
       );
     });
 
@@ -236,7 +237,7 @@ describe('UserPreferences', () => {
       fireEvent.keyDown(tab, { key: 'End' });
 
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.stringContaining(`tab=${UserPreferencesTab.SSH_KEYS}`),
+        expect.stringContaining(`tab=${UserPreferencesTab.DEVICE_AUTH_TOKENS}`),
       );
     });
 

--- a/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
@@ -183,7 +183,7 @@ class UserPreferences extends React.PureComponent<Props, State> {
             </Tab>
             <Tab
               eventKey={UserPreferencesTab.DEVICE_AUTH_TOKENS}
-              title="Device Auth Token"
+              title="Device Auth Tokens"
               tabIndex={activeTabKey === UserPreferencesTab.DEVICE_AUTH_TOKENS ? 0 : -1}
             >
               <DeviceAuthTokens />

--- a/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
+++ b/packages/dashboard-frontend/src/pages/UserPreferences/index.tsx
@@ -18,6 +18,7 @@ import { Location, NavigateFunction } from 'react-router-dom';
 import Head from '@/components/Head';
 import AiProviderKeys from '@/pages/UserPreferences/AiProviderKeys';
 import ContainerRegistries from '@/pages/UserPreferences/ContainerRegistriesTab';
+import DeviceAuthTokens from '@/pages/UserPreferences/DeviceAuthTokens';
 import GitConfig from '@/pages/UserPreferences/GitConfig';
 import GitServices from '@/pages/UserPreferences/GitServices';
 import PersonalAccessTokens from '@/pages/UserPreferences/PersonalAccessTokens';
@@ -45,6 +46,7 @@ class UserPreferences extends React.PureComponent<Props, State> {
     UserPreferencesTab.PERSONAL_ACCESS_TOKENS,
     UserPreferencesTab.GITCONFIG,
     UserPreferencesTab.SSH_KEYS,
+    UserPreferencesTab.DEVICE_AUTH_TOKENS,
   ];
 
   constructor(props: Props) {
@@ -68,6 +70,7 @@ class UserPreferences extends React.PureComponent<Props, State> {
         pathname === ROUTE.USER_PREFERENCES &&
         ((tab === UserPreferencesTab.AI_PROVIDER_KEYS && aiEnabled) ||
           tab === UserPreferencesTab.CONTAINER_REGISTRIES ||
+          tab === UserPreferencesTab.DEVICE_AUTH_TOKENS ||
           tab === UserPreferencesTab.GITCONFIG ||
           tab === UserPreferencesTab.GIT_SERVICES ||
           tab === UserPreferencesTab.PERSONAL_ACCESS_TOKENS ||
@@ -177,6 +180,13 @@ class UserPreferences extends React.PureComponent<Props, State> {
               tabIndex={activeTabKey === UserPreferencesTab.SSH_KEYS ? 0 : -1}
             >
               <SshKeys />
+            </Tab>
+            <Tab
+              eventKey={UserPreferencesTab.DEVICE_AUTH_TOKENS}
+              title="Device Auth Token"
+              tabIndex={activeTabKey === UserPreferencesTab.DEVICE_AUTH_TOKENS ? 0 : -1}
+            >
+              <DeviceAuthTokens />
             </Tab>
             {this.props.aiEnabled && (
               <Tab eventKey={UserPreferencesTab.AI_PROVIDER_KEYS} title="AI Providers Keys">

--- a/packages/dashboard-frontend/src/services/backend-client/deviceAuthTokenApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/deviceAuthTokenApi.ts
@@ -72,14 +72,14 @@ export async function pollDeviceAuth(
 export async function validateDeviceAuthToken(
   namespace: string,
   tokenName: string,
-): Promise<boolean | undefined> {
+): Promise<'valid' | 'invalid' | 'unknown'> {
   try {
     const response = await AxiosWrapper.createToRetryMissedBearerTokenError().get(
       `${dashboardBackendPrefix}/namespace/${namespace}/device-auth-token/${encodeURIComponent(tokenName)}/validate`,
     );
-    const { valid } = response.data as { valid: boolean | null };
-    return valid ?? undefined;
+    const { valid } = response.data as { valid: 'valid' | 'invalid' | 'unknown' };
+    return valid;
   } catch {
-    return undefined;
+    return 'unknown';
   }
 }

--- a/packages/dashboard-frontend/src/services/backend-client/deviceAuthTokenApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/deviceAuthTokenApi.ts
@@ -68,3 +68,18 @@ export async function pollDeviceAuth(
     throw new Error(`Failed to poll Device Authentication. ${helpers.errors.getMessage(e)}`);
   }
 }
+
+export async function validateDeviceAuthToken(
+  namespace: string,
+  tokenName: string,
+): Promise<boolean | undefined> {
+  try {
+    const response = await AxiosWrapper.createToRetryMissedBearerTokenError().get(
+      `${dashboardBackendPrefix}/namespace/${namespace}/device-auth-token/${encodeURIComponent(tokenName)}/validate`,
+    );
+    const { valid } = response.data as { valid: boolean | null };
+    return valid ?? undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/dashboard-frontend/src/services/backend-client/deviceAuthTokenApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/deviceAuthTokenApi.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api, helpers } from '@eclipse-che/common';
+
+export type DeviceCodeResponse = api.DeviceCodeResponse;
+export type DeviceAuthPollResult = api.DeviceAuthPollResult;
+
+import { AxiosWrapper } from '@/services/axios-wrapper/axiosWrapper';
+import { dashboardBackendPrefix } from '@/services/backend-client/const';
+
+export async function fetchDeviceAuthTokens(namespace: string): Promise<api.DeviceAuthToken[]> {
+  try {
+    const response = await AxiosWrapper.createToRetryMissedBearerTokenError().get(
+      `${dashboardBackendPrefix}/namespace/${namespace}/device-auth-token`,
+    );
+    return response.data;
+  } catch (e) {
+    throw new Error(
+      `Failed to fetch Device Authentication tokens. ${helpers.errors.getMessage(e)}`,
+    );
+  }
+}
+
+export async function deleteDeviceAuthToken(namespace: string, tokenName: string): Promise<void> {
+  try {
+    await AxiosWrapper.createToRetryMissedBearerTokenError().delete(
+      `${dashboardBackendPrefix}/namespace/${namespace}/device-auth-token/${encodeURIComponent(tokenName)}`,
+    );
+  } catch (e) {
+    throw new Error(
+      `Failed to delete Device Authentication token. ${helpers.errors.getMessage(e)}`,
+    );
+  }
+}
+
+export async function initiateDeviceAuth(namespace: string): Promise<DeviceCodeResponse> {
+  try {
+    const response = await AxiosWrapper.createToRetryMissedBearerTokenError().post(
+      `${dashboardBackendPrefix}/namespace/${namespace}/device-auth-token/initiate`,
+    );
+    return response.data;
+  } catch (e) {
+    throw new Error(`Failed to initiate Device Authentication. ${helpers.errors.getMessage(e)}`);
+  }
+}
+
+export async function pollDeviceAuth(
+  namespace: string,
+  deviceCode: string,
+): Promise<DeviceAuthPollResult> {
+  try {
+    const response = await AxiosWrapper.createToRetryMissedBearerTokenError().post(
+      `${dashboardBackendPrefix}/namespace/${namespace}/device-auth-token/poll`,
+      { deviceCode },
+    );
+    return response.data;
+  } catch (e) {
+    throw new Error(`Failed to poll Device Authentication. ${helpers.errors.getMessage(e)}`);
+  }
+}

--- a/packages/dashboard-frontend/src/services/helpers/types.ts
+++ b/packages/dashboard-frontend/src/services/helpers/types.ts
@@ -127,6 +127,7 @@ export enum WorkspaceAction {
 export enum UserPreferencesTab {
   AI_PROVIDER_KEYS = 'AiProviderKeys',
   CONTAINER_REGISTRIES = 'ContainerRegistries',
+  DEVICE_AUTH_TOKENS = 'DeviceAuthTokens',
   GIT_SERVICES = 'GitServices',
   GITCONFIG = 'Gitconfig',
   PERSONAL_ACCESS_TOKENS = 'PersonalAccessTokens',

--- a/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/reducer.spec.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/__tests__/reducer.spec.ts
@@ -32,6 +32,7 @@ describe('ClusterConfig, reducer', () => {
       clusterConfig: {
         allWorkspacesLimit: -1,
         runningWorkspacesLimit: 1,
+        githubDeviceAuthEnabled: false,
       },
       isLoading: true,
       error: undefined,
@@ -46,6 +47,7 @@ describe('ClusterConfig, reducer', () => {
       allWorkspacesLimit: -1,
       runningWorkspacesLimit: 1,
       currentArchitecture: 'x86_64',
+      githubDeviceAuthEnabled: true,
     };
 
     const action = clusterConfigReceiveAction(clusterConfig);
@@ -65,6 +67,7 @@ describe('ClusterConfig, reducer', () => {
       clusterConfig: {
         allWorkspacesLimit: -1,
         runningWorkspacesLimit: 1,
+        githubDeviceAuthEnabled: false,
       },
       isLoading: false,
       error: 'Error message',
@@ -79,6 +82,7 @@ describe('ClusterConfig, reducer', () => {
       clusterConfig: {
         allWorkspacesLimit: -1,
         runningWorkspacesLimit: 1,
+        githubDeviceAuthEnabled: false,
       },
       isLoading: false,
       error: undefined,

--- a/packages/dashboard-frontend/src/store/ClusterConfig/reducer.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/reducer.ts
@@ -31,6 +31,7 @@ export const unloadedState: State = {
     runningWorkspacesLimit: 1,
     allWorkspacesLimit: -1,
     currentArchitecture: undefined,
+    githubDeviceAuthEnabled: false,
   },
 };
 

--- a/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
+++ b/packages/dashboard-frontend/src/store/ClusterConfig/selectors.ts
@@ -42,3 +42,8 @@ export const selectCurrentArchitecture = createSelector(
   selectState,
   state => state.clusterConfig.currentArchitecture as Architecture,
 );
+
+export const selectGithubDeviceAuthEnabled = createSelector(
+  selectState,
+  state => state.clusterConfig.githubDeviceAuthEnabled === true,
+);

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/__tests__/actions.spec.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/__tests__/actions.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api, helpers } from '@eclipse-che/common';
+
+import {
+  deleteDeviceAuthToken,
+  fetchDeviceAuthTokens,
+  initiateDeviceAuth as apiInitiateDeviceAuth,
+} from '@/services/backend-client/deviceAuthTokenApi';
+import { createMockStore } from '@/store/__mocks__/mockActionsTestStore';
+import {
+  actionCreators,
+  deviceAuthTokenErrorAction,
+  deviceAuthTokenReceiveAction,
+  deviceAuthTokenRemoveAction,
+  deviceAuthTokenRequestAction,
+} from '@/store/DeviceAuthToken/actions';
+import * as infrastructureNamespacesSelectors from '@/store/InfrastructureNamespaces/selectors';
+import { verifyAuthorized } from '@/store/SanityCheck';
+
+jest.mock('@eclipse-che/common');
+jest.mock('@/services/backend-client/deviceAuthTokenApi');
+jest.mock('@/store/SanityCheck');
+
+const mockNamespace = 'test-namespace';
+jest
+  .spyOn(infrastructureNamespacesSelectors, 'selectDefaultNamespace')
+  .mockReturnValue({ name: mockNamespace, attributes: { default: 'true', phase: 'Active' } });
+
+const token1: api.DeviceAuthToken = { name: 'device-authentication-secret-abc12' };
+
+describe('DeviceAuthToken, actions', () => {
+  let store: ReturnType<typeof createMockStore>;
+
+  beforeEach(() => {
+    store = createMockStore({});
+    jest.clearAllMocks();
+  });
+
+  describe('requestDeviceAuthTokens', () => {
+    it('should dispatch receive action on successful fetch', async () => {
+      (verifyAuthorized as jest.Mock).mockResolvedValue(true);
+      (fetchDeviceAuthTokens as jest.Mock).mockResolvedValue([token1]);
+
+      await store.dispatch(actionCreators.requestDeviceAuthTokens());
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(deviceAuthTokenRequestAction());
+      expect(actions[1]).toEqual(deviceAuthTokenReceiveAction([token1]));
+    });
+
+    it('should dispatch error action on failed fetch', async () => {
+      const errorMessage = 'Network error';
+
+      (verifyAuthorized as jest.Mock).mockResolvedValue(true);
+      (fetchDeviceAuthTokens as jest.Mock).mockRejectedValue(new Error(errorMessage));
+      (helpers.errors.getMessage as jest.Mock).mockReturnValue(errorMessage);
+
+      await expect(store.dispatch(actionCreators.requestDeviceAuthTokens())).rejects.toThrow(
+        errorMessage,
+      );
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(deviceAuthTokenRequestAction());
+      expect(actions[1]).toEqual(deviceAuthTokenErrorAction(errorMessage));
+    });
+  });
+
+  describe('deleteDeviceAuthToken', () => {
+    it('should dispatch remove action on successful delete', async () => {
+      (verifyAuthorized as jest.Mock).mockResolvedValue(true);
+      (deleteDeviceAuthToken as jest.Mock).mockResolvedValue(undefined);
+
+      await store.dispatch(actionCreators.deleteDeviceAuthToken(token1.name));
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(deviceAuthTokenRequestAction());
+      expect(actions[1]).toEqual(deviceAuthTokenRemoveAction(token1.name));
+    });
+
+    it('should dispatch error action on failed delete', async () => {
+      const errorMessage = 'Delete failed';
+
+      (verifyAuthorized as jest.Mock).mockResolvedValue(true);
+      (deleteDeviceAuthToken as jest.Mock).mockRejectedValue(new Error(errorMessage));
+      (helpers.errors.getMessage as jest.Mock).mockReturnValue(errorMessage);
+
+      await expect(
+        store.dispatch(actionCreators.deleteDeviceAuthToken(token1.name)),
+      ).rejects.toThrow(errorMessage);
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(deviceAuthTokenRequestAction());
+      expect(actions[1]).toEqual(deviceAuthTokenErrorAction(errorMessage));
+    });
+  });
+
+  describe('initiateDeviceAuth', () => {
+    it('should return DeviceCodeResponse on success', async () => {
+      const response = {
+        deviceCode: 'dev-code',
+        userCode: 'ABCD-1234',
+        verificationUri: 'https://github.com/login/device',
+        interval: 5,
+      };
+      (verifyAuthorized as jest.Mock).mockResolvedValue(true);
+      (apiInitiateDeviceAuth as jest.Mock).mockResolvedValue(response);
+
+      const result = await store.dispatch(actionCreators.initiateDeviceAuth());
+      expect(result).toEqual(response);
+      expect(apiInitiateDeviceAuth).toHaveBeenCalledWith(mockNamespace);
+    });
+
+    it('should throw on API failure', async () => {
+      (verifyAuthorized as jest.Mock).mockResolvedValue(true);
+      (apiInitiateDeviceAuth as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+      await expect(store.dispatch(actionCreators.initiateDeviceAuth())).rejects.toThrow(
+        'Network error',
+      );
+    });
+  });
+});

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/__tests__/reducers.spec.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/__tests__/reducers.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import { UnknownAction } from 'redux';
+
+import {
+  deviceAuthTokenErrorAction,
+  deviceAuthTokenReceiveAction,
+  deviceAuthTokenRemoveAction,
+  deviceAuthTokenRequestAction,
+} from '@/store/DeviceAuthToken/actions';
+import { DeviceAuthTokenState, reducer, unloadedState } from '@/store/DeviceAuthToken/reducer';
+
+describe('DeviceAuthToken, reducer', () => {
+  let initialState: DeviceAuthTokenState;
+
+  beforeEach(() => {
+    initialState = { ...unloadedState };
+  });
+
+  it('should handle deviceAuthTokenRequestAction', () => {
+    const action = deviceAuthTokenRequestAction();
+    const expectedState: DeviceAuthTokenState = {
+      ...initialState,
+      isLoading: true,
+    };
+
+    expect(reducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle deviceAuthTokenReceiveAction', () => {
+    const tokens = [{ name: 'device-authentication-secret-abc12' }] as api.DeviceAuthToken[];
+    const action = deviceAuthTokenReceiveAction(tokens);
+    const expectedState: DeviceAuthTokenState = {
+      ...initialState,
+      isLoading: false,
+      tokens,
+    };
+
+    expect(reducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle deviceAuthTokenRemoveAction — filters by name', () => {
+    const token1: api.DeviceAuthToken = { name: 'device-authentication-secret-abc12' };
+    const token2: api.DeviceAuthToken = { name: 'device-authentication-secret-xyz34' };
+    const stateWithTokens: DeviceAuthTokenState = {
+      ...initialState,
+      tokens: [token1, token2],
+    };
+
+    const action = deviceAuthTokenRemoveAction(token1.name);
+    const expectedState: DeviceAuthTokenState = {
+      ...stateWithTokens,
+      isLoading: false,
+      tokens: [token2],
+    };
+
+    expect(reducer(stateWithTokens, action)).toEqual(expectedState);
+  });
+
+  it('should handle deviceAuthTokenErrorAction', () => {
+    const error = 'Something went wrong';
+    const action = deviceAuthTokenErrorAction(error);
+    const expectedState: DeviceAuthTokenState = {
+      ...initialState,
+      isLoading: false,
+      error,
+    };
+
+    expect(reducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should return the current state for unknown actions', () => {
+    const unknownAction = { type: 'UNKNOWN_ACTION' } as UnknownAction;
+    expect(reducer(initialState, unknownAction)).toEqual(initialState);
+  });
+});

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/__tests__/selectors.spec.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/__tests__/selectors.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { RootState } from '@/store';
+import {
+  selectDeviceAuthTokenError,
+  selectDeviceAuthTokenIsLoading,
+  selectDeviceAuthTokens,
+} from '@/store/DeviceAuthToken/selectors';
+
+describe('DeviceAuthToken, selectors', () => {
+  const mockState = {
+    deviceAuthToken: {
+      isLoading: true,
+      tokens: [
+        { name: 'device-authentication-secret-abc12' },
+        { name: 'device-authentication-secret-xyz34' },
+      ],
+      error: 'Something went wrong',
+    },
+  } as RootState;
+
+  it('should select isLoading', () => {
+    expect(selectDeviceAuthTokenIsLoading(mockState)).toBe(true);
+  });
+
+  it('should select tokens', () => {
+    expect(selectDeviceAuthTokens(mockState)).toEqual([
+      { name: 'device-authentication-secret-abc12' },
+      { name: 'device-authentication-secret-xyz34' },
+    ]);
+  });
+
+  it('should select error', () => {
+    expect(selectDeviceAuthTokenError(mockState)).toBe('Something went wrong');
+  });
+});

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/actions.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/actions.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api, helpers } from '@eclipse-che/common';
+import { createAction } from '@reduxjs/toolkit';
+
+import {
+  deleteDeviceAuthToken,
+  DeviceCodeResponse,
+  fetchDeviceAuthTokens,
+  initiateDeviceAuth as apiInitiateDeviceAuth,
+} from '@/services/backend-client/deviceAuthTokenApi';
+import { AppThunk } from '@/store';
+import { selectDefaultNamespace } from '@/store/InfrastructureNamespaces/selectors';
+import { verifyAuthorized } from '@/store/SanityCheck';
+
+export const deviceAuthTokenRequestAction = createAction('deviceAuthToken/request');
+export const deviceAuthTokenReceiveAction =
+  createAction<api.DeviceAuthToken[]>('deviceAuthToken/receive');
+export const deviceAuthTokenRemoveAction = createAction<string>('deviceAuthToken/remove');
+export const deviceAuthTokenErrorAction = createAction<string>('deviceAuthToken/error');
+
+export const actionCreators = {
+  requestDeviceAuthTokens: (): AppThunk => async (dispatch, getState) => {
+    const state = getState();
+    const namespace = selectDefaultNamespace(state).name;
+    try {
+      await verifyAuthorized(dispatch, getState);
+
+      dispatch(deviceAuthTokenRequestAction());
+
+      const tokens = await fetchDeviceAuthTokens(namespace);
+      dispatch(deviceAuthTokenReceiveAction(tokens));
+    } catch (e) {
+      const errorMessage = helpers.errors.getMessage(e);
+      dispatch(deviceAuthTokenErrorAction(errorMessage));
+      throw e;
+    }
+  },
+
+  deleteDeviceAuthToken:
+    (tokenName: string): AppThunk =>
+    async (dispatch, getState) => {
+      const state = getState();
+      const namespace = selectDefaultNamespace(state).name;
+      try {
+        await verifyAuthorized(dispatch, getState);
+
+        dispatch(deviceAuthTokenRequestAction());
+
+        await deleteDeviceAuthToken(namespace, tokenName);
+        dispatch(deviceAuthTokenRemoveAction(tokenName));
+      } catch (e) {
+        const errorMessage = helpers.errors.getMessage(e);
+        dispatch(deviceAuthTokenErrorAction(errorMessage));
+        throw e;
+      }
+    },
+
+  initiateDeviceAuth: (): AppThunk<Promise<DeviceCodeResponse>> => async (dispatch, getState) => {
+    const state = getState();
+    const namespace = selectDefaultNamespace(state).name;
+    await verifyAuthorized(dispatch, getState);
+    return apiInitiateDeviceAuth(namespace);
+  },
+};

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/actions.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/actions.ts
@@ -70,6 +70,7 @@ export const actionCreators = {
     const state = getState();
     const namespace = selectDefaultNamespace(state).name;
     await verifyAuthorized(dispatch, getState);
+    // Pass namespace so the backend can bind the device code to this user's namespace (security)
     return apiInitiateDeviceAuth(namespace);
   },
 };

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/index.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/index.ts
@@ -1,0 +1,21 @@
+/* c8 ignore start */
+
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export { actionCreators as deviceAuthTokenActionCreators } from '@/store/DeviceAuthToken/actions';
+export {
+  reducer as deviceAuthTokenReducer,
+  DeviceAuthTokenState,
+  unloadedState as deviceAuthTokenUnloadedState,
+} from '@/store/DeviceAuthToken/reducer';
+export * from '@/store/DeviceAuthToken/selectors';

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/reducer.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/reducer.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { api } from '@eclipse-che/common';
+import { createReducer } from '@reduxjs/toolkit';
+
+import {
+  deviceAuthTokenErrorAction,
+  deviceAuthTokenReceiveAction,
+  deviceAuthTokenRemoveAction,
+  deviceAuthTokenRequestAction,
+} from '@/store/DeviceAuthToken/actions';
+
+export type DeviceAuthTokenState = {
+  tokens: api.DeviceAuthToken[];
+  isLoading: boolean;
+  error: string | undefined;
+};
+
+export const unloadedState: DeviceAuthTokenState = {
+  tokens: [],
+  isLoading: false,
+  error: undefined,
+};
+
+export const reducer = createReducer(unloadedState, builder =>
+  builder
+    .addCase(deviceAuthTokenRequestAction, state => {
+      state.isLoading = true;
+      state.error = undefined;
+    })
+    .addCase(deviceAuthTokenReceiveAction, (state, action) => {
+      state.isLoading = false;
+      state.tokens = action.payload;
+    })
+    .addCase(deviceAuthTokenRemoveAction, (state, action) => {
+      state.isLoading = false;
+      state.tokens = state.tokens.filter(t => t.name !== action.payload);
+    })
+    .addCase(deviceAuthTokenErrorAction, (state, action) => {
+      state.isLoading = false;
+      state.error = action.payload;
+    })
+    .addDefaultCase(state => state),
+);

--- a/packages/dashboard-frontend/src/store/DeviceAuthToken/selectors.ts
+++ b/packages/dashboard-frontend/src/store/DeviceAuthToken/selectors.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { createSelector } from '@reduxjs/toolkit';
+
+import { RootState } from '@/store';
+
+const selectState = (state: RootState) => state.deviceAuthToken;
+
+export const selectDeviceAuthTokens = createSelector(selectState, state => state.tokens);
+
+export const selectDeviceAuthTokenIsLoading = createSelector(selectState, state => state.isLoading);
+
+export const selectDeviceAuthTokenError = createSelector(selectState, state => state.error);

--- a/packages/dashboard-frontend/src/store/__mocks__/mockStore.ts
+++ b/packages/dashboard-frontend/src/store/__mocks__/mockStore.ts
@@ -111,6 +111,10 @@ export class MockStoreBuilder {
           dashboardWarning:
             clusterConfig.dashboardWarning ??
             this.state.clusterConfig?.clusterConfig.dashboardWarning,
+          githubDeviceAuthEnabled:
+            clusterConfig.githubDeviceAuthEnabled ??
+            this.state.clusterConfig?.clusterConfig.githubDeviceAuthEnabled ??
+            false,
         },
         isLoading,
         error,
@@ -457,6 +461,24 @@ export class MockStoreBuilder {
       ...this.state,
       sshKeys: {
         keys: options.keys || [],
+        error: options.error,
+        isLoading,
+      },
+    };
+    return this;
+  }
+
+  public withDeviceAuthTokens(
+    options: {
+      tokens?: api.DeviceAuthToken[];
+      error?: string;
+    },
+    isLoading = false,
+  ) {
+    this.state = {
+      ...this.state,
+      deviceAuthToken: {
+        tokens: options.tokens || [],
         error: options.error,
         isLoading,
       },

--- a/packages/dashboard-frontend/src/store/rootReducer.ts
+++ b/packages/dashboard-frontend/src/store/rootReducer.ts
@@ -17,6 +17,7 @@ import { brandingReducer } from '@/store/Branding';
 import { clusterConfigReducer } from '@/store/ClusterConfig';
 import { clusterInfoReducer } from '@/store/ClusterInfo';
 import { devfileRegistriesReducer } from '@/store/DevfileRegistries';
+import { deviceAuthTokenReducer } from '@/store/DeviceAuthToken';
 import { devWorkspacesClusterReducer } from '@/store/DevWorkspacesCluster';
 import { dockerConfigReducer } from '@/store/DockerConfig';
 import { eventsReducer } from '@/store/Events';
@@ -46,6 +47,7 @@ export const rootReducer = {
   clusterConfig: clusterConfigReducer,
   clusterInfo: clusterInfoReducer,
   devfileRegistries: devfileRegistriesReducer,
+  deviceAuthToken: deviceAuthTokenReducer,
   devWorkspaces: devWorkspacesReducer,
   devWorkspacesCluster: devWorkspacesClusterReducer,
   dockerConfig: dockerConfigReducer,


### PR DESCRIPTION
### What does this PR do?

Adds a **Device Auth Tokens** tab to the User Preferences page with two capabilities:

1. **Connect to GitHub** — A **Connect to GitHub** button opens a modal displaying a one-time code with a copy button and a **"Copy & Continue to Browser"** primary button. The backend polls GitHub for authorization (RFC 8628) and on success writes a `che.eclipse.org/device-authentication=true` Kubernetes Secret to the user's namespace. The button appears automatically when the `device-auth-config` ConfigMap is present in the Che namespace — fully independent of Git Services OAuth configuration.

2. **View & delete (single and bulk)** — A compact card list (matching SSH Keys UI) shows stored tokens. A per-row **Actions ⋮** menu provides **Delete** and **Reconnect** actions. Deleting removes the K8s Secret **and** revokes the GitHub token via `POST /credentials/revoke` (no app credentials required). Reconnecting replaces the existing token (single-active-token model matching che-code). Replacing an existing secret preserves its `resourceVersion` and any extra labels applied by che-code or a mutating webhook.

Device Authentication tokens are GitHub OAuth tokens generated by the device authorization flow (RFC 8628). They are stored as Kubernetes Secrets labeled `che.eclipse.org/device-authentication=true`. Previously the only way to generate or remove a token was through the VS Code command palette inside a running workspace.


### Screenshot/screencast of this PR
<img width="1425" height="675" alt="Device Auth Tokens tab" src="https://github.com/user-attachments/assets/fb2b3959-d13c-495d-adc7-57b5a0bc4b02" />
<img width="1425" height="675" alt="Connect to GitHub modal" src="https://github.com/user-attachments/assets/e09292e8-30f9-4a94-b2a5-637893671e5b" />

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11582

### Is it tested? How?

**Unit / integration tests**

- `getDeviceAuthClientId.spec.ts` — 6 tests: ConfigMap read, TTL cache hit, env-var override, missing namespace, K8s 404
- `deviceAuthToken.spec.ts` — 4 route tests: 503 when ConfigMap absent, correct delegation when present
- `deviceAuthTokenApi.spec.ts` — 27 tests updated: clientId passed as parameter, revocation success path, createNamespacedSecret argument shape

**Deploy and verify**

1. Deploy Che with the PR image:

```bash
kubectl patch -n eclipse-che "checluster/eclipse-che" --type=json -p='[{"op": "replace", "path": "/spec/components/dashboard/deployment", "value": {"containers": [{"image": "quay.io/eclipse/che-dashboard:pr-1633", "name": "che-dashboard"}]}}]'
```

2. Apply the `device-auth-config` ConfigMap. Use VS Code's public OAuth App (`01ab8ac9400c4e429b23`) — it has Device Flow enabled by default and supports GitHub Copilot:

```bash
kubectl -n eclipse-che create configmap device-auth-config \
  --from-literal=github_client_id=01ab8ac9400c4e429b23
```

3. Navigate to **User Preferences → Device Auth Tokens**.
4. Click **Copy & Continue to Browser** → paste the code on `github.com/login/device` → authorize.
5. Verify: the token card appears with a validity icon.
6. Click **⋮ → Reconnect** to replace the token; **⋮ → Delete** to revoke and remove it.
7. Delete the ConfigMap and reload — verify the **Connect to GitHub** button is hidden.
8. Without the ConfigMap, call `POST .../device-auth-token/initiate` directly — verify HTTP 503 is returned.

#### Release Notes

Added a Device Auth Tokens tab to User Preferences. Users can connect their GitHub account using device authorization directly from the Dashboard, view tokens with on-demand validity checks, and delete/revoke tokens without requiring app credentials. The feature is enabled by creating a `device-auth-config` ConfigMap in the Che namespace — fully independent of Git Services OAuth.

#### Docs PR

https://github.com/eclipse-che/che-docs/pull/3168
