### PR TITLE
fix: include devfilePath in workspace reuse check

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
@@ -831,6 +831,96 @@ describe('Creating steps, checking existing workspaces', () => {
         await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
         expect(mockTabManagerReplace).not.toHaveBeenCalled();
       });
+
+      it('should reuse a workspace created without override when the factory URL specifies the resolver default source', async () => {
+        const defaultSource = 'devfile.yaml';
+        const localSearchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: factoryUrl,
+          'override.devfileFilename': defaultSource,
+        });
+        // Workspace was created without override.devfileFilename (devfilePath = undefined)
+        const localStore = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: workspaceName,
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: { params: `url=${factoryUrl}` },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withFactoryResolver({
+            resolver: {
+              source: defaultSource,
+              location: factoryUrl,
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: { name: workspaceName },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(localStore, localSearchParams);
+
+        await waitFor(() =>
+          expect(mockTabManagerReplace).toHaveBeenCalledWith(
+            expect.stringContaining(`/ide/user-che/${workspaceName}`),
+          ),
+        );
+      });
+
+      it('should reuse a workspace created with the explicit default source when the factory URL has no override', async () => {
+        const defaultSource = 'devfile.yaml';
+        const localSearchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: factoryUrl,
+          // no override.devfileFilename
+        });
+        // Workspace was created with override.devfileFilename=devfile.yaml (devfilePath = "devfile.yaml")
+        const localStore = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: workspaceName,
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: `url=${factoryUrl}&override.devfileFilename=${defaultSource}`,
+                      },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withFactoryResolver({
+            resolver: {
+              source: defaultSource,
+              location: factoryUrl,
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: { name: workspaceName },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(localStore, localSearchParams);
+
+        await waitFor(() =>
+          expect(mockTabManagerReplace).toHaveBeenCalledWith(
+            expect.stringContaining(`/ide/user-che/${workspaceName}`),
+          ),
+        );
+      });
     });
 
     describe('with several existing workspace created from the same repository', () => {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
@@ -921,6 +921,58 @@ describe('Creating steps, checking existing workspaces', () => {
           ),
         );
       });
+
+      it('should show alert when normalization reveals an existing workspace (buildAlertItem path)', async () => {
+        const defaultSource = 'devfile.yaml';
+        // Factory URL explicitly names the default source; existing targets a non-existent name
+        // so the conflict alert fires instead of silently redirecting.
+        const localSearchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: factoryUrl,
+          'override.devfileFilename': defaultSource,
+          [EXISTING_WORKSPACE_NAME]: 'no-such-workspace',
+        });
+        // Workspace was created without override.devfileFilename (devfilePath = undefined)
+        const localStore = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: workspaceName,
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: { params: `url=${factoryUrl}` },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withFactoryResolver({
+            resolver: {
+              source: defaultSource,
+              location: factoryUrl,
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: { name: workspaceName },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(localStore, localSearchParams);
+        await jest.advanceTimersByTimeAsync(MIN_STEP_DURATION_MS);
+
+        const expectAlertItem = expect.objectContaining({
+          title: 'Existing workspace found',
+          children: expect.stringContaining(workspaceName),
+          actionCallbacks: [
+            expect.objectContaining({ title: 'Open the existing workspace' }),
+            expect.objectContaining({ title: 'Create a new workspace' }),
+          ],
+        });
+        await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(expectAlertItem));
+      });
     });
 
     describe('with several existing workspace created from the same repository', () => {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/__tests__/index.spec.tsx
@@ -752,6 +752,87 @@ describe('Creating steps, checking existing workspaces', () => {
         });
       });
     });
