### PR TITLE
feat(workspace-details): add Change Editor to workspace Overview tab

### DIFF
--- a/packages/dashboard-backend/src/routes/api/__tests__/devworkspaceTemplates.spec.ts
+++ b/packages/dashboard-backend/src/routes/api/__tests__/devworkspaceTemplates.spec.ts
@@ -98,34 +98,6 @@ describe('DevWorkspaceTemplates Routes', () => {
         .inject()
         .delete(`${baseApiPath}/namespace/${namespace}/devworkspacetemplates/${templateName}`);
 
-      expect(res.statusCode).toEqual(404);
-    });
-  });
-
-  describe('LocalRun only', () => {
-    beforeAll(async () => {
-      const env = {
-        OPENSHIFT_CONSOLE_URL: clusterConsoleUrl,
-        LOCAL_RUN: 'true',
-        CHE_API_PROXY_UPSTREAM: 'http://127.0.0.1:80',
-      };
-      app = await setup({ env });
-    });
-
-    afterAll(() => {
-      teardown(app);
-    });
-
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
-    test('DELETE ${baseApiPath}/namespace/:namespace/devworkspacetemplates/:templateName', async () => {
-      const templateName = 'tmpl';
-      const res = await app
-        .inject()
-        .delete(`${baseApiPath}/namespace/${namespace}/devworkspacetemplates/${templateName}`);
-
       expect(res.statusCode).toEqual(204);
     });
   });

--- a/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
+++ b/packages/dashboard-backend/src/routes/api/devworkspaceTemplates.ts
@@ -19,7 +19,6 @@ import {
   namespacedTemplateSchema,
   templateStartedSchema,
 } from '@/constants/schemas';
-import { isLocalRun } from '@/localRun';
 import { restParams } from '@/models';
 import { getDevWorkspaceClient } from '@/routes/api/helpers/getDevWorkspaceClient';
 import { getToken } from '@/routes/api/helpers/getToken';
@@ -89,30 +88,27 @@ export function registerDevWorkspaceTemplates(instance: FastifyInstance) {
       },
     );
 
