### PR TITLE
fix: show Empty Workspace when internal registry is disabled

### DIFF
--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
@@ -14,7 +14,9 @@ import { container } from '@/inversify.config';
 import { provisionKubernetesNamespace } from '@/services/backend-client/kubernetesNamespaceApi';
 import { WebsocketClient } from '@/services/backend-client/websocketClient';
 import Bootstrap from '@/services/bootstrap';
+import { WorkspaceStoppedDetector } from '@/services/bootstrap/workspaceStoppedDetector';
 import { ResourceFetcherService } from '@/services/resource-fetcher';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
 import { bannerAlertActionCreators } from '@/store/BannerAlert';
 import { brandingActionCreators } from '@/store/Branding';
@@ -183,5 +185,64 @@ describe('Dashboard bootstrap', () => {
     expect(mockWebsocketClient.subscribeToChannel).toHaveBeenNthCalledWith(3, 'pod', 'test-che', {
       getResourceVersion: expect.any(Function),
     });
+  });
+
+  test('calls getWorkspaceTimeout when a stopped workspace with timeout issue is detected', async () => {
+    const devWorkspace = new DevWorkspaceBuilder()
+      .withId('wksp-inactive')
+      .withName('wksp-inactive')
+      .withNamespace('user-dev')
+      .withStatus({ phase: 'Stopped' })
+      .build();
+
+    const mockDetector = {
+      checkWorkspaceStopped: jest.fn().mockReturnValue({
+        id: 'wksp-inactive',
+        ideUrl: undefined,
+      }),
+      getWorkspaceStoppedIssueType: jest.fn().mockReturnValue('workspaceInactive'),
+      getWorkspaceStoppedError: jest.fn().mockReturnValue(new Error('workspace inactive')),
+    };
+    container
+      .rebind(WorkspaceStoppedDetector)
+      .toConstantValue(mockDetector as unknown as WorkspaceStoppedDetector);
+
+    const store = new MockStoreBuilder()
+      .withDevWorkspaces({ workspaces: [devWorkspace] })
+      .withDwServerConfig({
+        timeouts: {
+          inactivityTimeout: 1800,
+          runTimeout: 3600,
+          startTimeout: 300,
+          axiosRequestTimeout: 30000,
+          sessionTimeout: 86400,
+        },
+      })
+      .build();
+    const bootstrap = new Bootstrap(store);
+
+    await expect(bootstrap.init()).resolves.toBeUndefined();
+
+    expect(mockDetector.checkWorkspaceStopped).toHaveBeenCalled();
+    expect(mockDetector.getWorkspaceStoppedIssueType).toHaveBeenCalled();
+    expect(mockDetector.getWorkspaceStoppedError).toHaveBeenCalled();
+  });
+
+  test('fetches embedded registry when disableInternalRegistry is true', async () => {
+    const store = new MockStoreBuilder()
+      .withDwServerConfig({
+        devfileRegistry: {
+          disableInternalRegistry: true,
+          externalDevfileRegistries: [{ url: 'https://registry.devfile.io' }],
+        },
+      })
+      .build();
+    const bootstrap = new Bootstrap(store);
+
+    await expect(bootstrap.init()).resolves.toBeUndefined();
+
+    // DEFAULT_REGISTRY (embedded, always available) + external registry = 2 calls.
+    // getting-started-sample and airgap-sample are skipped when internal registry is disabled.
+    expect(devfileRegistriesActionCreators.requestRegistriesMetadata).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -342,18 +342,21 @@ export default class Bootstrap {
     const { requestRegistriesMetadata } = devfileRegistriesActionCreators;
     const serverConfig = this.store.getState().dwServerConfig.config;
     const devfileRegistry = serverConfig.devfileRegistry;
+    // The dashboard always serves its own embedded registry (which includes the Empty Workspace
+    // entry). Fetch it unconditionally so the Empty Workspace option is always available,
+    // even when disableInternalRegistry is true and the external devfile-registry pod is gone.
+    const defaultRegistry = DEFAULT_REGISTRY.startsWith('http')
+      ? DEFAULT_REGISTRY
+      : new URL(DEFAULT_REGISTRY, window.location.origin).href;
+    await requestRegistriesMetadata(defaultRegistry, false)(
+      this.store.dispatch,
+      this.store.getState,
+      undefined,
+    );
+
     const isInternalRegistryDisabled = devfileRegistry?.disableInternalRegistry === true;
 
     if (!isInternalRegistryDisabled) {
-      const defaultRegistry = DEFAULT_REGISTRY.startsWith('http')
-        ? DEFAULT_REGISTRY
-        : new URL(DEFAULT_REGISTRY, window.location.origin).href;
-      await requestRegistriesMetadata(defaultRegistry, false)(
-        this.store.dispatch,
-        this.store.getState,
-        undefined,
-      );
-
       const gettingStartedSampleURL = new URL(
         '/dashboard/api/getting-started-sample',
         window.location.origin,


### PR DESCRIPTION
### What does this PR do?

Fixes the Empty Workspace option disappearing from the Create Workspace page when
the operator configures an external devfile registry and disables the internal one.

### Root Cause

`fetchRegistriesMetadata()` in `services/bootstrap/index.ts` gated three fetches
behind a single `isInternalRegistryDisabled` flag:

```typescript
if (!isInternalRegistryDisabled) {
  await requestRegistriesMetadata(defaultRegistry, false)(...);   // DEFAULT_REGISTRY
  await requestRegistriesMetadata(gettingStartedSampleURL, false)(...);
  await requestRegistriesMetadata(airGapedSampleURL, false)(...);
}
```

### Screenshot/screencast of this PR

**Before** (fresh `next` install, `disableInternalRegistry: true`):
Empty Workspace is absent — only Devfile.io samples are shown.
<img width="1854" height="891" alt="Image" src="https://github.com/user-attachments/assets/670539e2-ea9f-449d-b9b5-41370223bda5" />

**After** (same install with this fix):
Empty Workspace appears first in the list, above all Devfile.io samples.
<img width="1768" height="737" alt="Знімок екрана 2026-07-23 о 00 56 08" src="https://github.com/user-attachments/assets/e826ed51-8eed-4d99-a092-04332cd8b633" />

### What issues does this PR fix or reference?

fixes https://github.com/eclipse-che/che/issues/23916

### Is it tested? How?

1. Deploy Eclipse Che `next` with `chectl server:deploy -p openshift` (deploys with
   `disableInternalRegistry: true` and `externalDevfileRegistries: [{url: "https://registry.devfile.io"}]`
   by default).
2. Navigate to **Create Workspace**.
3. Verify **Empty Workspace** appears as the first tile in the **Select a Sample** section.

#### Release Notes

Fixed the Empty Workspace option not appearing on the Create Workspace page after a
fresh Che installation that uses an external devfile registry.

#### Docs PR

N/A
