### PR TITLE
fix(a11y): Fixed workspace creation steps/sub-steps announcement.

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/Wizard/index.tsx
@@ -21,6 +21,7 @@ import { StepId } from '..';
 export interface WorkspaceProgressWizardStep {
   id: StepId;
   name: React.ReactNode;
+  ariaLabel?: string;
   canJumpTo?: boolean;
   isFinishedStep?: boolean;
   component?: React.ReactNode;
@@ -105,7 +106,7 @@ class WorkspaceProgressWizard extends React.Component<Props> {
     return (
       <WizardNav aria-label="Workspace Progress Steps">
         {stepsWithDefaults.map(step => {
-          const { canJumpTo, name, steps = [], id } = step;
+          const { ariaLabel, canJumpTo, name, steps = [], id } = step;
 
           const hasChildren = steps.length !== 0;
           const allChildrenFinished = steps.every(subStep => subStep.isFinishedStep);
@@ -120,6 +121,7 @@ class WorkspaceProgressWizard extends React.Component<Props> {
                 className={this.navLinkClassName(isCurrent, !canJumpTo)}
                 aria-current={isCurrent ? 'step' : undefined}
                 aria-disabled={!canJumpTo ? true : undefined}
+                aria-label={ariaLabel}
                 tabIndex={canJumpTo ? 0 : -1}
               >
                 <span className={wizardStyles.wizardNavLinkMain}>{name}</span>
@@ -127,7 +129,7 @@ class WorkspaceProgressWizard extends React.Component<Props> {
               {showChildren && (
                 <WizardNav isInnerList>
                   {steps.map(subStep => {
-                    const { canJumpTo, name, id } = subStep;
+                    const { ariaLabel, canJumpTo, name, id } = subStep;
                     const isSubCurrent = activeStepId === id;
 
                     return (
@@ -136,6 +138,7 @@ class WorkspaceProgressWizard extends React.Component<Props> {
                           className={this.navLinkClassName(isSubCurrent, !canJumpTo)}
                           aria-current={isSubCurrent ? 'step' : undefined}
                           aria-disabled={!canJumpTo ? true : undefined}
+                          aria-label={ariaLabel}
                           tabIndex={canJumpTo ? 0 : -1}
                         >
                           <span className={wizardStyles.wizardNavLinkMain}>{name}</span>

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/__tests__/__snapshots__/index.spec.tsx.snap
@@ -17,6 +17,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
       >
         <span
           aria-current="step"
+          aria-label="Initializing"
           className="pf-v6-c-wizard__nav-link pf-m-current"
           tabIndex={0}
         >
@@ -72,6 +73,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
         className="pf-v6-c-wizard__nav-item"
       >
         <span
+          aria-label="Checking for the limit of running workspaces"
           className="pf-v6-c-wizard__nav-link"
           tabIndex={0}
         >
@@ -127,6 +129,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
         className="pf-v6-c-wizard__nav-item"
       >
         <span
+          aria-label="Creating a workspace"
           className="pf-v6-c-wizard__nav-link"
           tabIndex={0}
         >
@@ -185,6 +188,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
+              aria-label="Fetching a devfile"
               className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
@@ -240,6 +244,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
+              aria-label="Checking existing workspaces"
               className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
@@ -295,6 +300,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
+              aria-label="Waiting for SCC permission"
               className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
@@ -350,6 +356,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
             className="pf-v6-c-wizard__nav-item"
           >
             <span
+              aria-label="Applying a devfile"
               className="pf-v6-c-wizard__nav-link"
               tabIndex={0}
             >
@@ -407,6 +414,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
         className="pf-v6-c-wizard__nav-item"
       >
         <span
+          aria-label="Waiting for workspace to start"
           className="pf-v6-c-wizard__nav-link"
           tabIndex={0}
         >
@@ -462,6 +470,7 @@ exports[`LoaderProgress workspace creation flow snapshot 1`] = `
         className="pf-v6-c-wizard__nav-item"
       >
         <span
+          aria-label="Open IDE"
           className="pf-v6-c-wizard__nav-link"
           tabIndex={0}
         >
@@ -535,6 +544,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
       >
         <span
           aria-current="step"
+          aria-label="Initializing"
           className="pf-v6-c-wizard__nav-link pf-m-current"
           tabIndex={0}
         >
@@ -590,6 +600,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
         className="pf-v6-c-wizard__nav-item"
       >
         <span
+          aria-label="Checking for the limit of running workspaces"
           className="pf-v6-c-wizard__nav-link"
           tabIndex={0}
         >
@@ -645,6 +656,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
         className="pf-v6-c-wizard__nav-item"
       >
         <span
+          aria-label="Waiting for workspace to start"
           className="pf-v6-c-wizard__nav-link"
           tabIndex={0}
         >
@@ -700,6 +712,7 @@ exports[`LoaderProgress workspace starting flow snapshot 1`] = `
         className="pf-v6-c-wizard__nav-item"
       >
         <span
+          aria-label="Open IDE"
           className="pf-v6-c-wizard__nav-link"
           tabIndex={0}
         >

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/index.tsx
@@ -402,6 +402,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.INITIALIZE,
+      ariaLabel: 'Initializing',
       name: (
         <CreatingStepInitialize
           distance={this.getDistance(Step.INITIALIZE)}
@@ -428,6 +429,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.INITIALIZE,
+      ariaLabel: 'Initializing',
       name: (
         <StartingStepInitialize
           distance={this.getDistance(Step.INITIALIZE)}
@@ -455,6 +457,7 @@ class Progress extends React.Component<Props, State> {
     return [
       {
         id: Step.LIMIT_CHECK,
+        ariaLabel: 'Checking for the limit of running workspaces',
         name: (
           <CommonStepCheckRunningWorkspacesLimit
             distance={this.getDistance(Step.LIMIT_CHECK)}
@@ -492,6 +495,7 @@ class Progress extends React.Component<Props, State> {
     return [
       {
         id: Step.CREATE,
+        ariaLabel: 'Creating a workspace',
         name: (
           <CreatingStepCreateWorkspace
             distance={distance}
@@ -518,6 +522,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.CONFLICT_CHECK,
+      ariaLabel: 'Checking existing workspaces',
       isFinishedStep: distance === 1,
       name: (
         <CreatingStepCheckExistingWorkspaces
@@ -543,6 +548,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.SCC_CHECK,
+      ariaLabel: 'Waiting for SCC permission',
       isFinishedStep: distance === 1,
       name: (
         <CreatingStepCheckSccPermission
@@ -567,6 +573,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.FETCH,
+      ariaLabel: 'Fetching pre-built resources',
       isFinishedStep: distance === 1,
       name: (
         <CreatingStepFetchResources
@@ -592,6 +599,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.APPLY,
+      ariaLabel: 'Applying resources',
       isFinishedStep: distance === 1,
       name: (
         <CreatingStepApplyResources
@@ -617,6 +625,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.FETCH,
+      ariaLabel: 'Fetching a devfile',
       isFinishedStep: distance === 1,
       name: (
         <CreatingStepFetchDevfile
@@ -642,6 +651,7 @@ class Progress extends React.Component<Props, State> {
 
     return {
       id: Step.APPLY,
+      ariaLabel: 'Applying a devfile',
       isFinishedStep: distance === 1,
       name: (
         <CreatingStepApplyDevfile
@@ -679,6 +689,7 @@ class Progress extends React.Component<Props, State> {
     return [
       {
         id: Step.START,
+        ariaLabel: 'Waiting for workspace to start',
         name: (
           <StartingStepStartWorkspace
             distance={this.getDistance(Step.START)}
@@ -697,6 +708,7 @@ class Progress extends React.Component<Props, State> {
       },
       {
         id: Step.OPEN,
+        ariaLabel: 'Open IDE',
         name: (
           <StartingStepOpenWorkspace
             distance={this.getDistance(Step.OPEN)}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes announces for main steps when step is focused by Tab.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-11826

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->
1. start workspace empty workspace
2. on Workspace Creation Page: using Tab move to workspace creation steps
3. verify they are announced once in focus

#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->