### PR TITLE
[cherry-pick] fix: fetch getting-started-sample regardless of disableInternalRegistry

### DIFF
--- a/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
+++ b/packages/dashboard-frontend/src/services/bootstrap/__tests__/index.spec.tsx
@@ -228,7 +228,7 @@ describe('Dashboard bootstrap', () => {
     expect(mockDetector.getWorkspaceStoppedError).toHaveBeenCalled();
   });
 
-  test('fetches embedded registry when disableInternalRegistry is true', async () => {
+  test('fetches both sample endpoints even when disableInternalRegistry is true', async () => {
     const store = new MockStoreBuilder()
       .withDwServerConfig({
         devfileRegistry: {
@@ -241,8 +241,17 @@ describe('Dashboard bootstrap', () => {
 
     await expect(bootstrap.init()).resolves.toBeUndefined();
 
-    // DEFAULT_REGISTRY (embedded, always available) + external registry = 2 calls.
-    // getting-started-sample and airgap-sample are skipped when internal registry is disabled.
-    expect(devfileRegistriesActionCreators.requestRegistriesMetadata).toHaveBeenCalledTimes(2);
+    // DEFAULT_REGISTRY + getting-started-sample + airgap-sample + external = 4 calls.
+    expect(devfileRegistriesActionCreators.requestRegistriesMetadata).toHaveBeenCalledTimes(4);
+
+    const calls = (
+      devfileRegistriesActionCreators.requestRegistriesMetadata as jest.Mock
+    ).mock.calls.map(call => call[0]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('/dashboard/api/getting-started-sample'),
+        expect.stringContaining('/dashboard/api/airgap-sample'),
+      ]),
+    );
   });
 });

--- a/packages/dashboard-frontend/src/services/bootstrap/index.ts
+++ b/packages/dashboard-frontend/src/services/bootstrap/index.ts
@@ -354,27 +354,25 @@ export default class Bootstrap {
       undefined,
     );
 
-    const isInternalRegistryDisabled = devfileRegistry?.disableInternalRegistry === true;
+    // Both sample endpoints are fetched unconditionally, regardless of disableInternalRegistry:
+    // getting-started-sample serves user-provided ConfigMap samples, and airgap-sample provides
+    // the built-in samples that getting-started-sample depends on.
+    const gettingStartedSampleURL = new URL(
+      '/dashboard/api/getting-started-sample',
+      window.location.origin,
+    ).href;
+    await requestRegistriesMetadata(gettingStartedSampleURL, false)(
+      this.store.dispatch,
+      this.store.getState,
+      undefined,
+    );
 
-    if (!isInternalRegistryDisabled) {
-      const gettingStartedSampleURL = new URL(
-        '/dashboard/api/getting-started-sample',
-        window.location.origin,
-      ).href;
-      await requestRegistriesMetadata(gettingStartedSampleURL, false)(
-        this.store.dispatch,
-        this.store.getState,
-        undefined,
-      );
-
-      const airGapedSampleURL = new URL('/dashboard/api/airgap-sample', window.location.origin)
-        .href;
-      await requestRegistriesMetadata(airGapedSampleURL, false)(
-        this.store.dispatch,
-        this.store.getState,
-        undefined,
-      );
-    }
+    const airGapedSampleURL = new URL('/dashboard/api/airgap-sample', window.location.origin).href;
+    await requestRegistriesMetadata(airGapedSampleURL, false)(
+      this.store.dispatch,
+      this.store.getState,
+      undefined,
+    );
 
     const externalRegistries = (devfileRegistry?.externalDevfileRegistries ?? []).map(
       registry => registry?.url,


### PR DESCRIPTION
### What does this PR do?

This PR fixes empty Get Started sample cards when `disableInternalRegistry: true` is set in the CheCluster CR.

cherry-pick of https://github.com/eclipse-che/che-dashboard/pull/1668 to the 7.121.x branch

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-13015

### Is it tested? How?

1. Deploy Eclipse Che with the dashboard image from this PR.
2. Set `spec.components.devfileRegistry.disableInternalRegistry: true` in the CheCluster CR.
3. Create a `getting-started-samples` ConfigMap with custom sample entries.
4. Navigate to the **Get Started** page.
5. Verify: custom sample cards from the ConfigMap are displayed.
6. Without this fix: the Get Started page is empty when `disableInternalRegistry` is true and no external registries are configured.

#### Release Notes

N/A - regression fix; no user-facing changes.

#### Docs PR

N/A