### PR TITLE
fix(ui): extend IDE URL timeout to 40 seconds

### DIFF
--- a/packages/dashboard-frontend/src/components/WorkspaceProgress/const.ts
+++ b/packages/dashboard-frontend/src/components/WorkspaceProgress/const.ts
@@ -12,6 +12,6 @@
 
 export const MIN_STEP_DURATION_MS = 200;
 export const TIMEOUT_TO_CREATE_SEC = 20;
-export const TIMEOUT_TO_GET_URL_SEC = 20;
+export const TIMEOUT_TO_GET_URL_SEC = 40;
 export const TIMEOUT_TO_RESOLVE_SEC = 20;
 export const TIMEOUT_TO_STOP_SEC = 60;


### PR DESCRIPTION
### What does this PR do?

Increases the IDE URL timeout from 20 to 40 seconds during workspace startup.

### Root Cause

When a workspace starts on a slow cluster or pulls a large editor image,
the IDE URL may not be available within 20 seconds. The `TIMEOUT_TO_GET_URL_SEC`
constant in `WorkspaceProgress/const.ts` controls how long the "Open IDE" step
waits before showing an error. 20 seconds is too aggressive for environments
with cold image pulls or high API latency.

### Fix

```diff
-export const TIMEOUT_TO_GET_URL_SEC = 20;
+export const TIMEOUT_TO_GET_URL_SEC = 40;
```

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://redhat.atlassian.net/browse/CRW-12569

### Is it tested? How?

Unit tests in `StartingSteps/OpenWorkspace/__tests__/index.spec.tsx` (12 tests) cover the timeout value and error message.

Manual verification:

1. Deploy Red Hat OpenShift Dev Spaces on an air-gapped cluster from changes from this PR
2. Open the dashboard
3. Select a desktop editor (e.g. Kiro)
4. Select Empty Workspace
5. Wait for the "Open IDE" step
6. Workspace should start without any errors

#### Release Notes

Extended the IDE URL timeout from 20 to 40 seconds to prevent false startup errors on slower clusters.

#### Docs PR

N/A