-    if (isLocalRun()) {
-      server.delete(
-        `${baseApiPath}/namespace/:namespace/devworkspacetemplates/:templateName`,
-        getSchema({
-          tags,
-          params: namespacedTemplateSchema,
-          response: {
-            204: {
-              description: 'The DevWorkspaceTemplate successfully deleted',
-              type: 'null',
-            },
+    server.delete(
+      `${baseApiPath}/namespace/:namespace/devworkspacetemplates/:templateName`,
+      getSchema({
+        tags,
+        params: namespacedTemplateSchema,
+        response: {
+          204: {
+            description: 'The DevWorkspaceTemplate successfully deleted',
+            type: 'null',
           },
-        }),
-        async function (request: FastifyRequest, reply: FastifyReply) {
-          const { namespace, templateName } =
-            request.params as restParams.INamespacedTemplateParams;
-          const token = getToken(request);
-          const { devWorkspaceTemplateApi: templateApi } = getDevWorkspaceClient(token);
-
-          await templateApi.delete(namespace, templateName);
-
-          reply.code(204).send();
         },
-      );
-    }
+      }),
+      async function (request: FastifyRequest, reply: FastifyReply) {
+        const { namespace, templateName } = request.params as restParams.INamespacedTemplateParams;
+        const token = getToken(request);
+        const { devWorkspaceTemplateApi: templateApi } = getDevWorkspaceClient(token);
+
+        await templateApi.delete(namespace, templateName);
+
+        reply.code(204).send();
+      },
+    );
   });
 }

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.module.css
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+.radioLabel {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.versionLabel {
+  cursor: default;
+}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.module.css
@@ -10,12 +10,36 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-.radioLabel {
+.editorSelectHeader {
   display: flex;
-  gap: 8px;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.filterInput {
+  max-width: 30%;
+}
+
+.editorList {
+  overflow-y: auto;
+  max-height: 18rem;
+}
+
+.radioLabel {
+  display: inline-flex;
+  gap: 4px;
   align-items: center;
 }
 
 .versionLabel {
-  cursor: default;
+  height: 0.8125rem;
+  margin-left: 0;
+}
+
+.customEditorRow {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+  color: var(--pf-t--global--text--color--subtle);
 }

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
@@ -12,6 +12,7 @@
 
 import {
   Button,
+  Checkbox,
   Content,
   ContentVariants,
   Dropdown,
@@ -25,7 +26,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalVariant,
-  Radio,
+  TextInput,
 } from '@patternfly/react-core';
 import { CheckIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import React from 'react';
@@ -46,6 +47,7 @@ type State = {
   selectedGroupKey: string;
   selectedVersion: string;
   openDropdownId: string | null;
+  filterText: string;
 };
 
 function resolveInitialState(currentEditorId: string | undefined, groups: EditorGroup[]): State {
@@ -55,13 +57,13 @@ function resolveInitialState(currentEditorId: string | undefined, groups: Editor
       selectedGroupKey: first?.key ?? '',
       selectedVersion: first?.versions[0]?.version ?? '',
       openDropdownId: null,
+      filterText: '',
     };
   }
-  // currentEditorId is "publisher/name/version"
   const parts = currentEditorId.split('/');
   const version = parts[parts.length - 1];
   const key = parts.slice(0, -1).join('/');
-  return { selectedGroupKey: key, selectedVersion: version, openDropdownId: null };
+  return { selectedGroupKey: key, selectedVersion: version, openDropdownId: null, filterText: '' };
 }
 
 export class EditorSelectorModal extends React.PureComponent<Props, State> {
@@ -78,6 +80,10 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
     ) {
       const groups = groupEditorsByName(this.props.editors);
       this.setState(resolveInitialState(this.props.currentEditorId, groups));
+    }
+    // Reset filter when modal closes
+    if (prevProps.isOpen && !this.props.isOpen) {
+      this.setState({ filterText: '' });
     }
   }
 
@@ -155,10 +161,29 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
   }
 
   public render(): React.ReactNode {
-    const { isOpen, editors, onConfirm, onClose } = this.props;
-    const { selectedGroupKey, selectedVersion } = this.state;
+    const { isOpen, currentEditorId, editors, onConfirm, onClose } = this.props;
+    const { selectedGroupKey, selectedVersion, filterText } = this.state;
 
     const groups = groupEditorsByName(editors);
+
+    const currentGroupKey = currentEditorId
+      ? currentEditorId.split('/').slice(0, -1).join('/')
+      : undefined;
+    const isCustomEditor =
+      currentGroupKey !== undefined && !groups.some(g => g.key === currentGroupKey);
+
+    const lowerFilter = filterText.toLowerCase();
+    const filteredGroups = filterText
+      ? groups.filter(
+          g =>
+            g.displayName.toLowerCase().includes(lowerFilter) ||
+            g.versions.some(
+              v =>
+                v.version.toLowerCase().includes(lowerFilter) ||
+                (v.description ?? '').toLowerCase().includes(lowerFilter),
+            ),
+        )
+      : groups;
 
     return (
       <Modal
@@ -169,47 +194,72 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
       >
         <ModalHeader title="Change Editor" />
         <ModalBody>
-          <Content data-pf-initial-focus tabIndex={-1} style={{ outline: 'none' }}>
+          <div data-pf-initial-focus tabIndex={-1} style={{ outline: 'none' }}>
             {groups.length === 0 ? (
               <Content component="p">No editors are available.</Content>
             ) : (
               <>
-                <Content component={ContentVariants.h6}>Select editor</Content>
-                {groups.map(group => {
-                  const isGroupSelected = selectedGroupKey === group.key;
-                  const activeVersion = isGroupSelected
-                    ? selectedVersion
-                    : group.versions[0].version;
-                  const versionDropdown = this.buildVersionDropdown(group);
-
-                  const radioLabel = (
-                    <span className={styles.radioLabel}>
-                      {group.displayName}
-                      {isGroupSelected && (
-                        <Label variant="outline" color="blue" className={styles.versionLabel}>
-                          {activeVersion}
+                <div className={styles.editorSelectHeader}>
+                  <Content component={ContentVariants.h6} style={{ marginBottom: 0 }}>
+                    Select editor
+                  </Content>
+                  <TextInput
+                    type="search"
+                    placeholder="Filter by"
+                    value={filterText}
+                    onChange={(_event, value) => this.setState({ filterText: value })}
+                    aria-label="Filter editors by name"
+                    className={styles.filterInput}
+                  />
+                </div>
+                <div className={styles.editorList}>
+                  {isCustomEditor && (
+                    <Content component={ContentVariants.h6}>
+                      <div className={styles.customEditorRow}>
+                        <span>{currentEditorId}</span>
+                        <Label variant="outline" color="orange" className={styles.versionLabel}>
+                          custom
                         </Label>
-                      )}
-                      {versionDropdown}
-                    </span>
-                  );
-
-                  return (
-                    <Content key={group.key} component={ContentVariants.h6}>
-                      <Radio
-                        label={radioLabel}
-                        id={`editor-${group.key.replace(/\//g, '-')}`}
-                        name="editor-selector"
-                        description={group.versions[0].description}
-                        isChecked={isGroupSelected}
-                        onChange={() => this.handleSelectGroup(group)}
-                      />
+                      </div>
                     </Content>
-                  );
-                })}
+                  )}
+                  {filteredGroups.length === 0 ? (
+                    <Content component="p">No editors match the filter.</Content>
+                  ) : (
+                    filteredGroups.map(group => {
+                      const isGroupSelected = selectedGroupKey === group.key;
+                      const activeVersion = isGroupSelected
+                        ? selectedVersion
+                        : group.versions[0].version;
+                      const versionDropdown = this.buildVersionDropdown(group);
+
+                      const radioLabel = (
+                        <span className={styles.radioLabel}>
+                          {group.displayName}
+                          <Label variant="outline" color="blue" className={styles.versionLabel}>
+                            {activeVersion}
+                          </Label>
+                          {versionDropdown}
+                        </span>
+                      );
+
+                      return (
+                        <Content key={group.key} component={ContentVariants.h6}>
+                          <Checkbox
+                            label={radioLabel}
+                            id={`editor-${group.key.replace(/\//g, '-')}`}
+                            description={group.versions[0].description}
+                            isChecked={isGroupSelected}
+                            onChange={() => this.handleSelectGroup(group)}
+                          />
+                        </Content>
+                      );
+                    })
+                  )}
+                </div>
               </>
             )}
-          </Content>
+          </div>
         </ModalBody>
         <ModalFooter>
           <Button

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import {
+  Button,
+  Content,
+  ContentVariants,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Label,
+  MenuToggle,
+  MenuToggleElement,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Radio,
+} from '@patternfly/react-core';
+import { CheckIcon, EllipsisVIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+import styles from '@/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.module.css';
+import { EditorGroup, groupEditorsByName } from '@/services/helpers/editor';
+import { che } from '@/services/models';
+
+export type Props = {
+  isOpen: boolean;
+  currentEditorId: string | undefined;
+  editors: che.Plugin[];
+  onConfirm: (editorId: string) => void;
+  onClose: () => void;
+};
+
+type State = {
+  selectedGroupKey: string;
+  selectedVersion: string;
+  openDropdownId: string | null;
+};
+
+function resolveInitialState(currentEditorId: string | undefined, groups: EditorGroup[]): State {
+  if (!currentEditorId) {
+    const first = groups[0];
+    return {
+      selectedGroupKey: first?.key ?? '',
+      selectedVersion: first?.versions[0]?.version ?? '',
+      openDropdownId: null,
+    };
+  }
+  // currentEditorId is "publisher/name/version"
+  const parts = currentEditorId.split('/');
+  const version = parts[parts.length - 1];
+  const key = parts.slice(0, -1).join('/');
+  return { selectedGroupKey: key, selectedVersion: version, openDropdownId: null };
+}
+
+export class EditorSelectorModal extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    const groups = groupEditorsByName(props.editors);
+    this.state = resolveInitialState(props.currentEditorId, groups);
+  }
+
+  public componentDidUpdate(prevProps: Props): void {
+    if (
+      prevProps.currentEditorId !== this.props.currentEditorId ||
+      prevProps.editors !== this.props.editors
+    ) {
+      const groups = groupEditorsByName(this.props.editors);
+      this.setState(resolveInitialState(this.props.currentEditorId, groups));
+    }
+  }
+
+  private get selectedEditorId(): string {
+    return `${this.state.selectedGroupKey}/${this.state.selectedVersion}`;
+  }
+
+  private get hasChanged(): boolean {
+    return this.selectedEditorId !== (this.props.currentEditorId ?? '');
+  }
+
+  private handleSelectGroup(group: EditorGroup): void {
+    this.setState({
+      selectedGroupKey: group.key,
+      selectedVersion: group.versions[0].version,
+      openDropdownId: null,
+    });
+  }
+
+  private handleVersionSelect(
+    event: React.MouseEvent | React.KeyboardEvent,
+    groupKey: string,
+    version: string,
+  ): void {
+    event.stopPropagation();
+    event.preventDefault();
+    this.setState({ selectedVersion: version, openDropdownId: null, selectedGroupKey: groupKey });
+  }
+
+  private buildVersionDropdown(group: EditorGroup): React.ReactElement | null {
+    if (group.versions.length <= 1) {
+      return null;
+    }
+    const { openDropdownId, selectedVersion, selectedGroupKey } = this.state;
+    const isOpen = openDropdownId === group.key;
+    const activeVersion =
+      selectedGroupKey === group.key ? selectedVersion : group.versions[0].version;
+
+    return (
+      <Dropdown
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="plain"
+            style={{ padding: 0 }}
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              this.setState({ openDropdownId: isOpen ? null : group.key });
+            }}
+            isExpanded={isOpen}
+            aria-label={`${group.displayName} version options`}
+            icon={<EllipsisVIcon />}
+          />
+        )}
+        isOpen={isOpen}
+        onOpenChange={open => this.setState({ openDropdownId: open ? group.key : null })}
+        popperProps={{ appendTo: 'inline', position: 'right' }}
+      >
+        <DropdownList>
+          {isOpen
+            ? group.versions.map(v => (
+                <DropdownItem
+                  key={v.version}
+                  onClick={event => this.handleVersionSelect(event, group.key, v.version)}
+                  aria-checked={v.version === activeVersion}
+                  icon={v.version === activeVersion ? <CheckIcon /> : undefined}
+                >
+                  {v.version}
+                </DropdownItem>
+              ))
+            : null}
+        </DropdownList>
+      </Dropdown>
+    );
+  }
+
+  public render(): React.ReactNode {
+    const { isOpen, editors, onConfirm, onClose } = this.props;
+    const { selectedGroupKey, selectedVersion } = this.state;
+
+    const groups = groupEditorsByName(editors);
+
+    return (
+      <Modal
+        variant={ModalVariant.small}
+        isOpen={isOpen}
+        onClose={onClose}
+        elementToFocus="[data-pf-initial-focus]"
+      >
+        <ModalHeader title="Change Editor" />
+        <ModalBody>
+          <Content data-pf-initial-focus tabIndex={-1} style={{ outline: 'none' }}>
+            {groups.length === 0 ? (
+              <Content component="p">No editors are available.</Content>
+            ) : (
+              <>
+                <Content component={ContentVariants.h6}>Select editor</Content>
+                {groups.map(group => {
+                  const isGroupSelected = selectedGroupKey === group.key;
+                  const activeVersion = isGroupSelected
+                    ? selectedVersion
+                    : group.versions[0].version;
+                  const versionDropdown = this.buildVersionDropdown(group);
+
+                  const radioLabel = (
+                    <span className={styles.radioLabel}>
+                      {group.displayName}
+                      {isGroupSelected && (
+                        <Label variant="outline" color="blue" className={styles.versionLabel}>
+                          {activeVersion}
+                        </Label>
+                      )}
+                      {versionDropdown}
+                    </span>
+                  );
+
+                  return (
+                    <Content key={group.key} component={ContentVariants.h6}>
+                      <Radio
+                        label={radioLabel}
+                        id={`editor-${group.key.replace(/\//g, '-')}`}
+                        name="editor-selector"
+                        description={group.versions[0].description}
+                        isChecked={isGroupSelected}
+                        onChange={() => this.handleSelectGroup(group)}
+                      />
+                    </Content>
+                  );
+                })}
+              </>
+            )}
+          </Content>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            key="confirm"
+            variant="primary"
+            isDisabled={!this.hasChanged}
+            onClick={() => onConfirm(this.selectedEditorId)}
+          >
+            Save
+          </Button>
+          <Button key="cancel" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
@@ -208,7 +208,7 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
                     placeholder="Filter by"
                     value={filterText}
                     onChange={(_event, value) => this.setState({ filterText: value })}
-                    aria-label="Filter editors by name"
+                    aria-label="Filter editors by"
                     className={styles.filterInput}
                   />
                 </div>

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
@@ -12,7 +12,6 @@
 
 import {
   Button,
-  Checkbox,
   Content,
   ContentVariants,
   Dropdown,
@@ -26,6 +25,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalVariant,
+  Radio,
   TextInput,
 } from '@patternfly/react-core';
 import { CheckIcon, EllipsisVIcon } from '@patternfly/react-icons';
@@ -245,12 +245,14 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
 
                       return (
                         <Content key={group.key} component={ContentVariants.h6}>
-                          <Checkbox
+                          <Radio
                             label={radioLabel}
                             id={`editor-${group.key.replace(/\//g, '-')}`}
+                            name="editor-selector"
                             description={group.versions[0].description}
                             isChecked={isGroupSelected}
                             onChange={() => this.handleSelectGroup(group)}
+                            value={group.key}
                           />
                         </Content>
                       );

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal.tsx
@@ -45,17 +45,21 @@ export type Props = {
 
 type State = {
   selectedGroupKey: string;
-  selectedVersion: string;
+  versionsByGroup: Record<string, string>;
   openDropdownId: string | null;
   filterText: string;
 };
 
 function resolveInitialState(currentEditorId: string | undefined, groups: EditorGroup[]): State {
+  const versionsByGroup: Record<string, string> = {};
   if (!currentEditorId) {
     const first = groups[0];
+    if (first) {
+      versionsByGroup[first.key] = first.versions[0]?.version ?? '';
+    }
     return {
       selectedGroupKey: first?.key ?? '',
-      selectedVersion: first?.versions[0]?.version ?? '',
+      versionsByGroup,
       openDropdownId: null,
       filterText: '',
     };
@@ -63,7 +67,8 @@ function resolveInitialState(currentEditorId: string | undefined, groups: Editor
   const parts = currentEditorId.split('/');
   const version = parts[parts.length - 1];
   const key = parts.slice(0, -1).join('/');
-  return { selectedGroupKey: key, selectedVersion: version, openDropdownId: null, filterText: '' };
+  versionsByGroup[key] = version;
+  return { selectedGroupKey: key, versionsByGroup, openDropdownId: null, filterText: '' };
 }
 
 export class EditorSelectorModal extends React.PureComponent<Props, State> {
@@ -76,7 +81,8 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
   public componentDidUpdate(prevProps: Props): void {
     if (
       prevProps.currentEditorId !== this.props.currentEditorId ||
-      prevProps.editors !== this.props.editors
+      prevProps.editors !== this.props.editors ||
+      (!prevProps.isOpen && this.props.isOpen)
     ) {
       const groups = groupEditorsByName(this.props.editors);
       this.setState(resolveInitialState(this.props.currentEditorId, groups));
@@ -88,7 +94,8 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
   }
 
   private get selectedEditorId(): string {
-    return `${this.state.selectedGroupKey}/${this.state.selectedVersion}`;
+    const version = this.state.versionsByGroup[this.state.selectedGroupKey] ?? '';
+    return `${this.state.selectedGroupKey}/${version}`;
   }
 
   private get hasChanged(): boolean {
@@ -96,11 +103,14 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
   }
 
   private handleSelectGroup(group: EditorGroup): void {
-    this.setState({
+    this.setState(prevState => ({
       selectedGroupKey: group.key,
-      selectedVersion: group.versions[0].version,
       openDropdownId: null,
-    });
+      versionsByGroup:
+        prevState.versionsByGroup[group.key] !== undefined
+          ? prevState.versionsByGroup
+          : { ...prevState.versionsByGroup, [group.key]: group.versions[0].version },
+    }));
   }
 
   private handleVersionSelect(
@@ -110,17 +120,20 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
   ): void {
     event.stopPropagation();
     event.preventDefault();
-    this.setState({ selectedVersion: version, openDropdownId: null, selectedGroupKey: groupKey });
+    this.setState(prevState => ({
+      versionsByGroup: { ...prevState.versionsByGroup, [groupKey]: version },
+      openDropdownId: null,
+      selectedGroupKey: groupKey,
+    }));
   }
 
   private buildVersionDropdown(group: EditorGroup): React.ReactElement | null {
     if (group.versions.length <= 1) {
       return null;
     }
-    const { openDropdownId, selectedVersion, selectedGroupKey } = this.state;
+    const { openDropdownId, versionsByGroup } = this.state;
     const isOpen = openDropdownId === group.key;
-    const activeVersion =
-      selectedGroupKey === group.key ? selectedVersion : group.versions[0].version;
+    const activeVersion = versionsByGroup[group.key] ?? group.versions[0].version;
 
     return (
       <Dropdown
@@ -162,7 +175,7 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
 
   public render(): React.ReactNode {
     const { isOpen, currentEditorId, editors, onConfirm, onClose } = this.props;
-    const { selectedGroupKey, selectedVersion, filterText } = this.state;
+    const { selectedGroupKey, versionsByGroup, filterText } = this.state;
 
     const groups = groupEditorsByName(editors);
 
@@ -228,9 +241,7 @@ export class EditorSelectorModal extends React.PureComponent<Props, State> {
                   ) : (
                     filteredGroups.map(group => {
                       const isGroupSelected = selectedGroupKey === group.key;
-                      const activeVersion = isGroupSelected
-                        ? selectedVersion
-                        : group.versions[0].version;
+                      const activeVersion = versionsByGroup[group.key] ?? group.versions[0].version;
                       const versionDropdown = this.buildVersionDropdown(group);
 
                       const radioLabel = (

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__mocks__/SelectorModal.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__mocks__/SelectorModal.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+
+import { Props } from '@/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal';
+
+export class EditorSelectorModal extends React.PureComponent<Props> {
+  render() {
+    const { isOpen, onConfirm, onClose, editors } = this.props;
+    if (!isOpen) {
+      return null;
+    }
+    const firstId = editors[0]?.id ?? '';
+    return (
+      <div data-testid="mock-editor-selector-modal">
+        <button onClick={() => onConfirm(firstId)}>Confirm Editor</button>
+        <button onClick={onClose}>Close Modal</button>
+      </div>
+    );
+  }
+}
+
+export default EditorSelectorModal;

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__mocks__/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__mocks__/index.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+
+import { Workspace } from '@/services/workspace-adapter';
+
+type MockProps = {
+  readonly: boolean;
+  workspace: Workspace;
+};
+
+export class EditorFormGroup extends React.PureComponent<MockProps> {
+  render() {
+    return (
+      <div>
+        Mock Editor Form Group
+        <button disabled={this.props.readonly}>Change editor</button>
+      </div>
+    );
+  }
+}
+
+export default EditorFormGroup;

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
@@ -39,7 +39,10 @@ function makePlugin(
 }
 
 const editors: che.Plugin[] = [
-  makePlugin('che-incubator', 'che-code', 'latest', 'VS Code - Open Source'),
+  {
+    ...makePlugin('che-incubator', 'che-code', 'latest', 'VS Code - Open Source'),
+    description: 'Microsoft Visual Studio Code - Open Source IDE for Eclipse Che',
+  },
   makePlugin('che-incubator', 'che-code', 'insiders', 'VS Code - Open Source'),
   makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
 ];
@@ -75,17 +78,17 @@ describe('EditorSelectorModal', () => {
     expect(screen.getByText('Change Editor')).toBeInTheDocument();
   });
 
-  it('renders one radio per editor group', () => {
+  it('renders one checkbox per editor group', () => {
     renderComponent(true, undefined);
-    const radios = screen.getAllByRole('radio');
+    const checkboxes = screen.getAllByRole('checkbox');
     // 2 groups: che-code, che-idea-server
-    expect(radios).toHaveLength(2);
+    expect(checkboxes).toHaveLength(2);
   });
 
-  it('pre-selects the radio that matches currentEditorId', () => {
+  it('pre-selects the checkbox that matches currentEditorId', () => {
     renderComponent(true, 'che-incubator/che-idea-server/latest');
-    const radio = screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i });
-    expect(radio).toBeChecked();
+    const checkbox = screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i });
+    expect(checkbox).toBeChecked();
   });
 
   it('Save button is disabled when selection has not changed', () => {
@@ -95,13 +98,13 @@ describe('EditorSelectorModal', () => {
 
   it('Save button becomes enabled after selecting a different editor', async () => {
     renderComponent(true, 'che-incubator/che-code/latest');
-    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
+    await userEvent.click(screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i }));
     expect(screen.getByRole('button', { name: /Save/i })).not.toBeDisabled();
   });
 
   it('calls onConfirm with the selected editor id on Save', async () => {
     renderComponent(true, 'che-incubator/che-code/latest');
-    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
+    await userEvent.click(screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i }));
     await userEvent.click(screen.getByRole('button', { name: /Save/i }));
     expect(mockOnConfirm).toHaveBeenCalledWith('che-incubator/che-idea-server/latest');
   });
@@ -112,15 +115,14 @@ describe('EditorSelectorModal', () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('shows a version label for each editor group', () => {
+  it('shows a version label for every editor group', () => {
     renderComponent(true, undefined);
-    // VS Code - Open Source has versions: latest, insiders
-    expect(screen.getByText('latest')).toBeInTheDocument();
+    // VS Code (2 versions) shows 'latest' (active), IntelliJ (1 version) shows 'latest'
+    expect(screen.getAllByText('latest')).toHaveLength(2);
   });
 
   it('shows version dropdown trigger for editors with multiple versions', () => {
     renderComponent(true, undefined);
-    // VS Code has 2 versions → kebab button present
     expect(
       screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
     ).toBeInTheDocument();
@@ -128,7 +130,6 @@ describe('EditorSelectorModal', () => {
 
   it('does NOT show version dropdown for editors with a single version', () => {
     renderComponent(true, undefined);
-    // IntelliJ has 1 version → no kebab
     expect(
       screen.queryByRole('button', { name: /JetBrains IntelliJ IDEA version options/i }),
     ).not.toBeInTheDocument();
@@ -136,23 +137,57 @@ describe('EditorSelectorModal', () => {
 
   it('updates selected version when a version is chosen from the dropdown', async () => {
     renderComponent(true, 'che-incubator/che-code/latest');
-    // open version dropdown
     await userEvent.click(
       screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
     );
     await userEvent.click(screen.getByRole('menuitem', { name: 'insiders' }));
-    // now version label shows insiders
     expect(screen.getByText('insiders')).toBeInTheDocument();
   });
 
   it('calls onConfirm with the correct version when a non-default version is selected then confirmed', async () => {
     renderComponent(true, 'che-incubator/che-code/latest');
-    // switch to insiders version
     await userEvent.click(
       screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
     );
     await userEvent.click(screen.getByRole('menuitem', { name: 'insiders' }));
     await userEvent.click(screen.getByRole('button', { name: /Save/i }));
     expect(mockOnConfirm).toHaveBeenCalledWith('che-incubator/che-code/insiders');
+  });
+
+  it('filters editors by display name', async () => {
+    renderComponent(true, undefined);
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    await userEvent.type(filter, 'JetBrains');
+    expect(screen.queryByRole('checkbox', { name: /VS Code/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i })).toBeInTheDocument();
+  });
+
+  it('filters editors by version string', async () => {
+    renderComponent(true, undefined);
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    await userEvent.type(filter, 'insiders');
+    expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /JetBrains/i })).not.toBeInTheDocument();
+  });
+
+  it('filters editors by description text', async () => {
+    renderComponent(true, undefined);
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    await userEvent.type(filter, 'Open Source IDE');
+    expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /JetBrains/i })).not.toBeInTheDocument();
+  });
+
+  it('shows "No editors match the filter" when filter yields no results', async () => {
+    renderComponent(true, undefined);
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    await userEvent.type(filter, 'NonExistentEditor');
+    expect(screen.getByText('No editors match the filter.')).toBeInTheDocument();
+  });
+
+  it('shows a custom label when currentEditorId does not match any known editor', () => {
+    renderComponent(true, 'custom-publisher/my-editor/dev');
+    expect(screen.getByText('custom-publisher/my-editor/dev')).toBeInTheDocument();
+    expect(screen.getByText('custom')).toBeInTheDocument();
   });
 });

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { EditorSelectorModal } from '@/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal';
+import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
+import { che } from '@/services/models';
+
+const { renderComponent } = getComponentRenderer(getComponent);
+
+function makePlugin(
+  publisher: string,
+  name: string,
+  version: string,
+  displayName: string,
+): che.Plugin {
+  return {
+    id: `${publisher}/${name}/${version}`,
+    name,
+    publisher,
+    displayName,
+    type: 'Che Editor',
+    version,
+    icon: '<svg/>',
+    iconMediatype: 'image/svg+xml',
+    links: { devfile: '' },
+  };
+}
+
+const editors: che.Plugin[] = [
+  makePlugin('che-incubator', 'che-code', 'latest', 'VS Code - Open Source'),
+  makePlugin('che-incubator', 'che-code', 'insiders', 'VS Code - Open Source'),
+  makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
+];
+
+const mockOnConfirm = jest.fn();
+const mockOnClose = jest.fn();
+
+function getComponent(isOpen: boolean, currentEditorId: string | undefined): React.ReactElement {
+  return (
+    <EditorSelectorModal
+      isOpen={isOpen}
+      currentEditorId={currentEditorId}
+      editors={editors}
+      onConfirm={mockOnConfirm}
+      onClose={mockOnClose}
+    />
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('EditorSelectorModal', () => {
+  it('renders nothing when isOpen is false', () => {
+    renderComponent(false, undefined);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders a dialog when isOpen is true', () => {
+    renderComponent(true, undefined);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Change Editor')).toBeInTheDocument();
+  });
+
+  it('renders one radio per editor group', () => {
+    renderComponent(true, undefined);
+    const radios = screen.getAllByRole('radio');
+    // 2 groups: che-code, che-idea-server
+    expect(radios).toHaveLength(2);
+  });
+
+  it('pre-selects the radio that matches currentEditorId', () => {
+    renderComponent(true, 'che-incubator/che-idea-server/latest');
+    const radio = screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i });
+    expect(radio).toBeChecked();
+  });
+
+  it('Save button is disabled when selection has not changed', () => {
+    renderComponent(true, 'che-incubator/che-code/latest');
+    expect(screen.getByRole('button', { name: /Save/i })).toBeDisabled();
+  });
+
+  it('Save button becomes enabled after selecting a different editor', async () => {
+    renderComponent(true, 'che-incubator/che-code/latest');
+    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
+    expect(screen.getByRole('button', { name: /Save/i })).not.toBeDisabled();
+  });
+
+  it('calls onConfirm with the selected editor id on Save', async () => {
+    renderComponent(true, 'che-incubator/che-code/latest');
+    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+    expect(mockOnConfirm).toHaveBeenCalledWith('che-incubator/che-idea-server/latest');
+  });
+
+  it('calls onClose on Cancel', async () => {
+    renderComponent(true, 'che-incubator/che-code/latest');
+    await userEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('shows a version label for each editor group', () => {
+    renderComponent(true, undefined);
+    // VS Code - Open Source has versions: latest, insiders
+    expect(screen.getByText('latest')).toBeInTheDocument();
+  });
+
+  it('shows version dropdown trigger for editors with multiple versions', () => {
+    renderComponent(true, undefined);
+    // VS Code has 2 versions → kebab button present
+    expect(
+      screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT show version dropdown for editors with a single version', () => {
+    renderComponent(true, undefined);
+    // IntelliJ has 1 version → no kebab
+    expect(
+      screen.queryByRole('button', { name: /JetBrains IntelliJ IDEA version options/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('updates selected version when a version is chosen from the dropdown', async () => {
+    renderComponent(true, 'che-incubator/che-code/latest');
+    // open version dropdown
+    await userEvent.click(
+      screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
+    );
+    await userEvent.click(screen.getByRole('menuitem', { name: 'insiders' }));
+    // now version label shows insiders
+    expect(screen.getByText('insiders')).toBeInTheDocument();
+  });
+
+  it('calls onConfirm with the correct version when a non-default version is selected then confirmed', async () => {
+    renderComponent(true, 'che-incubator/che-code/latest');
+    // switch to insiders version
+    await userEvent.click(
+      screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
+    );
+    await userEvent.click(screen.getByRole('menuitem', { name: 'insiders' }));
+    await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+    expect(mockOnConfirm).toHaveBeenCalledWith('che-incubator/che-code/insiders');
+  });
+});

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
@@ -156,7 +156,7 @@ describe('EditorSelectorModal', () => {
 
   it('filters editors by display name', async () => {
     renderComponent(true, undefined);
-    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by/i });
     await userEvent.type(filter, 'JetBrains');
     expect(screen.queryByRole('checkbox', { name: /VS Code/i })).not.toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i })).toBeInTheDocument();
@@ -164,7 +164,7 @@ describe('EditorSelectorModal', () => {
 
   it('filters editors by version string', async () => {
     renderComponent(true, undefined);
-    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by/i });
     await userEvent.type(filter, 'insiders');
     expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
     expect(screen.queryByRole('checkbox', { name: /JetBrains/i })).not.toBeInTheDocument();
@@ -172,7 +172,7 @@ describe('EditorSelectorModal', () => {
 
   it('filters editors by description text', async () => {
     renderComponent(true, undefined);
-    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by/i });
     await userEvent.type(filter, 'Open Source IDE');
     expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
     expect(screen.queryByRole('checkbox', { name: /JetBrains/i })).not.toBeInTheDocument();
@@ -180,7 +180,7 @@ describe('EditorSelectorModal', () => {
 
   it('shows "No editors match the filter" when filter yields no results', async () => {
     renderComponent(true, undefined);
-    const filter = screen.getByRole('searchbox', { name: /Filter editors by name/i });
+    const filter = screen.getByRole('searchbox', { name: /Filter editors by/i });
     await userEvent.type(filter, 'NonExistentEditor');
     expect(screen.getByText('No editors match the filter.')).toBeInTheDocument();
   });

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
@@ -190,4 +190,20 @@ describe('EditorSelectorModal', () => {
     expect(screen.getByText('custom-publisher/my-editor/dev')).toBeInTheDocument();
     expect(screen.getByText('custom')).toBeInTheDocument();
   });
+
+  it('resets the filter when the modal is closed then reopened', async () => {
+    const { reRenderComponent } = renderComponent(true, undefined);
+    // apply a filter
+    await userEvent.type(
+      screen.getByRole('searchbox', { name: /Filter editors by/i }),
+      'JetBrains',
+    );
+    expect(screen.queryByRole('checkbox', { name: /VS Code/i })).not.toBeInTheDocument();
+
+    // close
+    reRenderComponent(false, undefined);
+    // reopen — filter must be cleared
+    reRenderComponent(true, undefined);
+    expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
+  });
 });

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
@@ -78,17 +78,17 @@ describe('EditorSelectorModal', () => {
     expect(screen.getByText('Change Editor')).toBeInTheDocument();
   });
 
-  it('renders one checkbox per editor group', () => {
+  it('renders one radio per editor group', () => {
     renderComponent(true, undefined);
-    const checkboxes = screen.getAllByRole('checkbox');
+    const radios = screen.getAllByRole('radio');
     // 2 groups: che-code, che-idea-server
-    expect(checkboxes).toHaveLength(2);
+    expect(radios).toHaveLength(2);
   });
 
-  it('pre-selects the checkbox that matches currentEditorId', () => {
+  it('pre-selects the radio that matches currentEditorId', () => {
     renderComponent(true, 'che-incubator/che-idea-server/latest');
-    const checkbox = screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i });
-    expect(checkbox).toBeChecked();
+    const radio = screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i });
+    expect(radio).toBeChecked();
   });
 
   it('Save button is disabled when selection has not changed', () => {
@@ -98,13 +98,13 @@ describe('EditorSelectorModal', () => {
 
   it('Save button becomes enabled after selecting a different editor', async () => {
     renderComponent(true, 'che-incubator/che-code/latest');
-    await userEvent.click(screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i }));
+    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
     expect(screen.getByRole('button', { name: /Save/i })).not.toBeDisabled();
   });
 
   it('calls onConfirm with the selected editor id on Save', async () => {
     renderComponent(true, 'che-incubator/che-code/latest');
-    await userEvent.click(screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i }));
+    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
     await userEvent.click(screen.getByRole('button', { name: /Save/i }));
     expect(mockOnConfirm).toHaveBeenCalledWith('che-incubator/che-idea-server/latest');
   });
@@ -158,24 +158,24 @@ describe('EditorSelectorModal', () => {
     renderComponent(true, undefined);
     const filter = screen.getByRole('searchbox', { name: /Filter editors by/i });
     await userEvent.type(filter, 'JetBrains');
-    expect(screen.queryByRole('checkbox', { name: /VS Code/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: /JetBrains IntelliJ IDEA/i })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /VS Code/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i })).toBeInTheDocument();
   });
 
   it('filters editors by version string', async () => {
     renderComponent(true, undefined);
     const filter = screen.getByRole('searchbox', { name: /Filter editors by/i });
     await userEvent.type(filter, 'insiders');
-    expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: /JetBrains/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /VS Code/i })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /JetBrains/i })).not.toBeInTheDocument();
   });
 
   it('filters editors by description text', async () => {
     renderComponent(true, undefined);
     const filter = screen.getByRole('searchbox', { name: /Filter editors by/i });
     await userEvent.type(filter, 'Open Source IDE');
-    expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: /JetBrains/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /VS Code/i })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /JetBrains/i })).not.toBeInTheDocument();
   });
 
   it('shows "No editors match the filter" when filter yields no results', async () => {
@@ -198,12 +198,12 @@ describe('EditorSelectorModal', () => {
       screen.getByRole('searchbox', { name: /Filter editors by/i }),
       'JetBrains',
     );
-    expect(screen.queryByRole('checkbox', { name: /VS Code/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /VS Code/i })).not.toBeInTheDocument();
 
     // close
     reRenderComponent(false, undefined);
     // reopen — filter must be cleared
     reRenderComponent(true, undefined);
-    expect(screen.getByRole('checkbox', { name: /VS Code/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /VS Code/i })).toBeInTheDocument();
   });
 });

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/SelectorModal.spec.tsx
@@ -191,6 +191,74 @@ describe('EditorSelectorModal', () => {
     expect(screen.getByText('custom')).toBeInTheDocument();
   });
 
+  it('preserves preselected version when switching editor group and back', async () => {
+    // When insiders is listed first but current editor is latest, switching away and back
+    // must NOT reset the version to insiders (the first/default in the list).
+    const editorsInsidersFirst: che.Plugin[] = [
+      makePlugin('che-incubator', 'che-code', 'insiders', 'VS Code - Open Source'),
+      makePlugin('che-incubator', 'che-code', 'latest', 'VS Code - Open Source'),
+      makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
+    ];
+    function localGetComponent(isOpen: boolean, currentEditorId: string | undefined) {
+      return (
+        <EditorSelectorModal
+          isOpen={isOpen}
+          currentEditorId={currentEditorId}
+          editors={editorsInsidersFirst}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      );
+    }
+    const { renderComponent: renderLocal } = getComponentRenderer(localGetComponent);
+    renderLocal(true, 'che-incubator/che-code/latest');
+
+    // Switch to IntelliJ
+    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
+    // Switch back to VS Code
+    await userEvent.click(screen.getByRole('radio', { name: /VS Code - Open Source/i }));
+
+    // Save is disabled because we're back to the original selection (latest, not insiders)
+    expect(screen.getByRole('button', { name: /Save/i })).toBeDisabled();
+  });
+
+  it('preserves explicitly chosen version when switching away and back', async () => {
+    // Start with latest, change to insiders, switch to IntelliJ, switch back → still insiders
+    renderComponent(true, 'che-incubator/che-code/latest');
+
+    // Change version to insiders via dropdown
+    await userEvent.click(
+      screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
+    );
+    await userEvent.click(screen.getByRole('menuitem', { name: 'insiders' }));
+
+    // Switch to IntelliJ
+    await userEvent.click(screen.getByRole('radio', { name: /JetBrains IntelliJ IDEA/i }));
+
+    // Switch back to VS Code
+    await userEvent.click(screen.getByRole('radio', { name: /VS Code - Open Source/i }));
+
+    // Should confirm with insiders, not latest
+    await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+    expect(mockOnConfirm).toHaveBeenCalledWith('che-incubator/che-code/insiders');
+  });
+
+  it('resets version selection when modal is reopened', async () => {
+    const { reRenderComponent } = renderComponent(true, 'che-incubator/che-code/latest');
+
+    // Change version to insiders — Save becomes enabled
+    await userEvent.click(
+      screen.getByRole('button', { name: /VS Code - Open Source version options/i }),
+    );
+    await userEvent.click(screen.getByRole('menuitem', { name: 'insiders' }));
+    expect(screen.getByRole('button', { name: /Save/i })).not.toBeDisabled();
+
+    // Close and reopen modal — selection must reset to current editor (latest), Save disabled
+    reRenderComponent(false, 'che-incubator/che-code/latest');
+    reRenderComponent(true, 'che-incubator/che-code/latest');
+    expect(screen.getByRole('button', { name: /Save/i })).toBeDisabled();
+  });
+
   it('resets the filter when the modal is closed then reopened', async () => {
     const { reRenderComponent } = renderComponent(true, undefined);
     // apply a filter

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/index.spec.tsx
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import { Architecture } from '@eclipse-che/common';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -51,6 +52,11 @@ const editors = [
   makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
 ];
 
+const amd64OnlyEditor: che.Plugin = {
+  ...makePlugin('che-incubator', 'amd64-only', 'latest', 'AMD64 Only Editor'),
+  arch: ['amd64'],
+};
+
 const mockChangeEditor = jest.fn().mockResolvedValue(undefined);
 
 function buildWorkspace(editorId?: string): Workspace {
@@ -61,13 +67,13 @@ function buildWorkspace(editorId?: string): Workspace {
   return constructWorkspace(builder.build());
 }
 
-function getComponent(readonly: boolean, workspace: Workspace): React.ReactElement {
+function getComponent(readonly: boolean, workspace: Workspace, arch?: string): React.ReactElement {
   return (
     <EditorFormGroup
       readonly={readonly}
       workspace={workspace}
       editors={editors}
-      currentArchitecture={undefined}
+      currentArchitecture={arch as Architecture | undefined}
       changeEditor={mockChangeEditor}
     />
   );
@@ -135,6 +141,24 @@ describe('EditorFormGroup', () => {
     expect(mockShowAlert).toHaveBeenCalledWith(
       expect.objectContaining({ variant: 'danger', title: 'patch failed' }),
     );
+  });
+
+  it('filters editors by architecture when currentArchitecture is set', () => {
+    // amd64OnlyEditor should be excluded when architecture is arm64
+    const { renderComponent: render } = getComponentRenderer(
+      (readonly: boolean, workspace: Workspace) => (
+        <EditorFormGroup
+          readonly={readonly}
+          workspace={workspace}
+          editors={[...editors, amd64OnlyEditor]}
+          currentArchitecture={'arm64' as Architecture}
+          changeEditor={mockChangeEditor}
+        />
+      ),
+    );
+    render(false, buildWorkspace('che-incubator/amd64-only/latest'));
+    // label falls back to raw id since amd64-only is filtered out
+    expect(screen.getByText('che-incubator/amd64-only/latest')).toBeInTheDocument();
   });
 
   it('closes the modal without calling changeEditor when Close Modal is clicked', async () => {

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/index.spec.tsx
@@ -13,14 +13,18 @@
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { container } from '@/inversify.config';
 import { EditorFormGroup } from '@/pages/WorkspaceDetails/OverviewTab/Editor';
 import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
+import { AppAlerts } from '@/services/alerts/appAlerts';
+import { AlertItem } from '@/services/helpers/types';
 import { che } from '@/services/models';
 import { constructWorkspace, Workspace } from '@/services/workspace-adapter';
 import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 
 jest.mock('@/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal');
 
+const mockShowAlert = jest.fn();
 const { renderComponent } = getComponentRenderer(getComponent);
 
 function makePlugin(
@@ -69,7 +73,20 @@ function getComponent(readonly: boolean, workspace: Workspace): React.ReactEleme
   );
 }
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  class MockAppAlerts extends AppAlerts {
+    showAlert(alert: AlertItem): void {
+      mockShowAlert(alert);
+    }
+  }
+  container.snapshot();
+  container.rebind(AppAlerts).to(MockAppAlerts).inSingletonScope();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  container.restore();
+});
 
 describe('EditorFormGroup', () => {
   it('shows "Default" when no editor annotation is set', () => {
@@ -77,17 +94,17 @@ describe('EditorFormGroup', () => {
     expect(screen.getByText('Default')).toBeInTheDocument();
   });
 
-  it('shows the editor display name and version', () => {
+  it('shows the editor display name without version', () => {
     renderComponent(false, buildWorkspace('che-incubator/che-code/latest'));
-    expect(screen.getByText('VS Code - Open Source · latest')).toBeInTheDocument();
+    expect(screen.getByText('VS Code - Open Source')).toBeInTheDocument();
   });
 
-  it('pencil button is disabled when readonly is true', () => {
+  it('pencil button is not rendered when readonly is true', () => {
     renderComponent(true, buildWorkspace('che-incubator/che-code/latest'));
-    expect(screen.getByRole('button', { name: /Change editor/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /Change editor/i })).not.toBeInTheDocument();
   });
 
-  it('pencil button is enabled when readonly is false', () => {
+  it('pencil button is rendered and enabled when readonly is false', () => {
     renderComponent(false, buildWorkspace('che-incubator/che-code/latest'));
     expect(screen.getByRole('button', { name: /Change editor/i })).not.toBeDisabled();
   });
@@ -99,13 +116,25 @@ describe('EditorFormGroup', () => {
     expect(screen.getByTestId('mock-editor-selector-modal')).toBeInTheDocument();
   });
 
-  it('calls changeEditor with the selected editor id when confirm is clicked', async () => {
+  it('calls changeEditor and shows success alert on confirm', async () => {
     const workspace = buildWorkspace('che-incubator/che-code/latest');
     renderComponent(false, workspace);
     await userEvent.click(screen.getByRole('button', { name: /Change editor/i }));
     await userEvent.click(screen.getByRole('button', { name: /Confirm Editor/i }));
-    expect(mockChangeEditor).toHaveBeenCalledTimes(1);
     expect(mockChangeEditor).toHaveBeenCalledWith(workspace, 'che-incubator/che-code/latest');
+    expect(mockShowAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'success', title: 'Workspace has been updated' }),
+    );
+  });
+
+  it('shows danger alert when changeEditor throws', async () => {
+    mockChangeEditor.mockRejectedValueOnce(new Error('patch failed'));
+    renderComponent(false, buildWorkspace('che-incubator/che-code/latest'));
+    await userEvent.click(screen.getByRole('button', { name: /Change editor/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Confirm Editor/i }));
+    expect(mockShowAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'danger', title: 'patch failed' }),
+    );
   });
 
   it('closes the modal without calling changeEditor when Close Modal is clicked', async () => {

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/__tests__/index.spec.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { EditorFormGroup } from '@/pages/WorkspaceDetails/OverviewTab/Editor';
+import getComponentRenderer, { screen } from '@/services/__mocks__/getComponentRenderer';
+import { che } from '@/services/models';
+import { constructWorkspace, Workspace } from '@/services/workspace-adapter';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+
+jest.mock('@/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal');
+
+const { renderComponent } = getComponentRenderer(getComponent);
+
+function makePlugin(
+  publisher: string,
+  name: string,
+  version: string,
+  displayName: string,
+): che.Plugin {
+  return {
+    id: `${publisher}/${name}/${version}`,
+    name,
+    publisher,
+    displayName,
+    type: 'Che Editor',
+    version,
+    icon: '<svg/>',
+    iconMediatype: 'image/svg+xml',
+    links: { devfile: '' },
+  };
+}
+
+const editors = [
+  makePlugin('che-incubator', 'che-code', 'latest', 'VS Code - Open Source'),
+  makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
+];
+
+const mockChangeEditor = jest.fn().mockResolvedValue(undefined);
+
+function buildWorkspace(editorId?: string): Workspace {
+  const builder = new DevWorkspaceBuilder();
+  if (editorId) {
+    builder.withMetadata({ annotations: { 'che.eclipse.org/che-editor': editorId } });
+  }
+  return constructWorkspace(builder.build());
+}
+
+function getComponent(readonly: boolean, workspace: Workspace): React.ReactElement {
+  return (
+    <EditorFormGroup
+      readonly={readonly}
+      workspace={workspace}
+      editors={editors}
+      currentArchitecture={undefined}
+      changeEditor={mockChangeEditor}
+    />
+  );
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('EditorFormGroup', () => {
+  it('shows "Default" when no editor annotation is set', () => {
+    renderComponent(false, buildWorkspace());
+    expect(screen.getByText('Default')).toBeInTheDocument();
+  });
+
+  it('shows the editor display name and version', () => {
+    renderComponent(false, buildWorkspace('che-incubator/che-code/latest'));
+    expect(screen.getByText('VS Code - Open Source · latest')).toBeInTheDocument();
+  });
+
+  it('pencil button is disabled when readonly is true', () => {
+    renderComponent(true, buildWorkspace('che-incubator/che-code/latest'));
+    expect(screen.getByRole('button', { name: /Change editor/i })).toBeDisabled();
+  });
+
+  it('pencil button is enabled when readonly is false', () => {
+    renderComponent(false, buildWorkspace('che-incubator/che-code/latest'));
+    expect(screen.getByRole('button', { name: /Change editor/i })).not.toBeDisabled();
+  });
+
+  it('opens the selector modal when pencil button is clicked', async () => {
+    renderComponent(false, buildWorkspace('che-incubator/che-code/latest'));
+    expect(screen.queryByTestId('mock-editor-selector-modal')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Change editor/i }));
+    expect(screen.getByTestId('mock-editor-selector-modal')).toBeInTheDocument();
+  });
+
+  it('calls changeEditor with the selected editor id when confirm is clicked', async () => {
+    const workspace = buildWorkspace('che-incubator/che-code/latest');
+    renderComponent(false, workspace);
+    await userEvent.click(screen.getByRole('button', { name: /Change editor/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Confirm Editor/i }));
+    expect(mockChangeEditor).toHaveBeenCalledTimes(1);
+    expect(mockChangeEditor).toHaveBeenCalledWith(workspace, 'che-incubator/che-code/latest');
+  });
+
+  it('closes the modal without calling changeEditor when Close Modal is clicked', async () => {
+    renderComponent(false, buildWorkspace('che-incubator/che-code/latest'));
+    await userEvent.click(screen.getByRole('button', { name: /Change editor/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Close Modal/i }));
+    expect(mockChangeEditor).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('mock-editor-selector-modal')).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/index.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Architecture } from '@eclipse-che/common';
+import { Button, FormGroup } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { EditorSelectorModal } from '@/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal';
+import overviewStyles from '@/pages/WorkspaceDetails/OverviewTab/index.module.css';
+import { getCurrentEditorId, getCurrentEditorLabel } from '@/services/helpers/editor';
+import { che } from '@/services/models';
+import { Workspace } from '@/services/workspace-adapter';
+import { RootState } from '@/store';
+import { selectCurrentArchitecture } from '@/store/ClusterConfig/selectors';
+import { selectEditors } from '@/store/Plugins/chePlugins/selectors';
+import { changeWorkspaceEditor } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/changeWorkspaceEditor';
+
+export type Props = MappedProps & {
+  readonly: boolean;
+  workspace: Workspace;
+};
+
+type State = {
+  isSelectorOpen: boolean;
+};
+
+export class EditorFormGroup extends React.PureComponent<Props, State> {
+  state: State = { isSelectorOpen: false };
+
+  private get filteredEditors(): che.Plugin[] {
+    const { editors, currentArchitecture } = this.props;
+    return editors.filter(
+      e => !currentArchitecture || !e.arch || e.arch.includes(currentArchitecture as Architecture),
+    );
+  }
+
+  private async handleConfirm(newEditorId: string): Promise<void> {
+    const { workspace, changeEditor } = this.props;
+    this.setState({ isSelectorOpen: false });
+    await changeEditor(workspace, newEditorId);
+  }
+
+  public render(): React.ReactNode {
+    const { readonly, workspace } = this.props;
+    const { isSelectorOpen } = this.state;
+    const editors = this.filteredEditors;
+    const label = getCurrentEditorLabel(workspace, editors);
+    const currentEditorId = getCurrentEditorId(workspace);
+
+    return (
+      <FormGroup label="Editor" fieldId="editor">
+        <span className={readonly ? overviewStyles.readonly : overviewStyles.editable}>
+          {label}
+          <Button
+            data-testid="overview-editor-edit-toggle"
+            variant="plain"
+            onClick={() => this.setState({ isSelectorOpen: true })}
+            aria-label="Change editor"
+            title="Change editor"
+            isDisabled={readonly}
+          >
+            <PencilAltIcon />
+          </Button>
+        </span>
+        <EditorSelectorModal
+          isOpen={isSelectorOpen}
+          currentEditorId={currentEditorId}
+          editors={editors}
+          onConfirm={editorId => this.handleConfirm(editorId)}
+          onClose={() => this.setState({ isSelectorOpen: false })}
+        />
+      </FormGroup>
+    );
+  }
+}
+
+const mapStateToProps = (state: RootState) => ({
+  editors: selectEditors(state),
+  currentArchitecture: selectCurrentArchitecture(state) as Architecture | undefined,
+});
+
+const mapDispatchToProps = {
+  changeEditor: changeWorkspaceEditor,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+type MappedProps = ConnectedProps<typeof connector>;
+export default connector(EditorFormGroup);

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/Editor/index.tsx
@@ -10,15 +10,24 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { Architecture } from '@eclipse-che/common';
-import { Button, FormGroup } from '@patternfly/react-core';
+import common, { Architecture } from '@eclipse-che/common';
+import {
+  AlertVariant,
+  Button,
+  FormGroup,
+  FormGroupLabelHelp,
+  Popover,
+} from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
+import { lazyInject } from '@/inversify.config';
 import { EditorSelectorModal } from '@/pages/WorkspaceDetails/OverviewTab/Editor/SelectorModal';
 import overviewStyles from '@/pages/WorkspaceDetails/OverviewTab/index.module.css';
+import { AppAlerts } from '@/services/alerts/appAlerts';
 import { getCurrentEditorId, getCurrentEditorLabel } from '@/services/helpers/editor';
+import getRandomString from '@/services/helpers/random';
 import { che } from '@/services/models';
 import { Workspace } from '@/services/workspace-adapter';
 import { RootState } from '@/store';
@@ -36,6 +45,9 @@ type State = {
 };
 
 export class EditorFormGroup extends React.PureComponent<Props, State> {
+  @lazyInject(AppAlerts)
+  private appAlerts: AppAlerts;
+
   state: State = { isSelectorOpen: false };
 
   private get filteredEditors(): che.Plugin[] {
@@ -48,7 +60,20 @@ export class EditorFormGroup extends React.PureComponent<Props, State> {
   private async handleConfirm(newEditorId: string): Promise<void> {
     const { workspace, changeEditor } = this.props;
     this.setState({ isSelectorOpen: false });
-    await changeEditor(workspace, newEditorId);
+    try {
+      await changeEditor(workspace, newEditorId);
+      this.appAlerts.showAlert({
+        key: 'editor-change-' + getRandomString(4),
+        title: 'Workspace has been updated',
+        variant: AlertVariant.success,
+      });
+    } catch (e) {
+      this.appAlerts.showAlert({
+        key: 'editor-change-error-' + getRandomString(4),
+        title: common.helpers.errors.getMessage(e),
+        variant: AlertVariant.danger,
+      });
+    }
   }
 
   public render(): React.ReactNode {
@@ -59,20 +84,30 @@ export class EditorFormGroup extends React.PureComponent<Props, State> {
     const currentEditorId = getCurrentEditorId(workspace);
 
     return (
-      <FormGroup label="Editor" fieldId="editor">
-        <span className={readonly ? overviewStyles.readonly : overviewStyles.editable}>
-          {label}
-          <Button
-            data-testid="overview-editor-edit-toggle"
-            variant="plain"
-            onClick={() => this.setState({ isSelectorOpen: true })}
-            aria-label="Change editor"
-            title="Change editor"
-            isDisabled={readonly}
-          >
-            <PencilAltIcon />
-          </Button>
-        </span>
+      <FormGroup
+        label="Editor"
+        fieldId="editor"
+        labelHelp={
+          <Popover bodyContent="The IDE used to open this workspace. You can change it when the workspace is stopped.">
+            <FormGroupLabelHelp aria-label="More info for Editor" />
+          </Popover>
+        }
+      >
+        {readonly && <span className={overviewStyles.readonly}>{label}</span>}
+        {!readonly && (
+          <span className={overviewStyles.editable}>
+            {label}
+            <Button
+              data-testid="overview-editor-edit-toggle"
+              variant="plain"
+              onClick={() => this.setState({ isSelectorOpen: true })}
+              aria-label="Change editor"
+              title="Change editor"
+            >
+              <PencilAltIcon />
+            </Button>
+          </span>
+        )}
         <EditorSelectorModal
           isOpen={isSelectorOpen}
           currentEditorId={currentEditorId}

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__tests__/__snapshots__/index.spec.tsx.snap
@@ -47,6 +47,14 @@ exports[`OverviewTab With parent screenshot 1`] = `
         </span>
       </div>
       <div>
+        Mock Editor Form Group
+        <button
+          disabled={false}
+        >
+          Change editor
+        </button>
+      </div>
+      <div>
         Mock Projects Form
       </div>
       <div>
@@ -102,6 +110,14 @@ exports[`OverviewTab Without parent screenshot 1`] = `
         <span>
           StorageType: 
         </span>
+      </div>
+      <div>
+        Mock Editor Form Group
+        <button
+          disabled={false}
+        >
+          Change editor
+        </button>
       </div>
       <div>
         Mock Projects Form

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/__tests__/index.spec.tsx
@@ -21,6 +21,7 @@ import { constructWorkspace, Workspace } from '@/services/workspace-adapter';
 import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
 import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
 
+jest.mock('@/pages/WorkspaceDetails/OverviewTab/Editor');
 jest.mock('@/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace');
 jest.mock('@/pages/WorkspaceDetails/OverviewTab/Projects');
 jest.mock('@/pages/WorkspaceDetails/OverviewTab/StorageType');
@@ -184,6 +185,12 @@ describe('OverviewTab', () => {
       // proving the rename path is fully wired.
       expect(mockOnSave).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('renders EditorFormGroup', async () => {
+    const workspace = constructWorkspace(new DevWorkspaceBuilder().build());
+    renderComponent(workspace);
+    expect(screen.getByRole('button', { name: 'Change editor' })).toBeInTheDocument();
   });
 });
 

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.module.css
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.module.css
@@ -12,13 +12,13 @@
 
 .editable {
   position: relative;
-  top: 2px;
+  bottom: 2px;
   color: var(--pf-t--global--text--color--link--default);
 }
 
 .readonly {
   display: inline-block;
-  padding-top: 8px;
+  padding-top: 5px;
 }
 
 .labelHelp {

--- a/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
+++ b/packages/dashboard-frontend/src/pages/WorkspaceDetails/OverviewTab/index.tsx
@@ -15,6 +15,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
 
 import AiToolFormGroup from '@/pages/WorkspaceDetails/OverviewTab/AiTool';
+import EditorFormGroup from '@/pages/WorkspaceDetails/OverviewTab/Editor';
 import GitRepoFormGroup from '@/pages/WorkspaceDetails/OverviewTab/GitRepo';
 import { InfrastructureNamespaceFormGroup } from '@/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace';
 import { ProjectsFormGroup } from '@/pages/WorkspaceDetails/OverviewTab/Projects';
@@ -119,6 +120,7 @@ export class OverviewTab extends React.Component<Props, State> {
               parentStorageType={parentStorageType}
               onSave={storageType => this.handleStorageSave(storageType)}
             />
+            <EditorFormGroup readonly={isReadonly} workspace={workspace} />
             <AiToolFormGroup
               readonly={
                 isDeprecated ||

--- a/packages/dashboard-frontend/src/services/backend-client/__tests__/devWorkspaceTemplateApi.spec.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/__tests__/devWorkspaceTemplateApi.spec.ts
@@ -15,6 +15,7 @@ import mockAxios from 'axios';
 
 import {
   createTemplate,
+  deleteTemplate,
   getTemplateByName,
   getTemplates,
   patchTemplate,
@@ -25,6 +26,7 @@ describe('DevWorkspaceTemplate API', () => {
   const mockGet = mockAxios.get as jest.Mock;
   const mockPost = mockAxios.post as jest.Mock;
   const mockPatch = mockAxios.patch as jest.Mock;
+  const mockDelete = mockAxios.delete as jest.Mock;
 
   const namespace = 'test-name';
   const devWorkspaceTemplateName = 'che-code';
@@ -141,6 +143,25 @@ describe('DevWorkspaceTemplate API', () => {
       );
 
       expect(res).toEqual(devWorkspaceTemplate);
+    });
+  });
+
+  describe('delete a DevWorkspaceTemplate', () => {
+    it('should call the correct URL on success', async () => {
+      mockDelete.mockResolvedValueOnce(new Promise(resolve => resolve({ data: undefined })));
+      await deleteTemplate(namespace, devWorkspaceTemplateName);
+
+      expect(mockDelete).toHaveBeenCalledWith(
+        '/dashboard/api/namespace/test-name/devworkspacetemplates/che-code',
+        undefined,
+      );
+    });
+
+    it('should throw a wrapped error when the request fails', async () => {
+      mockDelete.mockRejectedValueOnce(new Error('network failure'));
+      await expect(deleteTemplate(namespace, devWorkspaceTemplateName)).rejects.toThrow(
+        "Failed to delete devWorkspaceTemplate 'che-code'",
+      );
     });
   });
 });

--- a/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
+++ b/packages/dashboard-frontend/src/services/backend-client/devWorkspaceTemplateApi.ts
@@ -76,3 +76,14 @@ export async function patchTemplate(
     );
   }
 }
+
+export async function deleteTemplate(namespace: string, name: string): Promise<void> {
+  const url = `${dashboardBackendPrefix}/namespace/${namespace}/devworkspacetemplates/${name}`;
+  try {
+    await AxiosWrapper.createToRetryMissedBearerTokenError().delete(url);
+  } catch (e) {
+    throw new Error(
+      `Failed to delete devWorkspaceTemplate '${name}'. ${common.helpers.errors.getMessage(e)}`,
+    );
+  }
+}

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/editor.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/editor.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import {
+  getCurrentEditorId,
+  getCurrentEditorLabel,
+  groupEditorsByName,
+} from '@/services/helpers/editor';
+import { che } from '@/services/models';
+import { constructWorkspace } from '@/services/workspace-adapter';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+
+function makePlugin(
+  publisher: string,
+  name: string,
+  version: string,
+  displayName: string,
+): che.Plugin {
+  return {
+    id: `${publisher}/${name}/${version}`,
+    name,
+    publisher,
+    displayName,
+    type: 'Che Editor',
+    version,
+    description: `${displayName} description`,
+    icon: '<svg/>',
+    iconMediatype: 'image/svg+xml',
+    links: { devfile: '' },
+  };
+}
+
+describe('groupEditorsByName', () => {
+  it('groups plugins with the same publisher/name together', () => {
+    const plugins = [
+      makePlugin('che-incubator', 'che-code', 'latest', 'VS Code - Open Source'),
+      makePlugin('che-incubator', 'che-code', 'insiders', 'VS Code - Open Source'),
+      makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
+    ];
+    const groups = groupEditorsByName(plugins);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe('che-incubator/che-code');
+    expect(groups[0].displayName).toBe('VS Code - Open Source');
+    expect(groups[0].versions).toHaveLength(2);
+    expect(groups[1].key).toBe('che-incubator/che-idea-server');
+    expect(groups[1].versions).toHaveLength(1);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(groupEditorsByName([])).toEqual([]);
+  });
+
+  it('preserves insertion order of groups', () => {
+    const plugins = [
+      makePlugin('che-incubator', 'che-idea-server', 'latest', 'IntelliJ IDEA'),
+      makePlugin('che-incubator', 'che-code', 'latest', 'VS Code'),
+    ];
+    const groups = groupEditorsByName(plugins);
+    expect(groups[0].key).toBe('che-incubator/che-idea-server');
+    expect(groups[1].key).toBe('che-incubator/che-code');
+  });
+});
+
+describe('getCurrentEditorId', () => {
+  it('returns the annotation value when present', () => {
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({
+        annotations: { 'che.eclipse.org/che-editor': 'che-incubator/che-code/latest' },
+      })
+      .build();
+    const workspace = constructWorkspace(dw);
+    expect(getCurrentEditorId(workspace)).toBe('che-incubator/che-code/latest');
+  });
+
+  it('returns undefined when annotation is absent', () => {
+    const dw = new DevWorkspaceBuilder().build();
+    const workspace = constructWorkspace(dw);
+    expect(getCurrentEditorId(workspace)).toBeUndefined();
+  });
+});
+
+describe('getCurrentEditorLabel', () => {
+  const editors = [
+    makePlugin('che-incubator', 'che-code', 'latest', 'VS Code - Open Source'),
+    makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
+  ];
+
+  it('returns "displayName · version" when the editor is found in the list', () => {
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({
+        annotations: { 'che.eclipse.org/che-editor': 'che-incubator/che-code/latest' },
+      })
+      .build();
+    const workspace = constructWorkspace(dw);
+    expect(getCurrentEditorLabel(workspace, editors)).toBe('VS Code - Open Source · latest');
+  });
+
+  it('returns the raw id when the editor is not in the list', () => {
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({ annotations: { 'che.eclipse.org/che-editor': 'unknown/editor/next' } })
+      .build();
+    const workspace = constructWorkspace(dw);
+    expect(getCurrentEditorLabel(workspace, editors)).toBe('unknown/editor/next');
+  });
+
+  it('returns "Default" when annotation is absent', () => {
+    const dw = new DevWorkspaceBuilder().build();
+    const workspace = constructWorkspace(dw);
+    expect(getCurrentEditorLabel(workspace, editors)).toBe('Default');
+  });
+});

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/editor.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/editor.spec.ts
@@ -68,6 +68,19 @@ describe('groupEditorsByName', () => {
     expect(groups[0].key).toBe('che-incubator/che-idea-server');
     expect(groups[1].key).toBe('che-incubator/che-code');
   });
+
+  it('falls back to plugin name when displayName is empty', () => {
+    const plugin: che.Plugin = {
+      ...makePlugin('che-incubator', 'che-code', 'latest', ''),
+      displayName: '',
+      icon: '',
+      iconMediatype: '',
+    };
+    const groups = groupEditorsByName([plugin]);
+    expect(groups[0].displayName).toBe('che-code');
+    expect(groups[0].icon).toBe('');
+    expect(groups[0].iconMediatype).toBe('');
+  });
 });
 
 describe('getCurrentEditorId', () => {
@@ -116,5 +129,19 @@ describe('getCurrentEditorLabel', () => {
     const dw = new DevWorkspaceBuilder().build();
     const workspace = constructWorkspace(dw);
     expect(getCurrentEditorLabel(workspace, editors)).toBe('Default');
+  });
+
+  it('falls back to plugin name when found editor has no displayName', () => {
+    const editorWithoutDisplayName: che.Plugin = {
+      ...makePlugin('che-incubator', 'che-code', 'latest', ''),
+      displayName: '',
+    };
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({
+        annotations: { 'che.eclipse.org/che-editor': 'che-incubator/che-code/latest' },
+      })
+      .build();
+    const workspace = constructWorkspace(dw);
+    expect(getCurrentEditorLabel(workspace, [editorWithoutDisplayName])).toBe('che-code');
   });
 });

--- a/packages/dashboard-frontend/src/services/helpers/__tests__/editor.spec.ts
+++ b/packages/dashboard-frontend/src/services/helpers/__tests__/editor.spec.ts
@@ -94,14 +94,14 @@ describe('getCurrentEditorLabel', () => {
     makePlugin('che-incubator', 'che-idea-server', 'latest', 'JetBrains IntelliJ IDEA'),
   ];
 
-  it('returns "displayName · version" when the editor is found in the list', () => {
+  it('returns displayName when the editor is found in the list', () => {
     const dw = new DevWorkspaceBuilder()
       .withMetadata({
         annotations: { 'che.eclipse.org/che-editor': 'che-incubator/che-code/latest' },
       })
       .build();
     const workspace = constructWorkspace(dw);
-    expect(getCurrentEditorLabel(workspace, editors)).toBe('VS Code - Open Source · latest');
+    expect(getCurrentEditorLabel(workspace, editors)).toBe('VS Code - Open Source');
   });
 
   it('returns the raw id when the editor is not in the list', () => {

--- a/packages/dashboard-frontend/src/services/helpers/editor.ts
+++ b/packages/dashboard-frontend/src/services/helpers/editor.ts
@@ -13,6 +13,9 @@
 import { dump } from 'js-yaml';
 
 import devfileApi from '@/services/devfileApi';
+import { DEVWORKSPACE_CHE_EDITOR } from '@/services/devfileApi/devWorkspace/metadata';
+import { che } from '@/services/models';
+import { Workspace } from '@/services/workspace-adapter';
 
 const sortOrder: Array<keyof devfileApi.Devfile> = [
   'schemaVersion',
@@ -57,4 +60,43 @@ export default function stringify(obj: devfileApi.Devfile | devfileApi.DevWorksp
     return '';
   }
   return dump(obj, { lineWidth, sortKeys });
+}
+
+export type EditorGroup = {
+  key: string;
+  displayName: string;
+  icon: string;
+  iconMediatype: string;
+  versions: che.Plugin[];
+};
+
+export function groupEditorsByName(editors: che.Plugin[]): EditorGroup[] {
+  const map = new Map<string, EditorGroup>();
+  for (const editor of editors) {
+    const key = `${editor.publisher}/${editor.name}`;
+    if (!map.has(key)) {
+      map.set(key, {
+        key,
+        displayName: editor.displayName || editor.name,
+        icon: editor.icon || '',
+        iconMediatype: editor.iconMediatype || '',
+        versions: [],
+      });
+    }
+    map.get(key)!.versions.push(editor);
+  }
+  return Array.from(map.values());
+}
+
+export function getCurrentEditorId(workspace: Workspace): string | undefined {
+  return workspace.ref.metadata?.annotations?.[DEVWORKSPACE_CHE_EDITOR];
+}
+
+export function getCurrentEditorLabel(workspace: Workspace, editors: che.Plugin[]): string {
+  const id = getCurrentEditorId(workspace);
+  if (!id) {
+    return 'Default';
+  }
+  const found = editors.find(e => e.id === id);
+  return found ? `${found.displayName || found.name} · ${found.version}` : id;
 }

--- a/packages/dashboard-frontend/src/services/helpers/editor.ts
+++ b/packages/dashboard-frontend/src/services/helpers/editor.ts
@@ -98,5 +98,5 @@ export function getCurrentEditorLabel(workspace: Workspace, editors: che.Plugin[
     return 'Default';
   }
   const found = editors.find(e => e.id === id);
-  return found ? `${found.displayName || found.name} · ${found.version}` : id;
+  return found ? found.displayName || found.name : id;
 }

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/changeWorkspaceEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/changeWorkspaceEditor.spec.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import devfileApi from '@/services/devfileApi';
+import { constructWorkspace } from '@/services/workspace-adapter';
+import { DevWorkspaceBuilder } from '@/store/__mocks__/devWorkspaceBuilder';
+import { MockStoreBuilder } from '@/store/__mocks__/mockStore';
+import { changeWorkspaceEditor } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/changeWorkspaceEditor';
+import { getDevWorkspaceClient } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers';
+
+jest.mock('@/store/SanityCheck', () => ({
+  ...jest.requireActual('@/store/SanityCheck'),
+  verifyAuthorized: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers');
+jest.mock('@/services/backend-client/devWorkspaceApi');
+jest.mock('@/services/backend-client/devWorkspaceTemplateApi');
+
+const wsAnnotations = {
+  'che.eclipse.org/che-editor': 'che-incubator/che-code/latest',
+  'che.eclipse.org/devfile-source':
+    'url:\n  location: https://example.com\nfactory:\n  params: >-\n    che-editor=che-incubator/che-code/latest&storageType=per-user\n',
+};
+
+function buildWorkspace() {
+  const dw = new DevWorkspaceBuilder()
+    .withMetadata({
+      name: 'empty-ido0',
+      namespace: 'test-ns',
+      uid: 'test-uid',
+      annotations: wsAnnotations,
+    })
+    .withContributions([{ name: 'editor', kubernetes: { name: 'che-code-empty-ido0' } }])
+    .build();
+  return constructWorkspace(dw);
+}
+
+describe('changeWorkspaceEditor', () => {
+  const intellijDevfile = {
+    schemaVersion: '2.3.0',
+    metadata: {
+      name: 'che-idea-server',
+      attributes: { publisher: 'che-incubator', version: 'latest' },
+    },
+    components: [
+      {
+        name: 'editor-injector',
+        container: { image: 'quay.io/che-incubator/che-idea-dev-server:latest' },
+      },
+    ],
+  };
+
+  let mockCreateDevWorkspaceTemplate: jest.Mock;
+  let mockPatchWorkspace: jest.Mock;
+  let mockDeleteTemplate: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCreateDevWorkspaceTemplate = jest.fn().mockResolvedValue({});
+    (getDevWorkspaceClient as jest.Mock).mockReturnValue({
+      createDevWorkspaceTemplate: mockCreateDevWorkspaceTemplate,
+    });
+
+    const DwApi = jest.requireMock('@/services/backend-client/devWorkspaceApi');
+    mockPatchWorkspace = DwApi.patchWorkspace = jest
+      .fn()
+      .mockResolvedValue({ devWorkspace: { metadata: { name: 'empty-ido0' } } });
+
+    const DwtApi = jest.requireMock('@/services/backend-client/devWorkspaceTemplateApi');
+    mockDeleteTemplate = DwtApi.deleteTemplate = jest.fn().mockResolvedValue({});
+  });
+
+  it('creates a new DevWorkspaceTemplate for the new editor', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const workspace = buildWorkspace();
+    await store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest'));
+
+    expect(mockCreateDevWorkspaceTemplate).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreateDevWorkspaceTemplate.mock.calls[0] as unknown[];
+    expect(callArgs[0]).toBe('test-ns');
+    expect(callArgs[1]).toMatchObject({ metadata: { name: 'empty-ido0' } });
+    expect(callArgs[2]).toMatchObject({
+      metadata: {
+        name: 'che-idea-server-empty-ido0',
+        annotations: {
+          'che.eclipse.org/plugin-registry-url': expect.stringContaining('che-idea-server/latest'),
+        },
+      },
+    });
+  });
+
+  it('patches che-editor annotation and spec.contributions on the workspace', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const workspace = buildWorkspace();
+    await store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest'));
+
+    expect(mockPatchWorkspace).toHaveBeenCalledWith(
+      'test-ns',
+      'empty-ido0',
+      expect.arrayContaining([
+        expect.objectContaining({ path: '/metadata/annotations' }),
+        expect.objectContaining({
+          path: '/spec/contributions/0/kubernetes/name',
+          value: 'che-idea-server-empty-ido0',
+        }),
+      ]),
+    );
+
+    const patches = mockPatchWorkspace.mock.calls[0][2] as Array<{
+      path: string;
+      value: Record<string, string>;
+    }>;
+    const annotationsPatch = patches.find(p => p.path === '/metadata/annotations');
+    expect(annotationsPatch?.value['che.eclipse.org/che-editor']).toBe(
+      'che-incubator/che-idea-server/latest',
+    );
+    expect(annotationsPatch?.value['che.eclipse.org/devfile-source']).toContain(
+      'che-editor=che-incubator/che-idea-server/latest',
+    );
+  });
+
+  it('deletes the old template', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const workspace = buildWorkspace();
+    await store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest'));
+
+    expect(mockDeleteTemplate).toHaveBeenCalledWith('test-ns', 'che-code-empty-ido0');
+  });
+
+  it('throws when editor is not found in cmEditors', async () => {
+    const store = new MockStoreBuilder().build(); // no cmEditors
+    const workspace = buildWorkspace();
+    await expect(
+      store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/unknown-editor/latest')),
+    ).rejects.toThrow('not found');
+  });
+});

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/changeWorkspaceEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/changeWorkspaceEditor.spec.ts
@@ -150,4 +150,39 @@ describe('changeWorkspaceEditor', () => {
       store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/unknown-editor/latest')),
     ).rejects.toThrow('not found');
   });
+
+  it('rethrows when patchWorkspace fails', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const workspace = buildWorkspace();
+    mockPatchWorkspace.mockRejectedValueOnce(new Error('patch failed'));
+
+    await expect(
+      store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest')),
+    ).rejects.toThrow('patch failed');
+  });
+
+  it('skips delete when old and new template names are the same', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    // workspace already points to the target editor
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({
+        name: 'empty-ido0',
+        namespace: 'test-ns',
+        uid: 'test-uid',
+        annotations: {
+          ...wsAnnotations,
+          'che.eclipse.org/che-editor': 'che-incubator/che-idea-server/latest',
+        },
+      })
+      .withContributions([{ name: 'editor', kubernetes: { name: 'che-idea-server-empty-ido0' } }])
+      .build();
+    const workspace = constructWorkspace(dw);
+    await store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest'));
+
+    expect(mockDeleteTemplate).not.toHaveBeenCalled();
+  });
 });

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/changeWorkspaceEditor.spec.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/__tests__/changeWorkspaceEditor.spec.ts
@@ -133,6 +133,95 @@ describe('changeWorkspaceEditor', () => {
     );
   });
 
+  it('patches the correct contributions index when editor is not at index 0', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({
+        name: 'empty-ido0',
+        namespace: 'test-ns',
+        uid: 'test-uid',
+        annotations: wsAnnotations,
+      })
+      .withContributions([
+        { name: 'ai-tool', kubernetes: { name: 'ai-tool-empty-ido0' } },
+        { name: 'editor', kubernetes: { name: 'che-code-empty-ido0' } },
+      ])
+      .build();
+    const workspace = constructWorkspace(dw);
+    await store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest'));
+
+    expect(mockPatchWorkspace).toHaveBeenCalledWith(
+      'test-ns',
+      'empty-ido0',
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: '/spec/contributions/1/kubernetes/name',
+          value: 'che-idea-server-empty-ido0',
+        }),
+      ]),
+    );
+  });
+
+  it('throws when editor contribution is absent from the workspace', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({ name: 'empty-ido0', namespace: 'test-ns', uid: 'test-uid' })
+      .withContributions([{ name: 'ai-tool', kubernetes: { name: 'ai-tool-empty-ido0' } }])
+      .build();
+    const workspace = constructWorkspace(dw);
+
+    await expect(
+      store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest')),
+    ).rejects.toThrow('Editor contribution not found');
+  });
+
+  it('succeeds even when deleteTemplate throws', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const workspace = buildWorkspace();
+    mockDeleteTemplate.mockRejectedValueOnce(new Error('already gone'));
+
+    await expect(
+      store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest')),
+    ).resolves.not.toThrow();
+    expect(mockPatchWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves devfile-source unchanged when che-editor= is absent', async () => {
+    const store = new MockStoreBuilder()
+      .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])
+      .build();
+    const devfileSourceWithoutEditor = 'url:\n  location: https://example.com\n';
+    const dw = new DevWorkspaceBuilder()
+      .withMetadata({
+        name: 'empty-ido0',
+        namespace: 'test-ns',
+        uid: 'test-uid',
+        annotations: {
+          'che.eclipse.org/che-editor': 'che-incubator/che-code/latest',
+          'che.eclipse.org/devfile-source': devfileSourceWithoutEditor,
+        },
+      })
+      .withContributions([{ name: 'editor', kubernetes: { name: 'che-code-empty-ido0' } }])
+      .build();
+    const workspace = constructWorkspace(dw);
+    await store.dispatch(changeWorkspaceEditor(workspace, 'che-incubator/che-idea-server/latest'));
+
+    const patches = mockPatchWorkspace.mock.calls[0][2] as Array<{
+      path: string;
+      value: Record<string, string>;
+    }>;
+    const annotationsPatch = patches.find(p => p.path === '/metadata/annotations');
+    expect(annotationsPatch?.value['che.eclipse.org/devfile-source']).toBe(
+      devfileSourceWithoutEditor,
+    );
+  });
+
   it('deletes the old template', async () => {
     const store = new MockStoreBuilder()
       .withDwPlugins({}, {}, false, [intellijDevfile as devfileApi.Devfile])

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/changeWorkspaceEditor.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/changeWorkspaceEditor.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { V1alpha2DevWorkspaceTemplateSpec } from '@devfile/api';
+import common, { ApplicationId } from '@eclipse-che/common';
+import cloneDeep from 'lodash/cloneDeep';
+
+import * as DwApi from '@/services/backend-client/devWorkspaceApi';
+import * as DwtApi from '@/services/backend-client/devWorkspaceTemplateApi';
+import devfileApi from '@/services/devfileApi';
+import { DEVWORKSPACE_CHE_EDITOR } from '@/services/devfileApi/devWorkspace/metadata';
+import { Workspace } from '@/services/workspace-adapter';
+import {
+  COMPONENT_UPDATE_POLICY,
+  DEVWORKSPACE_DEVFILE_SOURCE,
+  REGISTRY_URL,
+} from '@/services/workspace-client/devworkspace/devWorkspaceClient';
+import { AppThunk } from '@/store';
+import { selectApplications } from '@/store/ClusterInfo/selectors';
+import { EDITOR_DEVFILE_API_QUERY } from '@/store/DevfileRegistries/const';
+import { verifyAuthorized } from '@/store/SanityCheck';
+import { selectServerConfigState } from '@/store/ServerConfig/selectors';
+import { getDevWorkspaceClient } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers';
+import { getEditorName } from '@/store/Workspaces/devWorkspaces/actions/actionCreators/helpers/updateEditor';
+import {
+  devWorkspacesErrorAction,
+  devWorkspacesRequestAction,
+  devWorkspacesUpdateAction,
+} from '@/store/Workspaces/devWorkspaces/actions/actions';
+
+export const changeWorkspaceEditor =
+  (workspace: Workspace, newEditorId: string): AppThunk =>
+  async (dispatch, getState) => {
+    const dw = workspace.ref;
+    const namespace = dw.metadata.namespace;
+    const workspaceName = dw.metadata.name;
+    const state = getState();
+
+    try {
+      await verifyAuthorized(dispatch, getState);
+      dispatch(devWorkspacesRequestAction());
+
+      // Resolve editor devfile from store (same source checkForTemplatesUpdate uses at start time)
+      const editors = state.dwPlugins.cmEditors || [];
+      const editorDevfile = editors.find(
+        e =>
+          `${e.metadata.attributes.publisher}/${e.metadata.name}/${e.metadata.attributes.version}` ===
+          newEditorId,
+      );
+      if (!editorDevfile) {
+        throw new Error(`Editor "${newEditorId}" not found in the plugin registry`);
+      }
+
+      // Build template spec — same logic as checkForTemplatesUpdate uses internally
+      const spec: Partial<V1alpha2DevWorkspaceTemplateSpec> = {};
+      for (const key in editorDevfile) {
+        if (key === 'schemaVersion' || key === 'metadata') {
+          continue;
+        }
+        if (key === 'components') {
+          const components = cloneDeep(editorDevfile.components ?? []);
+          components.forEach(c => {
+            if (c.container && !c.container.sourceMapping) {
+              c.container.sourceMapping = '/projects';
+            }
+          });
+          spec.components = components as V1alpha2DevWorkspaceTemplateSpec['components'];
+        } else {
+          (spec as Record<string, unknown>)[key] = (
+            editorDevfile as unknown as Record<string, unknown>
+          )[key];
+        }
+      }
+
+      // Step 1: create new template (reuse createDevWorkspaceTemplate — adds ownerRef + env vars)
+      const newEditorName = newEditorId.split('/')[1];
+      const newTemplateName = `${newEditorName}-${workspaceName}`;
+
+      const newTemplate: devfileApi.DevWorkspaceTemplate = {
+        apiVersion: 'workspace.devfile.io/v1alpha2',
+        kind: 'DevWorkspaceTemplate',
+        metadata: {
+          name: newTemplateName,
+          namespace,
+          annotations: {
+            [COMPONENT_UPDATE_POLICY]: 'managed',
+            [REGISTRY_URL]: `${EDITOR_DEVFILE_API_QUERY}${newEditorId}`,
+          },
+        },
+        spec,
+      };
+
+      const serverConfig = selectServerConfigState(state).config;
+      const clusterConsole = selectApplications(state).find(
+        app => app.id === ApplicationId.CLUSTER_CONSOLE,
+      );
+      await getDevWorkspaceClient().createDevWorkspaceTemplate(
+        namespace,
+        dw,
+        newTemplate,
+        serverConfig?.pluginRegistryURL,
+        serverConfig?.pluginRegistryInternalURL,
+        serverConfig?.pluginRegistry?.openVSXURL,
+        clusterConsole,
+      );
+
+      // Step 2: patch workspace — annotations + spec.contributions
+      const annotations = { ...(dw.metadata.annotations ?? {}) };
+      annotations[DEVWORKSPACE_CHE_EDITOR] = newEditorId;
+      const devfileSource = annotations[DEVWORKSPACE_DEVFILE_SOURCE] ?? '';
+      annotations[DEVWORKSPACE_DEVFILE_SOURCE] = devfileSource.replace(
+        /che-editor=[^&\n]+/,
+        `che-editor=${newEditorId}`,
+      );
+
+      const { devWorkspace: updatedDw } = await DwApi.patchWorkspace(namespace, workspaceName, [
+        { op: 'replace', path: '/metadata/annotations', value: annotations },
+        { op: 'replace', path: '/spec/contributions/0/kubernetes/name', value: newTemplateName },
+      ]);
+      dispatch(devWorkspacesUpdateAction(updatedDw));
+
+      // Step 3: delete old template (ownerRef also GC-s it on workspace delete — explicit for cleanliness)
+      const oldTemplateName = getEditorName(dw);
+      if (oldTemplateName && oldTemplateName !== newTemplateName) {
+        await DwtApi.deleteTemplate(namespace, oldTemplateName);
+      }
+    } catch (e) {
+      const errorMessage =
+        `Failed to change editor for workspace ${workspaceName}, reason: ` +
+        common.helpers.errors.getMessage(e);
+      dispatch(devWorkspacesErrorAction(errorMessage));
+      throw e;
+    }
+  };

--- a/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/changeWorkspaceEditor.ts
+++ b/packages/dashboard-frontend/src/store/Workspaces/devWorkspaces/actions/actionCreators/changeWorkspaceEditor.ts
@@ -114,24 +114,39 @@ export const changeWorkspaceEditor =
       );
 
       // Step 2: patch workspace — annotations + spec.contributions
+      const editorIndex = (dw.spec?.contributions ?? []).findIndex(c => c.name === 'editor');
+      if (editorIndex === -1) {
+        throw new Error(`Editor contribution not found in workspace ${workspaceName}`);
+      }
+
       const annotations = { ...(dw.metadata.annotations ?? {}) };
       annotations[DEVWORKSPACE_CHE_EDITOR] = newEditorId;
       const devfileSource = annotations[DEVWORKSPACE_DEVFILE_SOURCE] ?? '';
-      annotations[DEVWORKSPACE_DEVFILE_SOURCE] = devfileSource.replace(
-        /che-editor=[^&\n]+/,
-        `che-editor=${newEditorId}`,
-      );
+      if (devfileSource.includes('che-editor=')) {
+        annotations[DEVWORKSPACE_DEVFILE_SOURCE] = devfileSource.replace(
+          /che-editor=[^&\n]+/,
+          `che-editor=${newEditorId}`,
+        );
+      }
 
       const { devWorkspace: updatedDw } = await DwApi.patchWorkspace(namespace, workspaceName, [
         { op: 'replace', path: '/metadata/annotations', value: annotations },
-        { op: 'replace', path: '/spec/contributions/0/kubernetes/name', value: newTemplateName },
+        {
+          op: 'replace',
+          path: `/spec/contributions/${editorIndex}/kubernetes/name`,
+          value: newTemplateName,
+        },
       ]);
       dispatch(devWorkspacesUpdateAction(updatedDw));
 
       // Step 3: delete old template (ownerRef also GC-s it on workspace delete — explicit for cleanliness)
       const oldTemplateName = getEditorName(dw);
       if (oldTemplateName && oldTemplateName !== newTemplateName) {
-        await DwtApi.deleteTemplate(namespace, oldTemplateName);
+        try {
+          await DwtApi.deleteTemplate(namespace, oldTemplateName);
+        } catch {
+          // Old template may already be gone — ownerRef GC handles it
+        }
       }
     } catch (e) {
       const errorMessage =


### PR DESCRIPTION
### What does this PR do?

Adds a **Change Editor** form group to the Workspace Details → Overview tab, following the same UX pattern as "Change AI Tools".

When a workspace is stopped, a pencil button opens a modal with radio buttons listing all available editors (grouped by display name). Each editor group with multiple versions shows an inline version picker (EllipsisV dropdown), matching the existing `EditorSelector` gallery in Create Workspace. On confirm, the dashboard:

1. Creates a new `DevWorkspaceTemplate` for the selected editor (reusing `DevWorkspaceClient.createDevWorkspaceTemplate`, which sets `ownerReferences` and injects cluster env vars).
2. Patches the workspace — updates `che.eclipse.org/che-editor`, the `devfile-source` factory params, and `spec.contributions[0].kubernetes.name` in one atomic PATCH.
3. Deletes the old `DevWorkspaceTemplate` (the backend DELETE route already existed; a `deleteTemplate` frontend wrapper is added to `devWorkspaceTemplateApi.ts`).

The button is disabled when the workspace is not `STOPPED` or `FAILED`, using the same `isReadonly` guard already in place for Name, Storage Type, and AI Tool.

### Screenshot/screencast of this PR

<img width="1320" height="775" alt="Знімок екрана 2026-09-04 о 18 24 45" src="https://github.com/user-attachments/assets/2f1a9f00-acdc-4c1c-99e2-5b400564d952" />
<img width="1320" height="775" alt="Знімок екрана 2026-09-04 о 18 24 32" src="https://github.com/user-attachments/assets/79505708-cc75-426a-9291-e28da251eee8" />



### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-10647

### Is it tested? How?

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Create a workspace (any sample, any editor).
3. Stop the workspace, then navigate to **Workspace Details → Overview**.
4. Verify the **Editor** row shows the current editor name and version with a pencil icon.
5. Click the pencil — the **Change Editor** modal opens with radio buttons for each available editor and an EllipsisV version picker for editors with multiple versions.
6. Select a different editor, optionally pick a non-default version, and click **Save**.
7. Verify the Overview tab updates to show the new editor.
8. Start the workspace — confirm it opens in the newly selected editor.

**Without this PR:** no way to change the editor on an existing stopped workspace without recreating it.

#### Release Notes

Added "Change Editor" option to the workspace Overview tab, allowing users to switch the IDE of a stopped workspace without recreating it.

#### Docs PR

https://github.com/eclipse-che/che-docs/pull/3192