### PR TITLE
fix: handle GitLab blob URLs in factory location parser

### DIFF
--- a/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/__tests__/helpers.spec.tsx
@@ -108,6 +108,37 @@ describe('helpers', () => {
     });
   });
 
+  describe('getRepositoryUrlFromLocation', () => {
+    describe('gitlab', () => {
+      test('should return repo URL from tree URL', () => {
+        expect(
+          helpers.getRepositoryUrlFromLocation(
+            'https://gitlab.com/eclipse-che/che-dashboard/-/tree/main',
+          ),
+        ).toBe('https://gitlab.com/eclipse-che/che-dashboard');
+      });
+      test('should return repo URL from blob URL', () => {
+        expect(
+          helpers.getRepositoryUrlFromLocation(
+            'https://gitlab.com/eclipse-che/che-dashboard/-/blob/main/devfile.yaml',
+          ),
+        ).toBe('https://gitlab.com/eclipse-che/che-dashboard');
+      });
+      test('should return repo URL from blob URL with subgroups', () => {
+        expect(
+          helpers.getRepositoryUrlFromLocation(
+            'https://gitlab.com/group/subgroup/repo/-/blob/main/devfile.yaml',
+          ),
+        ).toBe('https://gitlab.com/group/subgroup/repo');
+      });
+      test('should return repo URL unchanged when no tree or blob', () => {
+        expect(
+          helpers.getRepositoryUrlFromLocation('https://gitlab.com/eclipse-che/che-dashboard.git'),
+        ).toBe('https://gitlab.com/eclipse-che/che-dashboard.git');
+      });
+    });
+  });
+
   describe('getBranchFromLocation', () => {
     describe('supported GitServices', () => {
       const branch = 'main';
@@ -135,6 +166,28 @@ describe('helpers', () => {
           expect(
             helpers.getBranchFromLocation(
               `https://gitlab.com/eclipse-che/che-dashboard/-/tree/${branch}`,
+            ),
+          ).toBe(branch);
+        });
+        test('should return slashed branch from tree URL', () => {
+          expect(
+            helpers.getBranchFromLocation(
+              'https://gitlab.com/eclipse-che/che-dashboard/-/tree/feature/my-branch',
+            ),
+          ).toBe('feature/my-branch');
+        });
+        test('should return the revision from blob URL', () => {
+          const revision = 'f14e0f02e16a38d73115f8bf3b9d46f7b35fb5a9';
+          expect(
+            helpers.getBranchFromLocation(
+              `https://gitlab.com/eclipse-che/che-dashboard/-/blob/${revision}/devfile.yaml`,
+            ),
+          ).toBe(revision);
+        });
+        test('should return the branch name from blob URL', () => {
+          expect(
+            helpers.getBranchFromLocation(
+              `https://gitlab.com/eclipse-che/che-dashboard/-/blob/${branch}/devfile.yaml`,
             ),
           ).toBe(branch);
         });
@@ -231,6 +284,15 @@ describe('helpers', () => {
               branch,
             ),
           ).toBe(`https://gitlab.com/group/subgroup/repository.git/-/tree/${branch}`);
+        });
+        test('should convert blob URL to tree URL with branch', () => {
+          const revision = 'f14e0f02e16a38d73115f8bf3b9d46f7b35fb5a9';
+          expect(
+            helpers.setBranchToLocation(
+              `https://gitlab.com/eclipse-che/che-dashboard/-/blob/${revision}/devfile.yaml`,
+              branch,
+            ),
+          ).toBe(`https://gitlab.com/eclipse-che/che-dashboard/-/tree/${branch}`);
         });
       });
       describe('Bitbucket', () => {
@@ -334,6 +396,53 @@ describe('helpers', () => {
             gitBranch: undefined,
             remotes: undefined,
             devfilePath: undefined,
+          });
+        });
+        test('should return options from GitLab blob URL', () => {
+          const revision = 'f14e0f02e16a38d73115f8bf3b9d46f7b35fb5a9';
+          const location = `https://gitlab.com/eclipse-che/che-dashboard/-/blob/${revision}/devfile.yaml`;
+          const options = helpers.getGitRepoOptionsFromLocation(location);
+          expect(options).toEqual({
+            location: `https://gitlab.com/eclipse-che/che-dashboard/-/blob/${revision}/devfile.yaml`,
+            hasSupportedGitService: true,
+            gitBranch: revision,
+            remotes: [],
+            devfilePath: 'devfile.yaml',
+          });
+        });
+        test('should return options from GitLab blob URL with branch name', () => {
+          const location = 'https://gitlab.com/eclipse-che/che-dashboard/-/blob/main/devfile.yaml';
+          const options = helpers.getGitRepoOptionsFromLocation(location);
+          expect(options).toEqual({
+            location: 'https://gitlab.com/eclipse-che/che-dashboard/-/blob/main/devfile.yaml',
+            hasSupportedGitService: true,
+            gitBranch: 'main',
+            remotes: [],
+            devfilePath: 'devfile.yaml',
+          });
+        });
+        test('should return options from GitLab blob URL with nested file path', () => {
+          const revision = 'f14e0f02e16a38d73115f8bf3b9d46f7b35fb5a9';
+          const location = `https://gitlab.com/eclipse-che/che-dashboard/-/blob/${revision}/path/to/devfile.yaml`;
+          const options = helpers.getGitRepoOptionsFromLocation(location);
+          expect(options).toEqual({
+            location: `https://gitlab.com/eclipse-che/che-dashboard/-/blob/${revision}/path/to/devfile.yaml`,
+            hasSupportedGitService: true,
+            gitBranch: revision,
+            remotes: [],
+            devfilePath: 'path/to/devfile.yaml',
+          });
+        });
+        test('should return options from GitLab blob URL with subgroups', () => {
+          const revision = 'f14e0f02e16a38d73115f8bf3b9d46f7b35fb5a9';
+          const location = `https://gitlab.com/group/subgroup/repo/-/blob/${revision}/devfile.yaml`;
+          const options = helpers.getGitRepoOptionsFromLocation(location);
+          expect(options).toEqual({
+            location: `https://gitlab.com/group/subgroup/repo/-/blob/${revision}/devfile.yaml`,
+            hasSupportedGitService: true,
+            gitBranch: revision,
+            remotes: [],
+            devfilePath: 'devfile.yaml',
           });
         });
         test('should return all supported options', () => {

--- a/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
+++ b/packages/dashboard-frontend/src/components/ImportFromGit/helpers.ts
@@ -88,6 +88,9 @@ export function getRepositoryUrlFromLocation(location: string): string {
       break;
     case 'gitlab':
       indexOf = location.indexOf('/-/tree');
+      if (indexOf < 0) {
+        indexOf = location.indexOf('/-/blob');
+      }
       if (indexOf > 0) {
         repo = location.substring(0, indexOf);
       }
@@ -126,11 +129,15 @@ export function getBranchFromLocation(location: string): string | undefined {
         branch = pathname.slice(3).join('/');
       }
       break;
-    case 'gitlab':
-      if (pathname[2] === '-' && pathname[3] === 'tree') {
-        branch = pathname.slice(4).join('/');
+    case 'gitlab': {
+      const dashIdx = pathname.indexOf('-');
+      if (dashIdx >= 0 && pathname[dashIdx + 1] === 'tree') {
+        branch = pathname.slice(dashIdx + 2).join('/');
+      } else if (dashIdx >= 0 && pathname[dashIdx + 1] === 'blob') {
+        branch = pathname[dashIdx + 2];
       }
       break;
+    }
     case 'bitbucket-server':
       if (pathname[2] === 'src') {
         branch = pathname.slice(3).join('/');
@@ -209,7 +216,7 @@ export function setBranchToLocation(location: string, branch: string | undefined
         url.pathname = `${user}/${project}/tree/${branch}`;
         break;
       case 'gitlab':
-        url.pathname = `${pathname.replace(/\/-\/tree\/.*$/, '')}/-/tree/${branch}`;
+        url.pathname = `${pathname.replace(/\/-\/(tree|blob)\/.*$/, '')}/-/tree/${branch}`;
         break;
       case 'bitbucket-server':
         url.pathname = `${user}/${project}/src/${branch}`;
@@ -300,7 +307,19 @@ export function getGitRepoOptionsFromLocation(location: string): {
   hasSupportedGitService: boolean;
 } {
   const { path, searchParams } = getFactoryParamsFromLocation(location);
-  const devfilePath = searchParams.get('devfilePath') || undefined;
+  let devfilePath = searchParams.get('devfilePath') || undefined;
+
+  if (
+    !devfilePath &&
+    isSupportedGitService(location) &&
+    getSupportedGitService(location) === 'gitlab'
+  ) {
+    const pathname = new URL(location).pathname.replace(/^\//, '').replace(/\/$/, '').split('/');
+    const blobIdx = pathname.indexOf('-');
+    if (blobIdx >= 0 && pathname[blobIdx + 1] === 'blob' && pathname.length > blobIdx + 3) {
+      devfilePath = pathname.slice(blobIdx + 3).join('/');
+    }
+  }
   let remotes: GitRemote[] | undefined;
   const _remotes = searchParams.get('remotes') || undefined;
   if (_remotes === 'true' || _remotes === '{}') {


### PR DESCRIPTION
### What does this PR do?

Fix GitLab URL handling in the factory location parser. Two issues:

1. `/-/blob/<revision>/<file>` URLs are not supported at all - repo URL, revision, and devfile path are lost
2. `/-/tree/<branch>` URLs break for repos with subgroups (`group/subgroup/repo`) because the parser uses a fixed pathname index instead of finding `-` dynamically

### Screenshot/screencast of this PR

N/A - URL parsing logic, no UI changes.

### What issues does this PR fix or reference?

Part of https://issues.redhat.com/browse/CRW-10083

### Is it tested? How?


#### Release Notes

Fixed: GitLab `/-/blob/` URLs are now correctly parsed when creating workspaces, extracting the repository URL, revision, and devfile path. Also fixed `/-/tree/` URL parsing for repositories with subgroups.

#### Docs PR

N/A