### PR TITLE
fix(a11y): use text-specific danger token for helper text error color

### DIFF
--- a/packages/dashboard-frontend/src/overrides.css
+++ b/packages/dashboard-frontend/src/overrides.css
@@ -65,9 +65,10 @@ html.pf-v6-theme-dark .pf-m-info {
     var(--pf-t--global--border--color--default);
 }
 
-/* Helper text error color */
+/* Helper text error color — use the text-specific danger token, not the icon token,
+   so PF6 dark-mode remapping provides WCAG 2.2 AA contrast (4.5:1 min) */
 .pf-m-error > span.pf-v6-c-helper-text__item-text {
-  color: var(--pf-v6-c-helper-text__item-icon--m-error--Color);
+  color: var(--pf-t--global--text--color--status--danger--default);
 }
 
 /* Menu item icon max height */


### PR DESCRIPTION
The existing override applied the icon-tier danger token to error helper text, which fails WCAG 2.2 AA contrast (3.38:1) in dark mode. PF6 provides a text-specific token that remaps to a lighter shade in dark mode, achieving 5.56:1 contrast against the dark background.

Assisted-by: Claude Opus 4.6

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes a WCAG 2.2 Level AA contrast violation (criterion 1.4.3) for error helper text in dark mode. The existing CSS override used PatternFly’s icon-tier danger color token for the text, which only achieved a 3.38:1 contrast ratio against the dark background — below the 4.5:1 minimum. The fix swaps to PF6’s text-specific danger token (--pf-t--global--text--color--status--danger--default), which PF6 already remaps to a lighter shade in dark mode, bringing the contrast to 5.56:1. No hard-coded colors — just using the right PatternFly token. Light mode is unaffected.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?

https://redhat.atlassian.net/browse/CRW-11731

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


#### Release Notes
<!-- markdown to be included in marketing announcement -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