+    describe('devfilePath in factory params', () => {
+      const devfilePath = 'apps/appA/devfile.yaml';
+      const differentDevfilePath = 'apps/appB/devfile.yaml';
+
+      it('should open the existing workspace with the same devfilePath', async () => {
+        const localSearchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: factoryUrl,
+          'override.devfileFilename': devfilePath,
+        });
+        const localStore = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: workspaceName,
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: `url=${factoryUrl}&override.devfileFilename=${devfilePath}`,
+                      },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .withFactoryResolver({
+            resolver: {
+              location: factoryUrl,
+              devfile: {
+                schemaVersion: '2.1.0',
+                metadata: { name: workspaceName },
+              } as devfileApi.Devfile,
+            },
+          })
+          .build();
+
+        renderComponent(localStore, localSearchParams);
+
+        await waitFor(() =>
+          expect(mockTabManagerReplace).toHaveBeenCalledWith(
+            expect.stringContaining(`/ide/user-che/${workspaceName}`),
+          ),
+        );
+      });
+
+      it('should not reuse the workspace when devfilePath differs', async () => {
+        const localSearchParams = new URLSearchParams({
+          [FACTORY_URL_ATTR]: factoryUrl,
+          'override.devfileFilename': differentDevfilePath,
+        });
+        const localStore = new MockStoreBuilder()
+          .withDevWorkspaces({
+            workspaces: [
+              new DevWorkspaceBuilder()
+                .withMetadata({
+                  name: workspaceName,
+                  namespace: 'user-che',
+                  annotations: {
+                    [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+                      factory: {
+                        params: `url=${factoryUrl}&override.devfileFilename=${devfilePath}`,
+                      },
+                    }),
+                  },
+                })
+                .build(),
+            ],
+          })
+          .build();
+
+        renderComponent(localStore, localSearchParams);
+
+        await jest.runOnlyPendingTimersAsync();
+
+        await waitFor(() => expect(mockOnNextStep).toHaveBeenCalled());
+        expect(mockTabManagerReplace).not.toHaveBeenCalled();
+      });
+    });
+
     describe('with several existing workspace created from the same repository', () => {
       describe('DEVWORKSPACE_DEVFILE_SOURCE conflict faced', () => {
         beforeEach(() => {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
@@ -157,10 +157,12 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
     }
 
     // check if there are existing workspaces created from the same repo
+    const resolvedSource =
+      factoryResolver?.location === factoryParams.sourceUrl ? factoryResolver.source : undefined;
     const sameRepoWorkspaces = this.getSameRepoWorkspaces(
       allWorkspaces,
       factoryParams,
-      factoryResolver?.source,
+      resolvedSource,
     );
     if (sameRepoWorkspaces.length > 0) {
       let existingWorkspace: Workspace | undefined = undefined;
@@ -268,10 +270,13 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
     const { factoryParams } = this.state;
     const key = this.name;
 
+    const { factoryResolver } = this.props;
+    const resolvedSource =
+      factoryResolver?.location === factoryParams.sourceUrl ? factoryResolver.source : undefined;
     const sameRepoWorkspaces = this.getSameRepoWorkspaces(
       allWorkspaces,
       factoryParams,
-      this.props.factoryResolver?.source,
+      resolvedSource,
     );
     let title: string;
     let openExistingWorkspaceAction: ActionCallback | ActionGroup;

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
@@ -157,7 +157,11 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
     }
 
     // check if there are existing workspaces created from the same repo
-    const sameRepoWorkspaces = this.getSameRepoWorkspaces(allWorkspaces, factoryParams);
+    const sameRepoWorkspaces = this.getSameRepoWorkspaces(
+      allWorkspaces,
+      factoryParams,
+      factoryResolver?.source,
+    );
     if (sameRepoWorkspaces.length > 0) {
       let existingWorkspace: Workspace | undefined = undefined;
       if (factoryParams.existing) {
@@ -232,8 +236,13 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
   private getSameRepoWorkspaces(
     workspaces: Workspace[],
     factoryParams: FactoryParams,
+    resolvedDefaultSource?: string,
   ): Workspace[] {
     const factoryDevfilePath = factoryParams.overrides?.['override.devfileFilename'];
+    // Normalize: when devfileFilename is omitted, fall back to the resolver's source
+    // so that a workspace created without the override matches one created with the
+    // explicit default filename (e.g. devfile.yaml) and vice-versa.
+    const effectiveFactoryDevfilePath = factoryDevfilePath ?? resolvedDefaultSource;
     return workspaces.filter(workspace => {
       let revision: string | undefined;
       const projects = workspace.ref.spec.template.projects;
@@ -245,10 +254,11 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
           }
         }
       }
+      const effectiveWorkspaceDevfilePath = workspace.devfilePath ?? resolvedDefaultSource;
       return (
         workspace.source === factoryParams.sourceUrl &&
         revision === factoryParams.revision &&
-        workspace.devfilePath === factoryDevfilePath
+        effectiveWorkspaceDevfilePath === effectiveFactoryDevfilePath
       );
     });
   }
@@ -258,7 +268,11 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
     const { factoryParams } = this.state;
     const key = this.name;
 
-    const sameRepoWorkspaces = this.getSameRepoWorkspaces(allWorkspaces, factoryParams);
+    const sameRepoWorkspaces = this.getSameRepoWorkspaces(
+      allWorkspaces,
+      factoryParams,
+      this.props.factoryResolver?.source,
+    );
     let title: string;
     let openExistingWorkspaceAction: ActionCallback | ActionGroup;
     if (sameRepoWorkspaces.length > 1) {

--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/CreatingSteps/CheckExistingWorkspaces/index.tsx
@@ -233,6 +233,7 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
     workspaces: Workspace[],
     factoryParams: FactoryParams,
   ): Workspace[] {
+    const factoryDevfilePath = factoryParams.overrides?.['override.devfileFilename'];
     return workspaces.filter(workspace => {
       let revision: string | undefined;
       const projects = workspace.ref.spec.template.projects;
@@ -244,7 +245,11 @@ class CreatingStepCheckExistingWorkspaces extends ProgressStep<Props, State> {
           }
         }
       }
-      return workspace.source === factoryParams.sourceUrl && revision === factoryParams.revision;
+      return (
+        workspace.source === factoryParams.sourceUrl &&
+        revision === factoryParams.revision &&
+        workspace.devfilePath === factoryDevfilePath
+      );
     });
   }
 

--- a/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/__tests__/index.spec.ts
@@ -364,4 +364,46 @@ describe('for DevWorkspace', () => {
       expect(workspace.source).toEqual('https://dummy.repo/devfile.yaml');
     });
   });
