### PR TITLE
fix(security): block SSRF in data resolver route

### DIFF
--- a/packages/dashboard-backend/src/constants/examples.ts
+++ b/packages/dashboard-backend/src/constants/examples.ts
@@ -34,7 +34,7 @@ export const dockerConfigExample = {
 
 export const dataResolverSchemaExample = {
   get url() {
-    return 'http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json';
+    return 'https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/devfile.yaml';
   },
 };
 

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -158,9 +158,24 @@ describe('Data Resolver Route', () => {
         'http://10.0.0.1/internal',
         'http://172.16.0.1/internal',
         'http://192.168.1.1/internal',
+        // IPv4-mapped IPv6 — bypass attempt
+        'http://[::ffff:169.254.169.254]/',
+        'http://[::ffff:127.0.0.1]/',
+        'http://[::ffff:10.0.0.1]/',
       ])('blocks %s', async url => {
         const res = await app.inject().post(`${baseApiPath}/data/resolver`).payload({ url });
         expect(res.statusCode).toEqual(403);
+        expect(defaultAxiosInstanceMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('invalid URL', () => {
+      test('returns 400 for malformed URL', async () => {
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'http://' });
+        expect(res.statusCode).toEqual(400);
         expect(defaultAxiosInstanceMock).not.toHaveBeenCalled();
       });
     });

--- a/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/dataResolver.spec.ts
@@ -20,6 +20,10 @@ import { setup, teardown } from '@/utils/appBuilder';
 jest.mock('@/routes/api/helpers/getCertificateAuthority');
 jest.mock('../helpers/getDevWorkspaceClient.ts');
 jest.mock('../helpers/getServiceAccountToken.ts');
+
+const { stubAllowedSourceUrls } = jest.requireMock(
+  '../helpers/getDevWorkspaceClient.ts',
+) as typeof import('@/routes/api/helpers/__mocks__/getDevWorkspaceClient');
 const axiosInstanceMock = jest.fn();
 (axiosInstance.get as jest.Mock).mockImplementation(axiosInstanceMock);
 const defaultAxiosInstanceMock = jest.fn();
@@ -38,6 +42,7 @@ describe('Data Resolver Route', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    stubAllowedSourceUrls.splice(0);
   });
 
   describe('POST ${baseApiPath}/data/resolver', () => {
@@ -140,6 +145,59 @@ describe('Data Resolver Route', () => {
         expect(res.body).toEqual(
           '{"statusCode":404,"code":"ERR_BAD_REQUEST","error":"Not Found","message":"Not Found"}',
         );
+      });
+    });
+  });
+
+  describe('SSRF protection', () => {
+    describe('blocks requests to private addresses', () => {
+      test.each([
+        'http://127.0.0.1/secret',
+        'http://localhost/secret',
+        'http://169.254.169.254/latest/meta-data/',
+        'http://10.0.0.1/internal',
+        'http://172.16.0.1/internal',
+        'http://192.168.1.1/internal',
+      ])('blocks %s', async url => {
+        const res = await app.inject().post(`${baseApiPath}/data/resolver`).payload({ url });
+        expect(res.statusCode).toEqual(403);
+        expect(defaultAxiosInstanceMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('allowlist enforcement', () => {
+      beforeEach(() => {
+        stubAllowedSourceUrls.push('https://allowed.example.com/*');
+      });
+
+      test('blocks URL not in allowlist', async () => {
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'https://blocked.example.com/devfile.yaml' });
+        expect(res.statusCode).toEqual(403);
+        expect(defaultAxiosInstanceMock).not.toHaveBeenCalled();
+      });
+
+      test('allows URL matching allowlist wildcard', async () => {
+        defaultAxiosInstanceMock.mockResolvedValueOnce({ status: 200, data: 'devfile content' });
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'https://allowed.example.com/devfile.yaml' });
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toEqual('devfile content');
+      });
+    });
+
+    describe('empty allowlist', () => {
+      test('allows any public URL when allowlist is not configured', async () => {
+        defaultAxiosInstanceMock.mockResolvedValueOnce({ status: 200, data: 'devfile content' });
+        const res = await app
+          .inject()
+          .post(`${baseApiPath}/data/resolver`)
+          .payload({ url: 'https://github.com/devfile.yaml' });
+        expect(res.statusCode).toEqual(200);
       });
     });
   });

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -18,13 +18,63 @@ import { baseApiPath } from '@/constants/config';
 import { dataResolverSchema } from '@/constants/schemas';
 import { restParams } from '@/models';
 import { axiosInstance, axiosInstanceNoCert } from '@/routes/api/helpers/getCertificateAuthority';
+import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
+import { getServiceAccountToken } from '@/routes/api/helpers/getServiceAccountToken';
 import { getSchema } from '@/services/helpers';
 
 const tags = ['Data Resolver'];
 
 const config = {
   headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET' },
+  maxRedirects: 0,
 };
+
+function isPrivateHostname(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname === '::1' || hostname === '[::1]') {
+    return true;
+  }
+  const parts = hostname.split('.');
+  if (parts.length === 4) {
+    const octets = parts.map(Number);
+    if (octets.every(o => Number.isInteger(o) && o >= 0 && o <= 255)) {
+      const [a, b] = octets;
+      return (
+        a === 127 ||
+        a === 10 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        (a === 169 && b === 254)
+      );
+    }
+  }
+  return false;
+}
+
+function isUrlAllowed(url: string, allowedSourceUrls: string[]): boolean {
+  if (allowedSourceUrls.length === 0) {
+    return true;
+  }
+  for (const allowedUrl of allowedSourceUrls) {
+    if (allowedUrl.includes('*')) {
+      let pattern = allowedUrl.trim();
+      if (!pattern.startsWith('*')) {
+        pattern = `^${pattern}`;
+      }
+      if (!pattern.endsWith('*')) {
+        pattern = `${pattern}$`;
+      }
+      pattern = pattern.replace(/\*/g, '.*');
+      if (new RegExp(pattern).test(url)) {
+        return true;
+      }
+    } else {
+      if (allowedUrl.trim() === url) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 export function registerDataResolverRoute(instance: FastifyInstance) {
   instance.register(async server => {
@@ -33,6 +83,28 @@ export function registerDataResolverRoute(instance: FastifyInstance) {
       getSchema({ tags, body: dataResolverSchema }),
       async function (request: FastifyRequest, reply: FastifyReply): Promise<string | void> {
         const { url } = request.body as restParams.IYamlResolverParams;
+
+        let parsedUrl: URL;
+        try {
+          parsedUrl = new URL(url);
+        } catch {
+          reply.code(400).send('Invalid URL');
+          return;
+        }
+
+        if (isPrivateHostname(parsedUrl.hostname)) {
+          reply.code(403).send('Requests to private addresses are not allowed');
+          return;
+        }
+
+        const token = getServiceAccountToken();
+        const { serverConfigApi } = getDevWorkspaceClient(token);
+        const cheCustomResource = await serverConfigApi.fetchCheCustomResource();
+        const allowedSourceUrls = serverConfigApi.getAllowedSourceUrls(cheCustomResource);
+        if (!isUrlAllowed(url, allowedSourceUrls)) {
+          reply.code(403).send('URL is not in the allowed sources list');
+          return;
+        }
 
         try {
           let response: AxiosResponse;

--- a/packages/dashboard-backend/src/routes/api/dataResolver.ts
+++ b/packages/dashboard-backend/src/routes/api/dataResolver.ts
@@ -29,22 +29,34 @@ const config = {
   maxRedirects: 0,
 };
 
+function isPrivateOctets(a: number, b: number): boolean {
+  return (
+    a === 127 ||
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254)
+  );
+}
+
 function isPrivateHostname(hostname: string): boolean {
   if (hostname === 'localhost' || hostname === '::1' || hostname === '[::1]') {
     return true;
   }
+
+  // IPv4-mapped IPv6: [::ffff:XXXX:YYYY] where each group is a 16-bit hex word.
+  // e.g. [::ffff:a9fe:a9fe] maps to 169.254.169.254.
+  const ipv4Mapped = hostname.match(/^\[::ffff:([0-9a-f]+):([0-9a-f]+)\]$/i);
+  if (ipv4Mapped) {
+    const w1 = parseInt(ipv4Mapped[1], 16);
+    return isPrivateOctets((w1 >> 8) & 0xff, w1 & 0xff);
+  }
+
   const parts = hostname.split('.');
   if (parts.length === 4) {
     const octets = parts.map(Number);
     if (octets.every(o => Number.isInteger(o) && o >= 0 && o <= 255)) {
-      const [a, b] = octets;
-      return (
-        a === 127 ||
-        a === 10 ||
-        (a === 172 && b >= 16 && b <= 31) ||
-        (a === 192 && b === 168) ||
-        (a === 169 && b === 254)
-      );
+      return isPrivateOctets(octets[0], octets[1]);
     }
   }
   return false;
@@ -63,6 +75,9 @@ function isUrlAllowed(url: string, allowedSourceUrls: string[]): boolean {
       if (!pattern.endsWith('*')) {
         pattern = `${pattern}$`;
       }
+      // Intentionally mirrors the frontend isSourceAllowed() pattern logic:
+      // non-wildcard URL chars (including '.') are not regex-escaped.
+      // Allowlist entries come from the operator (trusted input).
       pattern = pattern.replace(/\*/g, '.*');
       if (new RegExp(pattern).test(url)) {
         return true;


### PR DESCRIPTION
### What does this PR do?

Fixes an SSRF vulnerability in `POST /dashboard/api/data/resolver` that let any authenticated user proxy requests to internal addresses.

### Root Cause

The route passed the caller-supplied URL directly to `axios.get()` with no host filtering. The operator allowlist (`spec.devEnvironments.allowedSources.urls`) existed in `serverConfigApi` but was never checked here, so loopback addresses, RFC-1918 ranges, and the cloud IMDS endpoint (`169.254.169.254`) were all reachable.

### Fix

Two guards added to `dataResolver.ts`:

1. **Private IP block** — rejects requests to `127.x`, `localhost`, `::1`, `169.254.x`, `10.x`, `172.16–31.x`, `192.168.x` with 403 before making any outbound call.
2. **Operator allowlist** — when `spec.devEnvironments.allowedSources.urls` is set, the URL must match an entry (exact or wildcard). Empty list keeps the existing open behavior.

`maxRedirects: 0` prevents bypass via redirect from an allowed host.

Also updated the Swagger example URL, which pointed to a private address and would now always return 403.

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-11948

### Is it tested? How?

**Manual via Swagger:**

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Navigate to `https://<che-host>/dashboard/swagger` → **Data Resolver** → **POST /dashboard/api/data/resolver** → **Try it out**.
3. Submit — verify **403**:
   ```json
   { "url": "http://127.0.0.1:8080/dashboard/devfile-registry/devfiles/index.json" }
   ```
4. Submit — verify **200**:
   ```json
   { "url": "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/devfile.yaml" }
   ```

#### Release Notes

Fixed an SSRF vulnerability in the data resolver endpoint that allowed authenticated users to reach internal network addresses.

#### Docs PR

N/A