+
+  describe('devfilePath', () => {
+    it('should return undefined if devfile source is not defined', () => {
+      const devWorkspace = new DevWorkspaceBuilder().build();
+      const workspace = constructWorkspace(devWorkspace);
+      expect(workspace.devfilePath).toBeUndefined();
+    });
+
+    it('should return devfilePath from override.devfileFilename in factory params', () => {
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withMetadata({
+          name: 'test-workspace',
+          annotations: {
+            [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+              factory: {
+                params: 'url=https://dummy.repo&override.devfileFilename=apps/appA/devfile.yaml',
+              },
+            }),
+          },
+        })
+        .build();
+      const workspace = constructWorkspace(devWorkspace);
+      expect(workspace.devfilePath).toEqual('apps/appA/devfile.yaml');
+    });
+
+    it('should return undefined when override.devfileFilename is not in factory params', () => {
+      const devWorkspace = new DevWorkspaceBuilder()
+        .withMetadata({
+          name: 'test-workspace',
+          annotations: {
+            [DEVWORKSPACE_DEVFILE_SOURCE]: dump({
+              factory: {
+                params: 'url=https://dummy.repo',
+              },
+            }),
+          },
+        })
+        .build();
+      const workspace = constructWorkspace(devWorkspace);
+      expect(workspace.devfilePath).toBeUndefined();
+    });
+  });
 });

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -40,6 +40,7 @@ export interface Workspace {
   readonly infrastructureNamespace: string;
   readonly created: number;
   readonly source?: string; // the repository URL or the factory URL
+  readonly devfilePath?: string; // the override.devfileFilename from factory params
   readonly updated: number;
   status: WorkspaceStatus | DevWorkspaceStatus | DeprecatedWorkspaceStatus;
   readonly ideUrl?: string;
@@ -233,6 +234,21 @@ export class WorkspaceAdapter<T extends devfileApi.DevWorkspace> implements Work
     }
     // If no URL found, return undefined
     return undefined;
+  }
+
+  get devfilePath(): string | undefined {
+    const devfileSourceStr = this.workspace.metadata.annotations?.[DEVWORKSPACE_DEVFILE_SOURCE];
+    if (!devfileSourceStr) {
+      return undefined;
+    }
+    const devfileSource = load(devfileSourceStr) as {
+      factory?: { params?: string };
+    };
+    const rawFactoryParams = devfileSource?.factory?.params;
+    if (!rawFactoryParams) {
+      return undefined;
+    }
+    return new URLSearchParams(rawFactoryParams).get('override.devfileFilename') ?? undefined;
   }
 
   /**

--- a/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
+++ b/packages/dashboard-frontend/src/services/workspace-adapter/index.ts
@@ -196,18 +196,16 @@ export class WorkspaceAdapter<T extends devfileApi.DevWorkspace> implements Work
       return undefined;
     }
     // Parse the devfile source annotation to extract the repository URL
-    const devfileSource = load(devfileSourceStr) as {
-      factory?: {
-        params?: string;
-      };
-      scm?: {
-        repo?: string;
-        fileName?: string;
-      };
-      url?: {
-        location?: string;
-      };
+    let devfileSource: {
+      factory?: { params?: string };
+      scm?: { repo?: string; fileName?: string };
+      url?: { location?: string };
     };
+    try {
+      devfileSource = load(devfileSourceStr) as typeof devfileSource;
+    } catch {
+      return undefined;
+    }
     // Check if the devfile source has a factory with parameters.
     // Use URLSearchParams.get() so that '=' characters inside the URL value are
     // handled correctly (the old split('=')[1] approach truncates the value at the
@@ -241,9 +239,12 @@ export class WorkspaceAdapter<T extends devfileApi.DevWorkspace> implements Work
     if (!devfileSourceStr) {
       return undefined;
     }
-    const devfileSource = load(devfileSourceStr) as {
-      factory?: { params?: string };
-    };
+    let devfileSource: { factory?: { params?: string } };
+    try {
+      devfileSource = load(devfileSourceStr) as typeof devfileSource;
+    } catch {
+      return undefined;
+    }
     const rawFactoryParams = devfileSource?.factory?.params;
     if (!rawFactoryParams) {
       return undefined;


### PR DESCRIPTION
### What does this PR do?

Fixes workspace reuse incorrectly ignoring `devfilePath` when checking for an existing workspace from the same repository.

#### Root Cause

`getSameRepoWorkspaces()` in `CheckExistingWorkspaces` matched workspaces using only the source URL and revision. When a factory link included `?devfilePath=apps/appA.yaml`, the parameter was forwarded to the factory resolver as `override.devfileFilename` but was never stored in `FactoryParams` for deduplication purposes. As a result, opening a second factory link pointing to a different devfile in the same repo — e.g. `?devfilePath=apps/appB.yaml` — matched the workspace from `appA.yaml` and reopened it instead of creating a new one.

#### Fix

Adds a `devfilePath` getter to `WorkspaceAdapter` that reads `override.devfileFilename` from the `factory.params` annotation stored on each DevWorkspace. The `getSameRepoWorkspaces()` filter now includes this value in its equality check alongside source URL and revision.

```diff
-      return workspace.source === factoryParams.sourceUrl && revision === factoryParams.revision;
+      return (
+        workspace.source === factoryParams.sourceUrl &&
+        revision === factoryParams.revision &&
+        workspace.devfilePath === factoryDevfilePath
+      );
```

Two workspaces created from the same repo are now considered distinct when they were started from different devfiles, and the same workspace is still correctly reused when the source URL, revision, and devfile path all match.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-10861

### Is it tested? How?

1. Deploy Che with the dashboard image from this PR.
2. Open a factory link for devfile A in a central repo:
   ```
   https://<che-host>#https://github.com/org/central-repo.git?devfilePath=apps/appA/devfile.yaml
   ```
   Verify workspace A is created and starts successfully.
3. Open a factory link for devfile B in the same repo:
   ```
   https://<che-host>#https://github.com/org/central-repo.git?devfilePath=apps/appB/devfile.yaml
   ```
   Verify a new workspace B is created — workspace A is **not** reopened.
4. Open the factory link for devfile A again; verify workspace A is reopened (correct reuse still works).

#### Release Notes

Fixed an issue where Dev Spaces would reopen an existing workspace instead of creating a new one when two factory links pointed to different devfiles in the same repository.

#### Docs PR

N/A